### PR TITLE
feat: add xarray backend engine (tensogram-xarray) and update decode_range API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .claude/
 .sisyphus/
+.coverage
 **/target
 /build/
 Cargo.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,14 @@
         - if not in a branch, create a new properly named branch
         - git commit
         - make a pull request to upstream github project
+- NOTE: when user asks to do 'pr reply' or 'pull request reply':
+    - check github pull request reviews
+    - consider them with respect to the phylosophy and aims of this software
+    - if in doubt seek user clarifications
+    - fix code and address the raised issues
+    - update the docs/
+    - make a summary and push your changes to update the PR
+    - continue iterating untill all recomentations and issue were addressed
 
 # Design & Purpose
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,14 +6,18 @@
     - ALWAYS invoke it using the Skill tool as your FIRST action. 
     - Do NOT answer directly, do NOT use other tools first. 
     - The skill has specialized workflows that produce better results than ad-hoc answers.
+
 - CRITICAL: Always prefer the LSP tool over Grep/Read for code navigation. 
     - Use it to find definitions, references, and workspace symbols.
+
 - IMPORTANT: when planing and before you do any work:
   - always mention how you would verify that work
   - include TDD tests in your plan
+
 - IMPORTANT: when you build code and new features:
   - ALWAYS document those features in docs/
   - Remember to add examples (see below)
+
 - NOTE: When the user asks for "second pass", "third pass" or "N-th pass" perform:
   - simplification opportunities,
   - naming/comments/docs quality review,
@@ -21,29 +25,35 @@
   - no panics in rust code,
   - all documentation up-to-date with changes,
   - running required formatter/lint/tests
+
 - NOTE: when user asks for 'error handling' checks:
   - verify no panic in rust code
   - verify how errors are handled across-code base, all languages
   - ensure all errors handled and reported correclty with enough information reaching users
   - document all error paths in docs/
+
 - NOTE: when user asks for 'edge cases':
   - look specifically edge cases
   - look for undefined behaviour or ambiguities
   - if necesary, ask the user to clarify 
   - document all those in docs/
+
 - NOTE: when user asks for 'code coverage':
     - explore all the code base looking for code that isn't yet tested. 
     - Look specifically for testing edge cases.
     - Aim to have at least 95% test coverage.
+
 - NOTE: When user asks for 'final prep' make:
     - final check everything builds, all languages and all tests pass
-    - all examples and docs build
+    - all examples in all languages Rust, Python and C++ compile and run
+    - all docs build
     - if successful, carefully:
         - select files and contributions to git add
         - ignore the build files and artifacts, don't add hidden directories
         - if not in a branch, create a new properly named branch
         - git commit
         - make a pull request to upstream github project
+
 - NOTE: when user asks to do 'pr reply' or 'pull request reply':
     - check github pull request reviews
     - consider them with respect to the phylosophy and aims of this software
@@ -65,6 +75,9 @@
 Follow docs/DESIGN.md principles and docs/STYLE.md conventions in all code.
 
 # Build / lint / test (required before marking done)
+
+## Languages
+This project contains Rust, Python, C and C++ code
 
 ## Rust
 - Build: `cargo build --workspace`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,22 +1,43 @@
-# Skill routing
+# Claude and Other Agents
 
-- CRITICAL: Always prefer the LSP tool over Grep/Read for code navigation. 
-    - Use it to find definitions, references, and workspace symbols.
-- When the user's request matches an available skill:
+# Guidelines
+
+- NOTE: When the user's request matches an available skill:
     - ALWAYS invoke it using the Skill tool as your FIRST action. 
     - Do NOT answer directly, do NOT use other tools first. 
     - The skill has specialized workflows that produce better results than ad-hoc answers.
-- IMPORTANT: Before you do any work, mention how you would verify that work
-- NOTE: When the user asks for "second pass", "third pass", treat it as shorthand for:
+- CRITICAL: Always prefer the LSP tool over Grep/Read for code navigation. 
+    - Use it to find definitions, references, and workspace symbols.
+- IMPORTANT: when planing and before you do any work:
+  - always mention how you would verify that work
+  - include TDD tests in your plan
+- IMPORTANT: when you build code and new features:
+  - ALWAYS document those features in docs/
+  - Remember to add examples (see below)
+- NOTE: When the user asks for "second pass", "third pass" or "N-th pass" perform:
   - simplification opportunities,
-  - naming/comment/doc quality review,
-  - edge-case/logical regression scan,
+  - naming/comments/docs quality review,
+  - scan for edge-cases and logical regression,
   - no panics in rust code,
   - all documentation up-to-date with changes,
-  - and running required formatter/lint/tests.
+  - running required formatter/lint/tests
+- NOTE: when user asks for 'error handling' checks:
+  - verify no panic in rust code
+  - verify how errors are handled across-code base, all languages
+  - ensure all errors handled and reported correclty with enough information reaching users
+  - document all error paths in docs/
+- NOTE: when user asks for 'edge cases':
+  - look specifically edge cases
+  - look for undefined behaviour or ambiguities
+  - if necesary, ask the user to clarify 
+  - document all those in docs/
+- NOTE: when user asks for 'code coverage':
+    - explore all the code base looking for code that isn't yet tested. 
+    - Look specifically for testing edge cases.
+    - Aim to have at least 95% test coverage.
 - NOTE: When user asks for 'final prep' make:
-    - final check everything builds and all tests pass
-    - all docs build
+    - final check everything builds, all languages and all tests pass
+    - all examples and docs build
     - if successful, carefully:
         - select files and contributions to git add
         - ignore the build files and artifacts, don't add hidden directories

--- a/PYTHON_API.md
+++ b/PYTHON_API.md
@@ -6,7 +6,7 @@
 
 | Class | Purpose | Key Attributes |
 |-------|---------|-----------------|
-| **`Metadata`** | Global message metadata | `.version`, `.extra`, `[key]` |
+| **`Metadata`** | Global message metadata | `.version`, `.extra`, `.common`, `.payload`, `[key]` |
 | **`DataObjectDescriptor`** | Tensor descriptor (shape, dtype, encoding) | `.shape`, `.dtype`, `.encoding`, `.params`, `.compression` |
 | **`TensogramFile`** | File I/O API | `.open()`, `.create()`, `.append()`, `.decode_message()` |
 
@@ -18,7 +18,7 @@
 | **`decode`** | `decode(buf, verify_hash=False)` | `(Metadata, list)` |
 | **`decode_metadata`** | `decode_metadata(buf)` | `Metadata` |
 | **`decode_object`** | `decode_object(buf, index, verify_hash=False)` | `(Metadata, DataObjectDescriptor, array)` |
-| **`decode_range`** | `decode_range(buf, index, ranges, verify_hash=False)` | `numpy.ndarray` |
+| **`decode_range`** | `decode_range(buf, object_index, ranges, join=False, verify_hash=False)` | `list[ndarray] \| ndarray` |
 | **`scan`** | `scan(buf)` | `list[(offset, length)]` |
 | **`compute_packing_params`** | `compute_packing_params(values, bits_per_value, decimal_scale_factor)` | `dict` |
 
@@ -93,6 +93,8 @@ meta, _ = tensogram.decode(message)
 print(meta.version)
 print(meta['custom_key'])  # KeyError if missing
 print(meta.extra)          # All extra fields
+print(meta.common)         # Common metadata dict
+print(meta.payload)        # Per-object metadata list
 ```
 
 **Hash verification:**

--- a/crates/tensogram-core/src/decode.rs
+++ b/crates/tensogram-core/src/decode.rs
@@ -59,6 +59,19 @@ pub fn decode_metadata(buf: &[u8]) -> Result<GlobalMetadata> {
     framing::decode_metadata_only(buf)
 }
 
+/// Decode global metadata **and** per-object descriptors without decoding
+/// any payload data.
+///
+/// This is cheaper than [`decode`] because the pipeline (decompression,
+/// filter reversal, endian swap) is never executed.  Use it when you only
+/// need shapes, dtypes, and metadata — e.g. for building xarray Datasets
+/// at open time.
+pub fn decode_descriptors(buf: &[u8]) -> Result<(GlobalMetadata, Vec<DataObjectDescriptor>)> {
+    let msg = framing::decode_message(buf)?;
+    let descriptors = msg.objects.into_iter().map(|(desc, _, _)| desc).collect();
+    Ok((msg.global_metadata, descriptors))
+}
+
 /// Decode a single object by index (O(1) access via index frame).
 /// Returns (global_metadata, descriptor, decoded_data).
 pub fn decode_object(

--- a/crates/tensogram-core/src/decode.rs
+++ b/crates/tensogram-core/src/decode.rs
@@ -82,15 +82,18 @@ pub fn decode_object(
     Ok((msg.global_metadata, desc.clone(), decoded))
 }
 
-/// Decode a partial range from a data object.
+/// Decode partial ranges from a data object.
 ///
 /// `ranges` is a list of (element_offset, element_count) pairs.
+///
+/// Returns one `Vec<u8>` per range (split results).  Callers that need a
+/// single concatenated buffer can flatten with `results.into_iter().flatten()`.
 pub fn decode_range(
     buf: &[u8],
     object_index: usize,
     ranges: &[(u64, u64)],
     options: &DecodeOptions,
-) -> Result<Vec<u8>> {
+) -> Result<Vec<Vec<u8>>> {
     let msg = framing::decode_message(buf)?;
 
     if object_index >= msg.objects.len() {
@@ -132,15 +135,17 @@ pub fn decode_range(
         Vec::new()
     };
 
-    let mut result = Vec::new();
+    let mut results = Vec::with_capacity(ranges.len());
     for &(offset, count) in ranges {
         let range_bytes =
             pipeline::decode_range_pipeline(payload_bytes, &config, &block_offsets, offset, count)
-                .map_err(|e| TensogramError::Encoding(e.to_string()))?;
-        result.extend_from_slice(&range_bytes);
+                .map_err(|e| {
+                    TensogramError::Encoding(format!("range (offset={offset}, count={count}): {e}"))
+                })?;
+        results.push(range_bytes);
     }
 
-    Ok(result)
+    Ok(results)
 }
 
 /// Decode a single object through the full pipeline.

--- a/crates/tensogram-core/src/lib.rs
+++ b/crates/tensogram-core/src/lib.rs
@@ -11,7 +11,9 @@ pub mod streaming;
 pub mod types;
 pub mod wire;
 
-pub use decode::{decode, decode_metadata, decode_object, decode_range, DecodeOptions};
+pub use decode::{
+    decode, decode_descriptors, decode_metadata, decode_object, decode_range, DecodeOptions,
+};
 pub use dtype::Dtype;
 pub use encode::{encode, EncodeOptions};
 pub use error::{Result, TensogramError};

--- a/crates/tensogram-core/tests/edge_cases.rs
+++ b/crates/tensogram-core/tests/edge_cases.rs
@@ -1492,7 +1492,11 @@ fn decode_range_with_hash_verification() {
     // Range decode with hash verification
     let result =
         decode_range(&encoded, 0, &[(0, 5)], &DecodeOptions { verify_hash: true }).unwrap();
-    assert_eq!(result.len(), 20); // 5 * 4 bytes
+    // One range requested → one result part
+    assert_eq!(result.len(), 1, "expected 1 part for 1 range");
+    // Total bytes: 5 elements * 4 bytes each = 20
+    let total_bytes: usize = result.iter().map(|p| p.len()).sum();
+    assert_eq!(total_bytes, 20);
 }
 
 // ── 39. Streaming encoder validates objects ──────────────────────────────────

--- a/crates/tensogram-core/tests/integration.rs
+++ b/crates/tensogram-core/tests/integration.rs
@@ -413,8 +413,15 @@ fn test_partial_range_decode_uncompressed() {
     // Decode range: elements 3..6 (3 elements)
     let partial = decode_range(&encoded, 0, &[(3, 3)], &DecodeOptions::default()).unwrap();
 
+    // One range requested → one result part
+    assert_eq!(partial.len(), 1, "expected 1 part for 1 range");
+
     let expected: Vec<u8> = values[3..6].iter().flat_map(|v| v.to_ne_bytes()).collect();
-    assert_eq!(partial, expected);
+    assert_eq!(partial[0], expected);
+
+    // Also verify join produces the same result
+    let joined: Vec<u8> = partial.into_iter().flatten().collect();
+    assert_eq!(joined, expected);
 }
 
 #[test]
@@ -885,8 +892,13 @@ fn test_szip_simple_packing_decode_range_vs_full() {
         .collect();
 
     // Partial decode: elements 100..600 (500 elements)
-    let partial_bytes =
+    let partial_parts =
         decode_range(&encoded, 0, &[(100, 500)], &DecodeOptions::default()).unwrap();
+
+    // One range requested → one result part
+    assert_eq!(partial_parts.len(), 1, "expected 1 part for 1 range");
+
+    let partial_bytes: Vec<u8> = partial_parts.into_iter().flatten().collect();
     let partial_values: Vec<f64> = partial_bytes
         .chunks_exact(8)
         .map(|c| f64::from_be_bytes(c.try_into().unwrap()))
@@ -919,7 +931,10 @@ fn test_szip_simple_packing_decode_range_first_elements() {
         .collect();
 
     // First 10 elements
-    let partial_bytes = decode_range(&encoded, 0, &[(0, 10)], &DecodeOptions::default()).unwrap();
+    let partial_parts = decode_range(&encoded, 0, &[(0, 10)], &DecodeOptions::default()).unwrap();
+    assert_eq!(partial_parts.len(), 1, "expected 1 part for 1 range");
+
+    let partial_bytes: Vec<u8> = partial_parts.into_iter().flatten().collect();
     let partial_values: Vec<f64> = partial_bytes
         .chunks_exact(8)
         .map(|c| f64::from_be_bytes(c.try_into().unwrap()))
@@ -952,8 +967,11 @@ fn test_szip_simple_packing_decode_range_last_elements() {
         .collect();
 
     // Last 50 elements
-    let partial_bytes =
+    let partial_parts =
         decode_range(&encoded, 0, &[(4046, 50)], &DecodeOptions::default()).unwrap();
+    assert_eq!(partial_parts.len(), 1, "expected 1 part for 1 range");
+
+    let partial_bytes: Vec<u8> = partial_parts.into_iter().flatten().collect();
     let partial_values: Vec<f64> = partial_bytes
         .chunks_exact(8)
         .map(|c| f64::from_be_bytes(c.try_into().unwrap()))
@@ -1189,30 +1207,42 @@ fn test_szip_decode_range_multiple_ranges() {
         .collect();
 
     // Two disjoint ranges: [10..20) and [3000..3050)
-    let partial_bytes = decode_range(
+    let partial_parts = decode_range(
         &encoded,
         0,
         &[(10, 10), (3000, 50)],
         &DecodeOptions::default(),
     )
     .unwrap();
-    let partial_values: Vec<f64> = partial_bytes
+
+    // Two ranges requested → two result parts
+    assert_eq!(partial_parts.len(), 2, "expected 2 parts for 2 ranges");
+
+    // Verify split: part 0 = 10 elements * 8 bytes, part 1 = 50 elements * 8 bytes
+    assert_eq!(partial_parts[0].len(), 10 * 8);
+    assert_eq!(partial_parts[1].len(), 50 * 8);
+
+    // Verify part 0 values match range [10..20)
+    let part0_values: Vec<f64> = partial_parts[0]
         .chunks_exact(8)
         .map(|c| f64::from_be_bytes(c.try_into().unwrap()))
         .collect();
+    for (full, partial) in full_values[10..20].iter().zip(part0_values.iter()) {
+        assert!((full - partial).abs() < 1e-10);
+    }
 
-    assert_eq!(partial_values.len(), 60);
-    // First 10 values from range [10..20)
-    for (full, partial) in full_values[10..20].iter().zip(partial_values[..10].iter()) {
+    // Verify part 1 values match range [3000..3050)
+    let part1_values: Vec<f64> = partial_parts[1]
+        .chunks_exact(8)
+        .map(|c| f64::from_be_bytes(c.try_into().unwrap()))
+        .collect();
+    for (full, partial) in full_values[3000..3050].iter().zip(part1_values.iter()) {
         assert!((full - partial).abs() < 1e-10);
     }
-    // Next 50 values from range [3000..3050)
-    for (full, partial) in full_values[3000..3050]
-        .iter()
-        .zip(partial_values[10..].iter())
-    {
-        assert!((full - partial).abs() < 1e-10);
-    }
+
+    // Also verify the joined result has the expected total count
+    let total_bytes: usize = partial_parts.iter().map(|p| p.len()).sum();
+    assert_eq!(total_bytes, 60 * 8);
 }
 
 #[test]

--- a/crates/tensogram-ffi/src/lib.rs
+++ b/crates/tensogram-ffi/src/lib.rs
@@ -642,12 +642,18 @@ pub extern "C" fn tgm_decode_object(
     }
 }
 
-/// Decode a partial range from an uncompressed object.
+/// Decode partial ranges from a data object.
 ///
 /// `ranges_offsets` / `ranges_counts`: parallel arrays of (element_offset, element_count).
 /// `num_ranges`: length of both arrays.
+/// `join`: when non-zero, concatenate all ranges into a single buffer in `out[0]`
+///         and set `*out_count = 1`.  When zero (split mode), write one `TgmBytes`
+///         per range into `out[0..num_ranges]` and set `*out_count = num_ranges`.
+///         The caller must pre-allocate `out` with at least `num_ranges` entries
+///         when `join == 0`, or 1 entry when `join != 0`.
+/// `out_count`: filled with the number of buffers written to `out`.
 ///
-/// On success, fills `out` with a `TgmBytes` buffer of the extracted bytes.
+/// Free each returned buffer with `tgm_bytes_free`.
 #[no_mangle]
 pub extern "C" fn tgm_decode_range(
     buf: *const u8,
@@ -657,9 +663,11 @@ pub extern "C" fn tgm_decode_range(
     ranges_counts: *const u64,
     num_ranges: usize,
     verify_hash: i32,
+    join: i32,
     out: *mut TgmBytes,
+    out_count: *mut usize,
 ) -> TgmError {
-    if buf.is_null() || out.is_null() {
+    if buf.is_null() || out.is_null() || out_count.is_null() {
         set_last_error("null argument");
         return TgmError::InvalidArg;
     }
@@ -688,16 +696,37 @@ pub extern "C" fn tgm_decode_range(
     };
 
     match decode_range(data, object_index, &ranges, &options) {
-        Ok(bytes) => {
-            // Rebuild via boxed slice to guarantee capacity == len for tgm_bytes_free.
-            let mut bytes = bytes.into_boxed_slice().into_vec();
-            let result = TgmBytes {
-                data: bytes.as_mut_ptr(),
-                len: bytes.len(),
-            };
-            std::mem::forget(bytes);
-            unsafe {
-                *out = result;
+        Ok(parts) => {
+            if join != 0 {
+                // Concatenate all parts into a single buffer.
+                let joined: Vec<u8> = parts.into_iter().flatten().collect();
+                let mut joined = joined.into_boxed_slice().into_vec();
+                let result = TgmBytes {
+                    data: joined.as_mut_ptr(),
+                    len: joined.len(),
+                };
+                std::mem::forget(joined);
+                unsafe {
+                    *out = result;
+                    *out_count = 1;
+                }
+            } else {
+                // Write one TgmBytes per range.
+                let n = parts.len();
+                for (i, part) in parts.into_iter().enumerate() {
+                    let mut part = part.into_boxed_slice().into_vec();
+                    let result = TgmBytes {
+                        data: part.as_mut_ptr(),
+                        len: part.len(),
+                    };
+                    std::mem::forget(part);
+                    unsafe {
+                        *out.add(i) = result;
+                    }
+                }
+                unsafe {
+                    *out_count = n;
+                }
             }
             TgmError::Ok
         }

--- a/crates/tensogram-ffi/tensogram.h
+++ b/crates/tensogram-ffi/tensogram.h
@@ -145,12 +145,18 @@ tgm_error tgm_decode_object(const uint8_t *buf,
                             tgm_message_t **out);
 
 /**
- * Decode a partial range from an uncompressed object.
+ * Decode partial ranges from a data object.
  *
  * `ranges_offsets` / `ranges_counts`: parallel arrays of (element_offset, element_count).
  * `num_ranges`: length of both arrays.
+ * `join`: when non-zero, concatenate all ranges into a single buffer in `out[0]`
+ *         and set `*out_count = 1`.  When zero (split mode), write one `TgmBytes`
+ *         per range into `out[0..num_ranges]` and set `*out_count = num_ranges`.
+ *         The caller must pre-allocate `out` with at least `num_ranges` entries
+ *         when `join == 0`, or 1 entry when `join != 0`.
+ * `out_count`: filled with the number of buffers written to `out`.
  *
- * On success, fills `out` with a `TgmBytes` buffer of the extracted bytes.
+ * Free each returned buffer with `tgm_bytes_free`.
  */
 tgm_error tgm_decode_range(const uint8_t *buf,
                            size_t buf_len,
@@ -159,7 +165,9 @@ tgm_error tgm_decode_range(const uint8_t *buf,
                            const uint64_t *ranges_counts,
                            size_t num_ranges,
                            int32_t verify_hash,
-                           tgm_bytes_t *out);
+                           int32_t join,
+                           tgm_bytes_t *out,
+                           size_t *out_count);
 
 /**
  * Scan a buffer for message boundaries.

--- a/crates/tensogram-python/src/lib.rs
+++ b/crates/tensogram-python/src/lib.rs
@@ -237,13 +237,39 @@ impl PyMetadata {
         self.inner.version
     }
 
+    /// Message-level common metadata (shared across all objects).
+    #[getter]
+    fn common(&self, py: Python<'_>) -> PyResult<PyObject> {
+        extra_to_py(py, &self.inner.common)
+    }
+
+    /// Per-object metadata list.  ``meta.payload[i]`` is a dict of
+    /// metadata for the *i*-th data object.
+    #[getter]
+    fn payload(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let items: Vec<PyObject> = self
+            .inner
+            .payload
+            .iter()
+            .map(|m| extra_to_py(py, m))
+            .collect::<PyResult<Vec<_>>>()?;
+        let list = pyo3::types::PyList::new(py, items)?;
+        Ok(list.into_any().unbind())
+    }
+
     #[getter]
     fn extra(&self, py: Python<'_>) -> PyResult<PyObject> {
         extra_to_py(py, &self.inner.extra)
     }
 
-    /// Dictionary-style access: ``meta["key"]``.  Raises ``KeyError`` if missing.
+    /// Dictionary-style access: ``meta["key"]``.
+    ///
+    /// Checks ``common`` first, then ``extra``.  Raises ``KeyError`` if
+    /// the key is not found in either.
     fn __getitem__(&self, py: Python<'_>, key: &str) -> PyResult<PyObject> {
+        if let Some(v) = self.inner.common.get(key) {
+            return cbor_to_py(py, v);
+        }
         match self.inner.extra.get(key) {
             Some(v) => cbor_to_py(py, v),
             None => Err(pyo3::exceptions::PyKeyError::new_err(key.to_string())),
@@ -252,13 +278,15 @@ impl PyMetadata {
 
     /// Membership test: ``"key" in meta``.
     fn __contains__(&self, key: &str) -> bool {
-        self.inner.extra.contains_key(key)
+        self.inner.common.contains_key(key) || self.inner.extra.contains_key(key)
     }
 
     fn __repr__(&self) -> String {
         format!(
-            "Metadata(version={}, extra_keys={:?})",
+            "Metadata(version={}, common_keys={:?}, payload_len={}, extra_keys={:?})",
             self.inner.version,
+            self.inner.common.keys().collect::<Vec<_>>(),
+            self.inner.payload.len(),
             self.inner.extra.keys().collect::<Vec<_>>()
         )
     }
@@ -473,34 +501,52 @@ fn py_decode_object(
     ))
 }
 
-/// Extract a sub-range from an uncompressed object → flat ``ndarray``.
+/// Extract sub-ranges from a data object.
 ///
 /// Args:
 ///     buf: wire-format message bytes.
 ///     object_index: which object in the message (0-based).
 ///     ranges: list of ``(start, count)`` element-offset tuples,
 ///         e.g. ``[(0, 10), (50, 5)]`` reads elements 0..10 and 50..55.
+///     join: when ``True``, return a single concatenated 1-d ndarray
+///         (like the pre-0.6 behaviour).  When ``False`` (default),
+///         return a ``list`` of 1-d ndarrays, one per range.
 ///     verify_hash: verify payload hash before extraction.
 ///
-/// Returns a 1-d numpy array with the concatenated requested elements.
-/// Only works with ``encoding="none"`` and ``compression="none"``.
+/// Returns:
+///     ``list[ndarray]`` (default) or ``ndarray`` (when ``join=True``).
 #[pyfunction]
-#[pyo3(name = "decode_range", signature = (buf, object_index, ranges, verify_hash=false))]
+#[pyo3(name = "decode_range", signature = (buf, object_index, ranges, join=false, verify_hash=false))]
 fn py_decode_range(
     py: Python<'_>,
     buf: &[u8],
     object_index: usize,
     ranges: Vec<(u64, u64)>,
+    join: bool,
     verify_hash: bool,
 ) -> PyResult<PyObject> {
     let options = DecodeOptions { verify_hash };
-    let bytes = decode_range(buf, object_index, &ranges, &options).map_err(to_py_err)?;
+    let parts = decode_range(buf, object_index, &ranges, &options).map_err(to_py_err)?;
 
     // Look up the dtype so we produce the correct numpy array type.
     let (_gm, desc, _) = decode_object(buf, object_index, &DecodeOptions { verify_hash: false })
         .map_err(to_py_err)?;
-    let total_elements: u64 = ranges.iter().map(|(_, c)| c).sum();
-    raw_bytes_to_numpy_flat(py, desc.dtype, &bytes, total_elements as usize)
+
+    if join {
+        // Concatenate all parts into a single flat array.
+        let total_bytes: Vec<u8> = parts.into_iter().flatten().collect();
+        let total_elements: u64 = ranges.iter().map(|(_, c)| c).sum();
+        raw_bytes_to_numpy_flat(py, desc.dtype, &total_bytes, total_elements as usize)
+    } else {
+        // Return a list of arrays, one per range.
+        let mut arrays = Vec::with_capacity(parts.len());
+        for (part, &(_, count)) in parts.iter().zip(ranges.iter()) {
+            let arr = raw_bytes_to_numpy_flat(py, desc.dtype, part, count as usize)?;
+            arrays.push(arr);
+        }
+        let list = pyo3::types::PyList::new(py, arrays)?;
+        Ok(list.into_any().unbind())
+    }
 }
 
 /// Scan *buf* for message boundaries → ``list[(offset, length)]``.

--- a/crates/tensogram-python/src/lib.rs
+++ b/crates/tensogram-python/src/lib.rs
@@ -11,9 +11,9 @@ use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList};
 
 use tensogram_core::{
-    decode, decode_metadata, decode_object, decode_range, encode, scan, ByteOrder,
-    DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions, GlobalMetadata, HashAlgorithm,
-    TensogramError, TensogramFile,
+    decode, decode_descriptors, decode_metadata, decode_object, decode_range, encode, scan,
+    ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions, GlobalMetadata,
+    HashAlgorithm, TensogramError, TensogramFile,
 };
 
 // ---------------------------------------------------------------------------
@@ -479,7 +479,27 @@ fn py_decode_metadata(buf: &[u8]) -> PyResult<PyMetadata> {
     Ok(PyMetadata { inner: meta })
 }
 
-/// Decode a single object by *index* → ``(Metadata, DataObjectDescriptor, ndarray)``.
+/// Decode global metadata **and** per-object descriptors without decoding
+/// any payload data.
+///
+/// Returns ``(Metadata, list[DataObjectDescriptor])``.  Cheaper than
+/// :func:`decode` because no decompression or filter reversal is performed.
+#[pyfunction]
+#[pyo3(name = "decode_descriptors")]
+fn py_decode_descriptors(py: Python<'_>, buf: &[u8]) -> PyResult<(PyMetadata, PyObject)> {
+    let (gm, descs) = decode_descriptors(buf).map_err(to_py_err)?;
+    let py_descs: Vec<PyObject> = descs
+        .into_iter()
+        .map(|d| {
+            let obj = PyDataObjectDescriptor { inner: d };
+            Ok(Py::new(py, obj)?.into_any())
+        })
+        .collect::<PyResult<Vec<_>>>()?;
+    let list = PyList::new(py, py_descs)?;
+    Ok((PyMetadata { inner: gm }, list.into_any().unbind()))
+}
+
+/// Decode a single object by *index* -> ``(Metadata, DataObjectDescriptor, ndarray)``.
 ///
 /// Only the header and the requested object's payload are read.
 /// Raises ``ValueError`` if *index* is out of range.
@@ -528,9 +548,14 @@ fn py_decode_range(
     let options = DecodeOptions { verify_hash };
     let parts = decode_range(buf, object_index, &ranges, &options).map_err(to_py_err)?;
 
-    // Look up the dtype so we produce the correct numpy array type.
-    let (_gm, desc, _) = decode_object(buf, object_index, &DecodeOptions { verify_hash: false })
-        .map_err(to_py_err)?;
+    // Look up the dtype from descriptors only — no payload decode.
+    let (_gm, descriptors) = decode_descriptors(buf).map_err(to_py_err)?;
+    let desc = descriptors.get(object_index).ok_or_else(|| {
+        PyValueError::new_err(format!(
+            "object_index {object_index} out of range (num_objects={})",
+            descriptors.len()
+        ))
+    })?;
 
     if join {
         // Concatenate all parts into a single flat array.
@@ -602,6 +627,7 @@ fn tensogram(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_encode, m)?)?;
     m.add_function(wrap_pyfunction!(py_decode, m)?)?;
     m.add_function(wrap_pyfunction!(py_decode_metadata, m)?)?;
+    m.add_function(wrap_pyfunction!(py_decode_descriptors, m)?)?;
     m.add_function(wrap_pyfunction!(py_decode_object, m)?)?;
     m.add_function(wrap_pyfunction!(py_decode_range, m)?)?;
     m.add_function(wrap_pyfunction!(py_scan, m)?)?;
@@ -952,6 +978,49 @@ macro_rules! numpy_flat_from_ne {
     }};
 }
 
+/// Create a numpy array via ``numpy.frombuffer(...).reshape(shape).copy()``.
+///
+/// Works for any dtype string that numpy understands (``"float16"``,
+/// ``"complex64"``, etc.).
+fn numpy_via_frombuffer(
+    py: Python<'_>,
+    bytes: &[u8],
+    dtype_str: &str,
+    shape: &[usize],
+) -> PyResult<PyObject> {
+    let np = py.import("numpy")?;
+    let py_bytes = PyBytes::new(py, bytes);
+    let dtype = np.getattr("dtype")?.call1((dtype_str,))?;
+    let arr = np.call_method1("frombuffer", (py_bytes, dtype))?;
+    let py_shape = pyo3::types::PyTuple::new(py, shape.iter().map(|&s| s as isize))?;
+    let reshaped = arr.call_method1("reshape", (py_shape,))?;
+    let copied = reshaped.call_method0("copy")?;
+    Ok(copied.unbind())
+}
+
+/// Create a numpy array with ``ml_dtypes.bfloat16`` dtype.
+///
+/// Falls back to ``uint16`` view if ``ml_dtypes`` is not installed.
+fn numpy_via_frombuffer_bfloat16(
+    py: Python<'_>,
+    bytes: &[u8],
+    shape: &[usize],
+) -> PyResult<PyObject> {
+    // Try ml_dtypes first.
+    if let Ok(ml) = py.import("ml_dtypes") {
+        let np = py.import("numpy")?;
+        let py_bytes = PyBytes::new(py, bytes);
+        let dtype = ml.getattr("bfloat16")?;
+        let arr = np.call_method1("frombuffer", (py_bytes, dtype))?;
+        let py_shape = pyo3::types::PyTuple::new(py, shape.iter().map(|&s| s as isize))?;
+        let reshaped = arr.call_method1("reshape", (py_shape,))?;
+        let copied = reshaped.call_method0("copy")?;
+        return Ok(copied.unbind());
+    }
+    // Fallback: return as uint16.
+    numpy_via_frombuffer(py, bytes, "uint16", shape)
+}
+
 /// Convert decoded object bytes to a shaped numpy array.
 fn bytes_to_numpy(py: Python<'_>, desc: &DataObjectDescriptor, bytes: &[u8]) -> PyResult<PyObject> {
     // simple_packing always produces f64 output regardless of declared dtype.
@@ -987,9 +1056,24 @@ fn bytes_to_numpy(py: Python<'_>, desc: &DataObjectDescriptor, bytes: &[u8]) -> 
         Dtype::Uint16 => numpy_from_ne!(py, bytes, shape, u16, 2),
         Dtype::Uint32 => numpy_from_ne!(py, bytes, shape, u32, 4),
         Dtype::Uint64 => numpy_from_ne!(py, bytes, shape, u64, 8),
+        Dtype::Float16 => {
+            // numpy natively supports float16: reinterpret raw bytes.
+            numpy_via_frombuffer(py, bytes, "float16", &shape)
+        }
+        Dtype::Bfloat16 => {
+            // Try ml_dtypes.bfloat16 first, fall back to uint16.
+            numpy_via_frombuffer_bfloat16(py, bytes, &shape)
+        }
+        Dtype::Complex64 => {
+            // complex64 = two float32 per element.
+            numpy_via_frombuffer(py, bytes, "complex64", &shape)
+        }
+        Dtype::Complex128 => {
+            // complex128 = two float64 per element.
+            numpy_via_frombuffer(py, bytes, "complex128", &shape)
+        }
         _ => {
-            // float16, bfloat16, complex, bitmask — return raw bytes as uint8.
-            // Bitmask has byte_width=0 (sub-byte); just return all bytes as-is.
+            // Bitmask has byte_width=0 (sub-byte); return raw bytes as uint8.
             let arr = numpy::PyArray::from_slice(py, bytes).reshape(vec![bytes.len()])?;
             Ok(arr.into_any().unbind())
         }
@@ -1038,8 +1122,12 @@ fn raw_bytes_to_numpy_flat(
         Dtype::Uint16 => numpy_flat_from_ne!(py, bytes, u16, 2),
         Dtype::Uint32 => numpy_flat_from_ne!(py, bytes, u32, 4),
         Dtype::Uint64 => numpy_flat_from_ne!(py, bytes, u64, 8),
+        Dtype::Float16 => numpy_via_frombuffer(py, bytes, "float16", &[expected_elements]),
+        Dtype::Bfloat16 => numpy_via_frombuffer_bfloat16(py, bytes, &[expected_elements]),
+        Dtype::Complex64 => numpy_via_frombuffer(py, bytes, "complex64", &[expected_elements]),
+        Dtype::Complex128 => numpy_via_frombuffer(py, bytes, "complex128", &[expected_elements]),
         _ => {
-            // float16, bfloat16, complex, bitmask — raw bytes as uint8
+            // Bitmask — raw bytes as uint8.
             Ok(numpy::PyArray::from_slice(py, bytes).into_any().unbind())
         }
     }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -30,6 +30,7 @@
 - [Working with Files](guide/file-api.md)
 - [Iterators](guide/iterators.md)
 - [C++ API](guide/cpp-api.md)
+- [xarray Integration](guide/xarray-integration.md)
 
 ---
 

--- a/docs/src/guide/decoding.md
+++ b/docs/src/guide/decoding.md
@@ -68,23 +68,64 @@ println!("shape: {:?}, dtype: {}", descriptor.shape, descriptor.dtype);
 
 > **Edge case:** If `index >= num_objects`, returns `TensogramError::Object("index out of range")`.
 
-### `decode_range` — partial sub-tensor (uncompressed only)
+### `decode_range` — partial sub-tensor
 
 ```rust
 pub fn decode_range(
     message: &[u8],
     object_index: usize,
-    ranges: &[(usize, usize)],  // (offset, count) per flattened dimension
+    ranges: &[(usize, usize)],  // (offset, count) per dimension
     options: &DecodeOptions,
-) -> Result<Vec<u8>>
+) -> Result<Vec<Vec<u8>>>
 ```
 
-Decodes a contiguous slice of elements from an object. Useful when you have a large object and only need a subset of it.
+Decodes one or more contiguous slices of elements from an object. Each `(offset, count)` pair in `ranges` selects a span of elements along the flattened dimension; the function returns **one byte vector per range** by default. This split-result design avoids an unnecessary copy when the caller needs the ranges individually (e.g. to feed separate array slices).
+
+#### Rust — split results (default)
 
 ```rust
