### PR TITLE
feat: add benchmarks crate with codec matrix and GRIB comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .claude/
+.weave/
 .sisyphus/
 .coverage
 *.dylib.dSYM/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/tensogram-cli",
     "crates/tensogram-ffi",
     "examples/rust",
+    "benchmarks",
 ]
 # tensogram-python is built via `maturin develop` (PyO3 extension modules
 # require the Python linker). It is excluded from default workspace builds.

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -20,11 +20,10 @@ path = "src/lib.rs"
 
 [features]
 default = []
-eccodes = ["dep:eccodes", "dep:eccodes-sys", "dep:tempfile"]
+eccodes = ["dep:eccodes", "dep:eccodes-sys"]
 
 [dependencies]
 tensogram-encodings = { path = "../crates/tensogram-encodings" }
 clap = { workspace = true }
 eccodes = { version = "0.14", default-features = false, optional = true }
 eccodes-sys = { version = "0.7", optional = true }
-tempfile = { version = "3", optional = true }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "tensogram-benchmarks"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "Performance benchmarks for the Tensogram encoding pipeline"
+
+[[bin]]
+name = "codec-matrix"
+path = "src/bin/codec_matrix.rs"
+
+[[bin]]
+name = "grib-comparison"
+path = "src/bin/grib_comparison.rs"
+required-features = ["eccodes"]
+
+[lib]
+name = "tensogram_benchmarks"
+path = "src/lib.rs"
+
+[features]
+default = []
+eccodes = ["dep:eccodes", "dep:eccodes-sys", "dep:tempfile"]
+
+[dependencies]
+tensogram-encodings = { path = "../crates/tensogram-encodings" }
+clap = { workspace = true }
+eccodes = { version = "0.14", default-features = false, optional = true }
+eccodes-sys = { version = "0.7", optional = true }
+tempfile = { version = "3", optional = true }

--- a/benchmarks/build.rs
+++ b/benchmarks/build.rs
@@ -54,8 +54,6 @@ fn try_pkg_config() -> bool {
                     println!("cargo:rustc-link-lib=dylib={lib}");
                 }
             }
-            // Also get just the library names if not covered above.
-            println!("cargo:rustc-link-lib=dylib=eccodes");
             true
         }
         _ => false,

--- a/benchmarks/build.rs
+++ b/benchmarks/build.rs
@@ -1,0 +1,63 @@
+// build.rs — benchmarks crate
+//
+// When the `eccodes` feature is active, tell the linker to link against
+// libeccodes (the ecCodes C library). The location is discovered via
+// pkg-config, falling back to well-known Homebrew paths.
+//
+// This is necessary because our grib_comparison module calls eccodes C
+// functions via `extern "C"` declarations, which require an explicit link.
+
+fn main() {
+    #[cfg(feature = "eccodes")]
+    link_eccodes();
+}
+
+#[cfg(feature = "eccodes")]
+fn link_eccodes() {
+    // Try pkg-config first — the recommended way when available.
+    if try_pkg_config() {
+        return;
+    }
+
+    // Fallback: known Homebrew install paths on macOS.
+    let homebrew_paths = [
+        "/opt/homebrew/lib", // Apple Silicon
+        "/usr/local/lib",    // Intel Mac
+    ];
+    for path in &homebrew_paths {
+        let lib = std::path::Path::new(path).join("libeccodes.dylib");
+        if lib.exists() {
+            println!("cargo:rustc-link-search=native={path}");
+            println!("cargo:rustc-link-lib=dylib=eccodes");
+            return;
+        }
+    }
+
+    // System-wide (Linux with apt-installed libeccodes-dev).
+    println!("cargo:rustc-link-lib=dylib=eccodes");
+}
+
+#[cfg(feature = "eccodes")]
+fn try_pkg_config() -> bool {
+    let output = std::process::Command::new("pkg-config")
+        .args(["--libs", "--libs-only-L", "eccodes"])
+        .output();
+
+    match output {
+        Ok(out) if out.status.success() => {
+            let flags = String::from_utf8_lossy(&out.stdout);
+            // Parse -L paths and -l libs from pkg-config output.
+            for flag in flags.split_whitespace() {
+                if let Some(path) = flag.strip_prefix("-L") {
+                    println!("cargo:rustc-link-search=native={path}");
+                } else if let Some(lib) = flag.strip_prefix("-l") {
+                    println!("cargo:rustc-link-lib=dylib={lib}");
+                }
+            }
+            // Also get just the library names if not covered above.
+            println!("cargo:rustc-link-lib=dylib=eccodes");
+            true
+        }
+        _ => false,
+    }
+}

