### PR TITLE
fix: blosc2 decode failure in decode-only processes and enable zstd/z…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = "1"
 libaec-sys = "0.1"
 zstd = "0.13"
 lz4_flex = "0.11"
-blosc2 = { version = "0.2", default-features = false }
+blosc2 = { version = "0.2", default-features = false, features = ["zstd", "zlib"] }
 zfp-sys-cc = "0.2"
 sz3 = "0.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ libaec-sys = "0.1"
 zstd = "0.13"
 lz4_flex = "0.11"
 blosc2 = { version = "0.2", default-features = false, features = ["zstd", "zlib"] }
+blosc2-sys = { package = "blosc2-rs-sys", version = "0.1" }
 zfp-sys-cc = "0.2"
 sz3 = "0.4"
 

--- a/crates/tensogram-encodings/Cargo.toml
+++ b/crates/tensogram-encodings/Cargo.toml
@@ -8,7 +8,7 @@ default = ["szip", "zstd", "lz4", "blosc2", "zfp", "sz3"]
 szip = ["dep:libaec-sys"]
 zstd = ["dep:zstd"]
 lz4 = ["dep:lz4_flex"]
-blosc2 = ["dep:blosc2"]
+blosc2 = ["dep:blosc2", "dep:blosc2-sys"]
 zfp = ["dep:zfp-sys-cc"]
 sz3 = ["dep:sz3"]
 
@@ -19,5 +19,6 @@ libaec-sys = { workspace = true, optional = true }
 zstd = { workspace = true, optional = true }
 lz4_flex = { workspace = true, optional = true }
 blosc2 = { workspace = true, optional = true }
+blosc2-sys = { package = "blosc2-rs-sys", version = "0.1", optional = true }
 zfp-sys-cc = { workspace = true, optional = true }
 sz3 = { workspace = true, optional = true }

--- a/crates/tensogram-encodings/Cargo.toml
+++ b/crates/tensogram-encodings/Cargo.toml
@@ -19,6 +19,6 @@ libaec-sys = { workspace = true, optional = true }
 zstd = { workspace = true, optional = true }
 lz4_flex = { workspace = true, optional = true }
 blosc2 = { workspace = true, optional = true }
-blosc2-sys = { package = "blosc2-rs-sys", version = "0.1", optional = true }
+blosc2-sys = { workspace = true, optional = true }
 zfp-sys-cc = { workspace = true, optional = true }
 sz3 = { workspace = true, optional = true }

--- a/crates/tensogram-encodings/src/compression/blosc2.rs
+++ b/crates/tensogram-encodings/src/compression/blosc2.rs
@@ -153,4 +153,55 @@ mod tests {
         assert_eq!(partial.len(), 500);
         assert_eq!(&partial[..], &data[200..700]);
     }
+
+    #[test]
+    fn blosc2_round_trip_zstd() {
+        let data: Vec<u8> = (0..4096).map(|i| (i % 256) as u8).collect();
+        let compressor = Blosc2Compressor {
+            codec: Blosc2Codec::Zstd,
+            clevel: 3,
+            typesize: 1,
+        };
+        let result = compressor.compress(&data).unwrap();
+        let decompressed = compressor.decompress(&result.data, data.len()).unwrap();
+        assert_eq!(decompressed, data);
+    }
+
+    #[test]
+    fn blosc2_round_trip_zlib() {
+        let data: Vec<u8> = (0..4096).map(|i| (i % 256) as u8).collect();
+        let compressor = Blosc2Compressor {
+            codec: Blosc2Codec::Zlib,
+            clevel: 5,
+            typesize: 1,
+        };
+        let result = compressor.compress(&data).unwrap();
+        let decompressed = compressor.decompress(&result.data, data.len()).unwrap();
+        assert_eq!(decompressed, data);
+    }
+
+    /// Regression guard for the decompress path.
+    ///
+    /// The real bug (missing blosc2_init in decode-only processes) cannot be
+    /// fully reproduced in a unit test because blosc2_init is global state —
+    /// once called by compress(), it stays initialized. This test still guards
+    /// against regressions in the decompress wiring itself.
+    #[test]
+    fn blosc2_decompress_path() {
+        let data: Vec<u8> = (0..4096).map(|i| (i % 256) as u8).collect();
+        let compressor = Blosc2Compressor {
+            codec: Blosc2Codec::Lz4,
+            clevel: 5,
+            typesize: 1,
+        };
+        let compressed = compressor.compress(&data).unwrap().data;
+
+        let decoder = Blosc2Compressor {
+            codec: Blosc2Codec::Lz4,
+            clevel: 0,
+            typesize: 1,
+        };
+        let decompressed = decoder.decompress(&compressed, data.len()).unwrap();
+        assert_eq!(decompressed, data);
+    }
 }