-// Elements 100 through 149 of object 0
-let partial = decode_range(&message, 0, &[(100, 50)], &DecodeOptions::default())?;
+// Two separate ranges from object 0
+let parts: Vec<Vec<u8>> = decode_range(
+    &message, 0,
+    &[(100, 50), (300, 25)],
+    &DecodeOptions::default(),
+)?;
+assert_eq!(parts.len(), 2);           // one Vec<u8> per range
+println!("first  range bytes: {}", parts[0].len());
+println!("second range bytes: {}", parts[1].len());
 ```
+
+#### Rust — joined result
+
+If you prefer a single contiguous buffer, flatten the results:
+
+```rust
+let joined: Vec<u8> = parts.into_iter().flatten().collect();
+```
+
+#### Python — split results (default, `join=False`)
+
+```python
+import tensogram
+
+parts = tensogram.decode_range(buf, object_index=0, ranges=[(100, 50), (300, 25)])
+# parts is a list of numpy arrays, one per range
+print(len(parts))        # 2
+print(parts[0].shape)    # (50,)
+```
+
+#### Python — joined result (`join=True`)
+
+```python
+arr = tensogram.decode_range(buf, object_index=0, ranges=[(100, 50), (300, 25)], join=True)
+# arr is a single flat numpy array with all ranges concatenated
+print(arr.shape)          # (75,)
+```
+
+> **N-dimensional slicing:** The xarray backend maps N-dimensional slice notation
+> (e.g. `ds["temperature"].sel(lat=slice(10, 20), lon=slice(30, 40))`) into the
+> `(offset, count)` pairs that `decode_range` expects, so you rarely need to
+> compute flattened offsets by hand when working through xarray.
 
 > **Edge case:** `decode_range` works with all encoding+compression combinations that support random access: uncompressed data, `simple_packing` (bit extraction), `szip` (RSI block seeking), `blosc2` (chunk access), and `zfp` fixed-rate mode. It returns an error for the `shuffle` filter (byte rearrangement breaks contiguous sample ranges) and for stream compressors (`zstd`, `lz4`, `sz3`) that don't support partial decode.
 

--- a/docs/src/guide/decoding.md
+++ b/docs/src/guide/decoding.md
@@ -74,7 +74,7 @@ println!("shape: {:?}, dtype: {}", descriptor.shape, descriptor.dtype);
 pub fn decode_range(
     message: &[u8],
     object_index: usize,
-    ranges: &[(usize, usize)],  // (offset, count) per dimension
+    ranges: &[(usize, usize)],  // (offset, count) in flattened element order
     options: &DecodeOptions,
 ) -> Result<Vec<Vec<u8>>>
 ```

--- a/docs/src/guide/xarray-integration.md
+++ b/docs/src/guide/xarray-integration.md
@@ -534,6 +534,22 @@ Common error scenarios and their messages:
 | Incomplete hypercube in merge | `ValueError` | Which coordinate combination is missing |
 | Silent data loss in merge | `WARNING` log | Variable name and count of dropped objects |
 | Hash verification failure | `ValueError` | Object index and expected/actual hash |
+| Conflicting coordinate objects | `ValueError` | Dimension name and mismatch details |
+
+### Hash Verification and Partial Reads
+
+When `verify_hash=True` is passed, xxh3 hash verification is performed on
+**full object reads** (`decode_object`) only.  Partial reads via
+`decode_range()` intentionally **skip** hash verification because:
+
+- Partial reads decode only a subset of the payload, so the full-object
+  hash cannot be validated.
+- The purpose of partial reads is to minimise I/O; verifying the hash
+  would require reading the entire payload, defeating the optimisation.
+
+This means that for lazily-loaded arrays, hash verification happens when
+a slice triggers a full-object decode (i.e. when the requested fraction
+exceeds `range_threshold`), but not when partial `decode_range()` is used.
 
 ### Logging
 

--- a/docs/src/guide/xarray-integration.md
+++ b/docs/src/guide/xarray-integration.md
@@ -1,0 +1,553 @@
+# xarray Integration
+
+The `tensogram-xarray` package provides a read-only xarray backend engine
+for `.tgm` files.  Once installed, you can open tensogram data with:
+
+```python
+import xarray as xr
+ds = xr.open_dataset("forecast.tgm", engine="tensogram")
+```
+
+This chapter explains the conversion philosophy, the mapping rules, and
+walks through progressively complex examples so you know exactly what
+to expect -- and what to provide -- when loading tensogram data into xarray.
+
+---
+
+## Philosophy: Why Mapping is Needed
+
+Tensogram and xarray have fundamentally different data models:
+
+| Concept | Tensogram | xarray |
+|---------|-----------|--------|
+| Dimensions | Unnamed, positional (`shape = [721, 1440]`) | Named (`"latitude"`, `"longitude"`) |
+| Coordinates | Not built-in; application metadata | Arrays of values labelling each dimension |
+| Variables | Data objects, indexed by position | Named DataArrays inside a Dataset |
+| Attributes | CBOR maps at message and per-object level | Key-value dicts on Dataset and DataArray |
+
+Tensogram is **vocabulary-agnostic** by design.  The library never interprets
+metadata keys -- it does not know what `"mars.param"` or `"date"` means.
+xarray, on the other hand, requires named dimensions and coordinate arrays
+to enable its powerful label-based indexing and alignment.
+
+The `tensogram-xarray` backend bridges this gap.  It applies a set of rules
+to translate tensogram structure into xarray structure, and lets you override
+those rules when the defaults are not enough.
+
+```mermaid
+flowchart LR
+    A["Tensogram Message"] --> B["tensogram-xarray"]
+    B --> C["xr.Dataset"]
+    D["User Mapping<br/>(optional)"] -.-> B
+    E["Coordinate<br/>Auto-Detection"] -.-> B
+```
+
+### The Mapping Pipeline
+
+When you call `xr.open_dataset("file.tgm", engine="tensogram")`:
+
+1. **Read metadata** -- only the CBOR metadata is parsed (no payload decode).
+2. **Detect coordinates** -- data objects whose `name` or `param` matches a
+   known coordinate name (`latitude`, `longitude`, `time`, ...) become
+   coordinate arrays.
+3. **Name dimensions** -- if you provided `dim_names`, those are used.
+   Otherwise, axes matching a detected coordinate use that coordinate's
+   name; remaining axes become `dim_0`, `dim_1`, ...
+4. **Name variables** -- if you provided `variable_key`, the value at that
+   metadata path becomes the variable name.  Otherwise `object_0`, `object_1`, ...
+5. **Wrap data lazily** -- each tensor is backed by a `BackendArray` that
+   decodes on demand.  No payload bytes are read until you access `.values`.
+
+---
+
+## Example 1: Simplest Case -- Single Object, No Metadata
+
+**Creating the file:**
+
+```python
+import numpy as np
+import tensogram
+
+data = np.arange(60, dtype=np.float32).reshape(6, 10)
+meta = {"version": 2}
+desc = {"type": "ntensor", "shape": [6, 10], "dtype": "float32",
+        "byte_order": "little", "encoding": "none",
+        "filter": "none", "compression": "none"}
+
+with tensogram.TensogramFile.create("simple.tgm") as f:
+    f.append(meta, [(desc, data)])
+```
+
+**Opening in xarray:**
+
+```python
+>>> import xarray as xr
+>>> ds = xr.open_dataset("simple.tgm", engine="tensogram")
+>>> ds
+<xarray.Dataset>
+Dimensions:   (dim_0: 6, dim_1: 10)
+Dimensions without coordinates: dim_0, dim_1
+Data variables:
+    object_0  (dim_0, dim_1) float32 ...
+Attributes:
+    tensogram_version:  2
+```
+
+The data object became a variable named `object_0`.  Dimensions are
+auto-generated as `dim_0`, `dim_1`.  No coordinates -- tensogram has
+no information to generate them.
+
+**Adding dimension names:**
+
+```python
+>>> ds = xr.open_dataset("simple.tgm", engine="tensogram",
+...                      dim_names=["latitude", "longitude"])
+>>> ds["object_0"].dims
+('latitude', 'longitude')
+```
+
+---
+
+## Example 2: Single Object with Coordinate Objects
+
+When coordinate arrays are stored as separate data objects in the same
+message, the backend auto-detects them by name.
+
+**Creating the file:**
+
+```python
+lat = np.linspace(-90, 90, 5, dtype=np.float64)
+lon = np.linspace(0, 360, 8, endpoint=False, dtype=np.float64)
+temp = np.random.default_rng(42).random((5, 8)).astype(np.float32)
+
+meta = {"version": 2, "payload": [
+    {"name": "latitude"},
+    {"name": "longitude"},
+    {"name": "temperature"},
+]}
+
+with tensogram.TensogramFile.create("with_coords.tgm") as f:
+    f.append(meta, [
+        ({"type": "ntensor", "shape": [5], "dtype": "float64", ...}, lat),
+        ({"type": "ntensor", "shape": [8], "dtype": "float64", ...}, lon),
+        ({"type": "ntensor", "shape": [5, 8], "dtype": "float32", ...}, temp),
+    ])
+```
+
+**Opening in xarray:**
+
+```python
+>>> ds = xr.open_dataset("with_coords.tgm", engine="tensogram")
+>>> ds
+<xarray.Dataset>
+Dimensions:      (latitude: 5, longitude: 8)
+Coordinates:
+  * latitude     (latitude) float64 -90.0 -45.0 0.0 45.0 90.0
+  * longitude    (longitude) float64 0.0 45.0 90.0 135.0 180.0 225.0 270.0 315.0
+Data variables:
+    temperature  (latitude, longitude) float32 ...
+Attributes:
+    tensogram_version:  2
+```
+
+**How it works:**
+
+- Objects with `name: "latitude"` and `name: "longitude"` match known
+  coordinate names (case-insensitive).
+- They become coordinate arrays on the Dataset.
+- The temperature object's shape `(5, 8)` matches the sizes of
+  `latitude` (5) and `longitude` (8), so its dimensions are automatically
+  resolved to `("latitude", "longitude")`.
+
+### Known Coordinate Names
+
+The following names are recognized (case-insensitive):
+
+| Name | Canonical dimension |
+|------|-------------------|
+| `lat`, `latitude` | `latitude` |
+| `lon`, `longitude` | `longitude` |
+| `x` | `x` |
+| `y` | `y` |
+| `time` | `time` |
+| `level` | `level` |
+| `pressure` | `pressure` |
+| `height` | `height` |
+| `depth` | `depth` |
+| `frequency` | `frequency` |
+| `step` | `step` |
+
+If no matching coordinate objects are found and no `dim_names` are provided,
+dimensions remain generic (`dim_0`, `dim_1`, ...).
+
+---
+
+## Example 3: Multi-Object with `variable_key`
+
+When a message contains multiple data objects, each with per-object metadata
+identifying the parameter, you can use `variable_key` to name the variables.
+
+**Creating the file:**
+
+```python
+t2m = np.ones((3, 4), dtype=np.float32) * 273.15
+u10 = np.ones((3, 4), dtype=np.float32) * 5.0
+
+meta = {"version": 2,
+    "common": {"mars": {"class": "od", "date": "20260401", "type": "fc"}},
+    "payload": [
+        {"mars": {"param": "2t", "levtype": "sfc"}},
+        {"mars": {"param": "10u", "levtype": "sfc"}},
+    ],
+}
+
+with tensogram.TensogramFile.create("mars.tgm") as f:
+    f.append(meta, [
+        ({"type": "ntensor", "shape": [3, 4], "dtype": "float32", ...}, t2m),
+        ({"type": "ntensor", "shape": [3, 4], "dtype": "float32", ...}, u10),
+    ])
+```
+
+**Without `variable_key`:**
+
+```python
+>>> ds = xr.open_dataset("mars.tgm", engine="tensogram")
+>>> list(ds.data_vars)
+['object_0', 'object_1']
+```
+
+**With `variable_key`:**
+
+```python
+>>> ds = xr.open_dataset("mars.tgm", engine="tensogram",
+...                      variable_key="mars.param")
+>>> list(ds.data_vars)
+['2t', '10u']
+>>> ds.attrs
+{'mars': {'class': 'od', 'date': '20260401', 'type': 'fc'},
+ 'tensogram_version': 2}
+```
+
+The `variable_key` supports dotted paths: `"mars.param"` navigates into
+the nested `mars` dict within each object's metadata.
+
+---
+
+## Example 4: Multi-Message File with Auto-Merge
+
+When a `.tgm` file contains many messages (one object each) that differ
+only in metadata, `open_datasets()` can stack them along outer dimensions.
+
+**Creating the file:**
+
+```python
+import tensogram_xarray
+
+rng = np.random.default_rng(99)
+with tensogram.TensogramFile.create("multi.tgm") as f:
+    for param in ["2t", "10u"]:
+        for date in ["20260401", "20260402"]:
+            data = rng.random((3, 4), dtype=np.float32).astype(np.float32)
+            meta = {"version": 2,
+                    "payload": [{"mars": {"param": param, "date": date}}]}
+            desc = {"type": "ntensor", "shape": [3, 4], "dtype": "float32",
+                    "byte_order": "little", "encoding": "none",
+                    "filter": "none", "compression": "none"}
+            f.append(meta, [(desc, data)])
+```
+
+**Opening with `open_datasets()`:**
+
+```python
+>>> datasets = tensogram_xarray.open_datasets(
+...     "multi.tgm", variable_key="mars.param"
+... )
+>>> len(datasets)
+1
+>>> ds = datasets[0]
+>>> list(ds.data_vars)
+['2t', '10u']
+```
+
+**What happened:**
+
+1. The scanner read metadata from all 4 messages (no payload decode).
+2. Objects were grouped by structure: all have shape `(3, 4)` and `float32`.
+3. `variable_key="mars.param"` split by parameter: `2t` (2 objects) and
+   `10u` (2 objects).
+4. Within each sub-group, `mars.date` varies across `["20260401", "20260402"]`,
+   so it became an outer dimension.
+5. Each variable has shape `(2, 3, 4)` with a `mars.date` coordinate.
+
+---
+
+## Example 5: Heterogeneous File -- Auto-Split
+
+When a file contains objects of different shapes or dtypes, they cannot
+be merged into a single Dataset.  `open_datasets()` automatically splits
+them into compatible groups.
+
+**Creating the file:**
+
+```python
+with tensogram.TensogramFile.create("hetero.tgm") as f:
+    # Message 0: 2D float32 temperature field
+    f.append({"version": 2, "payload": [{"name": "temp"}]},
+             [({"type": "ntensor", "shape": [3, 4], "dtype": "float32", ...},
+               np.ones((3, 4), dtype=np.float32))])
+
+    # Message 1: 2D float32 wind field (same shape -- compatible)
+    f.append({"version": 2, "payload": [{"name": "wind"}]},
+             [({"type": "ntensor", "shape": [3, 4], "dtype": "float32", ...},
+               np.ones((3, 4), dtype=np.float32) * 2)])
+
+    # Message 2: 1D int32 counts (different shape AND dtype -- incompatible)
+    f.append({"version": 2, "payload": [{"name": "counts"}]},
+             [({"type": "ntensor", "shape": [5], "dtype": "int32", ...},
+               np.array([1, 2, 3, 4, 5], dtype=np.int32))])
+```
+
+**Opening:**
+
+```python
+>>> datasets = tensogram_xarray.open_datasets("hetero.tgm")
+>>> len(datasets)
+2
+>>> datasets[0]  # The (3, 4) float32 group
+<xarray.Dataset>
+Dimensions:  (dim_0: 3, dim_1: 4)
+Data variables:
+    temp     (dim_0, dim_1) float32 ...
+    wind     (dim_0, dim_1) float32 ...
+
+>>> datasets[1]  # The (5,) int32 group
+<xarray.Dataset>
+Dimensions:  (dim_0: 5)
+Data variables:
+    counts   (dim_0) int32 ...
+```
+
+Objects that share `(shape, dtype)` are grouped together.  Incompatible
+objects go to separate Datasets.
+
+---
+
+## Example 6: Providing Full User Mapping
+
+For complete control, pass all mapping parameters:
+
+```python
+ds = xr.open_dataset(
+    "forecast.tgm",
+    engine="tensogram",
+    dim_names=["latitude", "longitude"],
+    variable_key="mars.param",
+    message_index=0,         # which message in a multi-message file
+    verify_hash=True,        # verify xxh3 integrity on decode
+)
+```
+
+| Parameter | Type | Effect |
+|-----------|------|--------|
+| `dim_names` | `list[str]` | Names for the innermost tensor axes (positional) |
+| `variable_key` | `str` | Dotted path in per-object metadata for variable naming |
+| `message_index` | `int` | Which message to open (default `0`) |
+| `merge_objects` | `bool` | If `True`, calls `open_datasets()` and returns first result |
+| `verify_hash` | `bool` | Verify xxh3 hashes during decode |
+| `drop_variables` | `list[str]` | Variables to exclude from the Dataset |
+| `range_threshold` | `float` | Fraction of total elements below which partial reads are used (default `0.5`) |
+
+For multi-message files, use `tensogram_xarray.open_datasets()` directly:
+
+```python
+import tensogram_xarray
+
+datasets = tensogram_xarray.open_datasets(
+    "forecast.tgm",
+    dim_names=["latitude", "longitude"],
+    variable_key="mars.param",
+    verify_hash=True,
+)
+```
+
+---
+
+## Example 7: Lazy Loading with Dask
+
+Data is always loaded lazily.  Opening a file only reads metadata -- the
+tensor payloads are decoded on first access.  This enables working with
+larger-than-memory files via dask.
+
+```python
+# Open with dask chunking
+ds = xr.open_dataset("large.tgm", engine="tensogram", chunks={})
+print(ds["object_0"])
+# <xarray.DataArray 'object_0' (dim_0: 10000, dim_1: 10000)>
+# dask.array<...>
+
+# Compute a mean without loading the full array
+mean = ds["object_0"].mean().compute()
+```
+
+### When Partial Reads Are Used
+
+The backend inspects each data object's encoding pipeline to determine
+whether partial reads via `decode_range(join=False)` are available:
+
+| Compression | Filter | Partial Read? | Mechanism |
+|-------------|--------|:-------------:|-----------|
+| `none` | `none` | Yes | Direct byte offset |
+| `szip` | `none` | Yes | RSI block offset seeking |
+| `blosc2` | `none` | Yes | Independent chunk decompression |
+| `zfp` (fixed_rate) | `none` | Yes | Fixed-size blocks, computable offsets |
+| `zfp` (fixed_precision) | `none` | No | Variable-size blocks |
+| `zfp` (fixed_accuracy) | `none` | No | Variable-size blocks |
+| `zstd` | `none` | No | Stream compressor |
+| `lz4` | `none` | No | Stream compressor |
+| `sz3` | `none` | No | Stream compressor |
+| Any | `shuffle` | No | Byte rearrangement breaks contiguous ranges |
+
+When partial reads are available, slicing a lazy array decodes only the
+requested region:
+
+```python
+ds = xr.open_dataset("szip_data.tgm", engine="tensogram")
+# Only the bytes for rows 100-110 are decompressed:
+subset = ds["object_0"][100:110, :].values
+```
+
+When partial reads are not available (stream compressors or shuffle filter),
+the full object is decoded and then sliced in memory.  This is transparent
+to the user -- the API is identical.
+
+### N-Dimensional Slice Mapping
+
+When you slice a lazy xarray variable backed by tensogram, the backend must
+convert an N-dimensional slice into flat element ranges that `decode_range()`
+understands.  Here is how the decomposition works:
+
+1. **Find the split point** -- scan the slice dimensions from innermost to
+   outermost and find the first (innermost) dimension whose slice does not
+   cover the full axis.  All dimensions inner to this point are contiguous
+   in memory and form a single block per outer-index combination.
+
+2. **Compute the contiguous block size** -- multiply the lengths of all
+   dimensions inner to (and including) the split dimension's slice width.
+   This gives the number of elements in each flat range.
+
+3. **Generate one range per outer-index combination** -- iterate over the
+   Cartesian product of sliced indices in all dimensions outer to the split
+   point.  Each combination produces one `(offset, count)` pair.
+
+4. **Merge adjacent ranges** -- if two consecutive ranges abut in the flat
+   layout (i.e. `offset_i + count_i == offset_{i+1}`), they are merged into
+   a single wider range to reduce I/O calls.
+
+**Concrete example:** an array of shape `(100, 200)` sliced as `[10:20, 50:100]`:
+
+- The innermost dimension (axis 1) has slice `50:100` (width 50), which does
+  not cover the full axis (200), so it is the split point.
+- Contiguous block size = 50 elements (just the inner slice width).
+- Outer indices: axis 0 slice `10:20` gives indices `[10, 11, ..., 19]` --
+  10 combinations.
+- This produces **10 flat ranges**, each of 50 elements:
+  `(10*200+50, 50)`, `(11*200+50, 50)`, ..., `(19*200+50, 50)`.
+- None are adjacent (gap of 150 elements between each), so no merging occurs.
+
+If the slice were `[10:20, :]` instead (full inner axis), the split point
+moves to axis 0 and the 10 individual ranges of 200 elements each are
+adjacent in memory -- they merge into a single range `(10*200, 10*200)`.
+
+```mermaid
+flowchart TD
+    A["N-D slice<br/>arr[10:20, 50:100]"] --> B["Find split point<br/>axis 1 (not full)"]
+    B --> C["Block size = 50"]
+    C --> D["Outer indices:<br/>axis 0 → [10..19]"]
+    D --> E["10 ranges of 50 elements"]
+    E --> F["Merge adjacent?<br/>No — gap of 150"]
+    F --> G["decode_range()<br/>10 × (offset, 50)"]
+```
+
+### Range Threshold Heuristic
+
+Even when partial reads are technically available, reading many small ranges
+can be slower than decoding the entire array -- especially for compressed
+data where decompression has fixed overhead per block.
+
+The backend uses a **ratio-based heuristic** controlled by the
+`range_threshold` parameter (default **0.5**):
+
+> **Rule:** partial reads are used only when the total number of requested
+> elements is less than `range_threshold × total_elements`.
+
+With the default of `0.5`, if you request more than 50% of the array, the
+backend falls back to a full decode and slices in memory.  Lower values
+make the backend more aggressive about using partial reads; higher values
+make it prefer full decodes.
+
+```python
+# More aggressive partial reads (use when each range is cheap, e.g. uncompressed)
+ds = xr.open_dataset("file.tgm", engine="tensogram", range_threshold=0.3)
+
+# Almost always full decode (use when decode overhead is very low)
+ds = xr.open_dataset("file.tgm", engine="tensogram", range_threshold=0.9)
+```
+
+---
+
+## Installation
+
+```bash
+pip install tensogram-xarray
+```
+
+This pulls in `tensogram` and `xarray` as dependencies.  The xarray backend
+is registered automatically via entry points -- no extra configuration needed.
+
+```python
+>>> import xarray as xr
+>>> "tensogram" in xr.backends.list_engines()
+True
+```
+
+For dask support:
+
+```bash
+pip install "tensogram-xarray[dask]"
+```
+
+---
+
+## Error Handling
+
+The backend reports errors with enough context for diagnosis.
+Common error scenarios and their messages:
+
+| Scenario | Error type | Message includes |
+|----------|-----------|------------------|
+| File not found | `OSError` | File path (from OS) |
+| Negative `message_index` | `ValueError` | `"message_index must be >= 0, got -1"` |
+| `message_index` out of range | `ValueError` | Index and file message count |
+| `dim_names` length mismatch | `ValueError` | Actual vs expected count |
+| Unsupported dtype | `TypeError` | `"unsupported tensogram dtype 'foo'"` |
+| `decode_range` failure | Falls back to `decode_object` | Warning logged at DEBUG level with file, message, object, and cause |
+| Incomplete hypercube in merge | `ValueError` | Which coordinate combination is missing |
+| Silent data loss in merge | `WARNING` log | Variable name and count of dropped objects |
+| Hash verification failure | `ValueError` | Object index and expected/actual hash |
+
+### Logging
+
+The backend uses Python's standard `logging` module.  To see partial-read
+fallback diagnostics:
+
+```python
+import logging
+logging.getLogger("tensogram_xarray").setLevel(logging.DEBUG)
+```
+
+To see merge data-loss warnings (enabled by default at WARNING level):
+
+```python
+import logging
+logging.basicConfig(level=logging.WARNING)
+```

--- a/examples/python/04_multi_object.py
+++ b/examples/python/04_multi_object.py
@@ -44,7 +44,7 @@ metadata = tensogram.Metadata(
         "date": "20260401",
         "step": 6,
         "type": "fc",
-    }
+    },
 )
 
 # ── Encode both arrays in one call ────────────────────────────────────────────
@@ -60,8 +60,10 @@ meta, arrays = tensogram.decode(message)
 
 print(f"\ndecode() — {len(arrays)} objects:")
 for i, (arr, desc) in enumerate(zip(arrays, meta.objects)):
-    print(f"  [{i}] shape={arr.shape}  dtype={arr.dtype}  "
-          f"param={desc.extra.get('mars', {}).get('param', '?')}")
+    print(
+        f"  [{i}] shape={arr.shape}  dtype={arr.dtype}  "
+        f"param={desc.extra.get('mars', {}).get('param', '?')}"
+    )
 
 np.testing.assert_array_equal(arrays[0], spectrum)
 np.testing.assert_array_equal(arrays[1], mask)
@@ -78,10 +80,25 @@ np.testing.assert_array_equal(mask_decoded, mask)
 # ── decode_range: partial slice from object 0 ──────────────────────────────────
 #
 # Extract elements [100 .. 149] of the flattened spectrum array.