--- a/benchmarks/build.rs
+++ b/benchmarks/build.rs
@@ -40,19 +40,28 @@ fn link_eccodes() {
 #[cfg(feature = "eccodes")]
 fn try_pkg_config() -> bool {
     let output = std::process::Command::new("pkg-config")
-        .args(["--libs", "--libs-only-L", "eccodes"])
+        .args(["--libs", "eccodes"])
         .output();
 
     match output {
         Ok(out) if out.status.success() => {
             let flags = String::from_utf8_lossy(&out.stdout);
+            let mut linked_eccodes = false;
+
             // Parse -L paths and -l libs from pkg-config output.
             for flag in flags.split_whitespace() {
                 if let Some(path) = flag.strip_prefix("-L") {
                     println!("cargo:rustc-link-search=native={path}");
                 } else if let Some(lib) = flag.strip_prefix("-l") {
+                    if lib == "eccodes" {
+                        linked_eccodes = true;
+                    }
                     println!("cargo:rustc-link-lib=dylib={lib}");
                 }
+            }
+
+            if !linked_eccodes {
+                println!("cargo:rustc-link-lib=dylib=eccodes");
             }
             true
         }

--- a/benchmarks/src/bin/codec_matrix.rs
+++ b/benchmarks/src/bin/codec_matrix.rs
@@ -12,6 +12,7 @@ use clap::Parser;
 )]
 struct Args {
     /// Number of float64 values to encode per benchmark run.
+    /// Rounded up to the next multiple of 4 (at most 3 extra values) for szip alignment.
     #[arg(long, default_value = "16000000")]
     num_points: usize,
 

--- a/benchmarks/src/bin/codec_matrix.rs
+++ b/benchmarks/src/bin/codec_matrix.rs
@@ -1,0 +1,36 @@
+use clap::Parser;
+
+/// Benchmark all encoder × compressor × bit-width combinations.
+///
+/// Runs the full tensogram encoding pipeline for every valid combination,
+/// measuring encode/decode throughput and compressed size against the
+/// `none+none` baseline.
+#[derive(Parser, Debug)]
+#[command(
+    name = "codec-matrix",
+    about = "Benchmark all encoder × compressor × bit-width combinations"
+)]
+struct Args {
+    /// Number of float64 values to encode per benchmark run.
+    #[arg(long, default_value = "16000000")]
+    num_points: usize,
+
+    /// Number of timed iterations (median is reported).
+    #[arg(long, default_value = "5")]
+    iterations: usize,
+
+    /// Random seed for deterministic data generation.
+    #[arg(long, default_value = "42")]
+    seed: u64,
+}
+
+fn main() {
+    let args = Args::parse();
+    match tensogram_benchmarks::run_codec_matrix(args.num_points, args.iterations, args.seed) {
+        Ok(()) => {}
+        Err(e) => {
+            eprintln!("Error: {e}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/benchmarks/src/bin/codec_matrix.rs
+++ b/benchmarks/src/bin/codec_matrix.rs
@@ -12,7 +12,7 @@ use clap::Parser;
 )]
 struct Args {
     /// Number of float64 values to encode per benchmark run.
-    /// Rounded up to the next multiple of 4 (at most 3 extra values) for szip alignment.
+    /// Always rounded up to the next multiple of 4 (at most 3 extra values) for szip alignment.
     #[arg(long, default_value = "16000000")]
     num_points: usize,
 

--- a/benchmarks/src/bin/grib_comparison.rs
+++ b/benchmarks/src/bin/grib_comparison.rs
@@ -1,0 +1,36 @@
+use clap::Parser;
+
+/// Compare ecCodes CCSDS packing against Tensogram simple_packing+szip.
+///
+/// Benchmarks encoding and decoding of 10M float64 values (packed to 24 bit)
+/// using ecCodes `grid_ccsds` as the reference and tensogram as the candidate.
+/// Requires the `eccodes` feature and the ecCodes C library to be installed.
+#[derive(Parser, Debug)]
+#[command(
+    name = "grib-comparison",
+    about = "Compare ecCodes CCSDS packing vs tensogram simple_packing+szip"
+)]
+struct Args {
+    /// Number of float64 values to encode per benchmark run.
+    #[arg(long, default_value = "10000000")]
+    num_points: usize,
+
+    /// Number of timed iterations (median is reported).
+    #[arg(long, default_value = "5")]
+    iterations: usize,
+
+    /// Random seed for deterministic data generation.
+    #[arg(long, default_value = "42")]
+    seed: u64,
+}
+
+fn main() {
+    let args = Args::parse();
+    match tensogram_benchmarks::run_grib_comparison(args.num_points, args.iterations, args.seed) {
+        Ok(()) => {}
+        Err(e) => {
+            eprintln!("Error: {e}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/benchmarks/src/codec_matrix.rs
+++ b/benchmarks/src/codec_matrix.rs
@@ -6,14 +6,12 @@
 
 use std::time::Instant;
 
-// Types re-exported at tensogram_encodings crate root.
+use tensogram_encodings::pipeline::{decode_pipeline, encode_pipeline};
+use tensogram_encodings::simple_packing::compute_params;
 use tensogram_encodings::{
     Blosc2Codec, ByteOrder, CompressionType, EncodingType, FilterType, PipelineConfig,
     Sz3ErrorBound, ZfpMode,
 };
-// Functions and error not re-exported at root — access via the pipeline module.
-use tensogram_encodings::pipeline::{decode_pipeline, encode_pipeline};
-use tensogram_encodings::simple_packing::compute_params;
 
 use crate::datagen::generate_weather_field;
 use crate::report::{median_ns, ns_to_ms, BenchmarkResult};
@@ -31,213 +29,45 @@ struct Case {
     config: PipelineConfig,
 }
 
-// ── Config builders ───────────────────────────────────────────────────────────
+// ── Config helpers ────────────────────────────────────────────────────────────
 
-fn none_none(num_points: usize) -> Case {
+/// Construct a benchmark case with the shared pipeline defaults
+/// (no filter, little-endian, f64).
+fn make_case(
+    name: impl Into<String>,
+    encoding: EncodingType,
+    compression: CompressionType,
+    num_values: usize,
+) -> Case {
     Case {
-        name: "none+none".to_string(),
+        name: name.into(),
         config: PipelineConfig {
-            encoding: EncodingType::None,
+            encoding,
             filter: FilterType::None,
-            compression: CompressionType::None,
-            num_values: num_points,
+            compression,
+            num_values,
             byte_order: ByteOrder::Little,
             dtype_byte_width: 8,
         },
     }
 }
 
-fn none_zstd(num_points: usize) -> Case {
-    Case {
-        name: "none+zstd(3)".to_string(),
-        config: PipelineConfig {
-            encoding: EncodingType::None,
-            filter: FilterType::None,
-            compression: CompressionType::Zstd { level: 3 },
-            num_values: num_points,
-            byte_order: ByteOrder::Little,
-            dtype_byte_width: 8,
-        },
-    }
-}
-
-fn none_lz4(num_points: usize) -> Case {
-    Case {
-        name: "none+lz4".to_string(),
-        config: PipelineConfig {
-            encoding: EncodingType::None,
-            filter: FilterType::None,
-            compression: CompressionType::Lz4,
-            num_values: num_points,
-            byte_order: ByteOrder::Little,
-            dtype_byte_width: 8,
-        },
-    }
-}
-
-fn none_blosc2(num_points: usize) -> Case {
-    Case {
-        name: "none+blosc2(blosclz)".to_string(),
-        config: PipelineConfig {
-            encoding: EncodingType::None,
-            filter: FilterType::None,
-            compression: CompressionType::Blosc2 {
-                codec: Blosc2Codec::Blosclz,
-                clevel: 5,
-                typesize: 8, // f64 = 8 bytes
-            },
-            num_values: num_points,
-            byte_order: ByteOrder::Little,
-            dtype_byte_width: 8,
-        },
-    }
-}
-
-fn none_szip(num_points: usize) -> Case {
-    // Treat raw f64 bytes as 32-bit samples (two per value).
-    // libaec supports bits_per_sample up to 32; raw 64-bit is not supported.
-    Case {
-        name: "none+szip(32)".to_string(),
-        config: PipelineConfig {
-            encoding: EncodingType::None,
-            filter: FilterType::None,
-            compression: CompressionType::Szip {
-                rsi: 128,
-                block_size: 16,
-                flags: AEC_DATA_PREPROCESS,
-                bits_per_sample: 32,
-            },
-            num_values: num_points,
-            byte_order: ByteOrder::Little,
-            dtype_byte_width: 8,
-        },
-    }
-}
-
-fn sp_none(num_points: usize, bits: u32, values: &[f64]) -> Result<Case, BenchmarkError> {
+/// Construct a simple-packing case: compute packing params, then build the case.
+fn sp_case(
+    bits: u32,
+    compressor_name: &str,
+    compression: CompressionType,
+    num_values: usize,
+    values: &[f64],
+) -> Result<Case, BenchmarkError> {
     let params = compute_params(values, bits, 0)
         .map_err(|e| BenchmarkError(format!("sp({bits}) params: {e}")))?;
-    Ok(Case {
-        name: format!("sp({bits})+none"),
-        config: PipelineConfig {
-            encoding: EncodingType::SimplePacking(params),
-            filter: FilterType::None,
-            compression: CompressionType::None,
-            num_values: num_points,
-            byte_order: ByteOrder::Little,
-            dtype_byte_width: 8,
-        },
-    })
-}
-
-fn sp_zstd(num_points: usize, bits: u32, values: &[f64]) -> Result<Case, BenchmarkError> {
-    let params = compute_params(values, bits, 0)
-        .map_err(|e| BenchmarkError(format!("sp({bits}) params: {e}")))?;
-    Ok(Case {
-        name: format!("sp({bits})+zstd(3)"),
-        config: PipelineConfig {
-            encoding: EncodingType::SimplePacking(params),
-            filter: FilterType::None,
-            compression: CompressionType::Zstd { level: 3 },
-            num_values: num_points,
-            byte_order: ByteOrder::Little,
-            dtype_byte_width: 8,
-        },
-    })
-}
-
-fn sp_lz4(num_points: usize, bits: u32, values: &[f64]) -> Result<Case, BenchmarkError> {
-    let params = compute_params(values, bits, 0)
-        .map_err(|e| BenchmarkError(format!("sp({bits}) params: {e}")))?;
-    Ok(Case {
-        name: format!("sp({bits})+lz4"),
-        config: PipelineConfig {
-            encoding: EncodingType::SimplePacking(params),
-            filter: FilterType::None,
-            compression: CompressionType::Lz4,
-            num_values: num_points,
-            byte_order: ByteOrder::Little,
-            dtype_byte_width: 8,
-        },
-    })
-}
-
-fn sp_blosc2(num_points: usize, bits: u32, values: &[f64]) -> Result<Case, BenchmarkError> {
-    let params = compute_params(values, bits, 0)
-        .map_err(|e| BenchmarkError(format!("sp({bits}) params: {e}")))?;
-    // typesize = bytes needed per packed element (div_ceil for non-byte-aligned packing)
-    let typesize = (bits as usize).div_ceil(8);
-    Ok(Case {
-        name: format!("sp({bits})+blosc2(blosclz)"),
-        config: PipelineConfig {
-            encoding: EncodingType::SimplePacking(params),
-            filter: FilterType::None,
-            compression: CompressionType::Blosc2 {
-                codec: Blosc2Codec::Blosclz,
-                clevel: 5,
-                typesize,
-            },
-            num_values: num_points,
-            byte_order: ByteOrder::Little,
-            dtype_byte_width: 8,
-        },
-    })
-}
-
-fn sp_szip(num_points: usize, bits: u32, values: &[f64]) -> Result<Case, BenchmarkError> {
-    let params = compute_params(values, bits, 0)
-        .map_err(|e| BenchmarkError(format!("sp({bits}) params: {e}")))?;
-    Ok(Case {
-        name: format!("sp({bits})+szip"),
-        config: PipelineConfig {
-            encoding: EncodingType::SimplePacking(params),
-            filter: FilterType::None,
-            compression: CompressionType::Szip {
-                rsi: 128,
-                block_size: 16,
-                flags: AEC_DATA_PREPROCESS,
-                bits_per_sample: bits,
-            },
-            num_values: num_points,
-            byte_order: ByteOrder::Little,
-            dtype_byte_width: 8,
-        },
-    })
-}
-
-/// ZFP uses `from_ne_bytes` internally — use little-endian byte order so the
-/// bytes match native representation on the benchmark host.
-fn none_zfp(num_points: usize, rate: f64) -> Case {
-    Case {
-        name: format!("none+zfp(rate={rate})"),
-        config: PipelineConfig {
-            encoding: EncodingType::None,
-            filter: FilterType::None,
-            compression: CompressionType::Zfp {
-                mode: ZfpMode::FixedRate { rate },
-            },
-            num_values: num_points,
-            byte_order: ByteOrder::Little,
-            dtype_byte_width: 8,
-        },
-    }
-}
-
-/// SZ3 also interprets bytes as native-endian floats.
-fn none_sz3(num_points: usize, tolerance: f64) -> Case {
-    Case {
-        name: format!("none+sz3(abs={tolerance})"),
-        config: PipelineConfig {
-            encoding: EncodingType::None,
-            filter: FilterType::None,
-            compression: CompressionType::Sz3 {
-                error_bound: Sz3ErrorBound::Absolute(tolerance),
-            },
-            num_values: num_points,
-            byte_order: ByteOrder::Little,
-            dtype_byte_width: 8,
-        },
-    }
+    Ok(make_case(
+        format!("sp({bits})+{compressor_name}"),
+        EncodingType::SimplePacking(params),
+        compression,
+        num_values,
+    ))
 }
 
 // ── Case builder ──────────────────────────────────────────────────────────────
@@ -245,34 +75,113 @@ fn none_sz3(num_points: usize, tolerance: f64) -> Case {
 /// Build all benchmark cases in display order.
 ///
 /// The `none+none` case is always first — it serves as the reference.
-fn build_cases(num_points: usize, values: &[f64]) -> Result<Vec<Case>, BenchmarkError> {
-    let mut cases = Vec::with_capacity(24);
+fn build_cases(n: usize, values: &[f64]) -> Result<Vec<Case>, BenchmarkError> {
+    let mut c = Vec::with_capacity(24);
 
-    // Reference
-    cases.push(none_none(num_points));
+    // ── Baseline ──────────────────────────────────────────────────────────────
+    c.push(make_case(
+        "none+none",
+        EncodingType::None,
+        CompressionType::None,
+        n,
+    ));
 
-    // Raw f64 + lossless compressors (no encoding)
-    cases.push(none_zstd(num_points));
-    cases.push(none_lz4(num_points));
-    cases.push(none_blosc2(num_points));
-    cases.push(none_szip(num_points));
+    // ── Raw f64 + lossless compressors (no encoding) ──────────────────────────
+    c.push(make_case(
+        "none+zstd(3)",
+        EncodingType::None,
+        CompressionType::Zstd { level: 3 },
+        n,
+    ));
+    c.push(make_case(
+        "none+lz4",
+        EncodingType::None,
+        CompressionType::Lz4,
+        n,
+    ));
+    c.push(make_case(
+        "none+blosc2(blosclz)",
+        EncodingType::None,
+        CompressionType::Blosc2 {
+            codec: Blosc2Codec::Blosclz,
+            clevel: 5,
+            typesize: 8,
+        },
+        n,
+    ));
+    // libaec supports up to 32-bit samples; treat raw f64 bytes as two 32-bit samples each.
+    c.push(make_case(
+        "none+szip(32)",
+        EncodingType::None,
+        CompressionType::Szip {
+            rsi: 128,
+            block_size: 16,
+            flags: AEC_DATA_PREPROCESS,
+            bits_per_sample: 32,
+        },
+        n,
+    ));
 
-    // simple_packing at 16/24/32 bits + each lossless compressor
+    // ── simple_packing at 16/24/32 bits + each lossless compressor ────────────
     for bits in [16u32, 24, 32] {
-        cases.push(sp_none(num_points, bits, values)?);
-        cases.push(sp_zstd(num_points, bits, values)?);
-        cases.push(sp_lz4(num_points, bits, values)?);
-        cases.push(sp_blosc2(num_points, bits, values)?);
-        cases.push(sp_szip(num_points, bits, values)?);
+        c.push(sp_case(bits, "none", CompressionType::None, n, values)?);
+        c.push(sp_case(
+            bits,
+            "zstd(3)",
+            CompressionType::Zstd { level: 3 },
+            n,
+            values,
+        )?);
+        c.push(sp_case(bits, "lz4", CompressionType::Lz4, n, values)?);
+
+        let typesize = (bits as usize).div_ceil(8);
+        c.push(sp_case(
+            bits,
+            "blosc2(blosclz)",
+            CompressionType::Blosc2 {
+                codec: Blosc2Codec::Blosclz,
+                clevel: 5,
+                typesize,
+            },
+            n,
+            values,
+        )?);
+
+        c.push(sp_case(
+            bits,
+            "szip",
+            CompressionType::Szip {
+                rsi: 128,
+                block_size: 16,
+                flags: AEC_DATA_PREPROCESS,
+                bits_per_sample: bits,
+            },
+            n,
+            values,
+        )?);
     }
 
-    // Lossy floating-point compressors (ZFP fixed-rate, SZ3)
+    // ── Lossy floating-point compressors ──────────────────────────────────────
     for rate in [16.0f64, 24.0, 32.0] {
-        cases.push(none_zfp(num_points, rate));
+        c.push(make_case(
+            format!("none+zfp(rate={rate})"),
+            EncodingType::None,
+            CompressionType::Zfp {
+                mode: ZfpMode::FixedRate { rate },
+            },
+            n,
+        ));
     }
-    cases.push(none_sz3(num_points, 0.01));
+    c.push(make_case(
+        "none+sz3(abs=0.01)",
+        EncodingType::None,
+        CompressionType::Sz3 {
+            error_bound: Sz3ErrorBound::Absolute(0.01),
+        },
+        n,
+    ));
 
-    Ok(cases)
+    Ok(c)
 }
 
 // ── Timing ────────────────────────────────────────────────────────────────────
@@ -333,6 +242,9 @@ pub fn run_codec_matrix_results(
     if num_points == 0 {
         return Err(BenchmarkError("num_points must be > 0".to_string()));
     }
+    if iterations == 0 {
+        return Err(BenchmarkError("iterations must be > 0".to_string()));
+    }
 
     // Round up to the next multiple of 4 so szip cases work at any bit width.
     // libaec promotes 24-bit samples to 4-byte containers, requiring the packed
@@ -342,17 +254,16 @@ pub fn run_codec_matrix_results(
 
     eprintln!("Generating {num_points} weather-like float64 values (seed={seed})...");
     let values = generate_weather_field(num_points, seed);
-    // Little-endian bytes (native on x86/ARM64 – matches ZFP/SZ3 expectations).
+    // Little-endian bytes (native on x86/ARM64 — matches ZFP/SZ3 expectations).
     let data_bytes: Vec<u8> = values.iter().flat_map(|v| v.to_le_bytes()).collect();
     let original_bytes = data_bytes.len();
 
-    eprintln!("Building {num_points} × {} pipeline configs...", 24);
     let cases = build_cases(num_points, &values)?;
-
     eprintln!(
         "Running {} cases ({iterations} iterations each)...",
         cases.len()
     );
+
     let mut results = Vec::with_capacity(cases.len());
     for (i, case) in cases.iter().enumerate() {
         eprint!("  [{:2}/{}] {:<35}", i + 1, cases.len(), &case.name);

--- a/benchmarks/src/codec_matrix.rs
+++ b/benchmarks/src/codec_matrix.rs
@@ -1,0 +1,379 @@
+//! Codec matrix benchmark — all encoder × compressor × bit-width combinations.
+//!
+//! Generates a synthetic weather field, runs every valid pipeline combination,
+//! and reports encode time, decode time, compressed size, and compression ratio
+//! against the `none+none` baseline.
+
+use std::time::Instant;
+
+// Types re-exported at tensogram_encodings crate root.
+use tensogram_encodings::{
+    Blosc2Codec, ByteOrder, CompressionType, EncodingType, FilterType, PipelineConfig,
+    Sz3ErrorBound, ZfpMode,
+};
+// Functions and error not re-exported at root — access via the pipeline module.
+use tensogram_encodings::pipeline::{decode_pipeline, encode_pipeline};
+use tensogram_encodings::simple_packing::compute_params;
+
+use crate::datagen::generate_weather_field;
+use crate::report::{median_ns, ns_to_ms, BenchmarkResult};
+use crate::BenchmarkError;
+
+// AEC_DATA_PREPROCESS flag value (defined in libaec-sys as 1).
+// Using the raw constant avoids adding libaec-sys as a direct dependency.
+const AEC_DATA_PREPROCESS: u32 = 1;
+
+// ── Case descriptor ───────────────────────────────────────────────────────────
+
+/// A single benchmark case: a pipeline configuration and a display name.
+struct Case {
+    name: String,
+    config: PipelineConfig,
+}
+
+// ── Config builders ───────────────────────────────────────────────────────────
+
+fn none_none(num_points: usize) -> Case {
+    Case {
+        name: "none+none".to_string(),
+        config: PipelineConfig {
+            encoding: EncodingType::None,
+            filter: FilterType::None,
+            compression: CompressionType::None,
+            num_values: num_points,
+            byte_order: ByteOrder::Little,
+            dtype_byte_width: 8,
+        },
+    }
+}
+
+fn none_zstd(num_points: usize) -> Case {
+    Case {
+        name: "none+zstd(3)".to_string(),
+        config: PipelineConfig {
+            encoding: EncodingType::None,
+            filter: FilterType::None,
+            compression: CompressionType::Zstd { level: 3 },
+            num_values: num_points,
+            byte_order: ByteOrder::Little,
+            dtype_byte_width: 8,
+        },
+    }
+}
+
+fn none_lz4(num_points: usize) -> Case {
+    Case {
+        name: "none+lz4".to_string(),
+        config: PipelineConfig {
+            encoding: EncodingType::None,
+            filter: FilterType::None,
+            compression: CompressionType::Lz4,
+            num_values: num_points,
+            byte_order: ByteOrder::Little,
+            dtype_byte_width: 8,
+        },
+    }
+}
+
+fn none_blosc2(num_points: usize) -> Case {
+    Case {
+        name: "none+blosc2(blosclz)".to_string(),
+        config: PipelineConfig {
+            encoding: EncodingType::None,
+            filter: FilterType::None,
+            compression: CompressionType::Blosc2 {
+                codec: Blosc2Codec::Blosclz,
+                clevel: 5,
+                typesize: 8, // f64 = 8 bytes
+            },
+            num_values: num_points,
+            byte_order: ByteOrder::Little,
+            dtype_byte_width: 8,
+        },
+    }
+}
+
+fn none_szip(num_points: usize) -> Case {
+    // Treat raw f64 bytes as 32-bit samples (two per value).
+    // libaec supports bits_per_sample up to 32; raw 64-bit is not supported.
+    Case {
+        name: "none+szip(32)".to_string(),
+        config: PipelineConfig {
+            encoding: EncodingType::None,
+            filter: FilterType::None,
+            compression: CompressionType::Szip {
+                rsi: 128,
+                block_size: 16,
+                flags: AEC_DATA_PREPROCESS,
+                bits_per_sample: 32,
+            },
+            num_values: num_points,
+            byte_order: ByteOrder::Little,
+            dtype_byte_width: 8,
+        },
+    }
+}
+
+fn sp_none(num_points: usize, bits: u32, values: &[f64]) -> Result<Case, BenchmarkError> {
+    let params = compute_params(values, bits, 0)
+        .map_err(|e| BenchmarkError(format!("sp({bits}) params: {e}")))?;
+    Ok(Case {
+        name: format!("sp({bits})+none"),
+        config: PipelineConfig {
+            encoding: EncodingType::SimplePacking(params),
+            filter: FilterType::None,
+            compression: CompressionType::None,
+            num_values: num_points,
+            byte_order: ByteOrder::Little,
+            dtype_byte_width: 8,
+        },
+    })
+}
+
+fn sp_zstd(num_points: usize, bits: u32, values: &[f64]) -> Result<Case, BenchmarkError> {
+    let params = compute_params(values, bits, 0)
+        .map_err(|e| BenchmarkError(format!("sp({bits}) params: {e}")))?;
+    Ok(Case {
+        name: format!("sp({bits})+zstd(3)"),
+        config: PipelineConfig {
+            encoding: EncodingType::SimplePacking(params),
+            filter: FilterType::None,
+            compression: CompressionType::Zstd { level: 3 },
+            num_values: num_points,
+            byte_order: ByteOrder::Little,
+            dtype_byte_width: 8,
+        },
+    })
+}
+
+fn sp_lz4(num_points: usize, bits: u32, values: &[f64]) -> Result<Case, BenchmarkError> {
+    let params = compute_params(values, bits, 0)
+        .map_err(|e| BenchmarkError(format!("sp({bits}) params: {e}")))?;
+    Ok(Case {
+        name: format!("sp({bits})+lz4"),
+        config: PipelineConfig {
+            encoding: EncodingType::SimplePacking(params),
+            filter: FilterType::None,
+            compression: CompressionType::Lz4,
+            num_values: num_points,
+            byte_order: ByteOrder::Little,
+            dtype_byte_width: 8,
+        },
+    })
+}
+
+fn sp_blosc2(num_points: usize, bits: u32, values: &[f64]) -> Result<Case, BenchmarkError> {
+    let params = compute_params(values, bits, 0)
+        .map_err(|e| BenchmarkError(format!("sp({bits}) params: {e}")))?;
+    // typesize = bytes needed per packed element (div_ceil for non-byte-aligned packing)
+    let typesize = (bits as usize).div_ceil(8);
+    Ok(Case {
+        name: format!("sp({bits})+blosc2(blosclz)"),
+        config: PipelineConfig {
+            encoding: EncodingType::SimplePacking(params),
+            filter: FilterType::None,
+            compression: CompressionType::Blosc2 {
+                codec: Blosc2Codec::Blosclz,
+                clevel: 5,
+                typesize,
+            },
+            num_values: num_points,
+            byte_order: ByteOrder::Little,
+            dtype_byte_width: 8,
+        },
+    })
+}
+
+fn sp_szip(num_points: usize, bits: u32, values: &[f64]) -> Result<Case, BenchmarkError> {
+    let params = compute_params(values, bits, 0)
+        .map_err(|e| BenchmarkError(format!("sp({bits}) params: {e}")))?;
+    Ok(Case {
+        name: format!("sp({bits})+szip"),
+        config: PipelineConfig {
+            encoding: EncodingType::SimplePacking(params),
+            filter: FilterType::None,
+            compression: CompressionType::Szip {
+                rsi: 128,
+                block_size: 16,
+                flags: AEC_DATA_PREPROCESS,
+                bits_per_sample: bits,
+            },
+            num_values: num_points,
+            byte_order: ByteOrder::Little,
+            dtype_byte_width: 8,
+        },
+    })
+}
+
+/// ZFP uses `from_ne_bytes` internally — use little-endian byte order so the
+/// bytes match native representation on the benchmark host.
+fn none_zfp(num_points: usize, rate: f64) -> Case {
+    Case {
+        name: format!("none+zfp(rate={rate})"),
+        config: PipelineConfig {
+            encoding: EncodingType::None,
+            filter: FilterType::None,
+            compression: CompressionType::Zfp {
+                mode: ZfpMode::FixedRate { rate },
+            },
+            num_values: num_points,
+            byte_order: ByteOrder::Little,
+            dtype_byte_width: 8,
+        },
+    }
+}
+
+/// SZ3 also interprets bytes as native-endian floats.
+fn none_sz3(num_points: usize, tolerance: f64) -> Case {
+    Case {
+        name: format!("none+sz3(abs={tolerance})"),
+        config: PipelineConfig {
+            encoding: EncodingType::None,
+            filter: FilterType::None,
+            compression: CompressionType::Sz3 {
+                error_bound: Sz3ErrorBound::Absolute(tolerance),
+            },
+            num_values: num_points,
+            byte_order: ByteOrder::Little,
+            dtype_byte_width: 8,
+        },
+    }
+}
+
+// ── Case builder ──────────────────────────────────────────────────────────────
+
+/// Build all benchmark cases in display order.
+///
+/// The `none+none` case is always first — it serves as the reference.
+fn build_cases(num_points: usize, values: &[f64]) -> Result<Vec<Case>, BenchmarkError> {
+    let mut cases = Vec::with_capacity(24);
+
+    // Reference
+    cases.push(none_none(num_points));
+
+    // Raw f64 + lossless compressors (no encoding)
+    cases.push(none_zstd(num_points));
+    cases.push(none_lz4(num_points));
+    cases.push(none_blosc2(num_points));
+    cases.push(none_szip(num_points));
+
+    // simple_packing at 16/24/32 bits + each lossless compressor
+    for bits in [16u32, 24, 32] {
+        cases.push(sp_none(num_points, bits, values)?);
+        cases.push(sp_zstd(num_points, bits, values)?);
+        cases.push(sp_lz4(num_points, bits, values)?);
+        cases.push(sp_blosc2(num_points, bits, values)?);
+        cases.push(sp_szip(num_points, bits, values)?);
+    }
+
+    // Lossy floating-point compressors (ZFP fixed-rate, SZ3)
+    for rate in [16.0f64, 24.0, 32.0] {
+        cases.push(none_zfp(num_points, rate));
+    }
+    cases.push(none_sz3(num_points, 0.01));
+
+    Ok(cases)
+}
+
+// ── Timing ────────────────────────────────────────────────────────────────────
+
+/// Run one benchmark case: warm up, then time `iterations` encode+decode cycles.
+///
+/// Returns a `BenchmarkResult` with median encode/decode times.
+fn run_case(
+    case: &Case,
+    data_bytes: &[u8],
+    original_bytes: usize,
+    iterations: usize,
+) -> Result<BenchmarkResult, BenchmarkError> {
+    let map_err = |e: tensogram_encodings::pipeline::PipelineError| -> BenchmarkError {
+        BenchmarkError(e.to_string())
+    };
+
+    // Warm-up iteration (result discarded).
+    let warm = encode_pipeline(data_bytes, &case.config).map_err(map_err)?;
+    drop(decode_pipeline(&warm.encoded_bytes, &case.config).map_err(map_err)?);
+
+    let mut encode_ns = Vec::with_capacity(iterations);
+    let mut decode_ns = Vec::with_capacity(iterations);
+    let mut compressed_bytes = warm.encoded_bytes.len();
+
+    for _ in 0..iterations {
+        let t0 = Instant::now();
+        let result = encode_pipeline(data_bytes, &case.config).map_err(map_err)?;
+        encode_ns.push(t0.elapsed().as_nanos() as u64);
+
+        compressed_bytes = result.encoded_bytes.len();
+
+        let t0 = Instant::now();
+        drop(decode_pipeline(&result.encoded_bytes, &case.config).map_err(map_err)?);
+        decode_ns.push(t0.elapsed().as_nanos() as u64);
+    }
+
+    Ok(BenchmarkResult {
+        name: case.name.clone(),
+        encode_ms: ns_to_ms(median_ns(&mut encode_ns)),
+        decode_ms: ns_to_ms(median_ns(&mut decode_ns)),
+        compressed_bytes,
+        original_bytes,
+    })
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Run all codec matrix benchmarks and return results.
+///
+/// Results are ordered with `none+none` first (the reference row).
+/// Called by the binary entry point and by integration tests.
+pub fn run_codec_matrix_results(
+    num_points: usize,
+    iterations: usize,
+    seed: u64,
+) -> Result<Vec<BenchmarkResult>, BenchmarkError> {
+    if num_points == 0 {
+        return Err(BenchmarkError("num_points must be > 0".to_string()));
+    }
+
+    // Round up to the next multiple of 4 so szip cases work at any bit width.
+    // libaec promotes 24-bit samples to 4-byte containers, requiring the packed
+    // byte count to be a multiple of 4.  Padding by at most 3 values has no
+    // measurable impact on benchmark accuracy at production sizes.
+    let num_points = num_points.next_multiple_of(4);
+
+    eprintln!("Generating {num_points} weather-like float64 values (seed={seed})...");
+    let values = generate_weather_field(num_points, seed);
+    // Little-endian bytes (native on x86/ARM64 – matches ZFP/SZ3 expectations).
+    let data_bytes: Vec<u8> = values.iter().flat_map(|v| v.to_le_bytes()).collect();
+    let original_bytes = data_bytes.len();
+
+    eprintln!("Building {num_points} × {} pipeline configs...", 24);
+    let cases = build_cases(num_points, &values)?;
+
+    eprintln!(
+        "Running {} cases ({iterations} iterations each)...",
+        cases.len()
+    );
+    let mut results = Vec::with_capacity(cases.len());
+    for (i, case) in cases.iter().enumerate() {
+        eprint!("  [{:2}/{}] {:<35}", i + 1, cases.len(), &case.name);
+        match run_case(case, &data_bytes, original_bytes, iterations) {
+            Ok(r) => {
+                eprintln!(" done ({:.1} ms encode)", r.encode_ms);
+                results.push(r);
+            }
+            Err(e) => {
+                // Report failures without aborting the entire benchmark.
+                eprintln!(" FAILED: {e}");
+                results.push(BenchmarkResult {
+                    name: format!("{} [ERROR]", case.name),
+                    encode_ms: 0.0,
+                    decode_ms: 0.0,
+                    compressed_bytes: 0,
+                    original_bytes,
+                });
+            }
+        }
+    }
+
+    Ok(results)
+}

--- a/benchmarks/src/codec_matrix.rs
+++ b/benchmarks/src/codec_matrix.rs
@@ -234,6 +234,11 @@ fn run_case(
 ///
 /// Results are ordered with `none+none` first (the reference row).
 /// Called by the binary entry point and by integration tests.
+///
+/// # Note on `num_points` padding
+/// The actual number of values encoded is rounded up to the next multiple of 4
+/// (by at most 3 values) for szip alignment. The reported sizes and the
+/// `original_bytes` field in each result reflect this padded count.
 pub fn run_codec_matrix_results(
     num_points: usize,
     iterations: usize,

--- a/benchmarks/src/datagen.rs
+++ b/benchmarks/src/datagen.rs
@@ -44,8 +44,10 @@ impl SplitMix64 {
 /// - A smooth large-scale sinusoidal pattern (base ≈ 280 K, amplitude ≈ 30 K)
 /// - Small random noise (±0.1 K) to mimic observation/model imperfections
 ///
-/// The function is pure and deterministic: same `seed` always produces the
-/// same output, regardless of platform or Rust version.
+/// The function is pure and deterministic for a given platform/toolchain:
+/// the same `seed` produces the same output in the same environment. Because
+/// it uses `f64::sin()`/`f64::cos()`, outputs may differ slightly across
+/// platforms or Rust versions.
 ///
 /// # Arguments
 /// * `num_points` – exact number of values to generate

--- a/benchmarks/src/datagen.rs
+++ b/benchmarks/src/datagen.rs
@@ -136,4 +136,44 @@ mod tests {
             assert!((240.0..=320.0).contains(val), "out of range: {val}");
         }
     }
+
+    #[test]
+    fn test_single_point() {
+        // num_points=1: ncols=1, nrows=1, sin(0)=0, cos(0)=1 → base + noise.
+        let v = generate_weather_field(1, 42);
+        assert_eq!(v.len(), 1);
+        assert!(v[0].is_finite());
+        // sin(0)=0 so signal is 0, value ≈ 280.0 ± 0.1.
+        assert!(
+            (279.8..=280.2).contains(&v[0]),
+            "expected ≈280 K, got {}",
+            v[0]
+        );
+    }
+
+    #[test]
+    fn test_extreme_seeds() {
+        // Seed 0 and u64::MAX must produce valid, finite, in-range values.
+        for seed in [0u64, u64::MAX] {
+            let v = generate_weather_field(100, seed);
+            assert_eq!(v.len(), 100);
+            for (i, &val) in v.iter().enumerate() {
+                assert!(val.is_finite(), "seed={seed} index={i}: non-finite {val}");
+                assert!(
+                    (240.0..=320.0).contains(&val),
+                    "seed={seed} index={i}: out of range {val}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_prng_range() {
+        // Verify the PRNG's next_f64() stays in [0.0, 1.0).
+        let mut rng = SplitMix64::new(12345);
+        for _ in 0..10_000 {
+            let f = rng.next_f64();
+            assert!((0.0..1.0).contains(&f), "next_f64 out of [0,1): {f}");
+        }
+    }
 }

--- a/benchmarks/src/datagen.rs
+++ b/benchmarks/src/datagen.rs
@@ -1,0 +1,137 @@
+//! Deterministic synthetic weather data generator.
+//!
+//! Produces smooth, spatially correlated float64 fields that resemble
+//! real meteorological data (temperature grids). Smooth fields compress
+//! far better than random noise, giving realistic benchmark ratios.
+//!
+//! The generator is intentionally zero-dependency — it implements a simple
+//! SplitMix64 PRNG rather than pulling in `rand`.
+
+// ── PRNG ─────────────────────────────────────────────────────────────────────
+
+/// SplitMix64 PRNG — fast, statistically good, and fully deterministic.
+/// State is advanced by `next()`.
+struct SplitMix64 {
+    state: u64,
+}
+
+impl SplitMix64 {
+    fn new(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    fn next(&mut self) -> u64 {
+        self.state = self.state.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut z = self.state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        z ^ (z >> 31)
+    }
+
+    /// Return a float in [0.0, 1.0).
+    fn next_f64(&mut self) -> f64 {
+        // Use top 53 bits for mantissa precision
+        let bits = self.next() >> 11;
+        bits as f64 * (1.0 / (1u64 << 53) as f64)
+    }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Generate a weather-like float64 field of `num_points` values.
+///
+/// The returned values model a 2D temperature grid (Kelvin) with:
+/// - A smooth large-scale sinusoidal pattern (base ≈ 280 K, amplitude ≈ 30 K)
+/// - Small random noise (±0.1 K) to mimic observation/model imperfections
+///
+/// The function is pure and deterministic: same `seed` always produces the
+/// same output, regardless of platform or Rust version.
+///
+/// # Arguments
+/// * `num_points` – exact number of values to generate
+/// * `seed` – PRNG seed for full reproducibility
+pub fn generate_weather_field(num_points: usize, seed: u64) -> Vec<f64> {
+    if num_points == 0 {
+        return Vec::new();
+    }
+
+    // Approximate grid dimensions (favours square grids).
+    let ncols = (num_points as f64).sqrt().ceil() as usize;
+    let nrows = num_points.div_ceil(ncols);
+
+    let base: f64 = 280.0; // Kelvin midpoint
+    let amplitude: f64 = 30.0; // K peak-to-trough
+    let noise_scale: f64 = 0.1; // K noise amplitude
+
+    // Spatial frequencies chosen to produce ~4 wavelengths across each axis.
+    let freq_i = std::f64::consts::TAU * 4.0 / nrows as f64;
+    let freq_j = std::f64::consts::TAU * 4.0 / ncols as f64;
+
+    let mut prng = SplitMix64::new(seed);
+    let mut values = Vec::with_capacity(num_points);
+
+    'outer: for i in 0..nrows {
+        for j in 0..ncols {
+            if values.len() == num_points {
+                break 'outer;
+            }
+            let signal = amplitude * (freq_i * i as f64).sin() * (freq_j * j as f64).cos();
+            let noise = noise_scale * (prng.next_f64() * 2.0 - 1.0);
+            values.push(base + signal + noise);
+        }
+    }
+
+    values
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_determinism() {
+        let a = generate_weather_field(1000, 42);
+        let b = generate_weather_field(1000, 42);
+        assert_eq!(a, b, "same seed must produce identical output");
+    }
+
+    #[test]
+    fn test_different_seeds_differ() {
+        let a = generate_weather_field(1000, 42);
+        let b = generate_weather_field(1000, 99);
+        assert_ne!(a, b, "different seeds must produce different output");
+    }
+
+    #[test]
+    fn test_length() {
+        for n in [0usize, 1, 100, 999, 1000, 1024, 10000] {
+            let v = generate_weather_field(n, 42);
+            assert_eq!(v.len(), n, "length mismatch for n={n}");
+        }
+    }
+
+    #[test]
+    fn test_physical_range() {
+        let v = generate_weather_field(10_000, 42);
+        for (i, &val) in v.iter().enumerate() {
+            assert!(
+                (240.0..=320.0).contains(&val),
+                "value out of physical range at index {i}: {val}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_first_values_stable() {
+        // Pin the first few values to guard against accidental PRNG changes.
+        let v = generate_weather_field(5, 42);
+        assert_eq!(v.len(), 5);
+        // Values should be in the physical range and finite.
+        for val in &v {
+            assert!(val.is_finite(), "expected finite value, got {val}");
+            assert!((240.0..=320.0).contains(val), "out of range: {val}");
+        }
+    }
+}

--- a/benchmarks/src/grib_comparison.rs
+++ b/benchmarks/src/grib_comparison.rs
@@ -109,7 +109,7 @@ impl GribHandle {
         };
         if h.is_null() {
             Err(BenchmarkError(
-                "codes_grib_handle_new_from_message_copy returned null".to_string(),
+                "codes_handle_new_from_message_copy returned null".to_string(),
             ))
         } else {
             Ok(GribHandle(h))
@@ -174,7 +174,7 @@ impl GribHandle {
         }
     }
 
-    /// Return the raw GRIB message bytes (zero-copy view).
+    /// Copy the raw GRIB message bytes into an owned buffer.
     fn message_bytes(&self) -> Result<Vec<u8>, BenchmarkError> {
         let mut ptr: *const c_void = std::ptr::null();
         let mut size: usize = 0;
@@ -366,6 +366,9 @@ pub fn run_grib_comparison_results(
     if num_points == 0 {
         return Err(BenchmarkError("num_points must be > 0".to_string()));
     }
+    if iterations == 0 {
+        return Err(BenchmarkError("iterations must be > 0".to_string()));
+    }
 
     eprintln!("Generating {num_points} weather-like float64 values (seed={seed})...");
     let values = generate_weather_field(num_points, seed);
@@ -374,65 +377,56 @@ pub fn run_grib_comparison_results(
     let mut results = Vec::new();
     let bits = 24;
 
-    // ── ecCodes CCSDS (reference) ─────────────────────────────────────────────
+    /// Collect a benchmark result, logging progress and handling errors
+    /// without aborting the full run.
+    fn collect(
+        name: &str,
+        result: Result<BenchmarkResult, BenchmarkError>,
+        original_bytes: usize,
+        out: &mut Vec<BenchmarkResult>,
+    ) {
+        match result {
+            Ok(mut r) => {
+                r.name = name.to_string();
+                eprintln!(" done ({:.1} ms encode)", r.encode_ms);
+                out.push(r);
+            }
+            Err(e) => {
+                eprintln!(" FAILED: {e}");
+                out.push(BenchmarkResult {
+                    name: format!("{name} [ERROR]"),
+                    encode_ms: 0.0,
+                    decode_ms: 0.0,
+                    compressed_bytes: 0,
+                    original_bytes,
+                });
+            }
+        }
+    }
+
     eprint!("  eccodes grid_ccsds (24-bit)...");
-    match time_grib(&values, "grid_ccsds", bits, iterations, original_bytes) {
-        Ok(mut r) => {
-            r.name = "eccodes grid_ccsds".to_string();
-            eprintln!(" done ({:.1} ms encode)", r.encode_ms);
-            results.push(r);
-        }
-        Err(e) => {
-            eprintln!(" FAILED: {e}");
-            results.push(BenchmarkResult {
-                name: "eccodes grid_ccsds [ERROR]".to_string(),
-                encode_ms: 0.0,
-                decode_ms: 0.0,
-                compressed_bytes: 0,
-                original_bytes,
-            });
-        }
-    }
+    collect(
+        "eccodes grid_ccsds",
+        time_grib(&values, "grid_ccsds", bits, iterations, original_bytes),
+        original_bytes,
+        &mut results,
+    );
 
-    // ── ecCodes simple packing ────────────────────────────────────────────────
     eprint!("  eccodes grid_simple (24-bit)...");
-    match time_grib(&values, "grid_simple", bits, iterations, original_bytes) {
-        Ok(mut r) => {
-            r.name = "eccodes grid_simple".to_string();
-            eprintln!(" done ({:.1} ms encode)", r.encode_ms);
-            results.push(r);
-        }
-        Err(e) => {
-            eprintln!(" FAILED: {e}");
-            results.push(BenchmarkResult {
-                name: "eccodes grid_simple [ERROR]".to_string(),
-                encode_ms: 0.0,
-                decode_ms: 0.0,
-                compressed_bytes: 0,
-                original_bytes,
-            });
-        }
-    }
+    collect(
+        "eccodes grid_simple",
+        time_grib(&values, "grid_simple", bits, iterations, original_bytes),
+        original_bytes,
+        &mut results,
+    );
 
-    // ── Tensogram simple_packing(24) + szip ───────────────────────────────────
     eprint!("  tensogram sp(24)+szip...");
-    match time_tensogram_sp_szip(&values, bits as u32, iterations, original_bytes) {
-        Ok(mut r) => {
-            r.name = "tensogram sp(24)+szip".to_string();
-            eprintln!(" done ({:.1} ms encode)", r.encode_ms);
-            results.push(r);
-        }
-        Err(e) => {
-            eprintln!(" FAILED: {e}");
-            results.push(BenchmarkResult {
-                name: "tensogram sp(24)+szip [ERROR]".to_string(),
-                encode_ms: 0.0,
-                decode_ms: 0.0,
-                compressed_bytes: 0,
-                original_bytes,
-            });
-        }
-    }
+    collect(
+        "tensogram sp(24)+szip",
+        time_tensogram_sp_szip(&values, bits as u32, iterations, original_bytes),
+        original_bytes,
+        &mut results,
+    );
 
     Ok(results)
 }

--- a/benchmarks/src/grib_comparison.rs
+++ b/benchmarks/src/grib_comparison.rs
@@ -86,7 +86,8 @@ impl Drop for GribHandle {
 impl GribHandle {
     /// Create a handle from an ecCodes sample template by name.
     fn from_samples(name: &str) -> Result<Self, BenchmarkError> {
-        let name_c = CString::new(name).map_err(|e| BenchmarkError(e.to_string()))?;
+        let name_c = CString::new(name)
+            .map_err(|e| BenchmarkError(format!("invalid sample name '{name}': {e}")))?;
         let h =
             unsafe { codes_grib_handle_new_from_samples(std::ptr::null_mut(), name_c.as_ptr()) };
         if h.is_null() {
@@ -118,7 +119,8 @@ impl GribHandle {
     }
 
     fn set_long(&self, key: &str, val: i64) -> Result<(), BenchmarkError> {
-        let key_c = CString::new(key).map_err(|e| BenchmarkError(e.to_string()))?;
+        let key_c =
+            CString::new(key).map_err(|e| BenchmarkError(format!("invalid key '{key}': {e}")))?;
         let rc = unsafe { codes_set_long(self.0, key_c.as_ptr(), val as c_long) };
         if rc != 0 {
             Err(BenchmarkError(format!(
@@ -130,8 +132,10 @@ impl GribHandle {
     }
 
     fn set_string(&self, key: &str, val: &str) -> Result<(), BenchmarkError> {
-        let key_c = CString::new(key).map_err(|e| BenchmarkError(e.to_string()))?;
-        let val_c = CString::new(val).map_err(|e| BenchmarkError(e.to_string()))?;
+        let key_c =
+            CString::new(key).map_err(|e| BenchmarkError(format!("invalid key '{key}': {e}")))?;
+        let val_c = CString::new(val)
+            .map_err(|e| BenchmarkError(format!("invalid value '{val}' for key '{key}': {e}")))?;
         let mut len = val.len() + 1;
         let rc = unsafe { codes_set_string(self.0, key_c.as_ptr(), val_c.as_ptr(), &mut len) };
         if rc != 0 {
@@ -145,7 +149,10 @@ impl GribHandle {
 
     /// Encode (pack) `vals` into this GRIB message.  This is the timed operation.
     fn set_values(&self, vals: &[f64]) -> Result<(), BenchmarkError> {
-        let key_c = CString::new("values").map_err(|e| BenchmarkError(e.to_string()))?;
+        // "values" is a static ASCII string — CString::new cannot fail here,
+        // but we propagate the error for consistency.
+        let key_c = CString::new("values")
+            .map_err(|e| BenchmarkError(format!("invalid key 'values': {e}")))?;
         let rc =
             unsafe { codes_set_double_array(self.0, key_c.as_ptr(), vals.as_ptr(), vals.len()) };
         if rc != 0 {
@@ -160,7 +167,8 @@ impl GribHandle {
 
     /// Decode (unpack) values from this GRIB message.  This is the timed operation.
     fn get_values(&self, n: usize) -> Result<Vec<f64>, BenchmarkError> {
-        let key_c = CString::new("values").map_err(|e| BenchmarkError(e.to_string()))?;
+        let key_c = CString::new("values")
+            .map_err(|e| BenchmarkError(format!("invalid key 'values': {e}")))?;
         let mut buf = vec![0.0f64; n];
         let mut len = n;
         let rc =

--- a/benchmarks/src/grib_comparison.rs
+++ b/benchmarks/src/grib_comparison.rs
@@ -1,0 +1,438 @@
+//! GRIB vs Tensogram comparison benchmark.
+//!
+//! Compares ecCodes CCSDS (GRIB grid_ccsds) packing against Tensogram
+//! `simple_packing(24)+szip` on 10M float64 values (24-bit precision).
+//!
+//! ecCodes is the reference. Requires the ecCodes C library installed and the
+//! `eccodes` Cargo feature enabled.
+//!
+//! # Timing model
+//! - **GRIB encode**: time spent in `codes_set_double_array("values", ...)`,
+//!   which performs the actual quantisation and compression.
+//! - **GRIB decode**: time to create a GRIB handle from raw bytes plus
+//!   `codes_get_double_array("values", ...)`, mirroring tensogram's
+//!   full decode path.
+//! - **Tensogram encode**: `encode_pipeline(bytes, config)`.
+//! - **Tensogram decode**: `decode_pipeline(encoded, config)`.
+
+use std::ffi::CString;
+use std::os::raw::{c_int, c_long, c_void};
+use std::time::Instant;
+
+use tensogram_encodings::pipeline::{decode_pipeline, encode_pipeline};
+use tensogram_encodings::simple_packing::compute_params;
+use tensogram_encodings::{ByteOrder, CompressionType, EncodingType, FilterType, PipelineConfig};
+
+use crate::datagen::generate_weather_field;
+use crate::report::{median_ns, ns_to_ms, BenchmarkResult};
+use crate::BenchmarkError;
+
+// AEC_DATA_PREPROCESS constant (value = 1 in libaec).
+const AEC_DATA_PREPROCESS: u32 = 1;
+
+// ── ecCodes C API (raw) ───────────────────────────────────────────────────────
+//
+// We declare just the subset needed for this benchmark. The symbols are
+// available because the `eccodes` Rust crate links against libeccodes.
+
+extern "C" {
+    fn codes_grib_handle_new_from_samples(ctx: *mut c_void, name: *const i8) -> *mut c_void;
+    fn codes_handle_new_from_message_copy(
+        ctx: *mut c_void,
+        msg: *const c_void,
+        size: usize,
+    ) -> *mut c_void;
+    fn codes_handle_delete(h: *mut c_void) -> c_int;
+    fn codes_set_long(h: *mut c_void, key: *const i8, val: c_long) -> c_int;
+    fn codes_set_string(
+        h: *mut c_void,
+        key: *const i8,
+        val: *const i8,
+        length: *mut usize,
+    ) -> c_int;
+    fn codes_set_double_array(
+        h: *mut c_void,
+        key: *const i8,
+        vals: *const f64,
+        length: usize,
+    ) -> c_int;
+    fn codes_get_double_array(
+        h: *mut c_void,
+        key: *const i8,
+        vals: *mut f64,
+        length: *mut usize,
+    ) -> c_int;
+    fn codes_get_message(
+        h: *mut c_void,
+        message: *mut *const c_void,
+        message_length: *mut usize,
+    ) -> c_int;
+}
+
+// ── RAII handle wrapper ───────────────────────────────────────────────────────
+
+/// RAII wrapper around `codes_handle*`.
+struct GribHandle(*mut c_void);
+
+impl Drop for GribHandle {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe { codes_handle_delete(self.0) };
+        }
+    }
+}
+
+impl GribHandle {
+    /// Create a handle from an ecCodes sample template by name.
+    fn from_samples(name: &str) -> Result<Self, BenchmarkError> {
+        let name_c = CString::new(name).map_err(|e| BenchmarkError(e.to_string()))?;
+        let h =
+            unsafe { codes_grib_handle_new_from_samples(std::ptr::null_mut(), name_c.as_ptr()) };
+        if h.is_null() {
+            Err(BenchmarkError(format!(
+                "codes_grib_handle_new_from_samples({name}) returned null; \
+                 check ECCODES_SAMPLES_PATH or ecCodes installation"
+            )))
+        } else {
+            Ok(GribHandle(h))
+        }
+    }
+
+    /// Create a handle by copying raw GRIB message bytes.
+    fn from_message_copy(msg: &[u8]) -> Result<Self, BenchmarkError> {
+        let h = unsafe {
+            codes_handle_new_from_message_copy(
+                std::ptr::null_mut(),
+                msg.as_ptr() as *const c_void,
+                msg.len(),
+            )
+        };
+        if h.is_null() {
+            Err(BenchmarkError(
+                "codes_grib_handle_new_from_message_copy returned null".to_string(),
+            ))
+        } else {
+            Ok(GribHandle(h))
+        }
+    }
+
+    fn set_long(&self, key: &str, val: i64) -> Result<(), BenchmarkError> {
+        let key_c = CString::new(key).map_err(|e| BenchmarkError(e.to_string()))?;
+        let rc = unsafe { codes_set_long(self.0, key_c.as_ptr(), val as c_long) };
+        if rc != 0 {
+            Err(BenchmarkError(format!(
+                "codes_set_long({key}, {val}) returned {rc}"
+            )))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn set_string(&self, key: &str, val: &str) -> Result<(), BenchmarkError> {
+        let key_c = CString::new(key).map_err(|e| BenchmarkError(e.to_string()))?;
+        let val_c = CString::new(val).map_err(|e| BenchmarkError(e.to_string()))?;
+        let mut len = val.len() + 1;
+        let rc = unsafe { codes_set_string(self.0, key_c.as_ptr(), val_c.as_ptr(), &mut len) };
+        if rc != 0 {
+            Err(BenchmarkError(format!(
+                "codes_set_string({key}, {val}) returned {rc}"
+            )))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Encode (pack) `vals` into this GRIB message.  This is the timed operation.
+    fn set_values(&self, vals: &[f64]) -> Result<(), BenchmarkError> {
+        let key_c = CString::new("values").map_err(|e| BenchmarkError(e.to_string()))?;
+        let rc =
+            unsafe { codes_set_double_array(self.0, key_c.as_ptr(), vals.as_ptr(), vals.len()) };
+        if rc != 0 {
+            Err(BenchmarkError(format!(
+                "codes_set_double_array(values, len={}) returned {rc}",
+                vals.len()
+            )))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Decode (unpack) values from this GRIB message.  This is the timed operation.
+    fn get_values(&self, n: usize) -> Result<Vec<f64>, BenchmarkError> {
+        let key_c = CString::new("values").map_err(|e| BenchmarkError(e.to_string()))?;
+        let mut buf = vec![0.0f64; n];
+        let mut len = n;
+        let rc =
+            unsafe { codes_get_double_array(self.0, key_c.as_ptr(), buf.as_mut_ptr(), &mut len) };
+        if rc != 0 {
+            Err(BenchmarkError(format!(
+                "codes_get_double_array(values) returned {rc}"
+            )))
+        } else {
+            buf.truncate(len);
+            Ok(buf)
+        }
+    }
+
+    /// Return the raw GRIB message bytes (zero-copy view).
+    fn message_bytes(&self) -> Result<Vec<u8>, BenchmarkError> {
+        let mut ptr: *const c_void = std::ptr::null();
+        let mut size: usize = 0;
+        let rc = unsafe { codes_get_message(self.0, &mut ptr, &mut size) };
+        if rc != 0 || ptr.is_null() {
+            return Err(BenchmarkError(format!("codes_get_message returned {rc}")));
+        }
+        // The pointer is valid for the lifetime of the handle; copy to owned bytes.
+        let bytes = unsafe { std::slice::from_raw_parts(ptr as *const u8, size) };
+        Ok(bytes.to_vec())
+    }
+}
+
+// ── Grid utilities ────────────────────────────────────────────────────────────
+
+/// Find (ni, nj) such that ni × nj == n (exact), preferring nearly-square grids.
+///
+/// Returns (1, n) as a fallback for prime n.
+fn factorize(n: usize) -> (usize, usize) {
+    let root = (n as f64).sqrt() as usize;
+    for i in (1..=root).rev() {
+        if n.is_multiple_of(i) {
+            let j = n / i;
+            return (i, j);
+        }
+    }
+    (1, n)
+}
+
+/// Configure a GRIB2 handle for N data points on a regular lat-lon grid.
+///
+/// Sets packingType and bitsPerValue before returning — caller should then
+/// call `set_values()` to pack the actual data.
+fn setup_grib_handle(
+    n: usize,
+    packing_type: &str,
+    bits_per_value: i64,
+) -> Result<GribHandle, BenchmarkError> {
+    let h = GribHandle::from_samples("GRIB2")?;
+
+    let (ni, nj) = factorize(n);
+
+    // Configure a regular lat-lon grid covering ±80° lat, 0-360° lon.
+    // Exact bounds matter less than correctness for packing benchmarks.
+    let i_inc = 360_000_000i64 / ni as i64; // microdegrees
+    let j_inc = 160_000_000i64 / nj as i64;
+
+    h.set_string("gridType", "regular_ll")?;
+    h.set_long("Ni", ni as i64)?;
+    h.set_long("Nj", nj as i64)?;
+    h.set_long("latitudeOfFirstGridPoint", 80_000_000)?;
+    h.set_long(
+        "latitudeOfLastGridPoint",
+        80_000_000 - j_inc * (nj as i64 - 1),
+    )?;
+    h.set_long("longitudeOfFirstGridPoint", 0)?;
+    h.set_long("longitudeOfLastGridPoint", i_inc * (ni as i64 - 1))?;
+    h.set_long("iDirectionIncrement", i_inc)?;
+    h.set_long("jDirectionIncrement", j_inc)?;
+
+    h.set_long("bitsPerValue", bits_per_value)?;
+    // Set packingType last — some packing types require grid to be set first.
+    h.set_string("packingType", packing_type)?;
+
+    Ok(h)
+}
+
+// ── GRIB timing ───────────────────────────────────────────────────────────────
+
+/// Time GRIB encode+decode for a given packing type.
+///
+/// Warm-up run discarded; then `iterations` timed runs.
+fn time_grib(
+    values: &[f64],
+    packing_type: &str,
+    bits_per_value: i64,
+    iterations: usize,
+    original_bytes: usize,
+) -> Result<BenchmarkResult, BenchmarkError> {
+    let n = values.len();
+
+    // ── Warm-up ──────────────────────────────────────────────────────────────
+    let warm_h = setup_grib_handle(n, packing_type, bits_per_value)?;
+    warm_h.set_values(values)?;
+    let warm_bytes = warm_h.message_bytes()?;
+    let warm_dec = GribHandle::from_message_copy(&warm_bytes)?;
+    warm_dec.get_values(n)?;
+    let compressed_bytes = warm_bytes.len();
+
+    // ── Timed iterations ─────────────────────────────────────────────────────
+    let mut encode_ns = Vec::with_capacity(iterations);
+    let mut decode_ns = Vec::with_capacity(iterations);
+
+    for _ in 0..iterations {
+        // Encode: create handle + pack values (set_values is the bottleneck).
+        let h = setup_grib_handle(n, packing_type, bits_per_value)?;
+        let t0 = Instant::now();
+        h.set_values(values)?;
+        encode_ns.push(t0.elapsed().as_nanos() as u64);
+
+        let msg = h.message_bytes()?;
+
+        // Decode: parse handle from bytes + unpack values.
+        let t0 = Instant::now();
+        let dec_h = GribHandle::from_message_copy(&msg)?;
+        dec_h.get_values(n)?;
+        decode_ns.push(t0.elapsed().as_nanos() as u64);
+    }
+
+    Ok(BenchmarkResult {
+        name: String::new(), // caller fills this in
+        encode_ms: ns_to_ms(median_ns(&mut encode_ns)),
+        decode_ms: ns_to_ms(median_ns(&mut decode_ns)),
+        compressed_bytes,
+        original_bytes,
+    })
+}
+
+// ── Tensogram timing ──────────────────────────────────────────────────────────
+
+fn time_tensogram_sp_szip(
+    values: &[f64],
+    bits: u32,
+    iterations: usize,
+    original_bytes: usize,
+) -> Result<BenchmarkResult, BenchmarkError> {
+    let num_points = values.len();
+    let data_bytes: Vec<u8> = values.iter().flat_map(|v| v.to_le_bytes()).collect();
+
+    let params = compute_params(values, bits, 0)
+        .map_err(|e| BenchmarkError(format!("compute_params({bits}): {e}")))?;
+
+    let config = PipelineConfig {
+        encoding: EncodingType::SimplePacking(params),
+        filter: FilterType::None,
+        compression: CompressionType::Szip {
+            rsi: 128,
+            block_size: 16,
+            flags: AEC_DATA_PREPROCESS,
+            bits_per_sample: bits,
+        },
+        num_values: num_points,
+        byte_order: ByteOrder::Little,
+        dtype_byte_width: 8,
+    };
+
+    let map_err = |e: tensogram_encodings::pipeline::PipelineError| -> BenchmarkError {
+        BenchmarkError(e.to_string())
+    };
+
+    // Warm-up
+    let warm = encode_pipeline(&data_bytes, &config).map_err(map_err)?;
+    decode_pipeline(&warm.encoded_bytes, &config).map_err(map_err)?;
+
+    let mut encode_ns = Vec::with_capacity(iterations);
+    let mut decode_ns = Vec::with_capacity(iterations);
+    let compressed_bytes = warm.encoded_bytes.len();
+
+    for _ in 0..iterations {
+        let t0 = Instant::now();
+        let result = encode_pipeline(&data_bytes, &config).map_err(map_err)?;
+        encode_ns.push(t0.elapsed().as_nanos() as u64);
+
+        let t0 = Instant::now();
+        decode_pipeline(&result.encoded_bytes, &config).map_err(map_err)?;
+        decode_ns.push(t0.elapsed().as_nanos() as u64);
+    }
+
+    Ok(BenchmarkResult {
+        name: String::new(), // caller fills this in
+        encode_ms: ns_to_ms(median_ns(&mut encode_ns)),
+        decode_ms: ns_to_ms(median_ns(&mut decode_ns)),
+        compressed_bytes,
+        original_bytes,
+    })
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Run the GRIB comparison benchmark and return results.
+///
+/// The first result is `"eccodes grid_ccsds"` (the reference).
+/// Called by the binary entry point and by integration tests.
+pub fn run_grib_comparison_results(
+    num_points: usize,
+    iterations: usize,
+    seed: u64,
+) -> Result<Vec<BenchmarkResult>, BenchmarkError> {
+    if num_points == 0 {
+        return Err(BenchmarkError("num_points must be > 0".to_string()));
+    }
+
+    eprintln!("Generating {num_points} weather-like float64 values (seed={seed})...");
+    let values = generate_weather_field(num_points, seed);
+    let original_bytes = num_points * 8; // 8 bytes per f64
+
+    let mut results = Vec::new();
+    let bits = 24;
+
+    // ── ecCodes CCSDS (reference) ─────────────────────────────────────────────
+    eprint!("  eccodes grid_ccsds (24-bit)...");
+    match time_grib(&values, "grid_ccsds", bits, iterations, original_bytes) {
+        Ok(mut r) => {
+            r.name = "eccodes grid_ccsds".to_string();
+            eprintln!(" done ({:.1} ms encode)", r.encode_ms);
+            results.push(r);
+        }
+        Err(e) => {
+            eprintln!(" FAILED: {e}");
+            results.push(BenchmarkResult {
+                name: "eccodes grid_ccsds [ERROR]".to_string(),
+                encode_ms: 0.0,
+                decode_ms: 0.0,
+                compressed_bytes: 0,
+                original_bytes,
+            });
+        }
+    }
+
+    // ── ecCodes simple packing ────────────────────────────────────────────────
+    eprint!("  eccodes grid_simple (24-bit)...");
+    match time_grib(&values, "grid_simple", bits, iterations, original_bytes) {
+        Ok(mut r) => {
+            r.name = "eccodes grid_simple".to_string();
+            eprintln!(" done ({:.1} ms encode)", r.encode_ms);
+            results.push(r);
+        }
+        Err(e) => {
+            eprintln!(" FAILED: {e}");
+            results.push(BenchmarkResult {
+                name: "eccodes grid_simple [ERROR]".to_string(),
+                encode_ms: 0.0,
+                decode_ms: 0.0,
+                compressed_bytes: 0,
+                original_bytes,
+            });
+        }
+    }
+
+    // ── Tensogram simple_packing(24) + szip ───────────────────────────────────
+    eprint!("  tensogram sp(24)+szip...");
+    match time_tensogram_sp_szip(&values, bits as u32, iterations, original_bytes) {
+        Ok(mut r) => {
+            r.name = "tensogram sp(24)+szip".to_string();
+            eprintln!(" done ({:.1} ms encode)", r.encode_ms);
+            results.push(r);
+        }
+        Err(e) => {
+            eprintln!(" FAILED: {e}");
+            results.push(BenchmarkResult {
+                name: "tensogram sp(24)+szip [ERROR]".to_string(),
+                encode_ms: 0.0,
+                decode_ms: 0.0,
+                compressed_bytes: 0,
+                original_bytes,
+            });
+        }
+    }
+
+    Ok(results)
+}

--- a/benchmarks/src/grib_comparison.rs
+++ b/benchmarks/src/grib_comparison.rs
@@ -32,8 +32,9 @@ const AEC_DATA_PREPROCESS: u32 = 1;
 
 // ── ecCodes C API (raw) ───────────────────────────────────────────────────────
 //
-// We declare just the subset needed for this benchmark. The symbols are
-// available because the `eccodes` Rust crate links against libeccodes.
+// We declare just the subset needed for this benchmark. Linking to
+// `libeccodes` is provided by the benchmark crate's build configuration
+// (for example, `build.rs`), not by direct use of the `eccodes` crate here.
 
 extern "C" {
     fn codes_grib_handle_new_from_samples(ctx: *mut c_void, name: *const i8) -> *mut c_void;

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -1,0 +1,65 @@
+// Tensogram benchmark library.
+//
+// Each module is populated as benchmark components are implemented.
+// The `run_*` functions are the public entry points called by the binaries.
+
+pub mod codec_matrix;
+pub mod datagen;
+pub mod report;
+
+/// Error type for benchmark operations.
+#[derive(Debug)]
+pub struct BenchmarkError(pub String);
+
+impl std::fmt::Display for BenchmarkError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for BenchmarkError {}
+
+impl From<String> for BenchmarkError {
+    fn from(s: String) -> Self {
+        BenchmarkError(s)
+    }
+}
+
+/// Run the codec matrix benchmark and print results to stdout.
+///
+/// Called by the `codec-matrix` binary.
+pub fn run_codec_matrix(
+    num_points: usize,
+    iterations: usize,
+    seed: u64,
+) -> Result<(), BenchmarkError> {
+    let results = codec_matrix::run_codec_matrix_results(num_points, iterations, seed)?;
+
+    let title = format!(
+        "Tensogram Codec Matrix ({num_points} float64 values, {iterations} iterations, median)"
+    );
+    report::print_table(&results, "none+none", &title);
+    Ok(())
+}
+
+/// Run the GRIB comparison benchmark and print results to stdout.
+///
+/// Called by the `grib-comparison` binary. Requires the `eccodes` C library.
+#[cfg(feature = "eccodes")]
+pub fn run_grib_comparison(
+    num_points: usize,
+    iterations: usize,
+    seed: u64,
+) -> Result<(), BenchmarkError> {
+    let results = grib_comparison::run_grib_comparison_results(num_points, iterations, seed)?;
+
+    let title = format!(
+        "GRIB vs Tensogram Comparison ({num_points} float64 values, 24 bit, {iterations} iterations)"
+    );
+    report::print_table(&results, "eccodes grid_ccsds", &title);
+    Ok(())
+}
+
+// grib_comparison module declared only when eccodes feature is active.
+#[cfg(feature = "eccodes")]
+pub mod grib_comparison;

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -34,8 +34,12 @@ pub fn run_codec_matrix(
 ) -> Result<(), BenchmarkError> {
     let results = codec_matrix::run_codec_matrix_results(num_points, iterations, seed)?;
 
+    // Derive actual count from results: original_bytes / 8 bytes per f64.
+    // This reflects the rounded-up value (num_points may have been padded to
+    // the next multiple of 4 for szip alignment).
+    let actual_count = results.first().map_or(num_points, |r| r.original_bytes / 8);
     let title = format!(
-        "Tensogram Codec Matrix ({num_points} float64 values, {iterations} iterations, median)"
+        "Tensogram Codec Matrix ({actual_count} float64 values, {iterations} iterations, median)"
     );
     report::print_table(&results, "none+none", &title);
     Ok(())

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -1,6 +1,5 @@
 // Tensogram benchmark library.
 //
-// Each module is populated as benchmark components are implemented.
 // The `run_*` functions are the public entry points called by the binaries.
 
 pub mod codec_matrix;

--- a/benchmarks/src/report.rs
+++ b/benchmarks/src/report.rs
@@ -366,4 +366,70 @@ mod tests {
         let mut s: [u64; 0] = [];
         assert_eq!(median_ns(&mut s), 0);
     }
+
+    #[test]
+    fn test_median_ns_large_values() {
+        // Two u64::MAX values — the u128 addition must not overflow.
+        let mut s = [u64::MAX, u64::MAX];
+        let m = median_ns(&mut s);
+        assert_eq!(m, u64::MAX);
+    }
+
+    #[test]
+    fn test_median_ns_two_elements() {
+        let mut s = [10u64, 20];
+        // (10+20)/2 = 15
+        assert_eq!(median_ns(&mut s), 15);
+    }
+
+    #[test]
+    fn test_ns_to_ms() {
+        assert!((ns_to_ms(1_000_000) - 1.0).abs() < f64::EPSILON);
+        assert!((ns_to_ms(0) - 0.0).abs() < f64::EPSILON);
+        assert!((ns_to_ms(500_000) - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_size_kib() {
+        let r = BenchmarkResult {
+            name: "x".to_string(),
+            encode_ms: 1.0,
+            decode_ms: 1.0,
+            compressed_bytes: 2048,
+            original_bytes: 4096,
+        };
+        assert!((r.size_kib() - 2.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_ratio_above_100() {
+        // Compression expansion: compressed > original (e.g. LZ4 on random data).
+        let r = BenchmarkResult {
+            name: "x".to_string(),
+            encode_ms: 1.0,
+            decode_ms: 1.0,
+            compressed_bytes: 10000,
+            original_bytes: 8000,
+        };
+        let ratio = r.ratio_pct();
+        assert!((ratio - 125.0).abs() < 0.001, "expected 125%, got {ratio}");
+    }
+
+    #[test]
+    fn test_format_table_empty_results() {
+        let table = format_table(&[], "ref", "Empty");
+        // Must not panic. Header and separator should still appear.
+        assert!(table.contains("Combo"), "header missing for empty table");
+        assert!(table.contains("Empty"), "title missing for empty table");
+    }
+
+    #[test]
+    fn test_format_table_vs_ref_values() {
+        let results = make_results();
+        let table = format_table(&results, "none+none", "Test");
+        // Reference row should show 1.00x for both vs-ref columns.
+        assert!(table.contains("1.00x"), "reference row must show 1.00x");
+        // sp(24)+szip: encode 10.0 / 0.5 = 20.00x
+        assert!(table.contains("20.00x"), "expected 20.00x vs-ref encode");
+    }
 }

--- a/benchmarks/src/report.rs
+++ b/benchmarks/src/report.rs
@@ -1,0 +1,369 @@
+//! ASCII table reporter for benchmark results.
+//!
+//! Formats a list of [`BenchmarkResult`] values into a human-readable table
+//! with reference-relative comparison columns. The reference row is marked
+//! with `[REF]` and the "vs Ref" columns show how many times faster or slower
+//! each variant is compared to the reference.
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/// Timing and size results for one benchmark run.
+#[derive(Debug, Clone)]
+pub struct BenchmarkResult {
+    /// Short display name, e.g. `"none+none"` or `"sp(24)+szip"`.
+    pub name: String,
+    /// Median encode time across all iterations, in milliseconds.
+    pub encode_ms: f64,
+    /// Median decode time across all iterations, in milliseconds.
+    pub decode_ms: f64,
+    /// Compressed payload size in bytes.
+    pub compressed_bytes: usize,
+    /// Original (uncompressed) payload size in bytes.
+    pub original_bytes: usize,
+}
+
+impl BenchmarkResult {
+    /// Compression ratio as a percentage: 100 % × compressed / original.
+    ///
+    /// Returns 100.0 when original_bytes is zero.
+    pub fn ratio_pct(&self) -> f64 {
+        if self.original_bytes == 0 {
+            return 100.0;
+        }
+        100.0 * self.compressed_bytes as f64 / self.original_bytes as f64
+    }
+
+    /// Compressed size in kibibytes.
+    pub fn size_kib(&self) -> f64 {
+        self.compressed_bytes as f64 / 1024.0
+    }
+}
+
+// ── Timing helpers ────────────────────────────────────────────────────────────
+
+/// Compute the median of a mutable slice of durations (in nanoseconds).
+///
+/// Returns 0 if the slice is empty.
+pub fn median_ns(samples: &mut [u64]) -> u64 {
+    if samples.is_empty() {
+        return 0;
+    }
+    samples.sort_unstable();
+    let mid = samples.len() / 2;
+    if samples.len().is_multiple_of(2) {
+        // Average of the two middle values (avoids overflow via u128).
+        ((samples[mid - 1] as u128 + samples[mid] as u128) / 2) as u64
+    } else {
+        samples[mid]
+    }
+}
+
+/// Convert nanoseconds to milliseconds.
+pub fn ns_to_ms(ns: u64) -> f64 {
+    ns as f64 / 1_000_000.0
+}
+
+// ── Table formatting ──────────────────────────────────────────────────────────
+
+/// Format benchmark results as an ASCII table string.
+///
+/// `reference_name` must match the `.name` field of exactly one result; that
+/// row is marked `[REF]` and used as the baseline for the "vs Ref" columns.
+/// If no matching row is found the function still produces a valid table but
+/// omits reference-relative columns.
+pub fn format_table(results: &[BenchmarkResult], reference_name: &str, title: &str) -> String {
+    // Find the reference row.
+    let ref_result = results.iter().find(|r| r.name == reference_name);
+
+    // Build display rows: (name, encode_ms, decode_ms, ratio, kib, vs_enc, vs_dec)
+    struct Row {
+        name: String,
+        encode_ms: String,
+        decode_ms: String,
+        ratio_pct: String,
+        size_kib: String,
+        vs_enc: String,
+        vs_dec: String,
+    }
+
+    let rows: Vec<Row> = results
+        .iter()
+        .map(|r| {
+            let is_ref = r.name == reference_name;
+            let display_name = if is_ref {
+                format!("{} [REF]", r.name)
+            } else {
+                r.name.clone()
+            };
+
+            let vs_enc = match ref_result {
+                Some(ref_r) if ref_r.encode_ms > 0.0 => {
+                    format!("{:.2}x", r.encode_ms / ref_r.encode_ms)
+                }
+                Some(_) => "N/A".to_string(),
+                None => "N/A".to_string(),
+            };
+            let vs_dec = match ref_result {
+                Some(ref_r) if ref_r.decode_ms > 0.0 => {
+                    format!("{:.2}x", r.decode_ms / ref_r.decode_ms)
+                }
+                Some(_) => "N/A".to_string(),
+                None => "N/A".to_string(),
+            };
+
+            Row {
+                name: display_name,
+                encode_ms: format!("{:.3}", r.encode_ms),
+                decode_ms: format!("{:.3}", r.decode_ms),
+                ratio_pct: format!("{:.2}", r.ratio_pct()),
+                size_kib: format!("{:.1}", r.size_kib()),
+                vs_enc,
+                vs_dec,
+            }
+        })
+        .collect();
+
+    // Column headers
+    let headers = [
+        "Combo",
+        "Encode (ms)",
+        "Decode (ms)",
+        "Ratio (%)",
+        "Size (KiB)",
+        "vs Ref Enc",
+        "vs Ref Dec",
+    ];
+
+    // Compute column widths from max of header and data.
+    let widths: [usize; 7] = {
+        let mut w = [0usize; 7];
+        for (i, h) in headers.iter().enumerate() {
+            w[i] = h.len();
+        }
+        for row in &rows {
+            let cells = [
+                row.name.as_str(),
+                row.encode_ms.as_str(),
+                row.decode_ms.as_str(),
+                row.ratio_pct.as_str(),
+                row.size_kib.as_str(),
+                row.vs_enc.as_str(),
+                row.vs_dec.as_str(),
+            ];
+            for (i, cell) in cells.iter().enumerate() {
+                w[i] = w[i].max(cell.len());
+            }
+        }
+        w
+    };
+
+    let mut out = String::new();
+
+    // Title line
+    out.push_str(title);
+    out.push('\n');
+
+    // Reference line
+    out.push_str(&format!("Reference: {reference_name}\n"));
+    out.push('\n');
+
+    // Header row
+    let header_line = format!(
+        " {:<w0$} | {:>w1$} | {:>w2$} | {:>w3$} | {:>w4$} | {:>w5$} | {:>w6$}",
+        headers[0],
+        headers[1],
+        headers[2],
+        headers[3],
+        headers[4],
+        headers[5],
+        headers[6],
+        w0 = widths[0],
+        w1 = widths[1],
+        w2 = widths[2],
+        w3 = widths[3],
+        w4 = widths[4],
+        w5 = widths[5],
+        w6 = widths[6],
+    );
+    out.push_str(&header_line);
+    out.push('\n');
+
+    // Separator
+    let sep: String = widths
+        .iter()
+        .enumerate()
+        .map(|(i, &w)| "-".repeat(w + if i == 0 { 2 } else { 3 }))
+        .collect::<Vec<_>>()
+        .join("+");
+    out.push_str(&sep);
+    out.push('\n');
+
+    // Data rows
+    for row in &rows {
+        let line = format!(
+            " {:<w0$} | {:>w1$} | {:>w2$} | {:>w3$} | {:>w4$} | {:>w5$} | {:>w6$}",
+            row.name,
+            row.encode_ms,
+            row.decode_ms,
+            row.ratio_pct,
+            row.size_kib,
+            row.vs_enc,
+            row.vs_dec,
+            w0 = widths[0],
+            w1 = widths[1],
+            w2 = widths[2],
+            w3 = widths[3],
+            w4 = widths[4],
+            w5 = widths[5],
+            w6 = widths[6],
+        );
+        out.push_str(&line);
+        out.push('\n');
+    }
+
+    out
+}
+
+/// Print benchmark results to stdout.
+pub fn print_table(results: &[BenchmarkResult], reference_name: &str, title: &str) {
+    print!("{}", format_table(results, reference_name, title));
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_results() -> Vec<BenchmarkResult> {
+        vec![
+            BenchmarkResult {
+                name: "none+none".to_string(),
+                encode_ms: 0.5,
+                decode_ms: 0.3,
+                compressed_bytes: 8000,
+                original_bytes: 8000,
+            },
+            BenchmarkResult {
+                name: "sp(24)+szip".to_string(),
+                encode_ms: 10.0,
+                decode_ms: 5.0,
+                compressed_bytes: 3000,
+                original_bytes: 8000,
+            },
+        ]
+    }
+
+    #[test]
+    fn test_reference_marked() {
+        let results = make_results();
+        let table = format_table(&results, "none+none", "Test");
+        assert!(
+            table.contains("[REF]"),
+            "reference row must be marked [REF]"
+        );
+        assert!(
+            table.contains("none+none [REF]"),
+            "reference name must appear with [REF] suffix"
+        );
+    }
+
+    #[test]
+    fn test_headers_present() {
+        let results = make_results();
+        let table = format_table(&results, "none+none", "Test");
+        assert!(table.contains("Encode (ms)"), "header Encode (ms) missing");
+        assert!(table.contains("Decode (ms)"), "header Decode (ms) missing");
+        assert!(table.contains("Ratio (%)"), "header Ratio (%) missing");
+        assert!(table.contains("Size (KiB)"), "header Size (KiB) missing");
+        assert!(table.contains("vs Ref Enc"), "header vs Ref Enc missing");
+    }
+
+    #[test]
+    fn test_reference_line() {
+        let results = make_results();
+        let table = format_table(&results, "none+none", "Test");
+        assert!(
+            table.contains("Reference: none+none"),
+            "reference line missing"
+        );
+    }
+
+    #[test]
+    fn test_ratio_calculation() {
+        let r = BenchmarkResult {
+            name: "x".to_string(),
+            encode_ms: 1.0,
+            decode_ms: 1.0,
+            compressed_bytes: 3000,
+            original_bytes: 8000,
+        };
+        let ratio = r.ratio_pct();
+        // 3000/8000 = 37.5%
+        assert!((ratio - 37.5).abs() < 0.001, "ratio {ratio} != 37.5");
+    }
+
+    #[test]
+    fn test_zero_original_bytes() {
+        let r = BenchmarkResult {
+            name: "x".to_string(),
+            encode_ms: 1.0,
+            decode_ms: 1.0,
+            compressed_bytes: 0,
+            original_bytes: 0,
+        };
+        // Must not divide by zero.
+        let ratio = r.ratio_pct();
+        assert_eq!(ratio, 100.0);
+    }
+
+    #[test]
+    fn test_zero_reference_time() {
+        let results = vec![
+            BenchmarkResult {
+                name: "ref".to_string(),
+                encode_ms: 0.0, // zero reference time
+                decode_ms: 0.0,
+                compressed_bytes: 100,
+                original_bytes: 100,
+            },
+            BenchmarkResult {
+                name: "other".to_string(),
+                encode_ms: 5.0,
+                decode_ms: 3.0,
+                compressed_bytes: 50,
+                original_bytes: 100,
+            },
+        ];
+        let table = format_table(&results, "ref", "Test");
+        // Should contain N/A for vs-ref columns when reference time is zero.
+        assert!(
+            table.contains("N/A"),
+            "N/A expected when reference time is zero"
+        );
+    }
+
+    #[test]
+    fn test_median_ns_odd() {
+        let mut s = [3u64, 1, 4, 1, 5];
+        assert_eq!(median_ns(&mut s), 3);
+    }
+
+    #[test]
+    fn test_median_ns_even() {
+        let mut s = [1u64, 2, 3, 4];
+        assert_eq!(median_ns(&mut s), 2); // (2+3)/2 = 2
+    }
+
+    #[test]
+    fn test_median_ns_single() {
+        let mut s = [42u64];
+        assert_eq!(median_ns(&mut s), 42);
+    }
+
+    #[test]
+    fn test_median_ns_empty() {
+        let mut s: [u64; 0] = [];
+        assert_eq!(median_ns(&mut s), 0);
+    }
+}

--- a/benchmarks/src/report.rs
+++ b/benchmarks/src/report.rs
@@ -69,8 +69,8 @@ pub fn ns_to_ms(ns: u64) -> f64 {
 ///
 /// `reference_name` must match the `.name` field of exactly one result; that
 /// row is marked `[REF]` and used as the baseline for the "vs Ref" columns.
-/// If no matching row is found the function still produces a valid table but
-/// omits reference-relative columns.
+/// If no matching row is found the function still produces a valid table and
+/// keeps the reference-relative columns, filling their cells with `N/A`.
 pub fn format_table(results: &[BenchmarkResult], reference_name: &str, title: &str) -> String {
     // Find the reference row.
     let ref_result = results.iter().find(|r| r.name == reference_name);

--- a/benchmarks/tests/smoke.rs
+++ b/benchmarks/tests/smoke.rs
@@ -192,6 +192,74 @@ fn test_codec_matrix_non_aligned_points() {
     }
 }
 
+#[test]
+fn test_codec_matrix_single_point() {
+    // num_points=1 rounds to 4. All 24 codecs should handle tiny data.
+    let results =
+        run_codec_matrix_results(1, 1, 42).expect("num_points=1 must succeed (rounded to 4)");
+    assert_eq!(results.len(), 24, "expected 24 results");
+    for r in &results {
+        assert!(
+            !r.name.contains("[ERROR]"),
+            "unexpected error for tiny data in '{}'",
+            r.name
+        );
+    }
+    // original_bytes should be 4 * 8 = 32 (padded to 4 values).
+    assert_eq!(
+        results[0].original_bytes, 32,
+        "expected 32 bytes for 4 f64 values"
+    );
+}
+
+#[test]
+fn test_codec_matrix_padded_original_bytes() {
+    // 501 rounds to 504. original_bytes = 504 * 8 = 4032.
+    let results = run_codec_matrix_results(501, 1, 42).expect("must succeed");
+    assert_eq!(
+        results[0].original_bytes,
+        504 * 8,
+        "original_bytes must reflect padded count (504 × 8)"
+    );
+}
+
+#[test]
+fn test_codec_matrix_error_message_content() {
+    let err = run_codec_matrix_results(0, 1, 42).unwrap_err();
+    assert!(
+        err.to_string().contains("num_points"),
+        "error message should mention 'num_points': got '{err}'"
+    );
+
+    let err = run_codec_matrix_results(100, 0, 42).unwrap_err();
+    assert!(
+        err.to_string().contains("iterations"),
+        "error message should mention 'iterations': got '{err}'"
+    );
+}
+
+// ── lib.rs entry points ──────────────────────────────────────────────────────
+
+#[test]
+fn test_run_codec_matrix_prints_table() {
+    // Just verify the top-level entry point doesn't panic.
+    tensogram_benchmarks::run_codec_matrix(100, 1, 42).expect("run_codec_matrix must not error");
+}
+
+#[test]
+fn test_benchmark_error_display() {
+    use tensogram_benchmarks::BenchmarkError;
+    let e = BenchmarkError("test error".to_string());
+    assert_eq!(format!("{e}"), "test error");
+}
+
+#[test]
+fn test_benchmark_error_from_string() {
+    use tensogram_benchmarks::BenchmarkError;
+    let e: BenchmarkError = String::from("from string").into();
+    assert_eq!(e.0, "from string");
+}
+
 // ── grib_comparison (eccodes feature-gated) ──────────────────────────────────
 
 #[cfg(feature = "eccodes")]

--- a/benchmarks/tests/smoke.rs
+++ b/benchmarks/tests/smoke.rs
@@ -1,0 +1,232 @@
+//! Smoke tests for the tensogram-benchmarks crate.
+//!
+//! These tests use small data sizes (1000 points, 1 iteration) so they
+//! run in milliseconds on CI, verifying that each benchmark module compiles,
+//! runs, and produces well-formed output without errors.
+
+use tensogram_benchmarks::codec_matrix::run_codec_matrix_results;
+use tensogram_benchmarks::datagen::generate_weather_field;
+use tensogram_benchmarks::report::{format_table, BenchmarkResult};
+
+// ── datagen ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_datagen_determinism() {
+    let a = generate_weather_field(1000, 42);
+    let b = generate_weather_field(1000, 42);
+    assert_eq!(a, b, "same seed must produce identical output");
+}
+
+#[test]
+fn test_datagen_different_seeds_differ() {
+    let a = generate_weather_field(1000, 1);
+    let b = generate_weather_field(1000, 2);
+    assert_ne!(a, b, "different seeds must produce different output");
+}
+
+#[test]
+fn test_datagen_exact_length() {
+    for n in [0usize, 1, 100, 999, 1000, 1024] {
+        let v = generate_weather_field(n, 42);
+        assert_eq!(v.len(), n, "length mismatch for n={n}");
+    }
+}
+
+#[test]
+fn test_datagen_physical_range() {
+    let v = generate_weather_field(1000, 42);
+    for (i, &val) in v.iter().enumerate() {
+        assert!(val.is_finite(), "non-finite value at index {i}: {val}");
+        assert!(
+            (240.0..=320.0).contains(&val),
+            "value out of physical range at index {i}: {val}"
+        );
+    }
+}
+
+// ── report ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_report_formatting() {
+    let results = vec![
+        BenchmarkResult {
+            name: "none+none".to_string(),
+            encode_ms: 1.0,
+            decode_ms: 0.5,
+            compressed_bytes: 8000,
+            original_bytes: 8000,
+        },
+        BenchmarkResult {
+            name: "sp(24)+szip".to_string(),
+            encode_ms: 20.0,
+            decode_ms: 15.0,
+            compressed_bytes: 3000,
+            original_bytes: 8000,
+        },
+    ];
+    let table = format_table(&results, "none+none", "Test title");
+
+    assert!(
+        table.contains("[REF]"),
+        "reference row must be marked [REF]"
+    );
+    assert!(
+        table.contains("none+none [REF]"),
+        "reference name must have [REF] suffix"
+    );
+    assert!(table.contains("Encode (ms)"), "header missing");
+    assert!(table.contains("Ratio (%)"), "ratio column missing");
+    assert!(
+        table.contains("Reference: none+none"),
+        "reference line missing"
+    );
+    assert!(table.contains("Test title"), "title missing");
+    // sp(24)+szip should show 37.5% ratio (3000/8000)
+    assert!(table.contains("37.50"), "expected 37.50% ratio");
+}
+
+#[test]
+fn test_report_ref_not_found() {
+    // Table should still render even if reference_name doesn't match any result.
+    let results = vec![BenchmarkResult {
+        name: "only".to_string(),
+        encode_ms: 1.0,
+        decode_ms: 1.0,
+        compressed_bytes: 100,
+        original_bytes: 100,
+    }];
+    let table = format_table(&results, "missing_ref", "Test");
+    // Must not panic and must contain the column headers.
+    assert!(table.contains("Encode (ms)"));
+    assert!(table.contains("N/A")); // vs-ref columns should be N/A
+}
+
+// ── codec_matrix ──────────────────────────────────────────────────────────────
+
+#[test]
+fn test_codec_matrix_smoke() {
+    // Run with 1000 points and 1 iteration — completes in < 5 seconds.
+    let results =
+        run_codec_matrix_results(1000, 1, 42).expect("codec matrix must not return an error");
+
+    // Should produce 24 results (one per combo).
+    assert_eq!(results.len(), 24, "expected 24 benchmark results");
+
+    // First result is the reference (none+none).
+    assert_eq!(
+        results[0].name, "none+none",
+        "first result must be the reference"
+    );
+
+    // All results must have positive original_bytes.
+    for r in &results {
+        assert!(
+            r.original_bytes > 0,
+            "original_bytes must be > 0 for '{}'",
+            r.name
+        );
+    }
+
+    // None of the results should be ERROR-tagged (compression should succeed
+    // for all 24 combos on this size of data).
+    for r in &results {
+        assert!(
+            !r.name.contains("[ERROR]"),
+            "unexpected error in result: '{}'",
+            r.name
+        );
+    }
+
+    // Compression ratios: sp(16) should give a ratio below 35%.
+    let sp16 = results
+        .iter()
+        .find(|r| r.name == "sp(16)+none")
+        .expect("sp(16)+none result missing");
+    assert!(
+        sp16.ratio_pct() < 35.0,
+        "sp(16) ratio {} should be below 35%",
+        sp16.ratio_pct()
+    );
+}
+
+#[test]
+fn test_codec_matrix_result_names_unique() {
+    let results = run_codec_matrix_results(500, 1, 0).expect("must not error");
+    let mut names: Vec<&str> = results.iter().map(|r| r.name.as_str()).collect();
+    names.sort_unstable();
+    names.dedup();
+    assert_eq!(
+        names.len(),
+        results.len(),
+        "duplicate result names detected"
+    );
+}
+
+// ── edge cases ────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_codec_matrix_zero_points_returns_err() {
+    let result = run_codec_matrix_results(0, 1, 42);
+    assert!(result.is_err(), "num_points=0 must return Err");
+}
+
+#[test]
+fn test_codec_matrix_non_aligned_points() {
+    // 501 is not a multiple of 4.  The codec matrix rounds up internally
+    // so that szip cases never fail due to alignment.
+    let results = run_codec_matrix_results(501, 1, 42)
+        .expect("non-aligned num_points must succeed (rounded up)");
+    assert_eq!(results.len(), 24, "expected 24 results");
+    for r in &results {
+        assert!(
+            !r.name.contains("[ERROR]"),
+            "unexpected error for non-aligned size in '{}'",
+            r.name
+        );
+    }
+}
+
+// ── grib_comparison (eccodes feature-gated) ──────────────────────────────────
+
+#[cfg(feature = "eccodes")]
+#[test]
+fn test_grib_comparison_zero_points_returns_err() {
+    use tensogram_benchmarks::grib_comparison::run_grib_comparison_results;
+    let result = run_grib_comparison_results(0, 1, 42);
+    assert!(result.is_err(), "num_points=0 must return Err");
+}
+
+#[cfg(feature = "eccodes")]
+#[test]
+fn test_grib_comparison_smoke() {
+    use tensogram_benchmarks::grib_comparison::run_grib_comparison_results;
+
+    let results = run_grib_comparison_results(1000, 1, 42).expect("grib comparison must not error");
+
+    // Expect exactly 3 results.
+    assert_eq!(results.len(), 3, "expected 3 results");
+
+    // First result must be the eccodes CCSDS reference.
+    assert_eq!(
+        results[0].name, "eccodes grid_ccsds",
+        "first result must be eccodes grid_ccsds"
+    );
+
+    // No results should be ERROR-tagged.
+    for r in &results {
+        assert!(
+            !r.name.contains("[ERROR]"),
+            "unexpected error in grib result: '{}'",
+            r.name
+        );
+    }
+
+    // All should have positive compressed_bytes.
+    for r in &results {
+        assert!(
+            r.compressed_bytes > 0,
+            "compressed_bytes must be > 0 for '{}'",
+            r.name
+        );
+    }
+}

--- a/benchmarks/tests/smoke.rs
+++ b/benchmarks/tests/smoke.rs
@@ -171,6 +171,12 @@ fn test_codec_matrix_zero_points_returns_err() {
 }
 
 #[test]
+fn test_codec_matrix_zero_iterations_returns_err() {
+    let result = run_codec_matrix_results(100, 0, 42);
+    assert!(result.is_err(), "iterations=0 must return Err");
+}
+
+#[test]
 fn test_codec_matrix_non_aligned_points() {
     // 501 is not a multiple of 4.  The codec matrix rounds up internally
     // so that szip cases never fail due to alignment.
@@ -194,6 +200,14 @@ fn test_grib_comparison_zero_points_returns_err() {
     use tensogram_benchmarks::grib_comparison::run_grib_comparison_results;
     let result = run_grib_comparison_results(0, 1, 42);
     assert!(result.is_err(), "num_points=0 must return Err");
+}
+
+#[cfg(feature = "eccodes")]
+#[test]
+fn test_grib_comparison_zero_iterations_returns_err() {
+    use tensogram_benchmarks::grib_comparison::run_grib_comparison_results;
+    let result = run_grib_comparison_results(100, 0, 42);
+    assert!(result.is_err(), "iterations=0 must return Err");
 }
 
 #[cfg(feature = "eccodes")]

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -33,6 +33,7 @@
 - [xarray Integration](guide/xarray-integration.md)
 - [Dask Integration](guide/dask-integration.md)
 - [Zarr v3 Backend](guide/zarr-backend.md)
+- [Benchmarks](guide/benchmarks.md)
 
 ---
 

--- a/docs/src/guide/benchmarks.md
+++ b/docs/src/guide/benchmarks.md
@@ -39,7 +39,7 @@ cargo run --release -p tensogram-benchmarks --bin codec-matrix -- \
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--num-points` | 16 000 000 | Number of float64 values to encode; when szip cases are enabled, rounded up to a multiple of 4 (up to 3 extra values) for alignment |
+| `--num-points` | 16 000 000 | Number of float64 values to encode; always rounded up to the next multiple of 4 (up to 3 extra values) for szip alignment |
 | `--iterations` | 5 | Timed iterations per combo (median reported) |
 | `--seed` | 42 | PRNG seed for deterministic data generation |
 

--- a/docs/src/guide/benchmarks.md
+++ b/docs/src/guide/benchmarks.md
@@ -39,7 +39,7 @@ cargo run --release -p tensogram-benchmarks --bin codec-matrix -- \
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--num-points` | 16 000 000 | Number of float64 values to encode |
+| `--num-points` | 16 000 000 | Number of float64 values to encode; when szip cases are enabled, rounded up to a multiple of 4 (up to 3 extra values) for alignment |
 | `--iterations` | 5 | Timed iterations per combo (median reported) |
 | `--seed` | 42 | PRNG seed for deterministic data generation |
 

--- a/docs/src/guide/benchmarks.md
+++ b/docs/src/guide/benchmarks.md
@@ -1,0 +1,174 @@
+# Benchmarks
+
+The `benchmarks/` crate provides reproducible, tabular performance comparisons for
+all encoding/compression pipeline combinations. It lives in the repository and can
+be re-run at any time to measure the effect of changes to the core encoding paths.
+
+## Design Rationale
+
+The benchmark suite is a standalone binary rather than a Criterion harness for two
+reasons:
+
+1. **Custom reporting** — the TODO spec requires formatted comparison tables with
+   compression ratios, sizes in KiB, and reference-relative speedup factors. Criterion
+   is purpose-built for statistical regression detection (mean ± stddev), not tabular
+   multi-metric comparison.
+2. **Zero extra dependencies** — a standalone binary with `std::time::Instant` adds
+   no compilation overhead to the workspace and is fully controlled.
+
+## Codec Matrix Benchmark
+
+Runs all valid encoder × compressor × bit-width combinations on 16 million synthetic
+float64 values and reports encode time, decode time, compressed size, and compression
+ratio against the `none+none` baseline.
+
+### Quick start
+
+```bash
+cargo run --release -p tensogram-benchmarks --bin codec-matrix
+```
+
+Override parameters with CLI flags:
+
+```bash
+cargo run --release -p tensogram-benchmarks --bin codec-matrix -- \
+    --num-points 16000000 \
+    --iterations 5 \
+    --seed 42
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--num-points` | 16 000 000 | Number of float64 values to encode |
+| `--iterations` | 5 | Timed iterations per combo (median reported) |
+| `--seed` | 42 | PRNG seed for deterministic data generation |
+
+### Combinations measured
+
+| Group | Description | Count |
+|-------|-------------|-------|
+| Baseline | `none+none` (raw f64 bytes, no compression) | 1 |
+| Raw + lossless | `none+{zstd,lz4,blosc2,szip}` | 4 |
+| SimplePacking + lossless | `sp(B)+{none,zstd,lz4,blosc2,szip}` at B=16, 24, 32 bits | 15 |
+| Lossy float | `none+zfp(rate=16/24/32)`, `none+sz3(abs=0.01)` | 4 |
+| **Total** | | **24** |
+
+### Example output
+
+```
+Tensogram Codec Matrix (16000000 float64 values, 5 iterations, median)
+Reference: none+none
+
+ Combo                  | Encode (ms) | Decode (ms) | Ratio (%) | Size (KiB) | vs Ref Enc | vs Ref Dec
+------------------------+-------------+-------------+-----------+------------+------------+-----------
+ none+none [REF]        |       4.123 |       3.891 |    100.00 |  125000.0  |      1.00x |      1.00x
+ none+zstd(3)           |     312.456 |      52.100 |     72.30 |   90375.0  |     75.79x |     13.39x
+ none+lz4               |      58.234 |       8.100 |     98.20 |  122750.0  |     14.12x |      2.08x
+ sp(16)+none            |      95.200 |     185.400 |     25.00 |   31250.0  |     23.09x |     47.65x
+ sp(24)+szip            |      70.100 |     175.200 |     28.50 |   35625.0  |     17.00x |     45.03x
+ none+zfp(rate=24)      |      52.300 |     155.100 |     37.50 |   46875.0  |     12.69x |     39.86x
+ ...
+```
+
+### Interpreting the output
+
+| Column | Meaning |
+|--------|---------|
+| `Encode (ms)` | Median time to compress the payload (wall clock, unloaded machine) |
+| `Decode (ms)` | Median time to decompress the payload |
+| `Ratio (%)` | `compressed_bytes / original_bytes × 100` — lower is better |
+| `Size (KiB)` | Compressed payload size |
+| `vs Ref Enc` | `this_encode_ms / reference_encode_ms` — values > 1.00× are slower than the reference |
+| `vs Ref Dec` | Same for decode |
+
+The reference (`none+none`) is the throughput of copying raw float64 bytes through the
+pipeline without any encoding or compression. It sets the baseline latency floor.
+
+## GRIB Comparison Benchmark
+
+Compares ecCodes CCSDS packing (`grid_ccsds`, 24 bit) — the operational reference —
+against Tensogram `simple_packing(24)+szip` on 10 million float64 values.
+
+### Requirements
+
+- ecCodes C library installed (`brew install eccodes` on macOS, `apt install libeccodes-dev` on Debian/Ubuntu)
+- Build with `--features eccodes`
+
+### Quick start
+
+```bash
+cargo run --release -p tensogram-benchmarks --bin grib-comparison --features eccodes
+```
+
+```bash
+cargo run --release -p tensogram-benchmarks --bin grib-comparison --features eccodes -- \
+    --num-points 10000000 \
+    --iterations 5 \
+    --seed 42
+```
+
+### Methods compared
+
+| Method | Description |
+|--------|-------------|
+| `eccodes grid_ccsds` **(reference)** | ecCodes CCSDS packing (CCSDS 121.0-B-3 via libaec) |
+| `eccodes grid_simple` | ecCodes simple packing (GRIB grid_simple, same bit depth) |
+| `tensogram sp(24)+szip` | Tensogram SimplePacking(24) + szip (same algorithm, different framing) |
+
+### Timing model
+
+- **GRIB encode**: time of `codes_set_double_array("values", ...)` — the quantisation and packing call.
+- **GRIB decode**: time to create a handle from raw GRIB bytes + `codes_get_double_array("values", ...)`.
+- **Tensogram encode/decode**: `encode_pipeline` / `decode_pipeline` on the packed bit stream.
+
+### Example output
+
+```
+GRIB vs Tensogram Comparison (10000000 float64 values, 24 bit, 5 iterations)
+Reference: eccodes grid_ccsds
+
+ Combo                    | Encode (ms) | Decode (ms) | Ratio (%) | Size (KiB)  | vs Ref Enc | vs Ref Dec
+--------------------------+-------------+-------------+-----------+-------------+------------+-----------
+ eccodes grid_ccsds [REF] |     312.000 |     245.000 |     37.50 |   36621.1   |      1.00x |      1.00x
+ eccodes grid_simple      |     180.000 |     120.000 |     37.50 |   36621.1   |      0.58x |      0.49x
+ tensogram sp(24)+szip    |     210.000 |     160.000 |     28.57 |   27915.1   |      0.67x |      0.65x
+```
+
+## Benchmark pipeline flow
+
+```mermaid
+flowchart LR
+    subgraph datagen
+        G[generate_weather_field\nnumpoints × f64]
+    end
+    subgraph timing
+        W[warm-up\n1 iteration\ndiscarded]
+        T[timed iterations\nmedian taken]
+    end
+    subgraph report
+        R[format_table\nreference comparison\nASCII table]
+    end
+
+    G --> W --> T --> R
+    T --> |encode_pipeline| Enc[compressed bytes]
+    Enc --> |decode_pipeline| Dec[f64 values]
+```
+
+## Reproducibility
+
+All benchmarks use a deterministic PRNG (SplitMix64) seeded by `--seed`. The same
+seed on the same machine produces identical data and therefore comparable timing
+across runs. For cross-machine comparisons, use the `Ratio (%)` and `Size (KiB)`
+columns (size-independent) rather than absolute millisecond values.
+
+## Running in CI
+
+For fast CI validation, pass `--num-points 10000 --iterations 1`:
+
+```bash
+cargo run -p tensogram-benchmarks --bin codec-matrix -- \
+    --num-points 10000 --iterations 1
+```
+
+The smoke test suite (`cargo test -p tensogram-benchmarks`) uses 500–1000 points
+and completes in under 5 seconds.

--- a/docs/src/guide/benchmarks.md
+++ b/docs/src/guide/benchmarks.md
@@ -198,6 +198,32 @@ ecCodes handles this correctly, but it differs from the typical nearly-square gr
 used in production. For representative GRIB benchmarks, use composite sizes
 (e.g. 10 000 000 = 2500 × 4000).
 
+## Error handling
+
+All benchmark functions return `Result<_, BenchmarkError>` — no panics, no
+`unwrap()` in library code. Errors propagate to the binary entry point, which
+prints them to stderr and exits with code 1.
+
+### Error paths
+
+| Source | When | Message |
+|--------|------|---------|
+| Input validation | `num_points = 0` | `"num_points must be > 0"` |
+| Input validation | `iterations = 0` | `"iterations must be > 0"` |
+| `compute_params` | All values identical (zero range) | `"sp(24) params: ..."` with inner error |
+| `encode_pipeline` | Codec failure (e.g. unsupported config) | Pipeline error description |
+| `decode_pipeline` | Corrupted or truncated encoded data | Pipeline error description |
+| ecCodes C API | `codes_set_long` returns non-zero | `"codes_set_long(key, val) returned rc"` |
+| ecCodes C API | Handle creation returns null | `"codes_grib_handle_new_from_samples(GRIB2) returned null; check ECCODES_SAMPLES_PATH..."` |
+| CString conversion | Key/value contains interior NUL byte | `"invalid key 'name': nul byte found..."` |
+
+### Graceful degradation
+
+In the codec matrix benchmark, if a single combination fails (e.g. a codec is
+unavailable at runtime), the error is logged to stderr and an `[ERROR]` row
+appears in the output table with zero times and zero size. The remaining
+combinations continue to run. The GRIB comparison benchmark uses the same pattern.
+
 ## Reproducibility
 
 All benchmarks use a deterministic PRNG (SplitMix64) seeded by `--seed`. The same

--- a/docs/src/guide/benchmarks.md
+++ b/docs/src/guide/benchmarks.md
@@ -154,6 +154,50 @@ flowchart LR
     Enc --> |decode_pipeline| Dec[f64 values]
 ```
 
+## Edge cases and limitations
+
+### Input validation
+
+Both benchmarks reject `num_points = 0` and `iterations = 0` with an `Err` return
+(no panic). These are caught before any data generation or pipeline calls.
+
+### Szip alignment padding
+
+The codec matrix rounds `num_points` up to the next multiple of 4 (by at most 3
+extra values) before running. This is required because libaec promotes 24-bit
+samples to 4-byte containers, so the packed byte count must be a multiple of 4.
+The padding values come from the same PRNG sequence, so the rounding has no effect
+on the overall benchmark character. The title line and `original_bytes` field both
+reflect the actual (padded) count.
+
+### Compression expansion
+
+Some compressors (especially LZ4 on raw f64 bytes) may produce output *larger*
+than the input (`Ratio > 100%`). This is expected and reported accurately — the
+`none+none` baseline itself is simply a memcpy and always shows 100.00%.
+
+### Very small data sizes
+
+With `--num-points 1` the codec matrix rounds to 4 values. All 24 combinations
+succeed at this size, but absolute timing values are dominated by per-call overhead
+rather than actual compression throughput. Use ≥ 10 000 points for meaningful
+relative comparisons.
+
+### PRNG determinism
+
+The SplitMix64 PRNG is fully deterministic for a given seed, but the weather field
+generator uses `f64::sin()` / `f64::cos()` whose implementations may differ across
+platforms or libm versions. Timing comparisons are therefore only valid within the
+same build environment. Size-based metrics (`Ratio %`, `Size KiB`) are
+platform-independent.
+
+### GRIB grid factorization
+
+For prime `num_points`, the GRIB benchmark creates a degenerate 1 × N grid.
+ecCodes handles this correctly, but it differs from the typical nearly-square grids
+used in production. For representative GRIB benchmarks, use composite sizes
+(e.g. 10 000 000 = 2500 × 4000).
+
 ## Reproducibility
 
 All benchmarks use a deterministic PRNG (SplitMix64) seeded by `--seed`. The same

--- a/plans/DONE.md
+++ b/plans/DONE.md
@@ -6,9 +6,23 @@
 ## Summary
 
 - **Version:** 0.5.0
-- **Workspace:** 5 default crates + 2 optional (Python, GRIB) + 2 separate packages (xarray, zarr)
-- **Tests:** 888 total (283 Rust + 200 Python + 124 xarray + 172 Zarr + 109 C++)
+- **Workspace:** 6 default crates + 2 optional (Python, GRIB) + 2 separate packages (xarray, zarr)
+- **Tests:** 897 total (292 Rust + 200 Python + 124 xarray + 172 Zarr + 109 C++)
 - **Quality:** 0 clippy warnings, 90.5% Rust line coverage
+
+## tensogram-benchmarks
+
+9 tests (8 smoke + 1 GRIB, gated on `eccodes` feature). Separate workspace crate.
+
+- `datagen.rs` — Deterministic SplitMix64-based synthetic weather field generator
+  (smooth sinusoidal temperature field, base ≈ 280 K, amplitude ≈ 30 K, ±0.1 K noise).
+- `report.rs` — ASCII table formatter with reference-relative comparison columns
+  (`vs Ref Enc`, `vs Ref Dec`, `Ratio %`, `Size KiB`). `median_ns` helper for timing.
+- `codec_matrix.rs` — 24 pipeline combos: baseline + raw f64 + simple_packing × {none,zstd,lz4,blosc2,szip} × {16,24,32 bits} + ZFP (rate 16/24/32) + SZ3 (abs=0.01).
+- `grib_comparison.rs` — ecCodes CCSDS (`grid_ccsds`) vs `grid_simple` vs tensogram `sp(24)+szip`. Feature-gated by `eccodes`. Uses raw C API via `extern "C"` declarations.
+- Two binaries: `codec-matrix` (default) and `grib-comparison` (requires `--features eccodes`).
+- `build.rs` — links `libeccodes` via pkg-config or Homebrew fallback when `eccodes` feature is active.
+- Documentation: `docs/src/guide/benchmarks.md`.
 
 ## tensogram-core
 


### PR DESCRIPTION
- [x] Fix `build.rs` `try_pkg_config()`: use `--libs` only, ensure `eccodes` is always linked
- [x] Remove unused `tempfile` dependency from `Cargo.toml` `eccodes` feature
- [x] Update `datagen.rs` doc comment: determinism claim narrowed to "for a given platform/toolchain"
- [x] Update `report.rs` docstring: N/A columns are kept (not omitted) when reference is missing
- [x] Document `num_points` padding in `codec_matrix.rs` public API doc and CLI help (always active, not feature-gated)
- [x] Update `grib_comparison.rs` comment: linking via `build.rs`, not the `eccodes` Rust crate
- [x] Update `benchmarks.md` `--num-points` entry: "always rounded up" wording

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/dev-section/tensogram/pull-requests/PR-16
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->