--- a/crates/tensogram-encodings/src/compression/blosc2.rs
+++ b/crates/tensogram-encodings/src/compression/blosc2.rs
@@ -1,8 +1,23 @@
+use std::sync::Once;
+
 use blosc2::chunk::SChunk;
 use blosc2::{CParams, CompressAlgo, DParams};
 
 use super::{CompressResult, CompressionError, Compressor};
 use crate::pipeline::Blosc2Codec;
+
+/// Ensure the blosc2 C library is initialized.
+///
+/// Workaround: the `blosc2` crate (v0.2.2) calls `blosc2_init()` inside
+/// `SChunk::new()` but not `SChunk::from_buffer()`. Decode-only processes
+/// that never compress will hit an uninitialized library and fail.
+fn ensure_blosc2_init() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        // SAFETY: blosc2_init() has no preconditions and is safe to call multiple times.
+        unsafe { blosc2_sys::blosc2_init() };
+    });
+}
 
 fn map_err(e: blosc2::Error) -> CompressionError {
     CompressionError::Blosc2(format!("{e:?}"))
@@ -13,10 +28,8 @@ fn codec_to_algo(codec: &Blosc2Codec) -> CompressAlgo {
         Blosc2Codec::Blosclz => CompressAlgo::Blosclz,
         Blosc2Codec::Lz4 => CompressAlgo::Lz4,
         Blosc2Codec::Lz4hc => CompressAlgo::Lz4hc,
-        // Zlib and Zstd require cargo features on the blosc2 crate.
-        // Fall back to blosclz if the feature is not enabled.
-        Blosc2Codec::Zlib => CompressAlgo::Blosclz,
-        Blosc2Codec::Zstd => CompressAlgo::Blosclz,
+        Blosc2Codec::Zlib => CompressAlgo::Zlib,
+        Blosc2Codec::Zstd => CompressAlgo::Zstd,
     }
 }
 
@@ -28,9 +41,11 @@ pub struct Blosc2Compressor {
 
 impl Compressor for Blosc2Compressor {
     fn compress(&self, data: &[u8]) -> Result<CompressResult, CompressionError> {
+        ensure_blosc2_init();
+        let algo = codec_to_algo(&self.codec);
         let mut cparams = CParams::default();
         cparams
-            .compressor(codec_to_algo(&self.codec))
+            .compressor(algo)
             .clevel(self.clevel as u32)
             .typesize(self.typesize)
             .map_err(map_err)?;
@@ -46,6 +61,7 @@ impl Compressor for Blosc2Compressor {
     }
 
     fn decompress(&self, data: &[u8], _expected_size: usize) -> Result<Vec<u8>, CompressionError> {
+        ensure_blosc2_init();
         let schunk = SChunk::from_buffer(data.into()).map_err(map_err)?;
         let num_items = schunk.items_num();
         if num_items == 0 {
@@ -61,6 +77,7 @@ impl Compressor for Blosc2Compressor {
         byte_pos: usize,
         byte_size: usize,
     ) -> Result<Vec<u8>, CompressionError> {
+        ensure_blosc2_init();
         let schunk = SChunk::from_buffer(data.into()).map_err(map_err)?;
         let ts = schunk.typesize();
         if ts == 0 {


### PR DESCRIPTION
## Summary                                                                                                                                                                               
                                                                                                                                                                                           
  Fix blosc2 decompression failure when decoding in a separate process from the one that encoded (e.g. CLI, Python bindings).                                                              
                                                                                                                                                                                           
  **Root cause:** The upstream `blosc2` Rust crate (v0.2.2) calls `blosc2_init()` inside `SChunk::new()` (compress path) but not inside `SChunk::from_buffer()` (decompress path). When    
  compressing, blosc2 automatically initializes itself as a side effect, so encoding and decoding in the same process always works. But when we try to decompress in a separate process,   
  the compression step never ran, so blosc2 was never initialized, and every read fails with a generic "Failure" error.
                                                                                                                                                                                           
  **Secondary fix:** The workspace declared `blosc2` with `default-features = false` without enabling the `zstd`/`zlib` features. This compiled the blosc2 C library with  `DEACTIVATE_ZSTD=ON` and `DEACTIVATE_ZLIB=ON`, and `codec_to_algo()` silently fell back to blosclz for any zstd/zlib request.                                                            
                                                                                                                                                                                         
  ## Changes                                                                                                                                                                               
                                          
  - **`Cargo.toml`** — Enable `zstd` and `zlib` features on the `blosc2` workspace dependency                                                                                              
  - **`crates/tensogram-encodings/Cargo.toml`** — Add `blosc2-rs-sys` as a direct dependency (for calling `blosc2_init()`)                                                                 
  - **`crates/tensogram-encodings/src/compression/blosc2.rs`**:
    - Add `ensure_blosc2_init()` — calls `blosc2_sys::blosc2_init()` via `Once` before any compress or decompress                                                                          
    - Fix `codec_to_algo()` — map `Zstd`/`Zlib` to the real `CompressAlgo` variants instead of silently falling back to `Blosclz`


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/dev-section/tensogram/pull-requests/PR-7
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->