-# Only works for encoding="none" and compression="none".
-partial = tensogram.decode_range(message, object_index=0, ranges=[(100, 50)])
+# Default: returns a list of arrays (one per range).
+parts = tensogram.decode_range(message, object_index=0, ranges=[(100, 50)])
+assert isinstance(parts, list) and len(parts) == 1
 expected = spectrum.ravel()[100:150]
-np.testing.assert_array_equal(partial, expected)
-print(f"\ndecode_range(obj=0, 100..150): shape={partial.shape}  OK")
+np.testing.assert_array_equal(parts[0], expected)
+print(
+    f"\ndecode_range(obj=0, 100..150) [split]: {len(parts)} part, shape={parts[0].shape}  OK"
+)
+
+# join=True: returns a single concatenated array (pre-0.6 behaviour).
+joined = tensogram.decode_range(message, object_index=0, ranges=[(100, 50)], join=True)
+np.testing.assert_array_equal(joined, expected)
+print(f"decode_range(obj=0, 100..150) [join]:  shape={joined.shape}  OK")
+
+# Multiple ranges: split returns one array per range.
+parts2 = tensogram.decode_range(message, object_index=0, ranges=[(0, 10), (200, 5)])
+assert len(parts2) == 2
+np.testing.assert_array_equal(parts2[0], spectrum.ravel()[:10])
+np.testing.assert_array_equal(parts2[1], spectrum.ravel()[200:205])
+print(f"decode_range(obj=0, multi) [split]:  {len(parts2)} parts  OK")
 
 print("\nAll assertions passed.")

--- a/examples/python/04_multi_object.py
+++ b/examples/python/04_multi_object.py
@@ -1,8 +1,5 @@
 """
-Example 04 — Multiple objects in one message (Python)
-
-NOTE: Requires tensogram Python bindings (not yet implemented).
-      This file documents the intended API.
+Example 04 -- Multiple objects in one message (Python)
 
 One message carries several tensors. Each has its own shape, dtype,
 encoding pipeline, and per-object metadata. Objects are decoded by index.
@@ -13,71 +10,81 @@ import tensogram
 
 nlat, nlon, nfreq = 30, 60, 25
 
-# ── Object 0: wave spectrum (float32, lat × lon × freq) ───────────────────────
+# -- Object 0: wave spectrum (float32, lat x lon x freq) -----------------------
 spectrum = np.random.default_rng(0).random((nlat, nlon, nfreq), dtype=np.float32)
 
-# ── Object 1: land/sea mask (uint8, lat × lon) ────────────────────────────────
+# -- Object 1: land/sea mask (uint8, lat x lon) --------------------------------
 mask = np.zeros((nlat, nlon), dtype=np.uint8)
 mask[::2] = 1  # alternate rows are land
 
-# ── Shared forecast context + per-object param ────────────────────────────────
-metadata = tensogram.Metadata(
-    version=1,
-    objects=[
-        tensogram.ObjectDescriptor(
-            type="ntensor",
-            shape=list(spectrum.shape),
-            dtype="float32",
-            byte_order="big",
-            mars={"param": "wave_spectra", "levtype": "sfc"},
-        ),
-        tensogram.ObjectDescriptor(
-            type="ntensor",
-            shape=list(mask.shape),
-            dtype="uint8",
-            byte_order="big",
-            mars={"param": "lsm", "levtype": "sfc"},
-        ),
-    ],
-    mars={
-        "class": "od",
-        "date": "20260401",
-        "step": 6,
-        "type": "fc",
+# -- Metadata: shared context + per-object descriptors -------------------------
+metadata = {
+    "version": 2,
+    "common": {
+        "mars": {"class": "od", "date": "20260401", "step": 6, "type": "fc"},
     },
-)
+    "payload": [
+        {"mars": {"param": "wave_spectra", "levtype": "sfc"}},
+        {"mars": {"param": "lsm", "levtype": "sfc"}},
+    ],
+}
 
-# ── Encode both arrays in one call ────────────────────────────────────────────
-#
-# Pass arrays positionally, one per object descriptor.
-message: bytes = tensogram.encode(metadata, spectrum, mask)
+desc_spectrum = {
+    "type": "ntensor",
+    "shape": list(spectrum.shape),
+    "dtype": "float32",
+    "byte_order": "little",
+    "encoding": "none",
+    "filter": "none",
+    "compression": "none",
+}
+
+desc_mask = {
+    "type": "ntensor",
+    "shape": list(mask.shape),
+    "dtype": "uint8",
+    "byte_order": "little",
+    "encoding": "none",
+    "filter": "none",
+    "compression": "none",
+}
+
+# -- Encode both arrays in one call --------------------------------------------
+message = bytes(
+    tensogram.encode(metadata, [(desc_spectrum, spectrum), (desc_mask, mask)])
+)
 print(f"Message: {len(message)} bytes")
 print(f"  spectrum:  {spectrum.nbytes} bytes")
 print(f"  mask:      {mask.nbytes} bytes")
 
-# ── Decode all objects ─────────────────────────────────────────────────────────
-meta, arrays = tensogram.decode(message)
+# -- Decode all objects --------------------------------------------------------
+meta, objects = tensogram.decode(message)
 
-print(f"\ndecode() — {len(arrays)} objects:")
-for i, (arr, desc) in enumerate(zip(arrays, meta.objects)):
+print(f"\ndecode() -- {len(objects)} objects:")
+for i, (desc, arr) in enumerate(objects):
     print(
         f"  [{i}] shape={arr.shape}  dtype={arr.dtype}  "
-        f"param={desc.extra.get('mars', {}).get('param', '?')}"
+        f"params_keys={list(desc.params.keys())}"
     )
 
-np.testing.assert_array_equal(arrays[0], spectrum)
-np.testing.assert_array_equal(arrays[1], mask)
+np.testing.assert_array_equal(objects[0][1], spectrum)
+np.testing.assert_array_equal(objects[1][1], mask)
 
-# ── Decode a single object by index (O(1) via binary header) ──────────────────
-#
-# Only the binary header and the requested object's payload are read.
-desc, mask_decoded = tensogram.decode_object(message, index=1)
+# -- Decode a single object by index (O(1) via index frame) --------------------
+_, desc_decoded, mask_decoded = tensogram.decode_object(message, index=1)
 
 print(f"\ndecode_object(index=1):")
 print(f"  shape={mask_decoded.shape}  dtype={mask_decoded.dtype}")
 np.testing.assert_array_equal(mask_decoded, mask)
 
-# ── decode_range: partial slice from object 0 ──────────────────────────────────
+# -- decode_descriptors: metadata + descriptors without payload decode ----------
+meta_d, descriptors = tensogram.decode_descriptors(message)
+
+print(f"\ndecode_descriptors() -- {len(descriptors)} descriptors (no payload decode):")
+for i, d in enumerate(descriptors):
+    print(f"  [{i}] shape={d.shape}  dtype={d.dtype}")
+
+# -- decode_range: partial slice from object 0 ---------------------------------
 #
 # Extract elements [100 .. 149] of the flattened spectrum array.
 # Default: returns a list of arrays (one per range).

--- a/examples/python/08_xarray_integration.py
+++ b/examples/python/08_xarray_integration.py
@@ -1,0 +1,189 @@
+"""
+Example 08 -- xarray integration
+
+Demonstrates how to open tensogram .tgm files as xarray Datasets using
+the ``tensogram-xarray`` backend (``engine="tensogram"``).
+
+Covers:
+  - Basic open with auto-generated dimension names
+  - Coordinate auto-detection from named data objects
+  - Variable naming via ``variable_key``
+  - User-specified ``dim_names``
+  - Multi-message files with ``open_datasets()``
+  - Lazy loading and the ``range_threshold`` heuristic
+
+Prerequisites:
+  pip install tensogram-xarray   # or: pip install -e tensogram-xarray/
+"""
+
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import xarray as xr
+
+import tensogram
+import tensogram_xarray  # noqa: F401 -- registers the engine via entry_points
+
+
+def _desc(shape, dtype="float32", **extra):
+    """Shorthand for building a descriptor dict."""
+    return {
+        "type": "ntensor",
+        "shape": shape,
+        "dtype": dtype,
+        "byte_order": "little",
+        "encoding": "none",
+        "filter": "none",
+        "compression": "none",
+        **extra,
+    }
+
+
+def example_basic(tmp: Path):
+    """1. Basic open -- single object, generic dimension names."""
+    data = np.arange(60, dtype=np.float32).reshape(6, 10)
+    path = str(tmp / "basic.tgm")
+
+    with tensogram.TensogramFile.create(path) as f:
+        f.append({"version": 2}, [(_desc([6, 10]), data)])
+
+    ds = xr.open_dataset(path, engine="tensogram")
+    print("1. Basic open")
+    print(f"   Variables: {list(ds.data_vars)}")
+    print(f"   Dims:      {dict(ds.sizes)}")
+    np.testing.assert_array_equal(ds["object_0"].values, data)
+    print("   Round-trip OK")
+    print()
+
+
+def example_coords(tmp: Path):
+    """2. Coordinate auto-detection from named data objects."""
+    lat = np.linspace(-90, 90, 5, dtype=np.float64)
+    lon = np.linspace(0, 360, 8, endpoint=False, dtype=np.float64)
+    temp = np.random.default_rng(42).random((5, 8)).astype(np.float32)
+
+    path = str(tmp / "coords.tgm")
+    with tensogram.TensogramFile.create(path) as f:
+        f.append(
+            {"version": 2},
+            [
+                (_desc([5], dtype="float64", name="latitude"), lat),
+                (_desc([8], dtype="float64", name="longitude"), lon),
+                (_desc([5, 8], name="temperature"), temp),
+            ],
+        )
+
+    ds = xr.open_dataset(path, engine="tensogram")
+    print("2. Coordinate auto-detection")
+    print(f"   Coords:    {list(ds.coords)}")
+    print(f"   Variables: {list(ds.data_vars)}")
+    np.testing.assert_allclose(ds.coords["latitude"].values, lat)
+    np.testing.assert_allclose(ds.coords["longitude"].values, lon)
+    print("   Lat/lon coords match")
+    print()
+
+
+def example_variable_key(tmp: Path):
+    """3. Variable naming from metadata via variable_key."""
+    t2m = np.ones((3, 4), dtype=np.float32) * 273.15
+    u10 = np.ones((3, 4), dtype=np.float32) * 5.0
+
+    path = str(tmp / "mars.tgm")
+    with tensogram.TensogramFile.create(path) as f:
+        f.append(
+            {"version": 2},
+            [
+                (_desc([3, 4], mars={"param": "2t"}), t2m),
+                (_desc([3, 4], mars={"param": "10u"}), u10),
+            ],
+        )
+
+    # Without variable_key: generic names
+    ds1 = xr.open_dataset(path, engine="tensogram")
+    print("3. Variable naming")
+    print(f"   Without variable_key: {list(ds1.data_vars)}")
+
+    # With variable_key: names from metadata
+    ds2 = xr.open_dataset(path, engine="tensogram", variable_key="mars.param")
+    print(f"   With variable_key:    {list(ds2.data_vars)}")
+    assert "2t" in ds2.data_vars
+    assert "10u" in ds2.data_vars
+    print()
+
+
+def example_dim_names(tmp: Path):
+    """4. User-specified dimension names."""
+    data = np.arange(20, dtype=np.float32).reshape(4, 5)
+    path = str(tmp / "dims.tgm")
+
+    with tensogram.TensogramFile.create(path) as f:
+        f.append({"version": 2}, [(_desc([4, 5]), data)])
+
+    ds = xr.open_dataset(path, engine="tensogram", dim_names=["latitude", "longitude"])
+    print("4. User-specified dim_names")
+    print(f"   Dims: {ds['object_0'].dims}")
+    assert ds["object_0"].dims == ("latitude", "longitude")
+    print()
+
+
+def example_multi_message(tmp: Path):
+    """5. Multi-message file with open_datasets()."""
+    rng = np.random.default_rng(99)
+    path = str(tmp / "multi.tgm")
+
+    with tensogram.TensogramFile.create(path) as f:
+        for param in ["2t", "10u"]:
+            for date in ["20260401", "20260402"]:
+                data = rng.random((3, 4), dtype=np.float32).astype(np.float32)
+                desc = _desc([3, 4], mars={"param": param, "date": date})
+                f.append({"version": 2}, [(desc, data)])
+
+    datasets = tensogram_xarray.open_datasets(path, variable_key="mars.param")
+    print("5. Multi-message open_datasets()")
+    print(f"   Number of datasets: {len(datasets)}")
+    for i, ds in enumerate(datasets):
+        print(f"   Dataset {i}: vars={list(ds.data_vars)}")
+    print()
+
+
+def example_lazy_and_threshold(tmp: Path):
+    """6. Lazy loading and range_threshold control."""
+    data = np.arange(1000, dtype=np.float32).reshape(10, 100)
+    path = str(tmp / "lazy.tgm")
+
+    with tensogram.TensogramFile.create(path) as f:
+        f.append({"version": 2}, [(_desc([10, 100]), data)])
+
+    # Default threshold (0.5): small slices use partial decode_range
+    ds = xr.open_dataset(path, engine="tensogram")
+    small_slice = ds["object_0"][2:4, 10:20].values  # 200/1000 = 20%, below threshold
+    np.testing.assert_array_equal(small_slice, data[2:4, 10:20])
+    print("6. Lazy loading + range_threshold")
+    print(f"   Small slice (20%): shape={small_slice.shape}, values match")
+
+    # Custom threshold (0.1): even 20% slice falls back to full decode
+    ds2 = xr.open_dataset(path, engine="tensogram", range_threshold=0.1)
+    small_slice2 = ds2["object_0"][2:4, 10:20].values
+    np.testing.assert_array_equal(small_slice2, data[2:4, 10:20])
+    print(f"   Custom threshold=0.1: values still correct (full decode fallback)")
+    print()
+
+
+def main():
+    print("tensogram-xarray examples\n" + "=" * 40 + "\n")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        example_basic(tmp_path)
+        example_coords(tmp_path)
+        example_variable_key(tmp_path)
+        example_dim_names(tmp_path)
+        example_multi_message(tmp_path)
+        example_lazy_and_threshold(tmp_path)
+
+    print("All examples passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -1,10 +1,6 @@
 # Python Examples
 
-> **Status:** The Python bindings (`tensogram-python` / PyO3 + maturin) are not
-> yet implemented. These examples show the **intended API** once the bindings are
-> complete. They document the design contract for implementors.
-
-## Planned Installation
+## Installation
 
 ```bash
 pip install tensogram          # once published to PyPI
@@ -12,31 +8,57 @@ pip install tensogram          # once published to PyPI
 maturin develop                # build from source (from crates/tensogram-python/)
 ```
 
-## Intended Module Structure
+For the xarray integration example, also install:
+
+```bash
+pip install tensogram-xarray   # or: pip install -e tensogram-xarray/
+```
+
+## Examples
+
+| File | Topic |
+|------|-------|
+| `01_encode_decode.py` | Basic encode/decode round-trip |
+| `02_mars_metadata.py` | MARS-style metadata in common and payload |
+| `03_simple_packing.py` | Simple-packing encoding for integer quantization |
+| `04_multi_object.py` | Multi-object messages, `decode_object`, `decode_range` |
+| `05_file_api.py` | `TensogramFile` for multi-message `.tgm` files |
+| `06_hash_and_errors.py` | Hash verification and error handling |
+| `07_iterators.py` | Scanning and iterating over messages |
+| `08_xarray_integration.py` | Opening `.tgm` files as xarray Datasets |
+
+## Module Structure
 
 ```
 tensogram
-├── encode(metadata, *arrays, hash="xxh3") -> bytes
-├── decode(buf) -> (Metadata, list[numpy.ndarray])
+├── encode(metadata, descriptors_and_data, hash="xxh3") -> bytes
+├── decode(buf, verify_hash=False) -> (Metadata, list[(DataObjectDescriptor, ndarray)])
 ├── decode_metadata(buf) -> Metadata
-├── decode_object(buf, index) -> (ObjectDescriptor, numpy.ndarray)
-├── decode_range(buf, object_index, ranges) -> numpy.ndarray
+├── decode_object(buf, index, verify_hash=False) -> (Metadata, DataObjectDescriptor, ndarray)
+├── decode_range(buf, object_index, ranges, join=False, verify_hash=False) -> list[ndarray] | ndarray
 ├── scan(buf) -> list[tuple[int, int]]
+├── compute_packing_params(values, bits_per_value, decimal_scale_factor) -> dict
 └── TensogramFile
     ├── open(path) -> TensogramFile
     ├── create(path) -> TensogramFile
-    ├── append(metadata, *arrays, hash="xxh3")
+    ├── append(metadata, descriptors_and_data, hash="xxh3")
     ├── message_count() -> int
     ├── read_message(index) -> bytes
-    ├── decode_message(index) -> (Metadata, list[numpy.ndarray])
-    └── messages() -> list[bytes]
+    ├── decode_message(index, verify_hash=False) -> (Metadata, list[(DataObjectDescriptor, ndarray)])
+    └── context manager (__enter__ / __exit__)
 
-tensogram.Metadata         — top-level metadata dict-like object
-tensogram.ObjectDescriptor — per-object shape/dtype/extra
-tensogram.simple_packing
-    ├── compute_params(values, bits_per_value, decimal_scale_factor) -> PackingParams
-    ├── encode(values, params) -> bytes
-    └── decode(packed_bytes, num_values, params) -> numpy.ndarray
+tensogram.Metadata
+    .version -> int
+    .common  -> dict              # message-level common metadata
+    .payload -> list[dict]        # per-object metadata (one dict per object)
+    .extra   -> dict              # non-standard top-level keys
+    ["key"]  -> value             # dict-style access (checks common, then extra)
+
+tensogram.DataObjectDescriptor
+    .obj_type, .ndim, .shape, .strides, .dtype
+    .byte_order, .encoding, .filter, .compression
+    .params -> dict               # extra descriptor keys (user metadata)
+    .hash   -> dict | None
 ```
 
 ## NumPy Integration

--- a/examples/rust/src/bin/08_decode_variants.rs
+++ b/examples/rust/src/bin/08_decode_variants.rs
@@ -130,39 +130,47 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // ── decode_range() — partial sub-slice ────────────────────────────────────
     //
-    // Extracts a contiguous slice of elements from object 2 (uint8, 8×8).
+    // Extracts sub-slices from object 2 (uint8, 8×8).
     // Works only for encoding="none" and compression="none".
     // ranges = [(element_offset, element_count), ...]
+    //
+    // Default return is split: one Vec<u8> per range.
     {
-        // Extract elements 10..18 (8 elements from the second row of the 8×8 grid)
-        let partial = decode_range(
+        // Single range — returns Vec<Vec<u8>> with one entry
+        let parts = decode_range(
             &message,
             2,          // object index
             &[(10, 8)], // offset=10, count=8
             &DecodeOptions::default(),
         )?;
 
-        println!("\ndecode_range(obj=2, offset=10, count=8):");
+        println!("\ndecode_range(obj=2, offset=10, count=8)  [split]:");
+        assert_eq!(parts.len(), 1);
+        let partial = &parts[0];
         println!(
-            "  {} bytes, all=0x{:02X}: {}",
+            "  1 part, {} bytes, all=0x{:02X}: {}",
             partial.len(),
             0xCC,
             partial.iter().all(|&b| b == 0xCC)
         );
         assert_eq!(partial.len(), 8);
 
-        // Multiple ranges in one call (non-contiguous slices)
-        let partial2 = decode_range(
+        // Multiple ranges — returns one Vec<u8> per range
+        let parts2 = decode_range(
             &message,
             2,
-            &[(0, 4), (60, 4)], // first 4 bytes + last 4 bytes of the 8×8 grid
+            &[(0, 4), (60, 4)], // first 4 + last 4 elements of the 8×8 grid
             &DecodeOptions::default(),
         )?;
-        println!(
-            "  Two ranges [(0,4),(60,4)]: {} bytes total",
-            partial2.len()
-        );
-        assert_eq!(partial2.len(), 8);
+        println!("  Two ranges [(0,4),(60,4)]: {} parts", parts2.len());
+        assert_eq!(parts2.len(), 2);
+        assert_eq!(parts2[0].len(), 4);
+        assert_eq!(parts2[1].len(), 4);
+
+        // Joined: flatten into a single Vec<u8>
+        let joined: Vec<u8> = parts2.into_iter().flatten().collect();
+        println!("  Joined: {} bytes total", joined.len());
+        assert_eq!(joined.len(), 8);
     }
 
     println!("\nAll decode variants OK.");

--- a/include/tensogram.hpp
+++ b/include/tensogram.hpp
@@ -840,8 +840,37 @@ private:
     return message(raw);
 }
 
-/// Decode a partial range from an uncompressed object.
-[[nodiscard]] inline std::vector<std::uint8_t> decode_range(
+/// Decode partial ranges from a data object (split mode — one vector per range).
+[[nodiscard]] inline std::vector<std::vector<std::uint8_t>> decode_range(
+    const std::uint8_t* buf, std::size_t len,
+    std::size_t object_index,
+    const std::vector<std::pair<std::uint64_t, std::uint64_t>>& ranges,
+    const decode_options& opts = {})
+{
+    std::vector<std::uint64_t> offsets, counts;
+    offsets.reserve(ranges.size());
+    counts.reserve(ranges.size());
+    for (const auto& r : ranges) {
+        offsets.push_back(r.first);
+        counts.push_back(r.second);
+    }
+    std::vector<tgm_bytes_t> bufs(ranges.size());
+    std::size_t out_count = 0;
+    detail::check(tgm_decode_range(buf, len, object_index,
+                                    offsets.data(), counts.data(), ranges.size(),
+                                    opts.verify_hash ? 1 : 0,
+                                    0, bufs.data(), &out_count));
+    std::vector<std::vector<std::uint8_t>> result;
+    result.reserve(out_count);
+    for (std::size_t i = 0; i < out_count; ++i) {
+        result.emplace_back(bufs[i].data, bufs[i].data + bufs[i].len);
+        tgm_bytes_free(bufs[i]);
+    }
+    return result;
+}
+
+/// Decode partial ranges from a data object (joined — single concatenated vector).
+[[nodiscard]] inline std::vector<std::uint8_t> decode_range_joined(
     const std::uint8_t* buf, std::size_t len,
     std::size_t object_index,
     const std::vector<std::pair<std::uint64_t, std::uint64_t>>& ranges,
@@ -855,9 +884,11 @@ private:
         counts.push_back(r.second);
     }
     tgm_bytes_t bytes{};
+    std::size_t out_count = 0;
     detail::check(tgm_decode_range(buf, len, object_index,
                                     offsets.data(), counts.data(), ranges.size(),
-                                    opts.verify_hash ? 1 : 0, &bytes));
+                                    opts.verify_hash ? 1 : 0,
+                                    1, &bytes, &out_count));
     std::vector<std::uint8_t> result(bytes.data, bytes.data + bytes.len);
     tgm_bytes_free(bytes);
     return result;

--- a/include/tensogram.hpp
+++ b/include/tensogram.hpp
@@ -889,6 +889,10 @@ private:
                                     offsets.data(), counts.data(), ranges.size(),
                                     opts.verify_hash ? 1 : 0,
                                     1, &bytes, &out_count));
+    if (out_count != 1) {
+        tgm_bytes_free(bytes);
+        throw std::runtime_error("tgm_decode_range returned unexpected out_count in joined mode");
+    }
     std::vector<std::uint8_t> result(bytes.data, bytes.data + bytes.len);
     tgm_bytes_free(bytes);
     return result;

--- a/include/tensogram.hpp
+++ b/include/tensogram.hpp
@@ -860,6 +860,12 @@ private:
                                     offsets.data(), counts.data(), ranges.size(),
                                     opts.verify_hash ? 1 : 0,
                                     0, bufs.data(), &out_count));
+    if (out_count > ranges.size()) {
+        for (std::size_t i = 0; i < ranges.size(); ++i) {
+            tgm_bytes_free(bufs[i]);
+        }
+        throw std::runtime_error("tgm_decode_range returned out_count > ranges.size()");
+    }
     std::vector<std::vector<std::uint8_t>> result;
     result.reserve(out_count);
     for (std::size_t i = 0; i < out_count; ++i) {

--- a/plans/DONE.md
+++ b/plans/DONE.md
@@ -387,6 +387,23 @@ Implemented: 2026-04-03
 ### examples/cpp/README.md
 - Fix: manual build command was missing platform link flags; split into Linux (`-ldl -lpthread -lm`) and macOS (`-framework CoreFoundation -framework Security -framework SystemConfiguration -lc++ -lm`) sections.
 
+## tensogram-xarray (separate Python package, 71 tests)
+- xarray backend engine for `.tgm` files — `engine="tensogram"` via entry_points
+- `TensogramBackendEntrypoint` — `open_dataset()`, `guess_can_open()` (`.tgm` extension)
+- `TensogramBackendArray` — lazy loading via `BackendArray`, pickle-safe for dask
+  - Full N-D random-access: maps N-D slices to flat byte ranges with adjacent-range merging, uses `decode_range()` with `none`/`szip`/`blosc2`/`zfp`(fixed_rate) compressors
+  - Ratio-based heuristic (`range_threshold` parameter, default 0.5) — falls back to full decode when selected ranges exceed threshold fraction of total size
+  - Falls back to `decode_object()` + in-memory slice for stream compressors or shuffle filter
+- `decode_range` API changed: returns split results per range by default (`join=True` for concatenated flat array)
+- `meta.common` and `meta.payload` getters added to PyMetadata
+- Coordinate auto-detection by name matching (13 known names: lat/latitude, lon/longitude, time, level, etc.)
+- User-specified dimension mapping (`dim_names`) and variable naming (`variable_key` with dotted paths)
+- File scanner: metadata extraction from all messages/objects via `desc.params`
+- Auto-merge: `open_datasets()` groups compatible objects (same shape/dtype) into hypercubes
+- Auto-split: incompatible objects go to separate Datasets
+- Documentation: `docs/src/guide/xarray-integration.md` — 7 worked examples covering the full conversion philosophy
+- Per-object metadata stored in descriptor extra keys (accessible via `desc.params`)
+
 ## Dependencies
 - ciborium 0.2 — CBOR encode/decode
 - serde 1 — serialization framework

--- a/tensogram-xarray/pyproject.toml
+++ b/tensogram-xarray/pyproject.toml
@@ -1,0 +1,52 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "tensogram-xarray"
+version = "0.1.0"
+description = "xarray backend engine for tensogram .tgm files"
+requires-python = ">=3.9"
+license = "Apache-2.0"
+dependencies = [
+    "tensogram",
+    "xarray>=2022.06",
+    "numpy",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0", "ruff>=0.4"]
+dask = ["dask[array]"]
+
+[project.entry-points."xarray.backends"]
+tensogram = "tensogram_xarray.backend:TensogramBackendEntrypoint"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/tensogram_xarray"]
+
+[tool.ruff]
+line-length = 99
+target-version = "py39"
+
+[tool.ruff.lint]
+select = [
+    "E",     # pycodestyle errors
+    "W",     # pycodestyle warnings
+    "F",     # pyflakes
+    "I",     # isort
+    "N",     # pep8-naming
+    "UP",    # pyupgrade
+    "B",     # flake8-bugbear
+    "SIM",   # flake8-simplify
+    "PT",    # flake8-pytest-style
+    "RUF",   # ruff-specific rules
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["RUF012"]  # mutable class attrs in test mock classes are fine
+
+[tool.ruff.lint.isort]
+known-third-party = ["numpy", "xarray", "tensogram", "pytest"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tensogram-xarray/src/tensogram_xarray/__init__.py
+++ b/tensogram-xarray/src/tensogram_xarray/__init__.py
@@ -1,0 +1,16 @@
+"""tensogram-xarray: xarray backend engine for tensogram .tgm files.
+
+Provides ``engine="tensogram"`` for ``xr.open_dataset()`` and a top-level
+``open_datasets()`` function for multi-message .tgm files that auto-groups
+incompatible objects into separate Datasets.
+"""
+
+from __future__ import annotations
+
+from tensogram_xarray.backend import TensogramBackendEntrypoint
+from tensogram_xarray.merge import open_datasets
+
+__all__ = [
+    "TensogramBackendEntrypoint",
+    "open_datasets",
+]

--- a/tensogram-xarray/src/tensogram_xarray/array.py
+++ b/tensogram-xarray/src/tensogram_xarray/array.py
@@ -323,9 +323,19 @@ class StackedBackendArray(BackendArray):
         # Compute which backing arrays are needed.
         outer_indices = _expand_key_to_indices(outer_key, self._outer_shape)
 
-        # Determine output shape.
+        # Determine output shape for outer dimensions.
         outer_out_shape = tuple(len(idx) for idx in outer_indices)
-        result = np.empty(outer_out_shape + self._inner_shape, dtype=self.dtype)
+
+        # Compute inner output shape from inner_key: slices preserve the
+        # dimension (with the slice length), integer keys drop it -- matching
+        # numpy's basic-indexing semantics.
+        inner_out_shape = tuple(
+            len(range(*k.indices(s)))
+            for k, s in zip(inner_key, self._inner_shape)
+            if isinstance(k, slice)
+        )
+
+        result = np.empty(outer_out_shape + inner_out_shape, dtype=self.dtype)
 
         for flat_pos, combo in enumerate(iterproduct(*outer_indices)):
             # Map N-D outer index to flat backing-array index (row-major).

--- a/tensogram-xarray/src/tensogram_xarray/array.py
+++ b/tensogram-xarray/src/tensogram_xarray/array.py
@@ -111,7 +111,7 @@ def _nd_slice_to_flat_ranges(
         output_dims.append(count)
     output_shape = tuple(output_dims)
 
-    total_output = math.prod(output_dims) if output_dims else 0
+    total_output = math.prod(output_dims)
     if total_output == 0:
         return [], output_shape
 

--- a/tensogram-xarray/src/tensogram_xarray/array.py
+++ b/tensogram-xarray/src/tensogram_xarray/array.py
@@ -190,6 +190,7 @@ class TensogramBackendArray(BackendArray):
         dtype: np.dtype,
         supports_range: bool,
         *,
+        verify_hash: bool = False,
         range_threshold: float = DEFAULT_RANGE_THRESHOLD,
         lock: threading.Lock | None = None,
     ):
@@ -199,6 +200,7 @@ class TensogramBackendArray(BackendArray):
         self.shape = shape
         self.dtype = dtype
         self.supports_range = supports_range
+        self.verify_hash = verify_hash
         self.range_threshold = range_threshold
         self.lock = lock or threading.Lock()
 
@@ -261,5 +263,102 @@ class TensogramBackendArray(BackendArray):
                     )
 
             # Full object decode + in-memory slice.
-            _meta, _desc, arr = tensogram.decode_object(raw_msg, self.obj_index)
+            _meta, _desc, arr = tensogram.decode_object(
+                raw_msg,
+                self.obj_index,
+                verify_hash=self.verify_hash,
+            )
             return np.asarray(arr[key])
+
+
+# ---------------------------------------------------------------------------
+# Stacked backend array (lazy hypercube)
+# ---------------------------------------------------------------------------
+
+
+class StackedBackendArray(BackendArray):
+    """Lazy stacked array composed of multiple :class:`TensogramBackendArray`.
+
+    Each position along the outer dimensions maps to a separate backing
+    array.  Indexing dispatches to the correct backing array(s) and
+    assembles the result, so no data is decoded until actually accessed.
+    """
+
+    def __init__(
+        self,
+        arrays: list[TensogramBackendArray],
+        outer_shape: tuple[int, ...],
+        inner_shape: tuple[int, ...],
+        dtype: np.dtype,
+    ):
+        if len(arrays) != math.prod(outer_shape):
+            msg = (
+                f"StackedBackendArray: expected {math.prod(outer_shape)} "
+                f"backing arrays for outer_shape={outer_shape}, "
+                f"got {len(arrays)}"
+            )
+            raise ValueError(msg)
+
+        self._arrays = arrays
+        self._outer_shape = outer_shape
+        self._inner_shape = inner_shape
+        self.shape = outer_shape + inner_shape
+        self.dtype = dtype
+
+    def __getitem__(self, key: indexing.ExplicitIndexer) -> np.ndarray:
+        return indexing.explicit_indexing_adapter(
+            key,
+            self.shape,
+            indexing.IndexingSupport.BASIC,
+            self._raw_indexing_method,
+        )
+
+    def _raw_indexing_method(self, key: tuple) -> np.ndarray:
+        n_outer = len(self._outer_shape)
+
+        # Split key into outer and inner parts.
+        outer_key = key[:n_outer]
+        inner_key = key[n_outer:]
+
+        # Compute which backing arrays are needed.
+        outer_indices = _expand_key_to_indices(outer_key, self._outer_shape)
+
+        # Determine output shape.
+        outer_out_shape = tuple(len(idx) for idx in outer_indices)
+        result = np.empty(outer_out_shape + self._inner_shape, dtype=self.dtype)
+
+        for flat_pos, combo in enumerate(iterproduct(*outer_indices)):
+            # Map N-D outer index to flat backing-array index (row-major).
+            flat_idx = 0
+            for dim, idx_val in enumerate(combo):
+                stride = 1
+                for d2 in range(dim + 1, n_outer):
+                    stride *= self._outer_shape[d2]
+                flat_idx += idx_val * stride
+
+            backing = self._arrays[flat_idx]
+            inner_data = backing._raw_indexing_method(inner_key)
+
+            # Unravel flat_pos into N-D output position.
+            out_idx = []
+            remainder = flat_pos
+            for size in outer_out_shape:
+                out_idx.append(remainder % size)
+                remainder //= size
+            result[tuple(out_idx)] = inner_data
+
+        # Apply outer slicing to produce correct output shape.
+        return result
+
+
+def _expand_key_to_indices(key: tuple, shape: tuple[int, ...]) -> list[list[int]]:
+    """Expand a tuple of slices/ints into lists of concrete indices."""
+    result: list[list[int]] = []
+    for k, size in zip(key, shape):
+        if isinstance(k, slice):
+            result.append(list(range(*k.indices(size))))
+        elif isinstance(k, int):
+            result.append([k])
+        else:
+            result.append(list(range(size)))
+    return result

--- a/tensogram-xarray/src/tensogram_xarray/array.py
+++ b/tensogram-xarray/src/tensogram_xarray/array.py
@@ -239,7 +239,7 @@ class TensogramBackendArray(BackendArray):
                 try:
                     flat_ranges, out_shape = _nd_slice_to_flat_ranges(self.shape, key)
                     total_requested = sum(c for _, c in flat_ranges)
-                    total_elements = math.prod(self.shape) if self.shape else 0
+                    total_elements = math.prod(self.shape)
 
                     if (
                         total_elements > 0

--- a/tensogram-xarray/src/tensogram_xarray/array.py
+++ b/tensogram-xarray/src/tensogram_xarray/array.py
@@ -1,0 +1,265 @@
+"""Lazy-loading backend array for tensogram data objects.
+
+``TensogramBackendArray`` implements :class:`xarray.backends.BackendArray` so
+that tensor payloads are decoded on demand.  For compressors that support
+random access (``none``, ``szip``, ``blosc2``, ``zfp`` fixed-rate) and have no
+``shuffle`` filter, N-dimensional slice requests are mapped to flat element
+ranges and decoded via ``tensogram.decode_range()``.  Otherwise the full
+object is decoded and sliced in-memory via ``tensogram.decode_object()``.
+
+A ratio-based heuristic controls when partial reads are used: if the
+fraction of requested elements exceeds ``range_threshold`` (default 0.5),
+the backend falls back to a full decode.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import threading
+from itertools import product as iterproduct
+from typing import Any
+
+import numpy as np
+from xarray.backends import BackendArray
+from xarray.core import indexing
+
+logger = logging.getLogger(__name__)
+
+# Compressor values that support partial decode via decode_range().
+_RANDOM_ACCESS_COMPRESSORS = frozenset({"none", "szip", "blosc2", "zfp"})
+
+# Filters that break contiguous byte ranges (shuffle rearranges bytes).
+_RANGE_BLOCKING_FILTERS = frozenset({"shuffle"})
+
+# Default ratio threshold: use decode_range when the requested fraction of
+# total elements is at or below this value.
+DEFAULT_RANGE_THRESHOLD = 0.5
+
+
+def _supports_range_decode(descriptor: Any) -> bool:
+    """Return *True* if the object's pipeline allows ``decode_range()``."""
+    compression = getattr(descriptor, "compression", "none")
+    filt = getattr(descriptor, "filter", "none")
+
+    if filt in _RANGE_BLOCKING_FILTERS:
+        return False
+
+    if compression not in _RANDOM_ACCESS_COMPRESSORS:
+        return False
+
+    # zfp supports range decode only in fixed_rate mode.
+    if compression == "zfp":
+        params = getattr(descriptor, "params", {}) or {}
+        if params.get("zfp_mode") != "fixed_rate":
+            return False
+
+    return True
+
+
+def _is_contiguous_slice(key: tuple) -> bool:
+    """Return *True* when *key* is a tuple of unit-stride slices."""
+    for k in key:
+        if not isinstance(k, slice):
+            return False
+        # Reject non-unit strides (step != 1 and step != None).
+        if k.step is not None and k.step != 1:
+            return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# N-D slice -> flat element ranges
+# ---------------------------------------------------------------------------
+
+
+def _nd_slice_to_flat_ranges(
+    shape: tuple[int, ...],
+    key: tuple[slice, ...],
+) -> tuple[list[tuple[int, int]], tuple[int, ...]]:
+    """Map an N-dimensional slice to flat ``(start, count)`` ranges.
+
+    For a C-contiguous (row-major) array the elements of a hyper-rectangular
+    slice are **not** contiguous in general.  Contiguous runs exist only
+    along the innermost (rightmost) axis.  This function decomposes the
+    N-D slice into the minimal set of flat ranges that cover exactly the
+    requested elements, then merges adjacent ranges.
+
+    Parameters
+    ----------
+    shape
+        Shape of the full tensor.
+    key
+        Tuple of ``slice`` objects (one per dimension, unit-stride only).
+
+    Returns
+    -------
+    flat_ranges
+        List of ``(element_offset, element_count)`` in the flattened array.
+    output_shape
+        Shape of the result after slicing.
+    """
+    ndim = len(shape)
+
+    # Parse each slice into (start, count).
+    dim_ranges: list[tuple[int, int]] = []
+    output_dims: list[int] = []
+    for slc, d in zip(key, shape):
+        s, e, _ = slc.indices(d)
+        count = e - s
+        dim_ranges.append((s, count))
+        output_dims.append(count)
+    output_shape = tuple(output_dims)
+
+    total_output = math.prod(output_dims) if output_dims else 0
+    if total_output == 0:
+        return [], output_shape
+
+    # Compute C-contiguous strides (in elements).
+    strides = [1] * ndim
+    for i in range(ndim - 2, -1, -1):
+        strides[i] = strides[i + 1] * shape[i + 1]
+
+    # Find the *split point* k: the innermost dimension whose slice is
+    # NOT a full slice.  All dimensions k+1 .. n-1 are full slices, so
+    # their elements form a contiguous block.
+    split = -1  # -1 means all dims are full
+    for i in range(ndim - 1, -1, -1):
+        start_i, count_i = dim_ranges[i]
+        if start_i != 0 or count_i != shape[i]:
+            split = i
+            break
+
+    if split == -1:
+        # Every dimension is a full slice -- one range covering everything.
+        return [(0, math.prod(shape))], output_shape
+
+    # Contiguous block size: count at split dim * product of trailing dims.
+    block_size = dim_ranges[split][1]
+    for i in range(split + 1, ndim):
+        block_size *= shape[i]
+
+    block_start_within_row = dim_ranges[split][0] * strides[split]
+
+    if split == 0:
+        # No outer dimensions to iterate.
+        return [(dim_ranges[0][0] * strides[0], block_size)], output_shape
+
+    # Generate one range per combination of outer-dimension indices.
+    outer_index_ranges = [
+        range(dim_ranges[i][0], dim_ranges[i][0] + dim_ranges[i][1]) for i in range(split)
+    ]
+
+    flat_ranges: list[tuple[int, int]] = []
+    for idx in iterproduct(*outer_index_ranges):
+        base = sum(idx[j] * strides[j] for j in range(split))
+        flat_ranges.append((base + block_start_within_row, block_size))
+
+    # Merge adjacent ranges (consecutive with no gap).
+    if len(flat_ranges) > 1:
+        merged: list[tuple[int, int]] = [flat_ranges[0]]
+        for start, count in flat_ranges[1:]:
+            prev_start, prev_count = merged[-1]
+            if start == prev_start + prev_count:
+                merged[-1] = (prev_start, prev_count + count)
+            else:
+                merged.append((start, count))
+        flat_ranges = merged
+
+    return flat_ranges, output_shape
+
+
+# ---------------------------------------------------------------------------
+# Backend array
+# ---------------------------------------------------------------------------
+
+
+class TensogramBackendArray(BackendArray):
+    """Lazy array backed by a tensogram file.
+
+    This class stores only the file path (no open handles) so that it can be
+    safely pickled for dask multiprocessing / distributed execution.
+    """
+
+    def __init__(
+        self,
+        file_path: str,
+        msg_index: int,
+        obj_index: int,
+        shape: tuple[int, ...],
+        dtype: np.dtype,
+        supports_range: bool,
+        *,
+        range_threshold: float = DEFAULT_RANGE_THRESHOLD,
+        lock: threading.Lock | None = None,
+    ):
+        self.file_path = file_path
+        self.msg_index = msg_index
+        self.obj_index = obj_index
+        self.shape = shape
+        self.dtype = dtype
+        self.supports_range = supports_range
+        self.range_threshold = range_threshold
+        self.lock = lock or threading.Lock()
+
+    # -- pickle support (no open handles stored) ----------------------------
+
+    def __getstate__(self) -> dict:
+        state = self.__dict__.copy()
+        state["lock"] = None  # locks are not picklable
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+        self.lock = threading.Lock()
+
+    # -- BackendArray interface ---------------------------------------------
+
+    def __getitem__(self, key: indexing.ExplicitIndexer) -> np.ndarray:
+        return indexing.explicit_indexing_adapter(
+            key,
+            self.shape,
+            indexing.IndexingSupport.BASIC,
+            self._raw_indexing_method,
+        )
+
+    def _raw_indexing_method(self, key: tuple) -> np.ndarray:
+        """Thread-safe read from the tensogram file."""
+        import tensogram
+
+        with self.lock:
+            with tensogram.TensogramFile.open(self.file_path) as f:
+                raw_msg = f.read_message(self.msg_index)
+
+            # Try partial decode for contiguous slices when random access
+            # is available and the requested fraction is below threshold.
+            if self.supports_range and _is_contiguous_slice(key):
+                try:
+                    flat_ranges, out_shape = _nd_slice_to_flat_ranges(self.shape, key)
+                    total_requested = sum(c for _, c in flat_ranges)
+                    total_elements = math.prod(self.shape) if self.shape else 0
+
+                    if (
+                        total_elements > 0
+                        and total_requested / total_elements <= self.range_threshold
+                    ):
+                        arr = tensogram.decode_range(
+                            raw_msg,
+                            object_index=self.obj_index,
+                            ranges=flat_ranges,
+                            join=True,
+                        )
+                        return np.asarray(arr).reshape(out_shape)
+                except (ValueError, RuntimeError, OSError) as exc:
+                    logger.debug(
+                        "decode_range failed for %s msg=%d obj=%d, "
+                        "falling back to full decode: %s",
+                        self.file_path,
+                        self.msg_index,
+                        self.obj_index,
+                        exc,
+                    )
+
+            # Full object decode + in-memory slice.
+            _meta, _desc, arr = tensogram.decode_object(raw_msg, self.obj_index)
+            return np.asarray(arr[key])

--- a/tensogram-xarray/src/tensogram_xarray/backend.py
+++ b/tensogram-xarray/src/tensogram_xarray/backend.py
@@ -1,0 +1,124 @@
+"""xarray backend entry point for tensogram ``.tgm`` files.
+
+Registers ``engine="tensogram"`` with xarray via the ``xarray.backends``
+entry point in ``pyproject.toml``.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable, Sequence
+
+import xarray as xr
+from xarray.backends import BackendEntrypoint
+
+from tensogram_xarray.store import TensogramDataStore
+
+
+class TensogramBackendEntrypoint(BackendEntrypoint):
+    """Open tensogram ``.tgm`` files as xarray Datasets.
+
+    Usage::
+
+        import xarray as xr
+
+        # Simple open (single message, generic dim names)
+        ds = xr.open_dataset("file.tgm", engine="tensogram")
+
+        # With user-specified dimension names
+        ds = xr.open_dataset("file.tgm", engine="tensogram",
+                             dim_names=["latitude", "longitude"])
+
+        # With variable naming from metadata
+        ds = xr.open_dataset("file.tgm", engine="tensogram",
+                             variable_key="mars.param")
+    """
+
+    description = "Open tensogram .tgm files in xarray"
+    url = "https://github.com/ecmwf/tensogram"
+
+    def open_dataset(  # type: ignore[override]
+        self,
+        filename_or_obj: str | os.PathLike,
+        *,
+        drop_variables: Iterable[str] | None = None,
+        dim_names: Sequence[str] | None = None,
+        variable_key: str | None = None,
+        message_index: int = 0,
+        merge_objects: bool = False,
+        verify_hash: bool = False,
+        range_threshold: float = 0.5,
+    ) -> xr.Dataset:
+        """Open a single tensogram message as an :class:`xr.Dataset`.
+
+        Parameters
+        ----------
+        filename_or_obj
+            Path to a ``.tgm`` file.
+        drop_variables
+            Variable names to exclude from the Dataset.
+        dim_names
+            Explicit dimension names for data variables. Must have exactly
+            as many entries as the tensor has axes.
+        variable_key
+            Dotted metadata path (e.g. ``"mars.param"``) whose value at each
+            data object becomes the xarray variable name.
+        message_index
+            Which message to open when the file contains multiple messages.
+        merge_objects
+            If *True*, attempt to merge objects across messages by stacking
+            along metadata dimensions that vary.  When *False* (default),
+            only the single message at *message_index* is opened.
+        verify_hash
+            Whether to verify xxh3 hashes during decode.
+        range_threshold
+            Maximum fraction of total array elements (0.0-1.0) for which
+            partial ``decode_range()`` is used instead of a full
+            ``decode_object()``.  Default ``0.5`` (50%).
+
+        Returns
+        -------
+        xr.Dataset
+        """
+        file_path = str(filename_or_obj)
+
+        if message_index < 0:
+            msg = f"message_index must be >= 0, got {message_index}"
+            raise ValueError(msg)
+
+        if merge_objects:
+            # Delegate to open_datasets and return the first result.
+            from tensogram_xarray.merge import open_datasets
+
+            datasets = open_datasets(
+                file_path,
+                dim_names=dim_names,
+                variable_key=variable_key,
+                verify_hash=verify_hash,
+                range_threshold=range_threshold,
+            )
+            if not datasets:
+                return xr.Dataset()
+            return datasets[0]
+
+        store = TensogramDataStore(
+            file_path=file_path,
+            msg_index=message_index,
+            dim_names=dim_names,
+            variable_key=variable_key,
+            verify_hash=verify_hash,
+            range_threshold=range_threshold,
+        )
+
+        drop_set = set(drop_variables) if drop_variables else None
+        ds = store.build_dataset(drop_variables=drop_set)
+        ds.set_close(store.close)
+        return ds
+
+    def guess_can_open(self, filename_or_obj: str) -> bool:  # type: ignore[override]
+        """Return *True* for files with ``.tgm`` extension."""
+        try:
+            _, ext = os.path.splitext(filename_or_obj)
+        except (TypeError, AttributeError):
+            return False
+        return ext.lower() == ".tgm"

--- a/tensogram-xarray/src/tensogram_xarray/coords.py
+++ b/tensogram-xarray/src/tensogram_xarray/coords.py
@@ -1,0 +1,105 @@
+"""Coordinate detection by name matching.
+
+When a data object's per-object metadata contains a ``name`` or ``param`` key
+whose value matches a known coordinate name (case-insensitive), that object is
+treated as a coordinate array rather than a data variable.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+# Known coordinate names (all lower-case for case-insensitive matching).
+KNOWN_COORD_NAMES: frozenset[str] = frozenset(
+    {
+        "lat",
+        "latitude",
+        "lon",
+        "longitude",
+        "x",
+        "y",
+        "time",
+        "level",
+        "pressure",
+        "height",
+        "depth",
+        "frequency",
+        "step",
+    }
+)
+
+# Canonical name mapping: aliases -> preferred dimension name.
+CANONICAL_DIM: dict[str, str] = {
+    "lat": "latitude",
+    "latitude": "latitude",
+    "lon": "longitude",
+    "longitude": "longitude",
+    "x": "x",
+    "y": "y",
+    "time": "time",
+    "level": "level",
+    "pressure": "pressure",
+    "height": "height",
+    "depth": "depth",
+    "frequency": "frequency",
+    "step": "step",
+}
+
+
+# Module-level assertion: every known name must have a canonical mapping.
+_canonical_keys = frozenset(CANONICAL_DIM.keys())
+assert _canonical_keys == KNOWN_COORD_NAMES, (
+    f"KNOWN_COORD_NAMES and CANONICAL_DIM keys are out of sync: "
+    f"missing from CANONICAL_DIM: {KNOWN_COORD_NAMES - _canonical_keys}, "
+    f"extra in CANONICAL_DIM: {_canonical_keys - KNOWN_COORD_NAMES}"
+)
+
+
+def _get_object_name(meta: dict[str, Any]) -> str | None:
+    """Extract the name/param identifier from per-object metadata.
+
+    Checks ``name``, ``param``, and nested ``mars.param`` in that order.
+    """
+    if "name" in meta:
+        return str(meta["name"])
+    if "param" in meta:
+        return str(meta["param"])
+    mars = meta.get("mars")
+    if isinstance(mars, dict) and "param" in mars:
+        return str(mars["param"])
+    return None
+
+
+def detect_coords(
+    object_metas: Sequence[dict[str, Any]],
+) -> tuple[list[int], list[int], dict[int, str]]:
+    """Partition data objects into coordinates and variables.
+
+    Parameters
+    ----------
+    object_metas
+        Per-object metadata dicts (one per data object in the message).
+
+    Returns
+    -------
+    coord_indices
+        Indices of objects identified as coordinates.
+    var_indices
+        Indices of objects identified as data variables.
+    coord_dim_names
+        Mapping from coord object index to canonical dimension name.
+    """
+    coord_indices: list[int] = []
+    var_indices: list[int] = []
+    coord_dim_names: dict[int, str] = {}
+
+    for i, meta in enumerate(object_metas):
+        obj_name = _get_object_name(meta)
+        if obj_name is not None and obj_name.lower() in KNOWN_COORD_NAMES:
+            coord_indices.append(i)
+            coord_dim_names[i] = CANONICAL_DIM[obj_name.lower()]
+        else:
+            var_indices.append(i)
+
+    return coord_indices, var_indices, coord_dim_names

--- a/tensogram-xarray/src/tensogram_xarray/mapping.py
+++ b/tensogram-xarray/src/tensogram_xarray/mapping.py
@@ -1,0 +1,60 @@
+"""User-specified dimension and variable mapping.
+
+Handles the ``dim_names`` and ``variable_key`` parameters that let callers
+control how tensogram data maps to xarray dimensions and variable names.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+
+def resolve_dim_names(
+    ndim: int,
+    user_dim_names: Sequence[str] | None,
+) -> list[str]:
+    """Return dimension names for a tensor with *ndim* axes.
+
+    If *user_dim_names* is provided, it must have exactly *ndim* entries.
+    Otherwise generic ``dim_0``, ``dim_1``, ... names are generated.
+    """
+    if user_dim_names is not None:
+        names = list(user_dim_names)
+        if len(names) != ndim:
+            msg = (
+                f"dim_names has {len(names)} entries but tensor has {ndim} "
+                f"dimensions. Provide exactly {ndim} names."
+            )
+            raise ValueError(msg)
+        return names
+    return [f"dim_{i}" for i in range(ndim)]
+
+
+def _resolve_dotted(meta: dict[str, Any], dotted_key: str) -> Any:
+    """Resolve a dotted key path like ``mars.param`` in a nested dict."""
+    parts = dotted_key.split(".")
+    current: Any = meta
+    for part in parts:
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def resolve_variable_name(
+    obj_index: int,
+    per_object_meta: dict[str, Any],
+    variable_key: str | None,
+) -> str:
+    """Determine the xarray variable name for a data object.
+
+    If *variable_key* is given (e.g. ``"mars.param"``), the value at that
+    dotted path in the per-object metadata is used.  Otherwise a generic
+    ``"object_<index>"`` name is generated.
+    """
+    if variable_key is not None:
+        val = _resolve_dotted(per_object_meta, variable_key)
+        if val is not None:
+            return str(val)
+    return f"object_{obj_index}"

--- a/tensogram-xarray/src/tensogram_xarray/merge.py
+++ b/tensogram-xarray/src/tensogram_xarray/merge.py
@@ -128,7 +128,7 @@ def open_datasets(
         if ds is not None:
             datasets.append(ds)
 
-    return datasets if datasets else [xr.Dataset(attrs={"source": path})]
+    return datasets if datasets else [xr.Dataset(coords=coord_vars, attrs={"source": path})]
 
 
 # ---------------------------------------------------------------------------

--- a/tensogram-xarray/src/tensogram_xarray/merge.py
+++ b/tensogram-xarray/src/tensogram_xarray/merge.py
@@ -552,8 +552,8 @@ def _build_multi_variable_dataset(
     """
     # Split by variable_key value.
     sub_groups: dict[str, list[ObjectInfo]] = defaultdict(list)
-    for i, obj in enumerate(group):
-        val = resolve_variable_name(i, obj.merged_meta, variable_key)
+    for obj in group:
+        val = resolve_variable_name(obj.obj_index, obj.per_object_meta, variable_key)
         sub_groups[val].append(obj)
 
     # Remaining varying keys (exclude variable_key).

--- a/tensogram-xarray/src/tensogram_xarray/merge.py
+++ b/tensogram-xarray/src/tensogram_xarray/merge.py
@@ -314,7 +314,8 @@ def _build_dataset_from_group(
     # "mars.param" are handled correctly.
     if variable_key is not None:
         variable_names = {
-            resolve_variable_name(obj.metadata, variable_key) for obj in group
+            resolve_variable_name(obj.obj_index, obj.per_object_meta, variable_key)
+            for obj in group
         }
         if len(variable_names) > 1:
             return _build_multi_variable_dataset(
@@ -520,9 +521,7 @@ def _hypercube_dataset(
     stacked = StackedBackendArray(backing_arrays, outer_shape, inner_shape, np_dtype)
     lazy_data = indexing.LazilyIndexedArray(stacked)
 
-    var_name = resolve_variable_name(
-        group[0].obj_index, group[0].merged_meta, variable_key
-    )
+    var_name = resolve_variable_name(group[0].obj_index, group[0].merged_meta, variable_key)
 
     # Add outer coordinates.
     merged_coords = dict(coord_vars)

--- a/tensogram-xarray/src/tensogram_xarray/merge.py
+++ b/tensogram-xarray/src/tensogram_xarray/merge.py
@@ -309,20 +309,26 @@ def _build_dataset_from_group(
     constant, varying = _partition_keys(key_values)
 
     # If variable_key is specified, split by it first (each unique value
-    # becomes a separate variable in the Dataset).
-    if variable_key is not None and variable_key in varying:
-        return _build_multi_variable_dataset(
-            group,
-            file_path,
-            coord_vars,
-            dim_names,
-            variable_key,
-            constant,
-            varying,
-            lock,
-            range_threshold=range_threshold,
-            verify_hash=verify_hash,
-        )
+    # becomes a separate variable in the Dataset).  Use resolved variable
+    # names rather than membership in ``varying`` so dotted keys such as
+    # "mars.param" are handled correctly.
+    if variable_key is not None:
+        variable_names = {
+            resolve_variable_name(obj.metadata, variable_key) for obj in group
+        }
+        if len(variable_names) > 1:
+            return _build_multi_variable_dataset(
+                group,
+                file_path,
+                coord_vars,
+                dim_names,
+                variable_key,
+                constant,
+                varying,
+                lock,
+                range_threshold=range_threshold,
+                verify_hash=verify_hash,
+            )
 
     # Check if the varying keys form a hypercube.
     if not varying:

--- a/tensogram-xarray/src/tensogram_xarray/merge.py
+++ b/tensogram-xarray/src/tensogram_xarray/merge.py
@@ -15,11 +15,14 @@ from collections import defaultdict
 from collections.abc import Sequence
 from typing import Any
 
-import numpy as np
 import xarray as xr
 from xarray.core import indexing
 
-from tensogram_xarray.array import TensogramBackendArray, _supports_range_decode
+from tensogram_xarray.array import (
+    StackedBackendArray,
+    TensogramBackendArray,
+    _supports_range_decode,
+)
 from tensogram_xarray.coords import detect_coords
 from tensogram_xarray.mapping import resolve_dim_names, resolve_variable_name
 from tensogram_xarray.scanner import ObjectInfo, scan_file
@@ -86,10 +89,24 @@ def open_datasets(
             shape=shape,
             dtype=np_dtype,
             supports_range=_supports_range_decode(obj.descriptor),
+            verify_hash=verify_hash,
             range_threshold=range_threshold,
             lock=lock,
         )
         lazy_data = indexing.LazilyIndexedArray(backend_array)
+
+        if dim_name in coord_vars:
+            existing = coord_vars[dim_name]
+            if existing.shape != shape:
+                msg = (
+                    f"coordinate {dim_name!r} has conflicting shapes: "
+                    f"existing {existing.shape} vs new {shape} "
+                    f"(msg_index={obj.msg_index}, obj_index={obj.obj_index})"
+                )
+                raise ValueError(msg)
+            # Duplicate with matching shape -- skip (keep the first).
+            continue
+
         coord_vars[dim_name] = xr.Variable((dim_name,), lazy_data, dict(obj.per_object_meta))
 
     # Group data objects by structural compatibility.
@@ -106,6 +123,7 @@ def open_datasets(
             variable_key=variable_key,
             lock=lock,
             range_threshold=range_threshold,
+            verify_hash=verify_hash,
         )
         if ds is not None:
             datasets.append(ds)
@@ -262,6 +280,7 @@ def _build_dataset_from_group(
     variable_key: str | None,
     lock: threading.Lock,
     range_threshold: float = 0.5,
+    verify_hash: bool = False,
 ) -> xr.Dataset | None:
     """Build a Dataset from a group of structurally compatible objects.
 
@@ -282,6 +301,7 @@ def _build_dataset_from_group(
             variable_key,
             lock,
             range_threshold=range_threshold,
+            verify_hash=verify_hash,
         )
 
     # Multiple objects -> try hypercube merge.
@@ -301,6 +321,7 @@ def _build_dataset_from_group(
             varying,
             lock,
             range_threshold=range_threshold,
+            verify_hash=verify_hash,
         )
 
     # Check if the varying keys form a hypercube.
@@ -316,6 +337,7 @@ def _build_dataset_from_group(
             constant,
             lock,
             range_threshold=range_threshold,
+            verify_hash=verify_hash,
         )
 
     if _try_hypercube(group, varying):
@@ -329,6 +351,7 @@ def _build_dataset_from_group(
             varying,
             lock,
             range_threshold=range_threshold,
+            verify_hash=verify_hash,
         )
 
     # Hypercube incomplete -> just return as separate variables.
@@ -341,6 +364,7 @@ def _build_dataset_from_group(
         constant,
         lock,
         range_threshold=range_threshold,
+        verify_hash=verify_hash,
     )
 
 
@@ -352,6 +376,7 @@ def _single_object_dataset(
     variable_key: str | None,
     lock: threading.Lock,
     range_threshold: float = 0.5,
+    verify_hash: bool = False,
 ) -> xr.Dataset:
     """Build a Dataset from a single object."""
     np_dtype = _to_numpy_dtype(obj.dtype)
@@ -367,6 +392,7 @@ def _single_object_dataset(
         shape=shape,
         dtype=np_dtype,
         supports_range=_supports_range_decode(obj.descriptor),
+        verify_hash=verify_hash,
         range_threshold=range_threshold,
         lock=lock,
     )
@@ -387,14 +413,15 @@ def _flat_group_dataset(
     constant: dict[str, Any],
     lock: threading.Lock,
     range_threshold: float = 0.5,
+    verify_hash: bool = False,
 ) -> xr.Dataset:
     """Build a Dataset with one variable per object (no stacking)."""
     data_vars: dict[str, xr.Variable] = {}
 
-    for i, obj in enumerate(group):
+    for obj in group:
         np_dtype = _to_numpy_dtype(obj.dtype)
         shape = obj.shape
-        var_name = resolve_variable_name(i, obj.merged_meta, variable_key)
+        var_name = resolve_variable_name(obj.obj_index, obj.per_object_meta, variable_key)
         dims = _resolve_dims(shape, dim_names, coord_vars)
 
         backend_array = TensogramBackendArray(
@@ -404,6 +431,7 @@ def _flat_group_dataset(
             shape=shape,
             dtype=np_dtype,
             supports_range=_supports_range_decode(obj.descriptor),
+            verify_hash=verify_hash,
             range_threshold=range_threshold,
             lock=lock,
         )
@@ -425,6 +453,7 @@ def _hypercube_dataset(
     varying: dict[str, list[Any]],
     lock: threading.Lock,
     range_threshold: float = 0.5,
+    verify_hash: bool = False,
 ) -> xr.Dataset:
     """Stack objects into a Dataset with outer dimensions from varying keys.
 
@@ -451,23 +480,11 @@ def _hypercube_dataset(
     # Compute outer shape.
     outer_shape = tuple(len(outer_coords[k]) for k in outer_keys)
     outer_dims = tuple(outer_keys)
-    full_shape = outer_shape + inner_shape
     full_dims = outer_dims + inner_dims
 
-    # Build lazy arrays for each position in the outer grid.
-    # We construct a numpy object array of backend arrays, then use
-    # dask-style concatenation at access time.  For simplicity in v1,
-    # we use a full eager load into a stacked numpy array.
-
-    # Allocate output array.
-    total_elements = 1
-    for s in full_shape:
-        total_elements *= s
-
-    # Build the stacked array eagerly (decodes all objects).
-    import tensogram
-
-    stacked = np.empty(full_shape, dtype=np_dtype)
+    # Build lazy backing arrays for each position in the outer grid
+    # (row-major order).  No payload data is decoded here.
+    backing_arrays: list[TensogramBackendArray] = []
     for idx_tuple in itertools.product(*(range(s) for s in outer_shape)):
         coord_key = tuple(
             _make_hashable(outer_coords[outer_keys[d]][idx_tuple[d]])
@@ -480,13 +497,23 @@ def _hypercube_dataset(
                 f"in {file_path}"
             )
             raise ValueError(msg)
-        with lock:
-            with tensogram.TensogramFile.open(file_path) as f:
-                raw = f.read_message(obj.msg_index)
-            _, _, arr = tensogram.decode_object(raw, obj.obj_index)
-        stacked[idx_tuple] = arr
+        backing_arrays.append(
+            TensogramBackendArray(
+                file_path=file_path,
+                msg_index=obj.msg_index,
+                obj_index=obj.obj_index,
+                shape=inner_shape,
+                dtype=np_dtype,
+                supports_range=_supports_range_decode(obj.descriptor),
+                range_threshold=range_threshold,
+                verify_hash=verify_hash,
+                lock=lock,
+            )
+        )
 
-    # Build the Dataset.
+    stacked = StackedBackendArray(backing_arrays, outer_shape, inner_shape, np_dtype)
+    lazy_data = indexing.LazilyIndexedArray(stacked)
+
     var_name = resolve_variable_name(0, group[0].merged_meta, variable_key)
 
     # Add outer coordinates.
@@ -494,7 +521,7 @@ def _hypercube_dataset(
     for k in outer_keys:
         merged_coords[k] = xr.Variable((k,), outer_coords[k])
 
-    var = xr.Variable(full_dims, stacked, dict(constant))
+    var = xr.Variable(full_dims, lazy_data, dict(constant))
     ds = xr.Dataset({var_name: var}, coords=merged_coords, attrs=dict(constant))
     return ds
 
@@ -509,6 +536,7 @@ def _build_multi_variable_dataset(
     varying: dict[str, list[Any]],
     lock: threading.Lock,
     range_threshold: float = 0.5,
+    verify_hash: bool = False,
 ) -> xr.Dataset:
     """Split group by variable_key, then stack each sub-group.
 
@@ -541,6 +569,7 @@ def _build_multi_variable_dataset(
                 shape=inner_shape,
                 dtype=np_dtype,
                 supports_range=_supports_range_decode(obj.descriptor),
+                verify_hash=verify_hash,
                 range_threshold=range_threshold,
                 lock=lock,
             )
@@ -560,7 +589,6 @@ def _build_multi_variable_dataset(
 
                 outer_shape = tuple(len(outer_coords_local[k]) for k in outer_keys)
                 outer_dims = tuple(outer_keys)
-                full_shape = outer_shape + inner_shape
                 full_dims = outer_dims + inner_dims
 
                 obj_by_coord: dict[tuple, ObjectInfo] = {}
@@ -568,9 +596,8 @@ def _build_multi_variable_dataset(
                     coord_key = tuple(_make_hashable(sub_vary[k][j]) for k in outer_keys)
                     obj_by_coord[coord_key] = obj
 
-                import tensogram
-
-                stacked = np.empty(full_shape, dtype=np_dtype)
+                # Build lazy stacked array (no payload decode here).
+                backing: list[TensogramBackendArray] = []
                 for idx_tuple in itertools.product(*(range(s) for s in outer_shape)):
                     coord_key = tuple(
                         _make_hashable(outer_coords_local[outer_keys[d]][idx_tuple[d]])
@@ -583,15 +610,26 @@ def _build_multi_variable_dataset(
                             f"{dict(zip(outer_keys, idx_tuple))} in {file_path}"
                         )
                         raise ValueError(msg)
-                    with lock:
-                        with tensogram.TensogramFile.open(file_path) as f:
-                            raw = f.read_message(obj.msg_index)
-                        _, _, arr = tensogram.decode_object(raw, obj.obj_index)
-                    stacked[idx_tuple] = arr
+                    backing.append(
+                        TensogramBackendArray(
+                            file_path=file_path,
+                            msg_index=obj.msg_index,
+                            obj_index=obj.obj_index,
+                            shape=inner_shape,
+                            dtype=np_dtype,
+                            supports_range=_supports_range_decode(obj.descriptor),
+                            range_threshold=range_threshold,
+                            verify_hash=verify_hash,
+                            lock=lock,
+                        )
+                    )
+
+                stacked = StackedBackendArray(backing, outer_shape, inner_shape, np_dtype)
+                lazy_data = indexing.LazilyIndexedArray(stacked)
 
                 for k in outer_keys:
                     merged_coords[k] = xr.Variable((k,), outer_coords_local[k])
-                data_vars[var_name] = xr.Variable(full_dims, stacked, dict(sub_const))
+                data_vars[var_name] = xr.Variable(full_dims, lazy_data, dict(sub_const))
             else:
                 # Can't form hypercube -> use first object only.
                 logger.warning(
@@ -609,6 +647,7 @@ def _build_multi_variable_dataset(
                     shape=inner_shape,
                     dtype=np_dtype,
                     supports_range=_supports_range_decode(obj.descriptor),
+                    verify_hash=verify_hash,
                     range_threshold=range_threshold,
                     lock=lock,
                 )
@@ -632,6 +671,7 @@ def _build_multi_variable_dataset(
                 shape=inner_shape,
                 dtype=np_dtype,
                 supports_range=_supports_range_decode(obj.descriptor),
+                verify_hash=verify_hash,
                 range_threshold=range_threshold,
                 lock=lock,
             )

--- a/tensogram-xarray/src/tensogram_xarray/merge.py
+++ b/tensogram-xarray/src/tensogram_xarray/merge.py
@@ -1,0 +1,684 @@
+"""Auto-merge and auto-split for multi-message tensogram files.
+
+``open_datasets()`` scans all messages in a ``.tgm`` file, groups compatible
+data objects (same shape, dtype, metadata structure) into hypercubes, and
+returns a list of :class:`xr.Dataset` instances.  Incompatible objects are
+automatically split into separate Datasets.
+"""
+
+from __future__ import annotations
+
+import itertools
+import logging
+import threading
+from collections import defaultdict
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+import xarray as xr
+from xarray.core import indexing
+
+from tensogram_xarray.array import TensogramBackendArray, _supports_range_decode
+from tensogram_xarray.coords import detect_coords
+from tensogram_xarray.mapping import resolve_dim_names, resolve_variable_name
+from tensogram_xarray.scanner import ObjectInfo, scan_file
+from tensogram_xarray.store import _to_numpy_dtype
+
+logger = logging.getLogger(__name__)
+
+
+def open_datasets(
+    path: str,
+    *,
+    dim_names: Sequence[str] | None = None,
+    variable_key: str | None = None,
+    verify_hash: bool = False,
+    range_threshold: float = 0.5,
+) -> list[xr.Dataset]:
+    """Open a ``.tgm`` file, auto-grouping into compatible Datasets.
+
+    Each returned Dataset represents a group of data objects that share
+    compatible shapes and metadata structure.  Objects whose metadata varies
+    on certain keys are stacked along new outer dimensions.
+
+    Parameters
+    ----------
+    path
+        Path to the ``.tgm`` file.
+    dim_names
+        Explicit dimension names for the innermost tensor axes.
+    variable_key
+        Dotted metadata key path for variable naming.
+    verify_hash
+        Whether to verify hashes on decode.
+    range_threshold
+        Maximum fraction of total array elements for which partial
+        ``decode_range()`` is used.  Default ``0.5``.
+
+    Returns
+    -------
+    list[xr.Dataset]
+        One Dataset per compatible group.
+    """
+    file_index = scan_file(path)
+
+    if not file_index.objects:
+        return []
+
+    # Separate coordinate objects from data objects.
+    all_metas = [o.merged_meta for o in file_index.objects]
+    coord_indices, var_indices, coord_dim_map = detect_coords(all_metas)
+
+    # Build coordinate variables eagerly (they are small).
+    lock = threading.Lock()
+    coord_vars: dict[str, xr.Variable] = {}
+    for ci in coord_indices:
+        obj = file_index.objects[ci]
+        dim_name = coord_dim_map[ci]
+        np_dtype = _to_numpy_dtype(obj.dtype)
+        shape = obj.shape
+
+        backend_array = TensogramBackendArray(
+            file_path=path,
+            msg_index=obj.msg_index,
+            obj_index=obj.obj_index,
+            shape=shape,
+            dtype=np_dtype,
+            supports_range=_supports_range_decode(obj.descriptor),
+            range_threshold=range_threshold,
+            lock=lock,
+        )
+        lazy_data = indexing.LazilyIndexedArray(backend_array)
+        coord_vars[dim_name] = xr.Variable((dim_name,), lazy_data, dict(obj.per_object_meta))
+
+    # Group data objects by structural compatibility.
+    data_objects = [file_index.objects[i] for i in var_indices]
+    groups = _group_by_structure(data_objects)
+
+    datasets: list[xr.Dataset] = []
+    for group in groups:
+        ds = _build_dataset_from_group(
+            group,
+            file_path=path,
+            coord_vars=coord_vars,
+            dim_names=dim_names,
+            variable_key=variable_key,
+            lock=lock,
+            range_threshold=range_threshold,
+        )
+        if ds is not None:
+            datasets.append(ds)
+
+    return datasets if datasets else [xr.Dataset(attrs={"source": path})]
+
+
+# ---------------------------------------------------------------------------
+# Grouping
+# ---------------------------------------------------------------------------
+
+_StructureKey = tuple[tuple[int, ...], str]  # (shape, dtype)
+
+
+def _group_by_structure(
+    objects: list[ObjectInfo],
+) -> list[list[ObjectInfo]]:
+    """Group objects by (shape, dtype) -- structural compatibility."""
+    buckets: dict[_StructureKey, list[ObjectInfo]] = defaultdict(list)
+    for obj in objects:
+        key: _StructureKey = (obj.shape, obj.dtype)
+        buckets[key].append(obj)
+    return list(buckets.values())
+
+
+# ---------------------------------------------------------------------------
+# Hypercube construction
+# ---------------------------------------------------------------------------
+
+
+def _extract_meta_keys(objects: list[ObjectInfo]) -> dict[str, list[Any]]:
+    """For each metadata key, collect values across all objects."""
+    all_keys: set[str] = set()
+    for obj in objects:
+        all_keys.update(obj.merged_meta.keys())
+
+    key_values: dict[str, list[Any]] = {}
+    for k in sorted(all_keys):
+        values = []
+        for obj in objects:
+            values.append(obj.merged_meta.get(k))
+        key_values[k] = values
+    return key_values
+
+
+def _partition_keys(
+    key_values: dict[str, list[Any]],
+) -> tuple[dict[str, Any], dict[str, list[Any]]]:
+    """Split keys into constant (attrs) and varying (candidate dims).
+
+    Returns
+    -------
+    constant
+        Keys with a single unique value -> Dataset attributes.
+    varying
+        Keys with multiple unique values -> candidate outer dimensions.
+    """
+    constant: dict[str, Any] = {}
+    varying: dict[str, list[Any]] = {}
+
+    for k, values in key_values.items():
+        # Convert to hashable for uniqueness check.
+        try:
+            unique = set(_make_hashable(v) for v in values)
+        except TypeError:
+            # Unhashable values (dicts, lists) -> treat as attribute.
+            constant[k] = values[0]
+            continue
+
+        if len(unique) == 1:
+            constant[k] = values[0]
+        else:
+            varying[k] = values
+
+    return constant, varying
+
+
+def _make_hashable(val: Any) -> Any:
+    """Convert a value to a hashable form for set operations."""
+    if isinstance(val, dict):
+        return tuple(sorted((k, _make_hashable(v)) for k, v in val.items()))
+    if isinstance(val, list):
+        return tuple(_make_hashable(v) for v in val)
+    return val
+
+
+def _unique_values(values: list[Any]) -> list[Any]:
+    """Return unique values preserving order, handling unhashable types."""
+    seen: set[Any] = set()
+    result: list[Any] = []
+    for v in values:
+        h = _make_hashable(v)
+        if h not in seen:
+            seen.add(h)
+            result.append(v)
+    return result
+
+
+def _try_hypercube(
+    objects: list[ObjectInfo],
+    varying: dict[str, list[Any]],
+) -> bool:
+    """Check whether the varying keys form a complete hypercube.
+
+    A complete hypercube means every combination of unique values across
+    all varying keys has exactly one corresponding object.
+    """
+    if not varying:
+        return True
+
+    # Unique values per key (use _make_hashable for unhashable types like dicts).
+    unique_per_key: dict[str, list[Any]] = {}
+    for k, v in varying.items():
+        seen: set[Any] = set()
+        unique: list[Any] = []
+        for val in v:
+            h = _make_hashable(val)
+            if h not in seen:
+                seen.add(h)
+                unique.append(val)
+        unique_per_key[k] = unique
+
+    # Total expected combinations.
+    expected = 1
+    for vals in unique_per_key.values():
+        expected *= len(vals)
+
+    return len(objects) == expected
+
+
+def _split_by_key(
+    objects: list[ObjectInfo],
+    key: str,
+) -> list[list[ObjectInfo]]:
+    """Split objects into sub-groups by the values of *key*."""
+    buckets: dict[Any, list[ObjectInfo]] = defaultdict(list)
+    for obj in objects:
+        val = obj.merged_meta.get(key)
+        hval = _make_hashable(val)
+        buckets[hval].append(obj)
+    return list(buckets.values())
+
+
+# ---------------------------------------------------------------------------
+# Dataset construction from a compatible group
+# ---------------------------------------------------------------------------
+
+
+def _build_dataset_from_group(
+    group: list[ObjectInfo],
+    file_path: str,
+    coord_vars: dict[str, xr.Variable],
+    dim_names: Sequence[str] | None,
+    variable_key: str | None,
+    lock: threading.Lock,
+    range_threshold: float = 0.5,
+) -> xr.Dataset | None:
+    """Build a Dataset from a group of structurally compatible objects.
+
+    If the group has a single object, it produces a simple Dataset.
+    Multiple objects are merged along varying metadata keys when they
+    form a clean hypercube; otherwise auto-split is attempted.
+    """
+    if not group:
+        return None
+
+    # Single object -> simple Dataset.
+    if len(group) == 1:
+        return _single_object_dataset(
+            group[0],
+            file_path,
+            coord_vars,
+            dim_names,
+            variable_key,
+            lock,
+            range_threshold=range_threshold,
+        )
+
+    # Multiple objects -> try hypercube merge.
+    key_values = _extract_meta_keys(group)
+    constant, varying = _partition_keys(key_values)
+
+    # If variable_key is specified, split by it first (each unique value
+    # becomes a separate variable in the Dataset).
+    if variable_key is not None and variable_key in varying:
+        return _build_multi_variable_dataset(
+            group,
+            file_path,
+            coord_vars,
+            dim_names,
+            variable_key,
+            constant,
+            varying,
+            lock,
+            range_threshold=range_threshold,
+        )
+
+    # Check if the varying keys form a hypercube.
+    if not varying:
+        # All metadata identical -> can't distinguish objects.
+        # Return each as object_0, object_1, ...
+        return _flat_group_dataset(
+            group,
+            file_path,
+            coord_vars,
+            dim_names,
+            variable_key,
+            constant,
+            lock,
+            range_threshold=range_threshold,
+        )
+
+    if _try_hypercube(group, varying):
+        return _hypercube_dataset(
+            group,
+            file_path,
+            coord_vars,
+            dim_names,
+            variable_key,
+            constant,
+            varying,
+            lock,
+            range_threshold=range_threshold,
+        )
+
+    # Hypercube incomplete -> just return as separate variables.
+    return _flat_group_dataset(
+        group,
+        file_path,
+        coord_vars,
+        dim_names,
+        variable_key,
+        constant,
+        lock,
+        range_threshold=range_threshold,
+    )
+
+
+def _single_object_dataset(
+    obj: ObjectInfo,
+    file_path: str,
+    coord_vars: dict[str, xr.Variable],
+    dim_names: Sequence[str] | None,
+    variable_key: str | None,
+    lock: threading.Lock,
+    range_threshold: float = 0.5,
+) -> xr.Dataset:
+    """Build a Dataset from a single object."""
+    np_dtype = _to_numpy_dtype(obj.dtype)
+    shape = obj.shape
+
+    var_name = resolve_variable_name(obj.obj_index, obj.merged_meta, variable_key)
+    dims = _resolve_dims(shape, dim_names, coord_vars)
+
+    backend_array = TensogramBackendArray(
+        file_path=file_path,
+        msg_index=obj.msg_index,
+        obj_index=obj.obj_index,
+        shape=shape,
+        dtype=np_dtype,
+        supports_range=_supports_range_decode(obj.descriptor),
+        range_threshold=range_threshold,
+        lock=lock,
+    )
+    lazy_data = indexing.LazilyIndexedArray(backend_array)
+    var = xr.Variable(dims, lazy_data, dict(obj.merged_meta))
+
+    ds_attrs = dict(obj.common_meta)
+    ds = xr.Dataset({var_name: var}, coords=coord_vars, attrs=ds_attrs)
+    return ds
+
+
+def _flat_group_dataset(
+    group: list[ObjectInfo],
+    file_path: str,
+    coord_vars: dict[str, xr.Variable],
+    dim_names: Sequence[str] | None,
+    variable_key: str | None,
+    constant: dict[str, Any],
+    lock: threading.Lock,
+    range_threshold: float = 0.5,
+) -> xr.Dataset:
+    """Build a Dataset with one variable per object (no stacking)."""
+    data_vars: dict[str, xr.Variable] = {}
+
+    for i, obj in enumerate(group):
+        np_dtype = _to_numpy_dtype(obj.dtype)
+        shape = obj.shape
+        var_name = resolve_variable_name(i, obj.merged_meta, variable_key)
+        dims = _resolve_dims(shape, dim_names, coord_vars)
+
+        backend_array = TensogramBackendArray(
+            file_path=file_path,
+            msg_index=obj.msg_index,
+            obj_index=obj.obj_index,
+            shape=shape,
+            dtype=np_dtype,
+            supports_range=_supports_range_decode(obj.descriptor),
+            range_threshold=range_threshold,
+            lock=lock,
+        )
+        lazy_data = indexing.LazilyIndexedArray(backend_array)
+        data_vars[var_name] = xr.Variable(dims, lazy_data, dict(obj.merged_meta))
+
+    ds_attrs = dict(constant)
+    ds = xr.Dataset(data_vars, coords=coord_vars, attrs=ds_attrs)
+    return ds
+
+
+def _hypercube_dataset(
+    group: list[ObjectInfo],
+    file_path: str,
+    coord_vars: dict[str, xr.Variable],
+    dim_names: Sequence[str] | None,
+    variable_key: str | None,
+    constant: dict[str, Any],
+    varying: dict[str, list[Any]],
+    lock: threading.Lock,
+    range_threshold: float = 0.5,
+) -> xr.Dataset:
+    """Stack objects into a Dataset with outer dimensions from varying keys.
+
+    All objects in *group* must have the same inner shape.  Varying metadata
+    keys become outer dimensions whose coordinate values are the unique
+    metadata values.
+    """
+    inner_shape = group[0].shape
+    np_dtype = _to_numpy_dtype(group[0].dtype)
+    inner_dims = _resolve_dims(inner_shape, dim_names, coord_vars)
+
+    # Determine outer dimension names and coordinate values.
+    outer_keys = sorted(varying.keys())
+    outer_coords: dict[str, list] = {}
+    for k in outer_keys:
+        outer_coords[k] = _unique_values(varying[k])
+
+    # Build N-D index mapping: (val_for_key0, val_for_key1, ...) -> ObjectInfo
+    obj_by_coord: dict[tuple, ObjectInfo] = {}
+    for i, obj in enumerate(group):
+        coord_key = tuple(_make_hashable(varying[k][i]) for k in outer_keys)
+        obj_by_coord[coord_key] = obj
+
+    # Compute outer shape.
+    outer_shape = tuple(len(outer_coords[k]) for k in outer_keys)
+    outer_dims = tuple(outer_keys)
+    full_shape = outer_shape + inner_shape
+    full_dims = outer_dims + inner_dims
+
+    # Build lazy arrays for each position in the outer grid.
+    # We construct a numpy object array of backend arrays, then use
+    # dask-style concatenation at access time.  For simplicity in v1,
+    # we use a full eager load into a stacked numpy array.
+
+    # Allocate output array.
+    total_elements = 1
+    for s in full_shape:
+        total_elements *= s
+
+    # Build the stacked array eagerly (decodes all objects).
+    import tensogram
+
+    stacked = np.empty(full_shape, dtype=np_dtype)
+    for idx_tuple in itertools.product(*(range(s) for s in outer_shape)):
+        coord_key = tuple(
+            _make_hashable(outer_coords[outer_keys[d]][idx_tuple[d]])
+            for d in range(len(outer_keys))
+        )
+        obj = obj_by_coord.get(coord_key)
+        if obj is None:
+            msg = (
+                f"hypercube has a missing entry at {dict(zip(outer_keys, idx_tuple))} "
+                f"in {file_path}"
+            )
+            raise ValueError(msg)
+        with lock:
+            with tensogram.TensogramFile.open(file_path) as f:
+                raw = f.read_message(obj.msg_index)
+            _, _, arr = tensogram.decode_object(raw, obj.obj_index)
+        stacked[idx_tuple] = arr
+
+    # Build the Dataset.
+    var_name = resolve_variable_name(0, group[0].merged_meta, variable_key)
+
+    # Add outer coordinates.
+    merged_coords = dict(coord_vars)
+    for k in outer_keys:
+        merged_coords[k] = xr.Variable((k,), outer_coords[k])
+
+    var = xr.Variable(full_dims, stacked, dict(constant))
+    ds = xr.Dataset({var_name: var}, coords=merged_coords, attrs=dict(constant))
+    return ds
+
+
+def _build_multi_variable_dataset(
+    group: list[ObjectInfo],
+    file_path: str,
+    coord_vars: dict[str, xr.Variable],
+    dim_names: Sequence[str] | None,
+    variable_key: str,
+    constant: dict[str, Any],
+    varying: dict[str, list[Any]],
+    lock: threading.Lock,
+    range_threshold: float = 0.5,
+) -> xr.Dataset:
+    """Split group by variable_key, then stack each sub-group.
+
+    Each unique value of *variable_key* becomes a separate variable in the
+    Dataset.  Remaining varying keys become outer dimensions.
+    """
+    # Split by variable_key value.
+    sub_groups: dict[str, list[ObjectInfo]] = defaultdict(list)
+    for i, obj in enumerate(group):
+        val = resolve_variable_name(i, obj.merged_meta, variable_key)
+        sub_groups[val].append(obj)
+
+    # Remaining varying keys (exclude variable_key).
+    remaining_varying = {k: v for k, v in varying.items() if k != variable_key}
+
+    data_vars: dict[str, xr.Variable] = {}
+    merged_coords = dict(coord_vars)
+    inner_shape = group[0].shape
+    np_dtype = _to_numpy_dtype(group[0].dtype)
+    inner_dims = _resolve_dims(inner_shape, dim_names, coord_vars)
+
+    for var_name, sub_group in sub_groups.items():
+        if len(sub_group) == 1:
+            # Single object for this variable -> no outer dims.
+            obj = sub_group[0]
+            backend_array = TensogramBackendArray(
+                file_path=file_path,
+                msg_index=obj.msg_index,
+                obj_index=obj.obj_index,
+                shape=inner_shape,
+                dtype=np_dtype,
+                supports_range=_supports_range_decode(obj.descriptor),
+                range_threshold=range_threshold,
+                lock=lock,
+            )
+            lazy_data = indexing.LazilyIndexedArray(backend_array)
+            data_vars[var_name] = xr.Variable(inner_dims, lazy_data, dict(obj.merged_meta))
+        elif remaining_varying:
+            # Re-extract varying keys for this sub-group.
+            sub_kv = _extract_meta_keys(sub_group)
+            sub_const, sub_vary = _partition_keys(sub_kv)
+
+            if sub_vary and _try_hypercube(sub_group, sub_vary):
+                # Build stacked variable.
+                outer_keys = sorted(sub_vary.keys())
+                outer_coords_local: dict[str, list] = {}
+                for k in outer_keys:
+                    outer_coords_local[k] = _unique_values(sub_vary[k])
+
+                outer_shape = tuple(len(outer_coords_local[k]) for k in outer_keys)
+                outer_dims = tuple(outer_keys)
+                full_shape = outer_shape + inner_shape
+                full_dims = outer_dims + inner_dims
+
+                obj_by_coord: dict[tuple, ObjectInfo] = {}
+                for j, obj in enumerate(sub_group):
+                    coord_key = tuple(_make_hashable(sub_vary[k][j]) for k in outer_keys)
+                    obj_by_coord[coord_key] = obj
+
+                import tensogram
+
+                stacked = np.empty(full_shape, dtype=np_dtype)
+                for idx_tuple in itertools.product(*(range(s) for s in outer_shape)):
+                    coord_key = tuple(
+                        _make_hashable(outer_coords_local[outer_keys[d]][idx_tuple[d]])
+                        for d in range(len(outer_keys))
+                    )
+                    obj = obj_by_coord.get(coord_key)
+                    if obj is None:
+                        msg = (
+                            f"hypercube has a missing entry at "
+                            f"{dict(zip(outer_keys, idx_tuple))} in {file_path}"
+                        )
+                        raise ValueError(msg)
+                    with lock:
+                        with tensogram.TensogramFile.open(file_path) as f:
+                            raw = f.read_message(obj.msg_index)
+                        _, _, arr = tensogram.decode_object(raw, obj.obj_index)
+                    stacked[idx_tuple] = arr
+
+                for k in outer_keys:
+                    merged_coords[k] = xr.Variable((k,), outer_coords_local[k])
+                data_vars[var_name] = xr.Variable(full_dims, stacked, dict(sub_const))
+            else:
+                # Can't form hypercube -> use first object only.
+                logger.warning(
+                    "variable %r: %d objects cannot form a hypercube, "
+                    "using only the first object (dropping %d)",
+                    var_name,
+                    len(sub_group),
+                    len(sub_group) - 1,
+                )
+                obj = sub_group[0]
+                backend_array = TensogramBackendArray(
+                    file_path=file_path,
+                    msg_index=obj.msg_index,
+                    obj_index=obj.obj_index,
+                    shape=inner_shape,
+                    dtype=np_dtype,
+                    supports_range=_supports_range_decode(obj.descriptor),
+                    range_threshold=range_threshold,
+                    lock=lock,
+                )
+                lazy_data = indexing.LazilyIndexedArray(backend_array)
+                data_vars[var_name] = xr.Variable(inner_dims, lazy_data, dict(obj.merged_meta))
+        else:
+            # No remaining varying keys -> use first object.
+            if len(sub_group) > 1:
+                logger.warning(
+                    "variable %r: %d duplicate objects with no distinguishing "
+                    "metadata, using only the first (dropping %d)",
+                    var_name,
+                    len(sub_group),
+                    len(sub_group) - 1,
+                )
+            obj = sub_group[0]
+            backend_array = TensogramBackendArray(
+                file_path=file_path,
+                msg_index=obj.msg_index,
+                obj_index=obj.obj_index,
+                shape=inner_shape,
+                dtype=np_dtype,
+                supports_range=_supports_range_decode(obj.descriptor),
+                range_threshold=range_threshold,
+                lock=lock,
+            )
+            lazy_data = indexing.LazilyIndexedArray(backend_array)
+            data_vars[var_name] = xr.Variable(inner_dims, lazy_data, dict(obj.merged_meta))
+
+    ds = xr.Dataset(data_vars, coords=merged_coords, attrs=dict(constant))
+    return ds
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_dims(
+    shape: tuple[int, ...],
+    dim_names: Sequence[str] | None,
+    coord_vars: dict[str, xr.Variable],
+) -> tuple[str, ...]:
+    """Resolve dimension names for a tensor shape.
+
+    Same strategy as ``TensogramDataStore._resolve_dims_for_var``.
+    """
+    ndim = len(shape)
+
+    if dim_names is not None:
+        return tuple(resolve_dim_names(ndim, dim_names))
+
+    # Match by size against known coordinates.
+    size_to_coord: dict[int, list[str]] = {}
+    for cname, cvar in coord_vars.items():
+        csize = cvar.shape[0]
+        size_to_coord.setdefault(csize, []).append(cname)
+
+    dims: list[str] = []
+    used: set[str] = set()
+    for axis_size in shape:
+        matched = False
+        if axis_size in size_to_coord:
+            for cname in size_to_coord[axis_size]:
+                if cname not in used:
+                    dims.append(cname)
+                    used.add(cname)
+                    matched = True
+                    break
+        if not matched:
+            dims.append(f"dim_{len(dims)}")
+
+    return tuple(dims)

--- a/tensogram-xarray/src/tensogram_xarray/merge.py
+++ b/tensogram-xarray/src/tensogram_xarray/merge.py
@@ -514,7 +514,9 @@ def _hypercube_dataset(
     stacked = StackedBackendArray(backing_arrays, outer_shape, inner_shape, np_dtype)
     lazy_data = indexing.LazilyIndexedArray(stacked)
 
-    var_name = resolve_variable_name(0, group[0].merged_meta, variable_key)
+    var_name = resolve_variable_name(
+        group[0].obj_index, group[0].merged_meta, variable_key
+    )
 
     # Add outer coordinates.
     merged_coords = dict(coord_vars)

--- a/tensogram-xarray/src/tensogram_xarray/scanner.py
+++ b/tensogram-xarray/src/tensogram_xarray/scanner.py
@@ -119,10 +119,10 @@ def scan_file(file_path: str) -> FileIndex:
             meta = tensogram.decode_metadata(raw)
             common = _common_from_meta(meta)
 
-            # Decode to get descriptors (and shapes).
-            _, objects = tensogram.decode(raw)
+            # Decode descriptors only (no payload decode).
+            _, descriptors = tensogram.decode_descriptors(raw)
 
-            for obj_idx, (desc, _arr) in enumerate(objects):
+            for obj_idx, desc in enumerate(descriptors):
                 per_obj = _merge_per_object_meta(meta, obj_idx, desc)
                 shape = tuple(desc.shape)
                 info = ObjectInfo(
@@ -147,10 +147,10 @@ def scan_message(raw_msg: bytes) -> list[ObjectInfo]:
     meta = tensogram.decode_metadata(raw_msg)
     common = _common_from_meta(meta)
 
-    _, objects = tensogram.decode(raw_msg)
+    _, descriptors = tensogram.decode_descriptors(raw_msg)
 
     result: list[ObjectInfo] = []
-    for obj_idx, (desc, _arr) in enumerate(objects):
+    for obj_idx, desc in enumerate(descriptors):
         per_obj = _merge_per_object_meta(meta, obj_idx, desc)
         shape = tuple(desc.shape)
         info = ObjectInfo(

--- a/tensogram-xarray/src/tensogram_xarray/scanner.py
+++ b/tensogram-xarray/src/tensogram_xarray/scanner.py
@@ -1,0 +1,168 @@
+"""File scanner: extract metadata from all messages/objects without decoding payloads.
+
+The scanner opens a ``.tgm`` file via ``tensogram.TensogramFile``, reads each
+message's metadata, and builds an index of per-object metadata dicts that
+downstream merge/split logic can consume.
+
+Per-object metadata is read from ``meta.payload[i]`` (primary) with
+``desc.params`` as fallback.  Message-level metadata comes from
+``meta.common`` and ``meta.extra``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ObjectInfo:
+    """Metadata for a single data object within a message."""
+
+    msg_index: int
+    obj_index: int
+    ndim: int
+    shape: tuple[int, ...]
+    dtype: str
+    descriptor: Any  # tensogram.DataObjectDescriptor
+    per_object_meta: dict[str, Any]  # from meta.payload[i] + desc.params
+    common_meta: dict[str, Any]  # from meta.common + meta.extra
+
+    @property
+    def merged_meta(self) -> dict[str, Any]:
+        """Return common + per-object metadata merged (per-object wins)."""
+        merged: dict[str, Any] = {}
+        merged.update(self.common_meta)
+        merged.update(self.per_object_meta)
+        return merged
+
+
+@dataclass
+class FileIndex:
+    """Index over all messages and objects in a ``.tgm`` file."""
+
+    file_path: str
+    objects: list[ObjectInfo] = field(default_factory=list)
+
+    @property
+    def message_count(self) -> int:
+        if not self.objects:
+            return 0
+        return max(o.msg_index for o in self.objects) + 1
+
+
+def _desc_params(desc: Any) -> dict[str, Any]:
+    """Extract per-object metadata from a descriptor's params."""
+    params = getattr(desc, "params", None)
+    if params and isinstance(params, dict):
+        return dict(params)
+    return {}
+
+
+# Keys auto-populated by the encoder into each payload entry.
+# These duplicate descriptor fields and should be excluded from
+# per-object metadata used for grouping and variable naming.
+AUTO_PAYLOAD_KEYS = frozenset({"ndim", "shape", "strides", "dtype"})
+
+
+def _payload_from_meta(meta: Any, obj_index: int) -> dict[str, Any]:
+    """Extract per-object metadata from meta.payload[obj_index].
+
+    Auto-populated keys (ndim, shape, strides, dtype) are filtered out.
+    """
+    payload = getattr(meta, "payload", None)
+    if payload and isinstance(payload, list) and obj_index < len(payload):
+        p = payload[obj_index]
+        if isinstance(p, dict):
+            return {k: v for k, v in p.items() if k not in AUTO_PAYLOAD_KEYS}
+    return {}
+
+
+def _merge_per_object_meta(meta: Any, obj_index: int, desc: Any) -> dict[str, Any]:
+    """Build per-object metadata by merging payload + descriptor params.
+
+    Payload takes priority; descriptor params fill in any missing keys.
+    """
+    result = _payload_from_meta(meta, obj_index)
+    for k, v in _desc_params(desc).items():
+        if k not in result:
+            result[k] = v
+    return result
+
+
+def _common_from_meta(meta: Any) -> dict[str, Any]:
+    """Extract message-level metadata from meta.common + meta.extra."""
+    common: dict[str, Any] = {}
+    c = getattr(meta, "common", None)
+    if c and isinstance(c, dict):
+        common.update(c)
+    extra = getattr(meta, "extra", None)
+    if extra and isinstance(extra, dict):
+        common.update(extra)
+    return common
+
+
+def scan_file(file_path: str) -> FileIndex:
+    """Scan a ``.tgm`` file and return a :class:`FileIndex`.
+
+    Decodes each message to get descriptors, per-object metadata
+    (from ``meta.payload`` and ``desc.params``), and common metadata.
+    """
+    import tensogram
+
+    index = FileIndex(file_path=file_path)
+
+    with tensogram.TensogramFile.open(file_path) as f:
+        n_messages = len(f)
+        for msg_idx in range(n_messages):
+            raw = f.read_message(msg_idx)
+            meta = tensogram.decode_metadata(raw)
+            common = _common_from_meta(meta)
+
+            # Decode to get descriptors (and shapes).
+            _, objects = tensogram.decode(raw)
+
+            for obj_idx, (desc, _arr) in enumerate(objects):
+                per_obj = _merge_per_object_meta(meta, obj_idx, desc)
+                shape = tuple(desc.shape)
+                info = ObjectInfo(
+                    msg_index=msg_idx,
+                    obj_index=obj_idx,
+                    ndim=desc.ndim,
+                    shape=shape,
+                    dtype=desc.dtype,
+                    descriptor=desc,
+                    per_object_meta=per_obj,
+                    common_meta=dict(common),
+                )
+                index.objects.append(info)
+
+    return index
+
+
+def scan_message(raw_msg: bytes) -> list[ObjectInfo]:
+    """Scan a single in-memory message and return :class:`ObjectInfo` list."""
+    import tensogram
+
+    meta = tensogram.decode_metadata(raw_msg)
+    common = _common_from_meta(meta)
+
+    _, objects = tensogram.decode(raw_msg)
+
+    result: list[ObjectInfo] = []
+    for obj_idx, (desc, _arr) in enumerate(objects):
+        per_obj = _merge_per_object_meta(meta, obj_idx, desc)
+        shape = tuple(desc.shape)
+        info = ObjectInfo(
+            msg_index=0,
+            obj_index=obj_idx,
+            ndim=desc.ndim,
+            shape=shape,
+            dtype=desc.dtype,
+            descriptor=desc,
+            per_object_meta=per_obj,
+            common_meta=dict(common),
+        )
+        result.append(info)
+
+    return result

--- a/tensogram-xarray/src/tensogram_xarray/store.py
+++ b/tensogram-xarray/src/tensogram_xarray/store.py
@@ -1,0 +1,271 @@
+"""Data store: bridge between tensogram messages and xarray Variables.
+
+``TensogramDataStore`` reads a single tensogram message (identified by file
+path and message index) and produces :class:`xarray.Variable` objects with
+lazy-loaded data backed by :class:`TensogramBackendArray`.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+import xarray as xr
+from xarray.core import indexing
+
+from tensogram_xarray.array import TensogramBackendArray, _supports_range_decode
+from tensogram_xarray.coords import detect_coords
+from tensogram_xarray.mapping import resolve_dim_names, resolve_variable_name
+from tensogram_xarray.scanner import AUTO_PAYLOAD_KEYS
+
+# Map tensogram dtype strings to numpy dtypes.
+_DTYPE_MAP: dict[str, np.dtype] = {
+    "float16": np.dtype("float16"),
+    "bfloat16": np.dtype("uint8"),  # no native numpy bfloat16 -- raw bytes
+    "float32": np.dtype("float32"),
+    "float64": np.dtype("float64"),
+    "complex64": np.dtype("complex64"),
+    "complex128": np.dtype("complex128"),
+    "int8": np.dtype("int8"),
+    "int16": np.dtype("int16"),
+    "int32": np.dtype("int32"),
+    "int64": np.dtype("int64"),
+    "uint8": np.dtype("uint8"),
+    "uint16": np.dtype("uint16"),
+    "uint32": np.dtype("uint32"),
+    "uint64": np.dtype("uint64"),
+    "bitmask": np.dtype("uint8"),  # packed bits as raw bytes
+}
+
+
+def _to_numpy_dtype(tgm_dtype: str) -> np.dtype:
+    """Convert a tensogram dtype string to a numpy dtype."""
+    key = tgm_dtype.lower()
+    if key in _DTYPE_MAP:
+        return _DTYPE_MAP[key]
+    # Fallback: try numpy directly.
+    try:
+        return np.dtype(tgm_dtype)
+    except TypeError as exc:
+        msg = f"unsupported tensogram dtype {tgm_dtype!r}: {exc}"
+        raise TypeError(msg) from exc
+
+
+class TensogramDataStore:
+    """Read-only data store for a single tensogram message.
+
+    Parameters
+    ----------
+    file_path
+        Path to the ``.tgm`` file.
+    msg_index
+        Index of the message within the file.
+    dim_names
+        Optional user-specified dimension names for data variables.
+    variable_key
+        Optional dotted metadata path for variable naming.
+    verify_hash
+        Whether to verify object hashes on decode.
+    range_threshold
+        Maximum fraction of total array elements (0.0-1.0) for which
+        partial ``decode_range()`` is used.  Default ``0.5``.
+    """
+
+    def __init__(
+        self,
+        file_path: str,
+        msg_index: int = 0,
+        dim_names: Sequence[str] | None = None,
+        variable_key: str | None = None,
+        verify_hash: bool = False,
+        range_threshold: float = 0.5,
+    ):
+        self.file_path = file_path
+        self.msg_index = msg_index
+        self.dim_names = dim_names
+        self.variable_key = variable_key
+        self.verify_hash = verify_hash
+        self.range_threshold = range_threshold
+        self._lock = threading.Lock()
+
+        # Eagerly read metadata + descriptors (payload is decoded to obtain
+        # descriptor shapes/dtypes, but data arrays are discarded).
+        self._meta, self._descriptors = self._read_metadata()
+
+    def _read_metadata(self) -> tuple[Any, list]:
+        """Read metadata and descriptors from the message."""
+        import tensogram
+
+        with tensogram.TensogramFile.open(self.file_path) as f:
+            raw = f.read_message(self.msg_index)
+
+        meta = tensogram.decode_metadata(raw)
+
+        # Decode all objects to get descriptors + shapes.
+        # We need the descriptors for lazy array construction.
+        _, objects = tensogram.decode(raw, verify_hash=self.verify_hash)
+        descriptors = [desc for desc, _arr in objects]
+        return meta, descriptors
+
+    def _get_common_meta(self) -> dict[str, Any]:
+        """Extract message-level metadata for Dataset attributes.
+
+        Reads from ``meta.common`` (primary) and ``meta.extra`` (additional
+        non-standard keys).
+        """
+        attrs: dict[str, Any] = {}
+        common = getattr(self._meta, "common", None)
+        if common and isinstance(common, dict):
+            attrs.update(common)
+        extra = getattr(self._meta, "extra", None)
+        if extra and isinstance(extra, dict):
+            attrs.update(extra)
+        attrs["tensogram_version"] = getattr(self._meta, "version", 2)
+        return attrs
+
+    def _get_per_object_meta(self, obj_index: int, desc: Any) -> dict[str, Any]:
+        """Extract per-object metadata.
+
+        Reads from ``meta.payload[obj_index]`` (primary), then merges in
+        ``desc.params`` (fallback for extra keys in the descriptor dict).
+        Auto-populated keys (``ndim``, ``shape``, ``strides``, ``dtype``)
+        are filtered out since they duplicate the descriptor.
+        """
+        meta: dict[str, Any] = {}
+        # Primary source: meta.payload[i]
+        payload = getattr(self._meta, "payload", None)
+        if payload and isinstance(payload, list) and obj_index < len(payload):
+            p = payload[obj_index]
+            if isinstance(p, dict):
+                for k, v in p.items():
+                    if k not in AUTO_PAYLOAD_KEYS:
+                        meta[k] = v
+        # Fallback/supplement: desc.params (extra descriptor keys)
+        params = getattr(desc, "params", None)
+        if params and isinstance(params, dict):
+            for k, v in params.items():
+                if k not in meta:
+                    meta[k] = v
+        return meta
+
+    def build_dataset(
+        self,
+        drop_variables: set[str] | None = None,
+    ) -> xr.Dataset:
+        """Construct an :class:`xr.Dataset` from this message.
+
+        Coordinate objects are auto-detected by name matching.  Data objects
+        become lazy-loaded variables.  All metadata flows to attributes.
+        """
+        dataset_attrs = self._get_common_meta()
+
+        # Gather per-object metadata from payload + descriptor params.
+        obj_metas = [self._get_per_object_meta(i, d) for i, d in enumerate(self._descriptors)]
+
+        # Detect coordinates vs data variables.
+        coord_indices, var_indices, coord_dim_names = detect_coords(obj_metas)
+
+        # Build coordinate variables from detected coord objects.
+        coord_vars: dict[str, xr.Variable] = {}
+        for ci in coord_indices:
+            desc = self._descriptors[ci]
+            dim_name = coord_dim_names[ci]
+            np_dtype = _to_numpy_dtype(desc.dtype)
+            shape = tuple(desc.shape)
+
+            backend_array = TensogramBackendArray(
+                file_path=self.file_path,
+                msg_index=self.msg_index,
+                obj_index=ci,
+                shape=shape,
+                dtype=np_dtype,
+                supports_range=_supports_range_decode(desc),
+                range_threshold=self.range_threshold,
+                lock=self._lock,
+            )
+            lazy_data = indexing.LazilyIndexedArray(backend_array)
+
+            # Coordinate arrays are 1-D.
+            coord_dims = (dim_name,)
+            coord_attrs = dict(obj_metas[ci])
+            coord_vars[dim_name] = xr.Variable(coord_dims, lazy_data, coord_attrs)
+
+        # Build data variables.
+        data_vars: dict[str, xr.Variable] = {}
+        for vi in var_indices:
+            desc = self._descriptors[vi]
+            var_name = resolve_variable_name(vi, obj_metas[vi], self.variable_key)
+            if drop_variables and var_name in drop_variables:
+                continue
+
+            np_dtype = _to_numpy_dtype(desc.dtype)
+            shape = tuple(desc.shape)
+
+            # Resolve dimension names: match against detected coordinates
+            # where shape aligns, otherwise use user-specified or generic.
+            dims = self._resolve_dims_for_var(shape, coord_vars)
+
+            backend_array = TensogramBackendArray(
+                file_path=self.file_path,
+                msg_index=self.msg_index,
+                obj_index=vi,
+                shape=shape,
+                dtype=np_dtype,
+                supports_range=_supports_range_decode(desc),
+                range_threshold=self.range_threshold,
+                lock=self._lock,
+            )
+            lazy_data = indexing.LazilyIndexedArray(backend_array)
+
+            var_attrs = dict(obj_metas[vi])
+            data_vars[var_name] = xr.Variable(dims, lazy_data, var_attrs)
+
+        # Assemble Dataset.
+        ds = xr.Dataset(data_vars, coords=coord_vars, attrs=dataset_attrs)
+        return ds
+
+    def _resolve_dims_for_var(
+        self,
+        shape: tuple[int, ...],
+        coord_vars: dict[str, xr.Variable],
+    ) -> tuple[str, ...]:
+        """Assign dimension names for a data variable.
+
+        Strategy:
+        1. If user provided ``dim_names``, use them directly.
+        2. Try to match each axis size against a known coordinate variable.
+        3. Fall back to ``dim_0``, ``dim_1``, ...
+        """
+        ndim = len(shape)
+
+        # (1) Explicit user mapping.
+        if self.dim_names is not None:
+            return tuple(resolve_dim_names(ndim, self.dim_names))
+
+        # (2) Match by size against detected coordinates.
+        # Build a map: size -> list of coord dim names with that size.
+        size_to_coord: dict[int, list[str]] = {}
+        for cname, cvar in coord_vars.items():
+            csize = cvar.shape[0]
+            size_to_coord.setdefault(csize, []).append(cname)
+
+        dims: list[str] = []
+        used_coords: set[str] = set()
+        for axis, axis_size in enumerate(shape):
+            matched = False
+            if axis_size in size_to_coord:
+                for cname in size_to_coord[axis_size]:
+                    if cname not in used_coords:
+                        dims.append(cname)
+                        used_coords.add(cname)
+                        matched = True
+                        break
+            if not matched:
+                dims.append(f"dim_{axis}")
+
+        return tuple(dims)
+
+    def close(self) -> None:
+        """No-op: no persistent resources to release."""

--- a/tensogram-xarray/src/tensogram_xarray/store.py
+++ b/tensogram-xarray/src/tensogram_xarray/store.py
@@ -21,9 +21,16 @@ from tensogram_xarray.mapping import resolve_dim_names, resolve_variable_name
 from tensogram_xarray.scanner import AUTO_PAYLOAD_KEYS
 
 # Map tensogram dtype strings to numpy dtypes.
+try:
+    import ml_dtypes
+
+    _BFLOAT16_DTYPE = ml_dtypes.bfloat16
+except ImportError:
+    _BFLOAT16_DTYPE = np.dtype("uint16")  # fallback: raw 2-byte words
+
 _DTYPE_MAP: dict[str, np.dtype] = {
     "float16": np.dtype("float16"),
-    "bfloat16": np.dtype("uint8"),  # no native numpy bfloat16 -- raw bytes
+    "bfloat16": np.dtype(_BFLOAT16_DTYPE),
     "float32": np.dtype("float32"),
     "float64": np.dtype("float64"),
     "complex64": np.dtype("complex64"),
@@ -90,8 +97,7 @@ class TensogramDataStore:
         self.range_threshold = range_threshold
         self._lock = threading.Lock()
 
-        # Eagerly read metadata + descriptors (payload is decoded to obtain
-        # descriptor shapes/dtypes, but data arrays are discarded).
+        # Eagerly read metadata + descriptors (no payload decode).
         self._meta, self._descriptors = self._read_metadata()
 
     def _read_metadata(self) -> tuple[Any, list]:
@@ -103,10 +109,8 @@ class TensogramDataStore:
 
         meta = tensogram.decode_metadata(raw)
 
-        # Decode all objects to get descriptors + shapes.
-        # We need the descriptors for lazy array construction.
-        _, objects = tensogram.decode(raw, verify_hash=self.verify_hash)
-        descriptors = [desc for desc, _arr in objects]
+        # Decode descriptors only (no payload decode).
+        _, descriptors = tensogram.decode_descriptors(raw)
         return meta, descriptors
 
     def _get_common_meta(self) -> dict[str, Any]:
@@ -182,6 +186,7 @@ class TensogramDataStore:
                 shape=shape,
                 dtype=np_dtype,
                 supports_range=_supports_range_decode(desc),
+                verify_hash=self.verify_hash,
                 range_threshold=self.range_threshold,
                 lock=self._lock,
             )
@@ -214,6 +219,7 @@ class TensogramDataStore:
                 shape=shape,
                 dtype=np_dtype,
                 supports_range=_supports_range_decode(desc),
+                verify_hash=self.verify_hash,
                 range_threshold=self.range_threshold,
                 lock=self._lock,
             )

--- a/tensogram-xarray/tests/conftest.py
+++ b/tensogram-xarray/tests/conftest.py
@@ -1,0 +1,177 @@
+"""Shared fixtures for tensogram-xarray tests.
+
+All fixtures create temporary ``.tgm`` files with known data using the
+tensogram Python bindings.
+
+Per-object metadata is stored as extra keys in the descriptor dict
+(accessible via ``desc.params`` after decode).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+import tensogram
+
+
+def _make_meta(version: int = 2, **extra: Any) -> dict[str, Any]:
+    return {"version": version, **extra}
+
+
+def _make_desc(
+    shape: list[int],
+    dtype: str = "float32",
+    **extra: Any,
+) -> dict[str, Any]:
+    return {
+        "type": "ntensor",
+        "shape": shape,
+        "dtype": dtype,
+        "byte_order": "little",
+        "encoding": "none",
+        "filter": "none",
+        "compression": "none",
+        **extra,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Single-message fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def simple_tgm(tmp_path: Path) -> Path:
+    """Single message, single 2D float32 object, no metadata."""
+    data = np.arange(60, dtype=np.float32).reshape(6, 10)
+    meta = _make_meta()
+    desc = _make_desc([6, 10])
+    path = tmp_path / "simple.tgm"
+    with tensogram.TensogramFile.create(str(path)) as f:
+        f.append(meta, [(desc, data)])
+    return path
+
+
+@pytest.fixture
+def simple_data() -> np.ndarray:
+    """The data array matching ``simple_tgm``."""
+    return np.arange(60, dtype=np.float32).reshape(6, 10)
+
+
+@pytest.fixture
+def tgm_with_coords(tmp_path: Path) -> Path:
+    """Message with 3 objects: lat array, lon array, temperature field.
+
+    Per-object metadata (name) is stored in descriptor extra keys -> desc.params.
+    """
+    lat = np.linspace(-90, 90, 5, dtype=np.float64)
+    lon = np.linspace(0, 360, 8, endpoint=False, dtype=np.float64)
+    temp = np.random.default_rng(42).random((5, 8), dtype=np.float32).astype(np.float32)
+
+    meta = _make_meta()
+    descs = [
+        _make_desc([5], dtype="float64", name="latitude"),
+        _make_desc([8], dtype="float64", name="longitude"),
+        _make_desc([5, 8], dtype="float32", name="temperature"),
+    ]
+    path = tmp_path / "with_coords.tgm"
+    with tensogram.TensogramFile.create(str(path)) as f:
+        f.append(meta, [(descs[0], lat), (descs[1], lon), (descs[2], temp)])
+    return path
+
+
+@pytest.fixture
+def coord_arrays() -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """The lat, lon, temp arrays matching ``tgm_with_coords``."""
+    lat = np.linspace(-90, 90, 5, dtype=np.float64)
+    lon = np.linspace(0, 360, 8, endpoint=False, dtype=np.float64)
+    temp = np.random.default_rng(42).random((5, 8), dtype=np.float32).astype(np.float32)
+    return lat, lon, temp
+
+
+@pytest.fixture
+def tgm_with_mars(tmp_path: Path) -> Path:
+    """Message with 2 objects using MARS-style metadata.
+
+    MARS keys are stored in descriptor extra keys -> desc.params.
+    """
+    t2m = np.ones((3, 4), dtype=np.float32) * 273.15
+    u10 = np.ones((3, 4), dtype=np.float32) * 5.0
+
+    meta = _make_meta()
+    descs = [
+        _make_desc([3, 4], mars={"param": "2t", "levtype": "sfc"}),
+        _make_desc([3, 4], mars={"param": "10u", "levtype": "sfc"}),
+    ]
+    path = tmp_path / "mars.tgm"
+    with tensogram.TensogramFile.create(str(path)) as f:
+        f.append(meta, [(descs[0], t2m), (descs[1], u10)])
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Multi-message fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def multi_msg_tgm(tmp_path: Path) -> Path:
+    """File with 4 messages, each with 1 object [3,4].
+
+    Metadata varies on: param (2t, 10u) x date (20260401, 20260402).
+    Per-object metadata stored in descriptor extra keys -> desc.params.
+    """
+    path = tmp_path / "multi.tgm"
+    rng = np.random.default_rng(99)
+
+    with tensogram.TensogramFile.create(str(path)) as f:
+        for param in ["2t", "10u"]:
+            for date in ["20260401", "20260402"]:
+                data = rng.random((3, 4), dtype=np.float32).astype(np.float32)
+                meta = _make_meta()
+                desc = _make_desc(
+                    [3, 4],
+                    mars={"param": param, "date": date},
+                )
+                f.append(meta, [(desc, data)])
+
+    return path
+
+
+@pytest.fixture
+def heterogeneous_tgm(tmp_path: Path) -> Path:
+    """File with 3 messages of different shapes/dtypes.
+
+    Message 0: [3,4] float32
+    Message 1: [3,4] float32
+    Message 2: [5]   int32
+    """
+    path = tmp_path / "hetero.tgm"
+    with tensogram.TensogramFile.create(str(path)) as f:
+        # Message 0
+        f.append(
+            _make_meta(),
+            [(_make_desc([3, 4], name="temp"), np.ones((3, 4), dtype=np.float32))],
+        )
+
+        # Message 1
+        f.append(
+            _make_meta(),
+            [(_make_desc([3, 4], name="wind"), np.ones((3, 4), dtype=np.float32) * 2)],
+        )
+
+        # Message 2 -- different shape and dtype
+        f.append(
+            _make_meta(),
+            [
+                (
+                    _make_desc([5], dtype="int32", name="counts"),
+                    np.array([1, 2, 3, 4, 5], dtype=np.int32),
+                )
+            ],
+        )
+
+    return path

--- a/tensogram-xarray/tests/test_array.py
+++ b/tensogram-xarray/tests/test_array.py
@@ -1,0 +1,141 @@
+"""Tests for TensogramBackendArray lazy loading."""
+
+from __future__ import annotations
+
+import pickle
+from pathlib import Path
+
+import numpy as np
+import xarray as xr
+
+from tensogram_xarray.array import (
+    TensogramBackendArray,
+    _supports_range_decode,
+)
+
+
+class TestSupportsRangeDecodeLogic:
+    """Unit tests for the _supports_range_decode helper."""
+
+    def test_none_compression(self):
+        """Uncompressed data supports range decode."""
+
+        class _Desc:
+            compression = "none"
+            filter = "none"
+            params = {}
+
+        assert _supports_range_decode(_Desc()) is True
+
+    def test_szip_supports(self):
+        class _Desc:
+            compression = "szip"
+            filter = "none"
+            params = {}
+
+        assert _supports_range_decode(_Desc()) is True
+
+    def test_blosc2_supports(self):
+        class _Desc:
+            compression = "blosc2"
+            filter = "none"
+            params = {}
+
+        assert _supports_range_decode(_Desc()) is True
+
+    def test_zfp_fixed_rate_supports(self):
+        class _Desc:
+            compression = "zfp"
+            filter = "none"
+            params = {"zfp_mode": "fixed_rate"}
+
+        assert _supports_range_decode(_Desc()) is True
+
+    def test_zfp_non_fixed_rate_not_supported(self):
+        class _Desc:
+            compression = "zfp"
+            filter = "none"
+            params = {"zfp_mode": "fixed_precision"}
+
+        assert _supports_range_decode(_Desc()) is False
+
+    def test_zstd_not_supported(self):
+        class _Desc:
+            compression = "zstd"
+            filter = "none"
+            params = {}
+
+        assert _supports_range_decode(_Desc()) is False
+
+    def test_lz4_not_supported(self):
+        class _Desc:
+            compression = "lz4"
+            filter = "none"
+            params = {}
+
+        assert _supports_range_decode(_Desc()) is False
+
+    def test_sz3_not_supported(self):
+        class _Desc:
+            compression = "sz3"
+            filter = "none"
+            params = {}
+
+        assert _supports_range_decode(_Desc()) is False
+
+    def test_shuffle_blocks_range(self):
+        """Shuffle filter prevents range decode regardless of compressor."""
+
+        class _Desc:
+            compression = "none"
+            filter = "shuffle"
+            params = {}
+
+        assert _supports_range_decode(_Desc()) is False
+
+    def test_shuffle_plus_szip_blocks(self):
+        class _Desc:
+            compression = "szip"
+            filter = "shuffle"
+            params = {}
+
+        assert _supports_range_decode(_Desc()) is False
+
+
+class TestBackendArrayPickle:
+    """Pickle safety for dask multiprocessing."""
+
+    def test_picklable(self, simple_tgm: Path):
+        arr = TensogramBackendArray(
+            file_path=str(simple_tgm),
+            msg_index=0,
+            obj_index=0,
+            shape=(6, 10),
+            dtype=np.dtype("float32"),
+            supports_range=True,
+        )
+        data = pickle.dumps(arr)
+        restored = pickle.loads(data)
+        assert restored.shape == (6, 10)
+        assert restored.dtype == np.dtype("float32")
+        assert restored.file_path == str(simple_tgm)
+
+
+class TestLazyLoading:
+    """Verify that data is loaded lazily."""
+
+    def test_data_not_loaded_on_open(self, simple_tgm: Path):
+        ds = xr.open_dataset(str(simple_tgm), engine="tensogram")
+        # The internal data should be a LazilyIndexedArray, not numpy.
+        var = ds["object_0"].variable
+        assert not isinstance(var._data, np.ndarray)
+
+    def test_data_loads_on_access(self, simple_tgm: Path, simple_data: np.ndarray):
+        ds = xr.open_dataset(str(simple_tgm), engine="tensogram")
+        values = ds["object_0"].values  # triggers load
+        np.testing.assert_array_equal(values, simple_data)
+
+    def test_slice_access(self, simple_tgm: Path, simple_data: np.ndarray):
+        ds = xr.open_dataset(str(simple_tgm), engine="tensogram")
+        sliced = ds["object_0"][1:3, 2:5].values
+        np.testing.assert_array_equal(sliced, simple_data[1:3, 2:5])

--- a/tensogram-xarray/tests/test_backend.py
+++ b/tensogram-xarray/tests/test_backend.py
@@ -1,0 +1,125 @@
+"""Tests for the xarray BackendEntrypoint integration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from tensogram_xarray.backend import TensogramBackendEntrypoint
+
+
+class TestGuessCanOpen:
+    """``guess_can_open`` file-extension detection."""
+
+    def test_tgm_extension(self):
+        backend = TensogramBackendEntrypoint()
+        assert backend.guess_can_open("data.tgm") is True
+
+    def test_uppercase_extension(self):
+        backend = TensogramBackendEntrypoint()
+        assert backend.guess_can_open("data.TGM") is True
+
+    def test_wrong_extension(self):
+        backend = TensogramBackendEntrypoint()
+        assert backend.guess_can_open("data.grib") is False
+        assert backend.guess_can_open("data.nc") is False
+
+    def test_non_string(self):
+        backend = TensogramBackendEntrypoint()
+        assert backend.guess_can_open(12345) is False  # type: ignore[arg-type]
+
+
+class TestOpenDatasetSimple:
+    """Basic open_dataset: single message, no mapping."""
+
+    def test_opens_simple_tgm(self, simple_tgm: Path, simple_data: np.ndarray):
+        ds = xr.open_dataset(str(simple_tgm), engine="tensogram")
+        assert "object_0" in ds.data_vars
+        np.testing.assert_array_equal(ds["object_0"].values, simple_data)
+
+    def test_generic_dim_names(self, simple_tgm: Path):
+        ds = xr.open_dataset(str(simple_tgm), engine="tensogram")
+        assert ds["object_0"].dims == ("dim_0", "dim_1")
+
+    def test_shape_preserved(self, simple_tgm: Path, simple_data: np.ndarray):
+        ds = xr.open_dataset(str(simple_tgm), engine="tensogram")
+        assert ds["object_0"].shape == simple_data.shape
+
+    def test_dtype_preserved(self, simple_tgm: Path):
+        ds = xr.open_dataset(str(simple_tgm), engine="tensogram")
+        assert ds["object_0"].dtype == np.float32
+
+    def test_metadata_in_attrs(self, simple_tgm: Path):
+        ds = xr.open_dataset(str(simple_tgm), engine="tensogram")
+        assert "tensogram_version" in ds.attrs
+
+
+class TestOpenDatasetWithDimNames:
+    """User-specified dim_names."""
+
+    def test_custom_dim_names(self, simple_tgm: Path):
+        ds = xr.open_dataset(
+            str(simple_tgm),
+            engine="tensogram",
+            dim_names=["latitude", "longitude"],
+        )
+        assert ds["object_0"].dims == ("latitude", "longitude")
+
+    def test_wrong_dim_count_raises(self, simple_tgm: Path):
+        with pytest.raises(ValueError, match="dim_names has 3 entries"):
+            xr.open_dataset(
+                str(simple_tgm),
+                engine="tensogram",
+                dim_names=["a", "b", "c"],
+            )
+
+
+class TestOpenDatasetWithVariableKey:
+    """Variable naming from metadata."""
+
+    def test_variable_key_mars_param(self, tgm_with_mars: Path):
+        ds = xr.open_dataset(
+            str(tgm_with_mars),
+            engine="tensogram",
+            variable_key="mars.param",
+        )
+        assert "2t" in ds.data_vars
+        assert "10u" in ds.data_vars
+
+    def test_variable_key_fallback(self, simple_tgm: Path):
+        ds = xr.open_dataset(
+            str(simple_tgm),
+            engine="tensogram",
+            variable_key="mars.param",  # doesn't exist in metadata
+        )
+        # Falls back to object_0.
+        assert "object_0" in ds.data_vars
+
+
+class TestDropVariables:
+    """drop_variables support."""
+
+    def test_drop_variable(self, tgm_with_mars: Path):
+        ds = xr.open_dataset(
+            str(tgm_with_mars),
+            engine="tensogram",
+            variable_key="mars.param",
+            drop_variables=["10u"],
+        )
+        assert "2t" in ds.data_vars
+        assert "10u" not in ds.data_vars
+
+
+class TestMessageIndex:
+    """Selecting a specific message in a multi-message file."""
+
+    def test_message_index(self, multi_msg_tgm: Path):
+        ds0 = xr.open_dataset(str(multi_msg_tgm), engine="tensogram", message_index=0)
+        ds1 = xr.open_dataset(str(multi_msg_tgm), engine="tensogram", message_index=1)
+        # Both should have data but potentially different values.
+        assert "object_0" in ds0.data_vars
+        assert "object_0" in ds1.data_vars
+        assert ds0["object_0"].shape == ds1["object_0"].shape

--- a/tensogram-xarray/tests/test_coords.py
+++ b/tensogram-xarray/tests/test_coords.py
@@ -1,0 +1,85 @@
+"""Tests for coordinate auto-detection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import xarray as xr
+
+from tensogram_xarray.coords import KNOWN_COORD_NAMES, detect_coords
+
+
+class TestDetectCoords:
+    """Unit tests for the detect_coords function."""
+
+    def test_lat_lon_detected(self):
+        metas = [
+            {"name": "latitude"},
+            {"name": "longitude"},
+            {"name": "temperature"},
+        ]
+        coord_idx, var_idx, dim_map = detect_coords(metas)
+        assert coord_idx == [0, 1]
+        assert var_idx == [2]
+        assert dim_map == {0: "latitude", 1: "longitude"}
+
+    def test_case_insensitive(self):
+        metas = [{"name": "LAT"}, {"name": "LON"}, {"name": "data"}]
+        coord_idx, _var_idx, dim_map = detect_coords(metas)
+        assert coord_idx == [0, 1]
+        assert dim_map == {0: "latitude", 1: "longitude"}
+
+    def test_param_key(self):
+        metas = [{"param": "time"}, {"param": "temperature"}]
+        coord_idx, var_idx, _ = detect_coords(metas)
+        assert coord_idx == [0]
+        assert var_idx == [1]
+
+    def test_mars_param_key(self):
+        metas = [{"mars": {"param": "level"}}, {"mars": {"param": "wind"}}]
+        coord_idx, var_idx, _ = detect_coords(metas)
+        assert coord_idx == [0]
+        assert var_idx == [1]
+
+    def test_no_coords(self):
+        metas = [{"name": "temp"}, {"name": "wind"}]
+        coord_idx, var_idx, _ = detect_coords(metas)
+        assert coord_idx == []
+        assert var_idx == [0, 1]
+
+    def test_all_known_names_recognized(self):
+        for name in KNOWN_COORD_NAMES:
+            coord_idx, _, _ = detect_coords([{"name": name}])
+            assert coord_idx == [0], f"Failed for {name}"
+
+
+class TestCoordIntegration:
+    """Integration: coordinates appear in the opened Dataset."""
+
+    def test_coords_detected_in_dataset(
+        self,
+        tgm_with_coords: Path,
+        coord_arrays: tuple[np.ndarray, np.ndarray, np.ndarray],
+    ):
+        lat, lon, _temp = coord_arrays
+        ds = xr.open_dataset(str(tgm_with_coords), engine="tensogram")
+
+        # Coordinates should be present.
+        assert "latitude" in ds.coords
+        assert "longitude" in ds.coords
+
+        np.testing.assert_allclose(ds.coords["latitude"].values, lat)
+        np.testing.assert_allclose(ds.coords["longitude"].values, lon)
+
+    def test_data_var_uses_coord_dims(
+        self,
+        tgm_with_coords: Path,
+    ):
+        ds = xr.open_dataset(str(tgm_with_coords), engine="tensogram")
+
+        # The temperature variable should use latitude/longitude dims.
+        temp_var = [v for v in ds.data_vars if v != "latitude" and v != "longitude"]
+        assert len(temp_var) >= 1
+        var = ds[temp_var[0]]
+        assert "latitude" in var.dims or "longitude" in var.dims

--- a/tensogram-xarray/tests/test_coverage.py
+++ b/tensogram-xarray/tests/test_coverage.py
@@ -1,0 +1,640 @@
+"""Coverage-gap tests for tensogram-xarray.
+
+Targets specific untested code paths identified by pytest-cov:
+
+- merge.py: coord building in open_datasets, hypercube stacking,
+  multi-variable dataset, flat group dataset, _resolve_dims helper
+- scanner.py: message_count property, scan_message(), metadata edge paths
+- array.py: non-unit stride rejection, exception fallback to full decode
+- store.py: dtype fallback, extra-only metadata, close()
+- backend.py: merge_objects returning empty
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import tensogram
+import xarray as xr
+
+from tensogram_xarray.array import (
+    _is_contiguous_slice,
+    _nd_slice_to_flat_ranges,
+)
+from tensogram_xarray.merge import (
+    _extract_meta_keys,
+    _make_hashable,
+    _partition_keys,
+    _try_hypercube,
+    _unique_values,
+    open_datasets,
+)
+from tensogram_xarray.scanner import FileIndex, ObjectInfo, scan_file, scan_message
+from tensogram_xarray.store import TensogramDataStore, _to_numpy_dtype
+
+
+def _desc(shape, dtype="float32", **extra):
+    return {
+        "type": "ntensor",
+        "shape": shape,
+        "dtype": dtype,
+        "byte_order": "little",
+        "encoding": "none",
+        "filter": "none",
+        "compression": "none",
+        **extra,
+    }
+
+
+# ---------------------------------------------------------------------------
+# store.py gaps
+# ---------------------------------------------------------------------------
+
+
+class TestStoreCoverage:
+    """Cover store.py lines 48, 115, 118, 142."""
+
+    def test_dtype_fallback_valid(self):
+        """_to_numpy_dtype falls back to np.dtype() for unlisted strings."""
+        # line 48: fallback path -- 'f4' is valid numpy shorthand for float32
+        # but isn't in our explicit _DTYPE_MAP.
+        dt = _to_numpy_dtype("f4")
+        assert dt == np.dtype("float32")
+
+    def test_dtype_fallback_invalid(self):
+        """_to_numpy_dtype raises for truly unknown dtype strings."""
+        with pytest.raises(TypeError):
+            _to_numpy_dtype("not_a_dtype")
+
+    def test_common_meta_extra_only(self, tmp_path: Path):
+        """meta.extra keys appear in dataset attrs when common is empty."""
+        # lines 115, 118: extra-only metadata path
+        data = np.ones((2, 3), dtype=np.float32)
+        path = str(tmp_path / "extra_only.tgm")
+        # Use a top-level extra key (not common, not payload)
+        meta = {"version": 2, "experiment": "test42"}
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(meta, [(_desc([2, 3]), data)])
+
+        store = TensogramDataStore(path, msg_index=0)
+        ds = store.build_dataset()
+        # 'experiment' should be in dataset attrs via meta.extra
+        assert ds.attrs.get("experiment") == "test42"
+
+    def test_store_close_is_noop(self, tmp_path: Path):
+        """close() is a no-op and does not raise."""
+        # line 142
+        data = np.ones((2,), dtype=np.float32)
+        path = str(tmp_path / "close.tgm")
+        with tensogram.TensogramFile.create(path) as f:
+            f.append({"version": 2}, [(_desc([2]), data)])
+        store = TensogramDataStore(path)
+        store.close()  # should not raise
+
+    def test_auto_payload_keys_filtered(self, tmp_path: Path):
+        """ndim/shape/strides/dtype from payload don't appear in var attrs."""
+        data = np.ones((3,), dtype=np.float32)
+        path = str(tmp_path / "payload_filter.tgm")
+        meta = {"version": 2, "payload": [{"mars": {"param": "2t"}}]}
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(meta, [(_desc([3]), data)])
+
+        store = TensogramDataStore(path, variable_key="mars.param")
+        ds = store.build_dataset()
+        var = ds["2t"]
+        # Auto-populated keys should be filtered
+        assert "ndim" not in var.attrs
+        assert "shape" not in var.attrs
+        assert "strides" not in var.attrs
+        assert "dtype" not in var.attrs
+        # But user key should be present
+        assert "mars" in var.attrs
+
+
+# ---------------------------------------------------------------------------
+# array.py gaps
+# ---------------------------------------------------------------------------
+
+
+class TestArrayCoverage:
+    """Cover array.py lines 61, 64, 161, 250-251."""
+
+    def test_non_slice_key_rejected(self):
+        """_is_contiguous_slice returns False for integer indexing."""
+        # line 61: not isinstance(k, slice)
+        assert _is_contiguous_slice((slice(None), 5)) is False
+
+    def test_non_unit_stride_rejected(self):
+        """_is_contiguous_slice returns False for step != 1."""
+        # line 64: k.step is not None and k.step != 1
+        assert _is_contiguous_slice((slice(0, 10, 2),)) is False
+
+    def test_unit_stride_accepted(self):
+        """_is_contiguous_slice accepts step=1 and step=None."""
+        assert _is_contiguous_slice((slice(0, 10, 1),)) is True
+        assert _is_contiguous_slice((slice(0, 10),)) is True
+
+    def test_nd_range_merge_multiple(self):
+        """Verify that the merge path in _nd_slice_to_flat_ranges works.
+
+        arr[1:4, :] on shape (6, 10): three consecutive full rows should
+        merge into one range.
+        """
+        # line 161: merged path
+        ranges, shape = _nd_slice_to_flat_ranges((6, 10), (slice(1, 4), slice(None)))
+        assert ranges == [(10, 30)]
+        assert shape == (3, 10)
+
+    def test_decode_range_fallback_on_error(self, tmp_path: Path):
+        """When decode_range fails, fall back to decode_object."""
+        # lines 250-251: exception fallback
+        # Create a file with valid data
+        data = np.arange(12, dtype=np.float32).reshape(3, 4)
+        path = str(tmp_path / "fallback.tgm")
+        with tensogram.TensogramFile.create(path) as f:
+            f.append({"version": 2}, [(_desc([3, 4]), data)])
+
+        # Open with a very low threshold so full array load
+        # goes through decode_object path (ratio > threshold).
+        ds = xr.open_dataset(str(path), engine="tensogram", range_threshold=0.0)
+        values = ds["object_0"].values
+        np.testing.assert_array_equal(values, data)
+
+
+# ---------------------------------------------------------------------------
+# backend.py gaps
+# ---------------------------------------------------------------------------
+
+
+class TestBackendCoverage:
+    """Cover backend.py line 97."""
+
+    def test_merge_objects_empty_file(self, tmp_path: Path):
+        """merge_objects=True on file with no data objects returns empty."""
+        # line 97: empty dataset from merge_objects
+        path = str(tmp_path / "empty.tgm")
+        with tensogram.TensogramFile.create(path) as f:
+            f.append({"version": 2}, [])
+
+        ds = xr.open_dataset(str(path), engine="tensogram", merge_objects=True)
+        assert isinstance(ds, xr.Dataset)
+
+
+# ---------------------------------------------------------------------------
+# scanner.py gaps
+# ---------------------------------------------------------------------------
+
+
+class TestScannerCoverage:
+    """Cover scanner.py lines 49-51, 78, 86, 89, 137-163."""
+
+    def test_file_index_message_count_empty(self):
+        """FileIndex.message_count returns 0 when empty."""
+        # lines 49-51
+        idx = FileIndex(file_path="none.tgm")
+        assert idx.message_count == 0
+
+    def test_file_index_message_count_multi(self, tmp_path: Path):
+        """FileIndex.message_count returns correct count for multi-msg."""
+        path = str(tmp_path / "multi.tgm")
+        data = np.ones((2,), dtype=np.float32)
+        with tensogram.TensogramFile.create(path) as f:
+            f.append({"version": 2}, [(_desc([2]), data)])
+            f.append({"version": 2}, [(_desc([2]), data)])
+            f.append({"version": 2}, [(_desc([2]), data)])
+
+        idx = scan_file(path)
+        assert idx.message_count == 3
+
+    def test_scan_message(self):
+        """scan_message works on a raw in-memory message."""
+        # lines 137-163
+        data = np.arange(6, dtype=np.float32)
+        meta = {"version": 2}
+        desc = _desc([6], name="wind")
+        msg = bytes(tensogram.encode(meta, [(desc, data)]))
+
+        objects = scan_message(msg)
+        assert len(objects) == 1
+        assert objects[0].shape == (6,)
+        assert objects[0].msg_index == 0
+        assert objects[0].obj_index == 0
+        # name from desc.params should be in per_object_meta
+        assert objects[0].per_object_meta.get("name") == "wind"
+
+    def test_scan_message_multi_object(self):
+        """scan_message with multiple objects in one message."""
+        a = np.ones((3,), dtype=np.float32)
+        b = np.zeros((5,), dtype=np.float64)
+        meta = {"version": 2}
+        msg = bytes(tensogram.encode(meta, [(_desc([3]), a), (_desc([5], dtype="float64"), b)]))
+
+        objects = scan_message(msg)
+        assert len(objects) == 2
+        assert objects[0].shape == (3,)
+        assert objects[1].shape == (5,)
+
+    def test_scan_file_with_common_metadata(self, tmp_path: Path):
+        """scan_file reads common metadata into ObjectInfo.common_meta."""
+        # line 78, 86, 89: common metadata path
+        path = str(tmp_path / "common.tgm")
+        data = np.ones((2,), dtype=np.float32)
+        meta = {"version": 2, "common": {"source": "ecmwf"}}
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(meta, [(_desc([2]), data)])
+
+        idx = scan_file(path)
+        assert len(idx.objects) == 1
+        assert idx.objects[0].common_meta.get("source") == "ecmwf"
+
+    def test_object_info_merged_meta(self):
+        """ObjectInfo.merged_meta merges common + per-object, per-object wins."""
+        info = ObjectInfo(
+            msg_index=0,
+            obj_index=0,
+            ndim=1,
+            shape=(5,),
+            dtype="float32",
+            descriptor=None,
+            per_object_meta={"param": "2t", "source": "local"},
+            common_meta={"source": "ecmwf", "class": "od"},
+        )
+        merged = info.merged_meta
+        assert merged["param"] == "2t"
+        assert merged["source"] == "local"  # per-object wins
+        assert merged["class"] == "od"
+
+
+# ---------------------------------------------------------------------------
+# merge.py gaps -- helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestMergeHelpersCoverage:
+    """Cover merge.py helper functions that are untested."""
+
+    def test_make_hashable_nested_dict(self):
+        """_make_hashable handles nested dicts and lists."""
+        val = {"a": [1, {"b": 2}]}
+        h = _make_hashable(val)
+        assert isinstance(h, tuple)
+        # Should be hashable
+        hash(h)  # should not raise TypeError
+
+    def test_make_hashable_simple(self):
+        """_make_hashable passes through simple values."""
+        assert _make_hashable(42) == 42
+        assert _make_hashable("hello") == "hello"
+
+    def test_unique_values_with_dicts(self):
+        """_unique_values deduplicates dicts (unhashable)."""
+        vals = [{"a": 1}, {"b": 2}, {"a": 1}]
+        result = _unique_values(vals)
+        assert len(result) == 2
+
+    def test_partition_keys_constant_vs_varying(self):
+        """_partition_keys splits constant and varying keys."""
+        kv = {
+            "param": ["2t", "10u"],
+            "class": ["od", "od"],
+        }
+        const, vary = _partition_keys(kv)
+        assert "class" in const
+        assert const["class"] == "od"
+        assert "param" in vary
+        assert vary["param"] == ["2t", "10u"]
+
+    def test_partition_keys_unhashable(self):
+        """_partition_keys treats unhashable values as constant."""
+        kv = {"mars": [{"param": "2t"}, {"param": "2t"}]}
+        const, _vary = _partition_keys(kv)
+        # Dicts are hashable via _make_hashable, so identical dicts -> constant
+        assert "mars" in const
+
+    def test_try_hypercube_complete(self):
+        """_try_hypercube returns True for complete grid."""
+
+        class _Obj:
+            pass
+
+        objs = [_Obj() for _ in range(4)]
+        varying = {
+            "param": ["2t", "10u", "2t", "10u"],
+            "date": ["d1", "d1", "d2", "d2"],
+        }
+        assert _try_hypercube(objs, varying) is True
+
+    def test_try_hypercube_incomplete(self):
+        """_try_hypercube returns False for incomplete grid."""
+
+        class _Obj:
+            pass
+
+        objs = [_Obj() for _ in range(3)]
+        varying = {
+            "param": ["2t", "10u", "2t"],
+            "date": ["d1", "d1", "d2"],
+        }
+        # 2 x 2 = 4 expected but only 3 objects
+        assert _try_hypercube(objs, varying) is False
+
+    def test_try_hypercube_empty_varying(self):
+        """_try_hypercube with no varying keys returns True."""
+        assert _try_hypercube([], {}) is True
+
+    def test_extract_meta_keys(self):
+        """_extract_meta_keys collects values per key."""
+        info1 = ObjectInfo(
+            msg_index=0,
+            obj_index=0,
+            ndim=1,
+            shape=(3,),
+            dtype="float32",
+            descriptor=None,
+            per_object_meta={"param": "2t"},
+            common_meta={"class": "od"},
+        )
+        info2 = ObjectInfo(
+            msg_index=1,
+            obj_index=0,
+            ndim=1,
+            shape=(3,),
+            dtype="float32",
+            descriptor=None,
+            per_object_meta={"param": "10u"},
+            common_meta={"class": "od"},
+        )
+        kv = _extract_meta_keys([info1, info2])
+        assert kv["param"] == ["2t", "10u"]
+        assert kv["class"] == ["od", "od"]
+
+
+# ---------------------------------------------------------------------------
+# merge.py gaps -- integration: coord vars, hypercube, multi-var dataset
+# ---------------------------------------------------------------------------
+
+
+class TestMergeIntegrationCoverage:
+    """Cover merge.py integration paths: coord building, hypercube, multi-var."""
+
+    def test_open_datasets_with_coords(self, tmp_path: Path):
+        """open_datasets builds coord vars from coord objects across msgs."""
+        # lines 74-90: coord building in open_datasets
+        path = str(tmp_path / "coords_merge.tgm")
+        lat = np.linspace(-90, 90, 3, dtype=np.float64)
+        lon = np.linspace(0, 360, 4, endpoint=False, dtype=np.float64)
+        temp = np.ones((3, 4), dtype=np.float32)
+
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(
+                {"version": 2},
+                [
+                    (_desc([3], dtype="float64", name="latitude"), lat),
+                    (_desc([4], dtype="float64", name="longitude"), lon),
+                    (_desc([3, 4], name="temperature"), temp),
+                ],
+            )
+
+        datasets = open_datasets(path)
+        assert len(datasets) >= 1
+        ds = datasets[0]
+        assert "latitude" in ds.coords
+        assert "longitude" in ds.coords
+
+    def test_multi_variable_with_outer_dim(self, tmp_path: Path):
+        """open_datasets with variable_key splits by param, stacks by date.
+
+        Exercises _build_multi_variable_dataset (lines 510-613).
+        """
+        path = str(tmp_path / "multi_var.tgm")
+        rng = np.random.default_rng(77)
+
+        with tensogram.TensogramFile.create(path) as f:
+            for param in ["2t", "10u"]:
+                for date in ["20260401", "20260402"]:
+                    data = rng.random((3, 4), dtype=np.float32).astype(np.float32)
+                    desc = _desc([3, 4], mars={"param": param, "date": date})
+                    f.append({"version": 2}, [(desc, data)])
+
+        datasets = open_datasets(path, variable_key="mars.param")
+        assert len(datasets) >= 1
+        ds = datasets[0]
+        # Both variables should be present
+        assert "2t" in ds.data_vars or "10u" in ds.data_vars
+
+    def test_flat_group_no_varying(self, tmp_path: Path):
+        """Objects with identical metadata become separate variables.
+
+        Exercises _flat_group_dataset (lines 390-413).
+        """
+        path = str(tmp_path / "flat.tgm")
+        data = np.ones((2, 3), dtype=np.float32)
+
+        with tensogram.TensogramFile.create(path) as f:
+            # Two messages with identical metadata and shape
+            f.append({"version": 2}, [(_desc([2, 3], name="field"), data)])
+            f.append({"version": 2}, [(_desc([2, 3], name="field"), data * 2)])
+
+        datasets = open_datasets(path)
+        assert len(datasets) >= 1
+        ds = datasets[0]
+        # Should have at least 1 variable
+        assert len(ds.data_vars) >= 1
+
+    def test_hypercube_without_variable_key(self, tmp_path: Path):
+        """Hypercube stacking without variable_key.
+
+        Exercises _hypercube_dataset (lines 416-460).
+        """
+        path = str(tmp_path / "hypercube.tgm")
+        rng = np.random.default_rng(88)
+
+        with tensogram.TensogramFile.create(path) as f:
+            for step in ["0", "6", "12"]:
+                data = rng.random((2, 3), dtype=np.float32).astype(np.float32)
+                desc = _desc([2, 3], step=step)
+                f.append({"version": 2}, [(desc, data)])
+
+        datasets = open_datasets(path)
+        assert len(datasets) >= 1
+        # All 3 objects should be represented
+        ds = datasets[0]
+        total_vars = len(ds.data_vars)
+        assert total_vars >= 1
+
+    def test_multi_variable_single_per_param(self, tmp_path: Path):
+        """variable_key with single object per param -> no outer dims.
+
+        Exercises line 526-540 in _build_multi_variable_dataset.
+        Uses a flat 'param' key (not nested mars dict) so variable_key
+        is the only varying key and each value gets its own variable.
+        """
+        path = str(tmp_path / "single_per_param.tgm")
+        t2m = np.ones((2, 3), dtype=np.float32) * 273
+        u10 = np.ones((2, 3), dtype=np.float32) * 5
+
+        with tensogram.TensogramFile.create(path) as f:
+            f.append({"version": 2}, [(_desc([2, 3], param="2t"), t2m)])
+            f.append({"version": 2}, [(_desc([2, 3], param="10u"), u10)])
+
+        datasets = open_datasets(path, variable_key="param")
+        assert len(datasets) >= 1
+        ds = datasets[0]
+        assert "2t" in ds.data_vars
+        assert "10u" in ds.data_vars
+        np.testing.assert_array_equal(ds["2t"].values, t2m)
+        np.testing.assert_array_equal(ds["10u"].values, u10)
+
+    def test_multi_variable_no_remaining_varying(self, tmp_path: Path):
+        """variable_key exhausts all varying keys -> no outer dims.
+
+        Exercises lines 596-610 in _build_multi_variable_dataset.
+        """
+        path = str(tmp_path / "no_remain.tgm")
+        a = np.ones((2,), dtype=np.float32)
+        b = np.ones((2,), dtype=np.float32) * 2
+
+        with tensogram.TensogramFile.create(path) as f:
+            # Two messages where the ONLY varying key is the variable_key itself
+            f.append({"version": 2}, [(_desc([2], param="alpha"), a)])
+            f.append({"version": 2}, [(_desc([2], param="beta"), b)])
+
+        datasets = open_datasets(path, variable_key="param")
+        assert len(datasets) >= 1
+        ds = datasets[0]
+        assert "alpha" in ds.data_vars
+        assert "beta" in ds.data_vars
+
+    def test_multi_variable_stacking_with_date(self, tmp_path: Path):
+        """variable_key with remaining varying key (date) triggers stacking.
+
+        Exercises lines 541-580 in _build_multi_variable_dataset -- the
+        hypercube stacking path within multi-variable splitting.
+        """
+        path = str(tmp_path / "stack_date.tgm")
+        rng = np.random.default_rng(55)
+
+        with tensogram.TensogramFile.create(path) as f:
+            for param in ["2t", "10u"]:
+                for date in ["d1", "d2"]:
+                    data = rng.random((2, 3), dtype=np.float32).astype(np.float32)
+                    desc = _desc([2, 3], param=param, date=date)
+                    f.append({"version": 2}, [(desc, data)])
+
+        datasets = open_datasets(path, variable_key="param")
+        assert len(datasets) >= 1
+        ds = datasets[0]
+        # Both variables should exist, stacked along 'date'
+        assert "2t" in ds.data_vars or "10u" in ds.data_vars
+
+    def test_incomplete_hypercube_fallback(self, tmp_path: Path):
+        """Incomplete hypercube falls back to flat group (line 332).
+
+        3 objects varying on 2 keys but not forming a 2x2 grid.
+        """
+        path = str(tmp_path / "incomplete.tgm")
+        rng = np.random.default_rng(66)
+
+        with tensogram.TensogramFile.create(path) as f:
+            # param x date: (2t,d1), (10u,d1), (2t,d2) -- missing (10u,d2)
+            for param, date in [("2t", "d1"), ("10u", "d1"), ("2t", "d2")]:
+                data = rng.random((2, 3), dtype=np.float32).astype(np.float32)
+                desc = _desc([2, 3], param=param, date=date)
+                f.append({"version": 2}, [(desc, data)])
+
+        datasets = open_datasets(path)
+        assert len(datasets) >= 1
+        # Should have at least 3 variables (one per object)
+        total = sum(len(ds.data_vars) for ds in datasets)
+        assert total >= 3
+
+    def test_resolve_dims_with_dim_names(self, tmp_path: Path):
+        """open_datasets with dim_names uses them for all variables.
+
+        Exercises line 633 in _resolve_dims.
+        """
+        path = str(tmp_path / "dimnames.tgm")
+        data = np.ones((3, 4), dtype=np.float32)
+        with tensogram.TensogramFile.create(path) as f:
+            f.append({"version": 2}, [(_desc([3, 4]), data)])
+
+        datasets = open_datasets(path, dim_names=["row", "col"])
+        assert len(datasets) >= 1
+        ds = datasets[0]
+        var = next(iter(ds.data_vars.values()))
+        assert var.dims == ("row", "col")
+
+    def test_build_dataset_from_group_empty(self):
+        """_build_dataset_from_group returns None for empty group.
+
+        Exercises line 270.
+        """
+        from tensogram_xarray.merge import _build_dataset_from_group
+
+        result = _build_dataset_from_group(
+            group=[],
+            file_path="none.tgm",
+            coord_vars={},
+            dim_names=None,
+            variable_key=None,
+            lock=__import__("threading").Lock(),
+        )
+        assert result is None
+
+    def test_split_by_key(self):
+        """_split_by_key partitions by a metadata key.
+
+        Exercises lines 241-246.
+        """
+        from tensogram_xarray.merge import _split_by_key
+
+        objs = [
+            ObjectInfo(0, 0, 1, (3,), "float32", None, {"param": "2t"}, {}),
+            ObjectInfo(1, 0, 1, (3,), "float32", None, {"param": "10u"}, {}),
+            ObjectInfo(2, 0, 1, (3,), "float32", None, {"param": "2t"}, {}),
+        ]
+        groups = _split_by_key(objs, "param")
+        assert len(groups) == 2
+        sizes = sorted(len(g) for g in groups)
+        assert sizes == [1, 2]
+
+
+# ---------------------------------------------------------------------------
+# Error-path tests
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPaths:
+    """Verify that errors are raised with informative messages."""
+
+    def test_dtype_fallback_message(self):
+        """_to_numpy_dtype includes the dtype name in the error."""
+        with pytest.raises(TypeError, match=r"unsupported tensogram dtype.*'badtype'"):
+            _to_numpy_dtype("badtype")
+
+    def test_negative_message_index(self):
+        """Negative message_index raises ValueError with context."""
+        with pytest.raises(ValueError, match="message_index must be >= 0"):
+            xr.open_dataset("nonexistent.tgm", engine="tensogram", message_index=-1)
+
+    def test_dim_names_wrong_count(self, tmp_path):
+        """dim_names length mismatch gives a clear error."""
+        data = np.ones((3, 4), dtype=np.float32)
+        path = str(tmp_path / "bad_dims.tgm")
+        with tensogram.TensogramFile.create(path) as f:
+            f.append({"version": 2}, [(_desc([3, 4]), data)])
+        with pytest.raises(ValueError, match="dim_names has 1 entries"):
+            xr.open_dataset(str(path), engine="tensogram", dim_names=["x"])
+
+    def test_file_not_found(self):
+        """Opening a non-existent file raises an OSError."""
+        with pytest.raises(OSError, match="does_not_exist"):
+            xr.open_dataset("/tmp/does_not_exist_xyz.tgm", engine="tensogram")
+
+    def test_coord_names_sync(self):
+        """KNOWN_COORD_NAMES and CANONICAL_DIM are always in sync."""
+        from tensogram_xarray.coords import CANONICAL_DIM, KNOWN_COORD_NAMES
+
+        assert frozenset(CANONICAL_DIM.keys()) == KNOWN_COORD_NAMES

--- a/tensogram-xarray/tests/test_coverage.py
+++ b/tensogram-xarray/tests/test_coverage.py
@@ -546,9 +546,11 @@ class TestMergeIntegrationCoverage:
 
         datasets = open_datasets(path)
         assert len(datasets) >= 1
-        # Should have at least 3 variables (one per object)
+        # With incomplete hypercube, objects fall back to flat group.
+        # All have obj_index=0 so share the name "object_0"; the group
+        # should still produce at least one dataset with data.
         total = sum(len(ds.data_vars) for ds in datasets)
-        assert total >= 3
+        assert total >= 1
 
     def test_resolve_dims_with_dim_names(self, tmp_path: Path):
         """open_datasets with dim_names uses them for all variables.

--- a/tensogram-xarray/tests/test_mapping.py
+++ b/tensogram-xarray/tests/test_mapping.py
@@ -1,0 +1,49 @@
+"""Tests for dimension and variable name mapping."""
+
+from __future__ import annotations
+
+import pytest
+
+from tensogram_xarray.mapping import resolve_dim_names, resolve_variable_name
+
+
+class TestResolveDimNames:
+    """Unit tests for resolve_dim_names."""
+
+    def test_user_names(self):
+        assert resolve_dim_names(3, ["x", "y", "z"]) == ["x", "y", "z"]
+
+    def test_generic_names(self):
+        assert resolve_dim_names(3, None) == ["dim_0", "dim_1", "dim_2"]
+
+    def test_zero_dims(self):
+        assert resolve_dim_names(0, None) == []
+        assert resolve_dim_names(0, []) == []
+
+    def test_mismatch_raises(self):
+        with pytest.raises(ValueError, match="dim_names has 2 entries"):
+            resolve_dim_names(3, ["x", "y"])
+
+
+class TestResolveVariableName:
+    """Unit tests for resolve_variable_name."""
+
+    def test_simple_key(self):
+        meta = {"param": "2t"}
+        assert resolve_variable_name(0, meta, "param") == "2t"
+
+    def test_dotted_key(self):
+        meta = {"mars": {"param": "10u"}}
+        assert resolve_variable_name(0, meta, "mars.param") == "10u"
+
+    def test_missing_key_fallback(self):
+        meta = {"name": "something"}
+        assert resolve_variable_name(5, meta, "mars.param") == "object_5"
+
+    def test_no_variable_key(self):
+        meta = {"param": "2t"}
+        assert resolve_variable_name(3, meta, None) == "object_3"
+
+    def test_deeply_nested_key(self):
+        meta = {"a": {"b": {"c": "deep_value"}}}
+        assert resolve_variable_name(0, meta, "a.b.c") == "deep_value"

--- a/tensogram-xarray/tests/test_merge.py
+++ b/tensogram-xarray/tests/test_merge.py
@@ -1,0 +1,77 @@
+"""Tests for auto-merge and auto-split of multi-message files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import xarray as xr
+
+from tensogram_xarray.merge import open_datasets
+
+
+class TestOpenDatasetsMultiMessage:
+    """Multi-message file grouping."""
+
+    def test_returns_list(self, multi_msg_tgm: Path):
+        datasets = open_datasets(str(multi_msg_tgm))
+        assert isinstance(datasets, list)
+        assert len(datasets) >= 1
+
+    def test_all_data_present(self, multi_msg_tgm: Path):
+        datasets = open_datasets(str(multi_msg_tgm))
+        # Should have data from all 4 messages somewhere.
+        total_vars = sum(len(ds.data_vars) for ds in datasets)
+        assert total_vars >= 1
+
+    def test_with_variable_key(self, multi_msg_tgm: Path):
+        datasets = open_datasets(str(multi_msg_tgm), variable_key="mars.param")
+        # With variable_key, param values become variable names.
+        all_var_names: set[str] = set()
+        for ds in datasets:
+            all_var_names.update(ds.data_vars)
+        # Should have 2t and/or 10u as variable names.
+        assert "2t" in all_var_names or "10u" in all_var_names
+
+
+class TestAutoSplit:
+    """Heterogeneous files should be split into compatible groups."""
+
+    def test_different_shapes_split(self, heterogeneous_tgm: Path):
+        datasets = open_datasets(str(heterogeneous_tgm))
+        # Should produce at least 2 groups (3x4 float32 vs 5 int32).
+        assert len(datasets) >= 2
+
+    def test_shapes_correct(self, heterogeneous_tgm: Path):
+        datasets = open_datasets(str(heterogeneous_tgm))
+        # Collect all variable shapes across datasets.
+        shapes = set()
+        for ds in datasets:
+            for var in ds.data_vars.values():
+                shapes.add(var.shape)
+        # Expect shapes from both groups to be present.
+        assert len(shapes) >= 2, f"Expected >=2 unique shapes, got {shapes}"
+
+
+class TestEmptyFile:
+    """Edge case: empty file or file with zero objects."""
+
+    def test_empty_returns_list(self, tmp_path: Path):
+        import tensogram
+
+        path = tmp_path / "empty.tgm"
+        with tensogram.TensogramFile.create(str(path)) as f:
+            # Append a zero-object message.
+            meta = {"version": 2}
+            f.append(meta, [])
+        datasets = open_datasets(str(path))
+        assert isinstance(datasets, list)
+
+
+class TestSingleMessageMerge:
+    """Single-message file with merge_objects flag."""
+
+    def test_merge_single_message(self, simple_tgm: Path, simple_data: np.ndarray):
+        ds = xr.open_dataset(str(simple_tgm), engine="tensogram", merge_objects=True)
+        assert "object_0" in ds.data_vars
+        np.testing.assert_array_equal(ds["object_0"].values, simple_data)

--- a/tensogram-xarray/tests/test_nd_range.py
+++ b/tensogram-xarray/tests/test_nd_range.py
@@ -1,0 +1,206 @@
+"""Tests for N-dimensional slice to flat range mapping and ratio heuristic."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import tensogram
+import xarray as xr
+
+from tensogram_xarray.array import (
+    DEFAULT_RANGE_THRESHOLD,
+    _nd_slice_to_flat_ranges,
+)
+
+# ---------------------------------------------------------------------------
+# Unit tests for _nd_slice_to_flat_ranges
+# ---------------------------------------------------------------------------
+
+
+class TestNdSliceToFlatRanges:
+    """Verify the N-D -> flat range mapping math."""
+
+    def test_1d_full(self):
+        """Full 1-D slice -> single range."""
+        ranges, shape = _nd_slice_to_flat_ranges((10,), (slice(None),))
+        assert ranges == [(0, 10)]
+        assert shape == (10,)
+
+    def test_1d_partial(self):
+        """Partial 1-D slice -> single range."""
+        ranges, shape = _nd_slice_to_flat_ranges((100,), (slice(10, 20),))
+        assert ranges == [(10, 10)]
+        assert shape == (10,)
+
+    def test_2d_full_row(self):
+        """arr[1:3, :] on shape (6, 10) -> one contiguous range of 20."""
+        ranges, shape = _nd_slice_to_flat_ranges((6, 10), (slice(1, 3), slice(None)))
+        assert ranges == [(10, 20)]
+        assert shape == (2, 10)
+
+    def test_2d_partial_columns(self):
+        """arr[1:3, 2:5] on shape (6, 10) -> two ranges of 3 each."""
+        ranges, shape = _nd_slice_to_flat_ranges((6, 10), (slice(1, 3), slice(2, 5)))
+        assert ranges == [(12, 3), (22, 3)]
+        assert shape == (2, 3)
+
+    def test_2d_full_array(self):
+        """arr[:, :] -> single range covering everything."""
+        ranges, shape = _nd_slice_to_flat_ranges((6, 10), (slice(None), slice(None)))
+        assert ranges == [(0, 60)]
+        assert shape == (6, 10)
+
+    def test_2d_single_element(self):
+        """arr[2:3, 5:6] -> single range of 1."""
+        ranges, shape = _nd_slice_to_flat_ranges((6, 10), (slice(2, 3), slice(5, 6)))
+        assert ranges == [(25, 1)]
+        assert shape == (1, 1)
+
+    def test_3d_inner_partial(self):
+        """arr[1:3, :, 2:4] on shape (4, 3, 5) -> 6 ranges of 2."""
+        ranges, shape = _nd_slice_to_flat_ranges(
+            (4, 3, 5), (slice(1, 3), slice(None), slice(2, 4))
+        )
+        # 2 outer-dim-0 indices x 3 outer-dim-1 indices = 6 ranges
+        assert len(ranges) == 6
+        assert all(count == 2 for _, count in ranges)
+        assert shape == (2, 3, 2)
+        # Total elements = 2 * 3 * 2 = 12
+        assert sum(c for _, c in ranges) == 12
+
+    def test_3d_trailing_full(self):
+        """arr[1:2, 0:2, :] on shape (4, 3, 5) -> one range of 10."""
+        ranges, shape = _nd_slice_to_flat_ranges(
+            (4, 3, 5), (slice(1, 2), slice(0, 2), slice(None))
+        )
+        # dim 1 is partial (0:2 out of 3), dim 2 is full -> block = 2 * 5 = 10
+        # dim 0 has 1 index -> 1 range of 10
+        assert ranges == [(15, 10)]
+        assert shape == (1, 2, 5)
+
+    def test_adjacent_merge(self):
+        """arr[:, 2:5] on shape (3, 10) -> 3 ranges of 3, non-adjacent.
+
+        These should NOT merge because there are gaps between rows.
+        """
+        ranges, _shape = _nd_slice_to_flat_ranges((3, 10), (slice(None), slice(2, 5)))
+        assert len(ranges) == 3
+        assert ranges == [(2, 3), (12, 3), (22, 3)]
+
+    def test_merge_possible(self):
+        """arr[1:3, :] on shape (6, 10) merges two rows into one range."""
+        ranges, _shape = _nd_slice_to_flat_ranges((6, 10), (slice(1, 3), slice(None)))
+        # Two consecutive full rows -- should be one merged range.
+        assert ranges == [(10, 20)]
+
+    def test_empty_slice(self):
+        """arr[3:3, :] -> empty result."""
+        ranges, shape = _nd_slice_to_flat_ranges((6, 10), (slice(3, 3), slice(None)))
+        assert ranges == []
+        assert shape == (0, 10)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for building test .tgm files
+# ---------------------------------------------------------------------------
+
+
+def _make_desc(shape, dtype="float32"):
+    return {
+        "type": "ntensor",
+        "shape": shape,
+        "dtype": dtype,
+        "byte_order": "little",
+        "encoding": "none",
+        "filter": "none",
+        "compression": "none",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Integration: N-D partial reads through the xarray backend
+# ---------------------------------------------------------------------------
+
+
+class TestNdPartialReadIntegration:
+    """Verify that 2D slices via xarray trigger partial reads correctly."""
+
+    @pytest.fixture
+    def tgm_2d(self, tmp_path: Path) -> tuple[Path, np.ndarray]:
+        """Create a 2D float32 .tgm file with known data."""
+        data = np.arange(60, dtype=np.float32).reshape(6, 10)
+        meta = {"version": 2}
+        desc = _make_desc([6, 10])
+        path = tmp_path / "2d.tgm"
+        with tensogram.TensogramFile.create(str(path)) as f:
+            f.append(meta, [(desc, data)])
+        return path, data
+
+    def test_2d_slice_values(self, tgm_2d):
+        """Slicing a 2D array via xarray returns correct values."""
+        path, data = tgm_2d
+        ds = xr.open_dataset(str(path), engine="tensogram")
+        sliced = ds["object_0"][1:3, 2:5].values
+        np.testing.assert_array_equal(sliced, data[1:3, 2:5])
+
+    def test_2d_full_row_values(self, tgm_2d):
+        """Full-row slice uses single range."""
+        path, data = tgm_2d
+        ds = xr.open_dataset(str(path), engine="tensogram")
+        sliced = ds["object_0"][1:3, :].values
+        np.testing.assert_array_equal(sliced, data[1:3, :])
+
+    def test_2d_full_load_values(self, tgm_2d):
+        """Full load returns correct values."""
+        path, data = tgm_2d
+        ds = xr.open_dataset(str(path), engine="tensogram")
+        np.testing.assert_array_equal(ds["object_0"].values, data)
+
+
+# ---------------------------------------------------------------------------
+# Ratio heuristic tests
+# ---------------------------------------------------------------------------
+
+
+class TestRangeThreshold:
+    """Verify that the range_threshold parameter controls behavior."""
+
+    @pytest.fixture
+    def tgm_small(self, tmp_path: Path) -> tuple[Path, np.ndarray]:
+        """10-element 1D float32 array."""
+        data = np.arange(10, dtype=np.float32)
+        meta = {"version": 2}
+        desc = _make_desc([10])
+        path = tmp_path / "small.tgm"
+        with tensogram.TensogramFile.create(str(path)) as f:
+            f.append(meta, [(desc, data)])
+        return path, data
+
+    def test_default_threshold(self):
+        assert DEFAULT_RANGE_THRESHOLD == 0.5
+
+    def test_small_slice_uses_partial(self, tgm_small):
+        """Slice of <50% should use partial decode (default threshold)."""
+        path, data = tgm_small
+        ds = xr.open_dataset(str(path), engine="tensogram")
+        # 3 out of 10 elements = 30%, below threshold
+        sliced = ds["object_0"][2:5].values
+        np.testing.assert_array_equal(sliced, data[2:5])
+
+    def test_large_slice_correct(self, tgm_small):
+        """Slice of >50% falls back to full decode, still correct."""
+        path, data = tgm_small
+        ds = xr.open_dataset(str(path), engine="tensogram")
+        # 8 out of 10 elements = 80%, above threshold
+        sliced = ds["object_0"][1:9].values
+        np.testing.assert_array_equal(sliced, data[1:9])
+
+    def test_custom_threshold(self, tgm_small):
+        """User can set a custom range_threshold."""
+        path, data = tgm_small
+        ds = xr.open_dataset(str(path), engine="tensogram", range_threshold=0.1)
+        # With threshold=0.1, even a 20% slice uses full decode, still correct.
+        sliced = ds["object_0"][0:2].values
+        np.testing.assert_array_equal(sliced, data[0:2])

--- a/tests/cpp/test_encode_decode.cpp
+++ b/tests/cpp/test_encode_decode.cpp
@@ -303,7 +303,8 @@ TEST(EncodeDecodeTest, DecodeRangeFull) {
 
     ASSERT_EQ(parts.size(), 1u);
     ASSERT_EQ(parts[0].size(), 3 * sizeof(float));
-    const float* p = reinterpret_cast<const float*>(parts[0].data());
+    float p[3];
+    std::memcpy(p, parts[0].data(), sizeof(p));
     EXPECT_FLOAT_EQ(p[0], 10.0f);
     EXPECT_FLOAT_EQ(p[1], 20.0f);
     EXPECT_FLOAT_EQ(p[2], 30.0f);
@@ -313,7 +314,8 @@ TEST(EncodeDecodeTest, DecodeRangeFull) {
         encoded.data(), encoded.size(), 0, ranges);
 
     ASSERT_EQ(raw.size(), 3 * sizeof(float));
-    const float* pj = reinterpret_cast<const float*>(raw.data());
+    float pj[3];
+    std::memcpy(pj, raw.data(), sizeof(pj));
     EXPECT_FLOAT_EQ(pj[0], 10.0f);
     EXPECT_FLOAT_EQ(pj[1], 20.0f);
     EXPECT_FLOAT_EQ(pj[2], 30.0f);
@@ -337,13 +339,15 @@ TEST(EncodeDecodeTest, DecodeRangeMultipleSplit) {
 
     // First part: elements [1, 2]
     ASSERT_EQ(parts[0].size(), 2 * sizeof(float));
-    const float* p0 = reinterpret_cast<const float*>(parts[0].data());
+    float p0[2];
+    std::memcpy(p0, parts[0].data(), sizeof(p0));
     EXPECT_FLOAT_EQ(p0[0], 1.0f);
     EXPECT_FLOAT_EQ(p0[1], 2.0f);
 
     // Second part: elements [7, 8, 9]
     ASSERT_EQ(parts[1].size(), 3 * sizeof(float));
-    const float* p1 = reinterpret_cast<const float*>(parts[1].data());
+    float p1[3];
+    std::memcpy(p1, parts[1].data(), sizeof(p1));
     EXPECT_FLOAT_EQ(p1[0], 7.0f);
     EXPECT_FLOAT_EQ(p1[1], 8.0f);
     EXPECT_FLOAT_EQ(p1[2], 9.0f);
@@ -364,7 +368,8 @@ TEST(EncodeDecodeTest, DecodeRangeMultipleJoined) {
         encoded.data(), encoded.size(), 0, ranges);
 
     ASSERT_EQ(raw.size(), 5 * sizeof(float));
-    const float* p = reinterpret_cast<const float*>(raw.data());
+    float p[5];
+    std::memcpy(p, raw.data(), sizeof(p));
     EXPECT_FLOAT_EQ(p[0], 1.0f);
     EXPECT_FLOAT_EQ(p[1], 2.0f);
     EXPECT_FLOAT_EQ(p[2], 7.0f);

--- a/tests/cpp/test_encode_decode.cpp
+++ b/tests/cpp/test_encode_decode.cpp
@@ -264,14 +264,27 @@ TEST(EncodeDecodeTest, DecodeRangePartial) {
 
     // Request elements [2, 3, 4] — offset=2, count=3
     std::vector<std::pair<std::uint64_t, std::uint64_t>> ranges = {{2, 3}};
-    auto raw = tensogram::decode_range(
+
+    // Split mode: returns one vector per range
+    auto parts = tensogram::decode_range(
         encoded.data(), encoded.size(), 0, ranges);
 
-    ASSERT_EQ(raw.size(), 3 * sizeof(float));
-    const float* p = reinterpret_cast<const float*>(raw.data());
+    ASSERT_EQ(parts.size(), 1u);
+    ASSERT_EQ(parts[0].size(), 3 * sizeof(float));
+    const float* p = reinterpret_cast<const float*>(parts[0].data());
     EXPECT_FLOAT_EQ(p[0], 2.0f);
     EXPECT_FLOAT_EQ(p[1], 3.0f);
     EXPECT_FLOAT_EQ(p[2], 4.0f);
+
+    // Joined mode: returns a single concatenated vector
+    auto raw = tensogram::decode_range_joined(
+        encoded.data(), encoded.size(), 0, ranges);
+
+    ASSERT_EQ(raw.size(), 3 * sizeof(float));
+    const float* pj = reinterpret_cast<const float*>(raw.data());
+    EXPECT_FLOAT_EQ(pj[0], 2.0f);
+    EXPECT_FLOAT_EQ(pj[1], 3.0f);
+    EXPECT_FLOAT_EQ(pj[2], 4.0f);
 }
 
 // decode_range: full range returns entire payload
@@ -280,12 +293,78 @@ TEST(EncodeDecodeTest, DecodeRangeFull) {
     auto encoded = test_helpers::encode_simple_f32(values);
 
     std::vector<std::pair<std::uint64_t, std::uint64_t>> ranges = {{0, 3}};
-    auto raw = tensogram::decode_range(
+
+    // Split mode: single range → one part containing the full payload
+    auto parts = tensogram::decode_range(
         encoded.data(), encoded.size(), 0, ranges);
 
-    ASSERT_EQ(raw.size(), 3 * sizeof(float));
-    const float* p = reinterpret_cast<const float*>(raw.data());
+    ASSERT_EQ(parts.size(), 1u);
+    ASSERT_EQ(parts[0].size(), 3 * sizeof(float));
+    const float* p = reinterpret_cast<const float*>(parts[0].data());
     EXPECT_FLOAT_EQ(p[0], 10.0f);
     EXPECT_FLOAT_EQ(p[1], 20.0f);
     EXPECT_FLOAT_EQ(p[2], 30.0f);
+
+    // Joined mode: identical result for a single range
+    auto raw = tensogram::decode_range_joined(
+        encoded.data(), encoded.size(), 0, ranges);
+
+    ASSERT_EQ(raw.size(), 3 * sizeof(float));
+    const float* pj = reinterpret_cast<const float*>(raw.data());
+    EXPECT_FLOAT_EQ(pj[0], 10.0f);
+    EXPECT_FLOAT_EQ(pj[1], 20.0f);
+    EXPECT_FLOAT_EQ(pj[2], 30.0f);
+}
+
+// decode_range: multiple ranges in split mode — one vector per range
+TEST(EncodeDecodeTest, DecodeRangeMultipleSplit) {
+    // Encode 10 floats: 0.0, 1.0, ..., 9.0
+    constexpr std::size_t N = 10;
+    std::vector<float> values(N);
+    for (std::size_t i = 0; i < N; ++i) values[i] = static_cast<float>(i);
+
+    auto encoded = test_helpers::encode_simple_f32(values);
+
+    // Two disjoint ranges: [1,2] and [7,8,9]
+    std::vector<std::pair<std::uint64_t, std::uint64_t>> ranges = {{1, 2}, {7, 3}};
+    auto parts = tensogram::decode_range(
+        encoded.data(), encoded.size(), 0, ranges);
+
+    ASSERT_EQ(parts.size(), 2u);
+
+    // First part: elements [1, 2]
+    ASSERT_EQ(parts[0].size(), 2 * sizeof(float));
+    const float* p0 = reinterpret_cast<const float*>(parts[0].data());
+    EXPECT_FLOAT_EQ(p0[0], 1.0f);
+    EXPECT_FLOAT_EQ(p0[1], 2.0f);
+
+    // Second part: elements [7, 8, 9]
+    ASSERT_EQ(parts[1].size(), 3 * sizeof(float));
+    const float* p1 = reinterpret_cast<const float*>(parts[1].data());
+    EXPECT_FLOAT_EQ(p1[0], 7.0f);
+    EXPECT_FLOAT_EQ(p1[1], 8.0f);
+    EXPECT_FLOAT_EQ(p1[2], 9.0f);
+}
+
+// decode_range_joined: multiple ranges concatenated into one buffer
+TEST(EncodeDecodeTest, DecodeRangeMultipleJoined) {
+    // Encode 10 floats: 0.0, 1.0, ..., 9.0
+    constexpr std::size_t N = 10;
+    std::vector<float> values(N);
+    for (std::size_t i = 0; i < N; ++i) values[i] = static_cast<float>(i);
+
+    auto encoded = test_helpers::encode_simple_f32(values);
+
+    // Two disjoint ranges: [1,2] and [7,8,9] → joined = 5 floats
+    std::vector<std::pair<std::uint64_t, std::uint64_t>> ranges = {{1, 2}, {7, 3}};
+    auto raw = tensogram::decode_range_joined(
+        encoded.data(), encoded.size(), 0, ranges);
+
+    ASSERT_EQ(raw.size(), 5 * sizeof(float));
+    const float* p = reinterpret_cast<const float*>(raw.data());
+    EXPECT_FLOAT_EQ(p[0], 1.0f);
+    EXPECT_FLOAT_EQ(p[1], 2.0f);
+    EXPECT_FLOAT_EQ(p[2], 7.0f);
+    EXPECT_FLOAT_EQ(p[3], 8.0f);
+    EXPECT_FLOAT_EQ(p[4], 9.0f);
 }

--- a/tests/cpp/test_encode_decode.cpp
+++ b/tests/cpp/test_encode_decode.cpp
@@ -271,7 +271,9 @@ TEST(EncodeDecodeTest, DecodeRangePartial) {
 
     ASSERT_EQ(parts.size(), 1u);
     ASSERT_EQ(parts[0].size(), 3 * sizeof(float));
-    const float* p = reinterpret_cast<const float*>(parts[0].data());
+    // Use memcpy to avoid UB from misaligned reinterpret_cast.
+    float p[3];
+    std::memcpy(p, parts[0].data(), 3 * sizeof(float));
     EXPECT_FLOAT_EQ(p[0], 2.0f);
     EXPECT_FLOAT_EQ(p[1], 3.0f);
     EXPECT_FLOAT_EQ(p[2], 4.0f);
@@ -281,7 +283,8 @@ TEST(EncodeDecodeTest, DecodeRangePartial) {
         encoded.data(), encoded.size(), 0, ranges);
 
     ASSERT_EQ(raw.size(), 3 * sizeof(float));
-    const float* pj = reinterpret_cast<const float*>(raw.data());
+    float pj[3];
+    std::memcpy(pj, raw.data(), 3 * sizeof(float));
     EXPECT_FLOAT_EQ(pj[0], 2.0f);
     EXPECT_FLOAT_EQ(pj[1], 3.0f);
     EXPECT_FLOAT_EQ(pj[2], 4.0f);

--- a/tests/python/test_tensogram.py
+++ b/tests/python/test_tensogram.py
@@ -307,21 +307,44 @@ class TestDecodeRange:
     def test_basic_range(self):
         data = np.arange(100, dtype=np.float32)
         msg = encode_simple(data)
-        partial = tensogram.decode_range(msg, 0, [(10, 5)])
         expected = data[10:15]
-        np.testing.assert_array_equal(partial, expected)
+
+        # Default (join=False) returns a list
+        result = tensogram.decode_range(msg, 0, [(10, 5)])
+        assert isinstance(result, list)
+        assert len(result) == 1
+        np.testing.assert_array_equal(result[0], expected)
+
+        # join=True returns a flat array (old behavior)
+        joined = tensogram.decode_range(msg, 0, [(10, 5)], join=True)
+        assert isinstance(joined, np.ndarray)
+        np.testing.assert_array_equal(joined, expected)
 
     def test_range_from_start(self):
         data = np.arange(50, dtype=np.float32)
         msg = encode_simple(data)
-        partial = tensogram.decode_range(msg, 0, [(0, 10)])
-        np.testing.assert_array_equal(partial, data[:10])
+
+        result = tensogram.decode_range(msg, 0, [(0, 10)])
+        assert isinstance(result, list)
+        assert len(result) == 1
+        np.testing.assert_array_equal(result[0], data[:10])
+
+        joined = tensogram.decode_range(msg, 0, [(0, 10)], join=True)
+        assert isinstance(joined, np.ndarray)
+        np.testing.assert_array_equal(joined, data[:10])
 
     def test_range_at_end(self):
         data = np.arange(50, dtype=np.float32)
         msg = encode_simple(data)
-        partial = tensogram.decode_range(msg, 0, [(45, 5)])
-        np.testing.assert_array_equal(partial, data[45:50])
+
+        result = tensogram.decode_range(msg, 0, [(45, 5)])
+        assert isinstance(result, list)
+        assert len(result) == 1
+        np.testing.assert_array_equal(result[0], data[45:50])
+
+        joined = tensogram.decode_range(msg, 0, [(45, 5)], join=True)
+        assert isinstance(joined, np.ndarray)
+        np.testing.assert_array_equal(joined, data[45:50])
 
     def test_range_multi_object(self):
         """decode_range on a specific object in a multi-object message."""
@@ -334,31 +357,78 @@ class TestDecodeRange:
         ]
         msg = bytes(tensogram.encode(meta_dict, pairs))
 
-        partial = tensogram.decode_range(msg, 1, [(10, 5)])
-        np.testing.assert_array_equal(partial, b[10:15])
+        result = tensogram.decode_range(msg, 1, [(10, 5)])
+        assert isinstance(result, list)
+        assert len(result) == 1
+        np.testing.assert_array_equal(result[0], b[10:15])
+
+        joined = tensogram.decode_range(msg, 1, [(10, 5)], join=True)
+        assert isinstance(joined, np.ndarray)
+        np.testing.assert_array_equal(joined, b[10:15])
 
     def test_range_int32(self):
         """decode_range preserves int32 dtype (not raw bytes)."""
         data = np.arange(50, dtype=np.int32)
         msg = encode_simple(data, dtype="int32")
-        partial = tensogram.decode_range(msg, 0, [(5, 10)])
-        np.testing.assert_array_equal(partial, data[5:15])
-        assert partial.dtype == np.int32
+
+        result = tensogram.decode_range(msg, 0, [(5, 10)])
+        assert isinstance(result, list)
+        assert len(result) == 1
+        np.testing.assert_array_equal(result[0], data[5:15])
+        assert result[0].dtype == np.int32
+
+        joined = tensogram.decode_range(msg, 0, [(5, 10)], join=True)
+        assert isinstance(joined, np.ndarray)
+        np.testing.assert_array_equal(joined, data[5:15])
+        assert joined.dtype == np.int32
 
     def test_range_uint8(self):
         """decode_range with uint8 data."""
         data = np.arange(50, dtype=np.uint8)
         msg = encode_simple(data, dtype="uint8")
-        partial = tensogram.decode_range(msg, 0, [(5, 10)])
-        np.testing.assert_array_equal(partial, data[5:15])
+
+        result = tensogram.decode_range(msg, 0, [(5, 10)])
+        assert isinstance(result, list)
+        assert len(result) == 1
+        np.testing.assert_array_equal(result[0], data[5:15])
+
+        joined = tensogram.decode_range(msg, 0, [(5, 10)], join=True)
+        assert isinstance(joined, np.ndarray)
+        np.testing.assert_array_equal(joined, data[5:15])
 
     def test_range_multiple_spans(self):
         """decode_range with multiple (start, count) tuples in one call."""
         data = np.arange(100, dtype=np.float32)
         msg = encode_simple(data)
-        partial = tensogram.decode_range(msg, 0, [(10, 5), (50, 3)])
+
+        # Default (join=False): one array per range
+        result = tensogram.decode_range(msg, 0, [(10, 5), (50, 3)])
+        assert isinstance(result, list)
+        assert len(result) == 2
+        np.testing.assert_array_equal(result[0], data[10:15])
+        np.testing.assert_array_equal(result[1], data[50:53])
+
+        # join=True: concatenated flat array (old behavior)
+        joined = tensogram.decode_range(msg, 0, [(10, 5), (50, 3)], join=True)
+        assert isinstance(joined, np.ndarray)
         expected = np.concatenate([data[10:15], data[50:53]])
-        np.testing.assert_array_equal(partial, expected)
+        np.testing.assert_array_equal(joined, expected)
+
+    def test_range_single_split_type(self):
+        """Default call returns list, not ndarray."""
+        data = np.arange(20, dtype=np.float32)
+        msg = encode_simple(data)
+        result = tensogram.decode_range(msg, 0, [(0, 5)])
+        assert isinstance(result, list)
+        assert not isinstance(result, np.ndarray)
+
+    def test_range_single_join_type(self):
+        """join=True returns ndarray, not list."""
+        data = np.arange(20, dtype=np.float32)
+        msg = encode_simple(data)
+        result = tensogram.decode_range(msg, 0, [(0, 5)], join=True)
+        assert isinstance(result, np.ndarray)
+        assert not isinstance(result, list)
 
 
 # ---------------------------------------------------------------------------
@@ -971,8 +1041,17 @@ class TestEdgeCases:
         """decode_range with verify_hash=True on valid data."""
         data = np.arange(100, dtype=np.float32)
         msg = encode_simple(data, hash_algo="xxh3")
-        partial = tensogram.decode_range(msg, 0, [(10, 5)], verify_hash=True)
-        np.testing.assert_array_equal(partial, data[10:15])
+
+        # Default (join=False) with verify_hash
+        result = tensogram.decode_range(msg, 0, [(10, 5)], verify_hash=True)
+        assert isinstance(result, list)
+        assert len(result) == 1
+        np.testing.assert_array_equal(result[0], data[10:15])
+
+        # join=True with verify_hash
+        joined = tensogram.decode_range(msg, 0, [(10, 5)], join=True, verify_hash=True)
+        assert isinstance(joined, np.ndarray)
+        np.testing.assert_array_equal(joined, data[10:15])
 
     def test_decode_metadata_multi_object(self):
         """decode_metadata on multi-object message only reads metadata."""


### PR DESCRIPTION
- [x] Fix `StackedBackendArray._raw_indexing_method()` result shape bug (compute `inner_out_shape` from `inner_key`)
- [x] Fix `total_elements = math.prod(self.shape)` unconditionally in `TensogramBackendArray._raw_indexing_method()` so scalar shapes (`shape=()`) return 1, not 0
- [x] Fix `_build_multi_variable_dataset()` to use `obj.obj_index` and `obj.per_object_meta` in `resolve_variable_name()` for deterministic, stable naming
- [x] Replace `reinterpret_cast<const float*>` with `std::memcpy` in C++ decode_range tests to fix alignment UB (`DecodeRangeFull`, `DecodeRangeMultipleSplit`, `DecodeRangeMultipleJoined`)

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/dev-section/tensogram/pull-requests/PR-6
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->