### PR TITLE
feat: add encode_pre_encoded API for already-framed payloads

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -75,6 +75,7 @@ src/
 ├── types.rs      GlobalMetadata, DataObjectDescriptor, IndexFrame, HashFrame
 ├── dtype.rs      15 data types (float16..complex128, bitmask)
 ├── encode.rs     Full encode pipeline: validate, build config, encode per object, hash, assemble
+│                 encode_pre_encoded: bypass pipeline for already-encoded payloads
 ├── decode.rs     decode, decode_metadata, decode_object, decode_range
 ├── file.rs       TensogramFile: open, create, append, scan, mmap, async variants
 ├── iter.rs       MessageIter (zero-copy), ObjectIter (lazy decode), FileMessageIter (seek-based)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - Auto-populated tensor metadata (ndim/shape/strides/dtype) now lives under `base[i]["_reserved_"]["tensor"]`
 
 ### Added
+- `encode_pre_encoded()` API for advanced callers (e.g., GPU pipelines) across Rust, Python, C FFI, and C++ — bypasses the encoding pipeline for already-encoded payloads
+- `StreamingEncoder::write_object_pre_encoded()` for streaming pre-encoded objects
 - `compute_common()` utility for extracting shared keys from `base` entries in software
 - Encoder validates that client code does not write to `_reserved_` at any level
 - Preceder Metadata Frames (type 8) for streaming per-object metadata

--- a/PYTHON_API.md
+++ b/PYTHON_API.md
@@ -10,12 +10,14 @@
 | **`Metadata`** | Global message metadata | `.version`, `.base`, `.reserved`, `.extra`, `[key]` |
 | **`DataObjectDescriptor`** | Tensor descriptor (shape, dtype, encoding) | `.shape`, `.dtype`, `.encoding`, `.params`, `.compression` |
 | **`TensogramFile`** | File I/O API | `.open()`, `.create()`, `.append()`, `.decode_message()` |
+| **`StreamingEncoder`** | Progressive encode to file | `.write_object()`, `.write_object_pre_encoded()`, `.finish()` |
 
 ### Module Functions
 
 | Function | Signature | Returns |
 |----------|-----------|---------|
 | **`encode`** | `encode(meta, descriptors_and_data, hash="xxh3")` | `bytes` |
+| **`encode_pre_encoded`** | `encode_pre_encoded(meta, descriptors_and_data, hash="xxh3")` | `bytes` |
 | **`decode`** | `decode(buf, verify_hash=False)` | `Message` |
 | **`decode_metadata`** | `decode_metadata(buf)` | `Metadata` |
 | **`decode_object`** | `decode_object(buf, index, verify_hash=False)` | `(Metadata, DataObjectDescriptor, array)` |

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -14,6 +14,10 @@ name = "grib-comparison"
 path = "src/bin/grib_comparison.rs"
 required-features = ["eccodes"]
 
+[[bench]]
+name = "encode_pre_encoded"
+harness = false
+
 [lib]
 name = "tensogram_benchmarks"
 path = "src/lib.rs"
@@ -24,6 +28,11 @@ eccodes = ["dep:eccodes", "dep:eccodes-sys"]
 
 [dependencies]
 tensogram-encodings = { path = "../crates/tensogram-encodings" }
+tensogram-core = { path = "../crates/tensogram-core" }
+ciborium = { workspace = true }
 clap = { workspace = true }
 eccodes = { version = "0.14", default-features = false, optional = true }
 eccodes-sys = { version = "0.7", optional = true }
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }

--- a/benchmarks/benches/encode_pre_encoded.rs
+++ b/benchmarks/benches/encode_pre_encoded.rs
@@ -1,0 +1,129 @@
+//! Benchmark: `encode_full_pipeline` vs `encode_pre_encoded`
+//!
+//! Measures the cost of:
+//! - Full pipeline: simple_packing 24-bit → szip (encoding + compression + framing)
+//! - Pre-encoded path: framing only (no encoding/compression, caller bytes passed through)
+//!
+//! Setup: 16M float64 values (~128 MiB raw), sinusoidal synthetic data.
+//! The pre-encoded bytes are captured once outside the timed loop to simulate
+//! "the GPU produced these bytes earlier" — they are then fed directly to
+//! `encode_pre_encoded`, which skips simple_packing + szip entirely.
+
+use std::collections::BTreeMap;
+
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use tensogram_core::{
+    encode, encode_pre_encoded, framing, ByteOrder, DataObjectDescriptor, Dtype, EncodeOptions,
+    GlobalMetadata,
+};
+use tensogram_encodings::simple_packing::compute_params;
+
+const N_FLOATS: usize = 16 * 1024 * 1024; // 16 Mi float64 (~128 MiB raw)
+
+fn bench_encode_paths(c: &mut Criterion) {
+    // ── Synthesize 16M float64 values ────────────────────────────────────────
+    // Sinusoidal pattern with a 280-unit offset; smooth fields compress well with szip.
+    let raw: Vec<f64> = (0..N_FLOATS)
+        .map(|i| (i as f64 * 0.0001).sin() * 1000.0 + 280.0)
+        .collect();
+
+    // Encode as big-endian bytes (matches ByteOrder::Big descriptor below).
+    let raw_bytes: Vec<u8> = raw.iter().flat_map(|v| v.to_be_bytes()).collect();
+
+    // ── Compute simple_packing params from the actual data ────────────────────
+    let sp_params = compute_params(&raw, 24, 0).expect("compute_params failed");
+
+    // ── Build params map (ciborium Values) ────────────────────────────────────
+    let mut params_map: BTreeMap<String, ciborium::Value> = BTreeMap::new();
+    params_map.insert(
+        "reference_value".to_string(),
+        ciborium::Value::Float(sp_params.reference_value),
+    );
+    params_map.insert(
+        "binary_scale_factor".to_string(),
+        ciborium::Value::Integer((sp_params.binary_scale_factor as i64).into()),
+    );
+    params_map.insert(
+        "decimal_scale_factor".to_string(),
+        ciborium::Value::Integer((sp_params.decimal_scale_factor as i64).into()),
+    );
+    params_map.insert(
+        "bits_per_value".to_string(),
+        ciborium::Value::Integer((sp_params.bits_per_value as i64).into()),
+    );
+    // szip parameters (RSI=128 restart interval, block_size=16, flags=8 = AEC_DATA_PREPROCESS)
+    params_map.insert(
+        "szip_rsi".to_string(),
+        ciborium::Value::Integer(128_i64.into()),
+    );
+    params_map.insert(
+        "szip_block_size".to_string(),
+        ciborium::Value::Integer(16_i64.into()),
+    );
+    params_map.insert(
+        "szip_flags".to_string(),
+        ciborium::Value::Integer(8_i64.into()),
+    );
+
+    // ── Build the DataObjectDescriptor ───────────────────────────────────────
+    let desc = DataObjectDescriptor {
+        obj_type: "ntensor".to_string(),
+        ndim: 1,
+        shape: vec![N_FLOATS as u64],
+        strides: vec![1],
+        dtype: Dtype::Float64,
+        byte_order: ByteOrder::Big,
+        encoding: "simple_packing".to_string(),
+        filter: "none".to_string(),
+        compression: "szip".to_string(),
+        params: params_map,
+        hash: None,
+    };
+
+    let meta = GlobalMetadata::default();
+    // Disable hashing to isolate encode pipeline cost (not hash cost).
+    let opts = EncodeOptions {
+        hash_algorithm: None,
+        ..Default::default()
+    };
+
+    // ── Prime: encode once outside the timed loop ─────────────────────────────
+    // This simulates "the GPU already produced these bytes".
+    // We capture the encoded payload and updated descriptor (with szip_block_offsets)
+    // by calling encode() and then extracting via framing::decode_message.
+    let wire_msg = encode(&meta, &[(&desc, &raw_bytes)], &opts).expect("priming encode failed");
+    let gpu_desc: DataObjectDescriptor;
+    let gpu_bytes: Vec<u8>;
+    {
+        let decoded_msg =
+            framing::decode_message(&wire_msg).expect("priming framing decode failed");
+        let (pre_desc, pre_bytes_slice, _) = &decoded_msg.objects[0];
+        gpu_desc = pre_desc.clone();
+        gpu_bytes = pre_bytes_slice.to_vec();
+    }
+
+    // ── Benchmark group ───────────────────────────────────────────────────────
+    let mut group = c.benchmark_group("encode_pre_encoded_vs_full");
+    // Report throughput as raw bytes in (128 MiB) so MB/s figures are comparable.
+    group.throughput(Throughput::Bytes(raw_bytes.len() as u64));
+
+    // Full pipeline: simple_packing 24-bit + szip + framing
+    group.bench_function("encode_full_pipeline", |b| {
+        b.iter(|| {
+            encode(&meta, &[(&desc, &raw_bytes)], &opts).expect("encode failed");
+        });
+    });
+
+    // Pre-encoded path: framing only (no simple_packing, no szip)
+    group.bench_function("encode_pre_encoded", |b| {
+        b.iter(|| {
+            encode_pre_encoded(&meta, &[(&gpu_desc, &gpu_bytes)], &opts)
+                .expect("encode_pre_encoded failed");
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_encode_paths);
+criterion_main!(benches);

--- a/crates/tensogram-core/Cargo.toml
+++ b/crates/tensogram-core/Cargo.toml
@@ -29,3 +29,4 @@ tokio = { version = "1", features = ["fs", "rt"], optional = true }
 [dev-dependencies]
 tempfile = "3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+sha2 = "0.10"

--- a/crates/tensogram-core/src/encode.rs
+++ b/crates/tensogram-core/src/encode.rs
@@ -78,16 +78,18 @@ pub(crate) fn validate_object(desc: &DataObjectDescriptor, data_len: usize) -> R
     Ok(())
 }
 
-/// Encode a complete Tensogram message.
-///
-/// `global_metadata` is the message-level metadata (version, MARS keys, etc.).
-/// `descriptors` is a list of (DataObjectDescriptor, raw_data) pairs.
-/// Returns the complete wire-format message.
-#[tracing::instrument(skip(global_metadata, descriptors, options), fields(objects = descriptors.len()))]
-pub fn encode(
+#[derive(Debug, Clone, Copy)]
+enum EncodeMode {
+    Raw,
+    #[allow(dead_code)] // Will be fully wired in Task 2
+    PreEncoded,
+}
+
+fn encode_inner(
     global_metadata: &GlobalMetadata,
     descriptors: &[(&DataObjectDescriptor, &[u8])],
     options: &EncodeOptions,
+    mode: EncodeMode,
 ) -> Result<Vec<u8>> {
     // Buffered encode does not support emit_preceders — use StreamingEncoder
     // with write_preceder() instead.
@@ -112,8 +114,13 @@ pub fn encode(
         let dtype = desc.dtype;
 
         let config = build_pipeline_config(desc, num_elements, dtype)?;
-        let result = pipeline::encode_pipeline(data, &config)
-            .map_err(|e| TensogramError::Encoding(e.to_string()))?;
+        // For Raw: run the full encoding pipeline.
+        // For PreEncoded: data bytes are already encoded — pipeline call is a
+        // placeholder that will be replaced in Task 2.
+        let result = match mode {
+            EncodeMode::Raw | EncodeMode::PreEncoded => pipeline::encode_pipeline(data, &config)
+                .map_err(|e| TensogramError::Encoding(e.to_string()))?,
+        };
 
         // Build the final descriptor with computed fields
         let mut final_desc = (*desc).clone();
@@ -168,6 +175,20 @@ pub fn encode(
     populate_reserved_provenance(&mut enriched_meta.reserved);
 
     framing::encode_message(&enriched_meta, &encoded_objects)
+}
+
+/// Encode a complete Tensogram message.
+///
+/// `global_metadata` is the message-level metadata (version, MARS keys, etc.).
+/// `descriptors` is a list of (DataObjectDescriptor, raw_data) pairs.
+/// Returns the complete wire-format message.
+#[tracing::instrument(skip(global_metadata, descriptors, options), fields(objects = descriptors.len()))]
+pub fn encode(
+    global_metadata: &GlobalMetadata,
+    descriptors: &[(&DataObjectDescriptor, &[u8])],
+    options: &EncodeOptions,
+) -> Result<Vec<u8>> {
+    encode_inner(global_metadata, descriptors, options, EncodeMode::Raw)
 }
 
 /// Validate that the caller hasn't written to `_reserved_` at any level.

--- a/crates/tensogram-core/src/encode.rs
+++ b/crates/tensogram-core/src/encode.rs
@@ -81,7 +81,6 @@ pub(crate) fn validate_object(desc: &DataObjectDescriptor, data_len: usize) -> R
 #[derive(Debug, Clone, Copy)]
 enum EncodeMode {
     Raw,
-    #[allow(dead_code)] // Will be fully wired in Task 2
     PreEncoded,
 }
 
@@ -114,33 +113,46 @@ fn encode_inner(
         let dtype = desc.dtype;
 
         let config = build_pipeline_config(desc, num_elements, dtype)?;
-        // For Raw: run the full encoding pipeline.
-        // For PreEncoded: data bytes are already encoded — pipeline call is a
-        // placeholder that will be replaced in Task 2.
-        let result = match mode {
-            EncodeMode::Raw | EncodeMode::PreEncoded => pipeline::encode_pipeline(data, &config)
-                .map_err(|e| TensogramError::Encoding(e.to_string()))?,
-        };
 
         // Build the final descriptor with computed fields
         let mut final_desc = (*desc).clone();
 
-        // Store szip block offsets if produced
-        if let Some(offsets) = &result.block_offsets {
-            final_desc.params.insert(
-                "szip_block_offsets".to_string(),
-                ciborium::Value::Array(
-                    offsets
-                        .iter()
-                        .map(|&o| ciborium::Value::Integer(o.into()))
-                        .collect(),
-                ),
-            );
-        }
+        let encoded_payload: Vec<u8> = match mode {
+            EncodeMode::Raw => {
+                // Run the full encoding pipeline.
+                let result = pipeline::encode_pipeline(data, &config)
+                    .map_err(|e| TensogramError::Encoding(e.to_string()))?;
 
-        // Compute hash
+                // Store szip block offsets if produced
+                if let Some(offsets) = &result.block_offsets {
+                    final_desc.params.insert(
+                        "szip_block_offsets".to_string(),
+                        ciborium::Value::Array(
+                            offsets
+                                .iter()
+                                .map(|&o| ciborium::Value::Integer(o.into()))
+                                .collect(),
+                        ),
+                    );
+                }
+
+                result.encoded_bytes
+            }
+            EncodeMode::PreEncoded => {
+                // Caller's bytes are already encoded — use them directly.
+                // build_pipeline_config() was already called above for
+                // defense-in-depth validation of encoding/compression params.
+                validate_no_szip_offsets_for_non_szip(desc)?;
+                if desc.compression == "szip" && desc.params.contains_key("szip_block_offsets") {
+                    validate_szip_block_offsets(&desc.params, data.len())?;
+                }
+                data.to_vec()
+            }
+        };
+
+        // Compute hash over encoded payload (overwrites any caller-supplied hash)
         if let Some(algorithm) = options.hash_algorithm {
-            let hash_value = compute_hash(&result.encoded_bytes, algorithm);
+            let hash_value = compute_hash(&encoded_payload, algorithm);
             final_desc.hash = Some(HashDescriptor {
                 hash_type: algorithm.as_str().to_string(),
                 value: hash_value,
@@ -149,7 +161,7 @@ fn encode_inner(
 
         encoded_objects.push(EncodedObject {
             descriptor: final_desc,
-            encoded_payload: result.encoded_bytes,
+            encoded_payload,
         });
     }
 
@@ -189,6 +201,32 @@ pub fn encode(
     options: &EncodeOptions,
 ) -> Result<Vec<u8>> {
     encode_inner(global_metadata, descriptors, options, EncodeMode::Raw)
+}
+
+/// Encode a pre-encoded Tensogram message where callers supply already-encoded bytes.
+///
+/// Use this when the payload bytes have already been encoded/compressed by an external
+/// pipeline. The library will:
+/// - Validate object descriptors (shape, dtype, etc.)
+/// - Validate encoding/compression params via `build_pipeline_config()` (defense-in-depth)
+/// - Use the caller's bytes directly as the encoded payload (no pipeline call)
+/// - Compute a fresh xxh3 hash over the caller's bytes (overwrites any caller-supplied hash)
+/// - Preserve caller-supplied `szip_block_offsets` in descriptor params
+///
+/// Callers must NOT set `emit_preceders = true` — use `StreamingEncoder::write_preceder()`
+/// for streaming preceder support.
+#[tracing::instrument(name = "encode_pre_encoded", skip_all, fields(num_objects = descriptors.len()))]
+pub fn encode_pre_encoded(
+    global_metadata: &GlobalMetadata,
+    descriptors: &[(&DataObjectDescriptor, &[u8])],
+    options: &EncodeOptions,
+) -> Result<Vec<u8>> {
+    encode_inner(
+        global_metadata,
+        descriptors,
+        options,
+        EncodeMode::PreEncoded,
+    )
 }
 
 /// Validate that the caller hasn't written to `_reserved_` at any level.
@@ -589,6 +627,99 @@ pub(crate) fn get_u64_param(params: &BTreeMap<String, ciborium::Value>, key: &st
             "missing required parameter: {key}"
         ))),
     }
+}
+
+fn validate_szip_block_offsets(
+    params: &BTreeMap<String, ciborium::Value>,
+    encoded_bytes_len: usize,
+) -> Result<()> {
+    let value = params.get("szip_block_offsets").ok_or_else(|| {
+        TensogramError::Metadata(
+            "missing required parameter: szip_block_offsets for szip compression".to_string(),
+        )
+    })?;
+
+    let offsets = match value {
+        ciborium::Value::Array(arr) => arr,
+        other => {
+            return Err(TensogramError::Metadata(format!(
+                "szip_block_offsets must be an array, got {other:?}"
+            )));
+        }
+    };
+
+    if offsets.is_empty() {
+        return Err(TensogramError::Metadata(
+            "szip_block_offsets must not be empty; first offset must be 0".to_string(),
+        ));
+    }
+
+    let bit_bound = encoded_bytes_len.checked_mul(8).ok_or_else(|| {
+        TensogramError::Metadata(format!(
+            "encoded byte length {encoded_bytes_len} overflows bit-bound calculation"
+        ))
+    })?;
+    let bit_bound_u64 = u64::try_from(bit_bound).map_err(|_| {
+        TensogramError::Metadata(format!(
+            "bit-bound {bit_bound} derived from {encoded_bytes_len} bytes does not fit in u64"
+        ))
+    })?;
+
+    let mut parsed_offsets = Vec::with_capacity(offsets.len());
+    for (idx, item) in offsets.iter().enumerate() {
+        let offset = match item {
+            ciborium::Value::Integer(i) => {
+                let n: i128 = (*i).into();
+                u64::try_from(n).map_err(|_| {
+                    TensogramError::Metadata(format!(
+                        "szip_block_offsets[{idx}] = {n} out of u64 range"
+                    ))
+                })?
+            }
+            other => {
+                return Err(TensogramError::Metadata(format!(
+                    "szip_block_offsets[{idx}] must be an integer, got {other:?}"
+                )));
+            }
+        };
+
+        if offset > bit_bound_u64 {
+            return Err(TensogramError::Metadata(format!(
+                "szip_block_offsets[{idx}] = {offset} exceeds bit bound {bit_bound_u64} (encoded_bytes_len = {encoded_bytes_len} bytes, {bit_bound_u64} bits)"
+            )));
+        }
+
+        if idx == 0 {
+            if offset != 0 {
+                return Err(TensogramError::Metadata(format!(
+                    "szip_block_offsets[0] must be 0, got {offset}"
+                )));
+            }
+        } else {
+            let prev = parsed_offsets[idx - 1];
+            if offset <= prev {
+                return Err(TensogramError::Metadata(format!(
+                    "szip_block_offsets must be strictly increasing: szip_block_offsets[{}] = {}, szip_block_offsets[{idx}] = {offset}",
+                    idx - 1,
+                    prev
+                )));
+            }
+        }
+
+        parsed_offsets.push(offset);
+    }
+
+    Ok(())
+}
+
+fn validate_no_szip_offsets_for_non_szip(desc: &DataObjectDescriptor) -> Result<()> {
+    if desc.compression != "szip" && desc.params.contains_key("szip_block_offsets") {
+        return Err(TensogramError::Metadata(format!(
+            "szip_block_offsets provided but compression is '{}', not 'szip'",
+            desc.compression
+        )));
+    }
+    Ok(())
 }
 
 // ── Edge case tests ─────────────────────────────────────────────────────────
@@ -1330,5 +1461,273 @@ mod tests {
         let decoded: GlobalMetadata = crate::metadata::cbor_to_global_metadata(&bytes).unwrap();
         assert!(decoded.reserved.contains_key("encoder"));
         assert!(!decoded.reserved.contains_key("old"));
+    }
+
+    // ── Category 8: encode_pre_encoded smoke tests ───────────────────────
+
+    /// Roundtrip: encode raw bytes via encode(), then re-encode the exact same
+    /// payload bytes via encode_pre_encoded(). Both decoded payloads must be
+    /// byte-identical. We compare payload bytes, NOT raw wire messages (provenance
+    /// UUIDs make raw message equality impossible).
+    #[test]
+    fn test_encode_pre_encoded_roundtrip_simple_packing() {
+        // Use encoding="none" (raw float32) for maximum portability — no feature flags needed.
+        let desc = make_descriptor(vec![4]);
+        let raw_data: Vec<u8> = vec![0u8; 4 * 4]; // 4 float32 values, all-zero
+
+        let meta = GlobalMetadata::default();
+        let options = EncodeOptions::default();
+
+        // Step 1: encode normally
+        let msg1 = encode(&meta, &[(&desc, raw_data.as_slice())], &options).unwrap();
+
+        // Step 2: decode to get the encoded payload bytes + descriptor
+        let (_, objects1) = decode(&msg1, &DecodeOptions::default()).unwrap();
+        let (decoded_desc1, decoded_payload1) = &objects1[0];
+
+        // Step 3: re-encode the same bytes via encode_pre_encoded
+        let msg2 = encode_pre_encoded(
+            &meta,
+            &[(&decoded_desc1.clone(), decoded_payload1.as_slice())],
+            &options,
+        )
+        .unwrap();
+
+        // Step 4: decode the second message
+        let (_, objects2) = decode(&msg2, &DecodeOptions::default()).unwrap();
+        let (_, decoded_payload2) = &objects2[0];
+
+        // Payloads must be identical — same bytes, same encoding
+        // (raw wire messages differ due to non-deterministic provenance UUIDs)
+        assert_eq!(
+            decoded_payload1, decoded_payload2,
+            "decoded payloads should be equal after encode/re-encode roundtrip"
+        );
+    }
+
+    /// emit_preceders=true must be rejected by encode_pre_encoded (buffered mode).
+    #[test]
+    fn test_encode_pre_encoded_rejects_emit_preceders() {
+        let desc = make_descriptor(vec![2]);
+        let data = vec![0u8; 8];
+        let meta = GlobalMetadata::default();
+        let options = EncodeOptions {
+            emit_preceders: true,
+            ..Default::default()
+        };
+        let result = encode_pre_encoded(&meta, &[(&desc, data.as_slice())], &options);
+        assert!(
+            result.is_err(),
+            "encode_pre_encoded with emit_preceders=true should fail"
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("emit_preceders"),
+            "error should mention emit_preceders: {err}"
+        );
+    }
+
+    /// Caller-supplied hash in descriptor must be overwritten by the library-computed hash.
+    #[test]
+    fn test_encode_pre_encoded_overwrites_caller_hash() {
+        let mut desc = make_descriptor(vec![2]);
+        // Plant garbage hash in descriptor
+        desc.hash = Some(HashDescriptor {
+            hash_type: "xxh3".to_string(),
+            value: "deadbeefdeadbeef".to_string(),
+        });
+
+        let data = vec![0xAB_u8; 8]; // non-trivial payload bytes
+        let meta = GlobalMetadata::default();
+        let options = EncodeOptions::default(); // includes xxh3 hashing
+
+        let msg = encode_pre_encoded(&meta, &[(&desc, data.as_slice())], &options).unwrap();
+        let (_, objects) = decode(&msg, &DecodeOptions::default()).unwrap();
+        let (decoded_desc, decoded_payload) = &objects[0];
+
+        // Library should have computed a fresh hash
+        let computed_hash = match options.hash_algorithm {
+            Some(algorithm) => compute_hash(decoded_payload, algorithm),
+            None => panic!("expected hash algorithm"),
+        };
+
+        let stored_hash = decoded_desc
+            .hash
+            .as_ref()
+            .expect("hash should be present in decoded descriptor")
+            .value
+            .clone();
+
+        assert_ne!(
+            stored_hash, "deadbeefdeadbeef",
+            "caller's garbage hash must be overwritten"
+        );
+        assert_eq!(
+            stored_hash, computed_hash,
+            "library-computed hash must match hash over decoded payload"
+        );
+    }
+
+    #[test]
+    fn test_validate_szip_block_offsets_happy_path() {
+        let mut params = BTreeMap::new();
+        params.insert(
+            "szip_block_offsets".to_string(),
+            ciborium::Value::Array(vec![0u64, 100, 200].into_iter().map(|n| n.into()).collect()),
+        );
+
+        assert!(validate_szip_block_offsets(&params, 100).is_ok());
+    }
+
+    #[test]
+    fn test_validate_szip_block_offsets_missing_key() {
+        let params = BTreeMap::new();
+
+        let err = validate_szip_block_offsets(&params, 100)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("missing") && err.contains("szip_block_offsets"),
+            "error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_szip_block_offsets_not_array() {
+        let mut params = BTreeMap::new();
+        params.insert(
+            "szip_block_offsets".to_string(),
+            ciborium::Value::Integer(0.into()),
+        );
+
+        let err = validate_szip_block_offsets(&params, 100)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("array") && err.contains("szip_block_offsets"),
+            "error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_szip_block_offsets_non_integer_element() {
+        let mut params = BTreeMap::new();
+        params.insert(
+            "szip_block_offsets".to_string(),
+            ciborium::Value::Array(vec![
+                ciborium::Value::Integer(0.into()),
+                ciborium::Value::Text("x".to_string()),
+            ]),
+        );
+
+        let err = validate_szip_block_offsets(&params, 100)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("integer") && err.contains("szip_block_offsets"),
+            "error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_szip_block_offsets_nonzero_first() {
+        let mut params = BTreeMap::new();
+        params.insert(
+            "szip_block_offsets".to_string(),
+            ciborium::Value::Array(vec![5u64, 100, 200].into_iter().map(|n| n.into()).collect()),
+        );
+
+        let err = validate_szip_block_offsets(&params, 100)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("must be 0") && err.contains("got 5"),
+            "error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_szip_block_offsets_non_monotonic() {
+        let mut params = BTreeMap::new();
+        params.insert(
+            "szip_block_offsets".to_string(),
+            ciborium::Value::Array(vec![0u64, 100, 50].into_iter().map(|n| n.into()).collect()),
+        );
+
+        let err = validate_szip_block_offsets(&params, 100)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("increasing") || err.contains("monotonic"),
+            "error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_szip_block_offsets_offset_beyond_bound() {
+        let mut params = BTreeMap::new();
+        params.insert(
+            "szip_block_offsets".to_string(),
+            ciborium::Value::Array(vec![0u64, 100, 801].into_iter().map(|n| n.into()).collect()),
+        );
+
+        let err = validate_szip_block_offsets(&params, 100)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("800") && err.contains("801"), "error: {err}");
+    }
+
+    #[test]
+    fn test_validate_no_szip_offsets_for_non_szip_rejects() {
+        let mut params = BTreeMap::new();
+        params.insert(
+            "szip_block_offsets".to_string(),
+            ciborium::Value::Array(vec![0u64, 1].into_iter().map(|n| n.into()).collect()),
+        );
+        let desc = DataObjectDescriptor {
+            obj_type: "ntensor".to_string(),
+            ndim: 1,
+            shape: vec![2],
+            strides: vec![1],
+            dtype: Dtype::Float32,
+            byte_order: ByteOrder::Big,
+            encoding: "none".to_string(),
+            filter: "none".to_string(),
+            compression: "zstd".to_string(),
+            params,
+            hash: None,
+        };
+
+        let err = validate_no_szip_offsets_for_non_szip(&desc)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("szip_block_offsets") && err.contains("zstd"),
+            "error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_no_szip_offsets_for_non_szip_allows_szip() {
+        let mut params = BTreeMap::new();
+        params.insert(
+            "szip_block_offsets".to_string(),
+            ciborium::Value::Array(vec![0u64, 1].into_iter().map(|n| n.into()).collect()),
+        );
+        let desc = DataObjectDescriptor {
+            obj_type: "ntensor".to_string(),
+            ndim: 1,
+            shape: vec![2],
+            strides: vec![1],
+            dtype: Dtype::Float32,
+            byte_order: ByteOrder::Big,
+            encoding: "none".to_string(),
+            filter: "none".to_string(),
+            compression: "szip".to_string(),
+            params,
+            hash: None,
+        };
+
+        assert!(validate_no_szip_offsets_for_non_szip(&desc).is_ok());
     }
 }

--- a/crates/tensogram-core/src/encode.rs
+++ b/crates/tensogram-core/src/encode.rs
@@ -629,7 +629,7 @@ pub(crate) fn get_u64_param(params: &BTreeMap<String, ciborium::Value>, key: &st
     }
 }
 
-fn validate_szip_block_offsets(
+pub(crate) fn validate_szip_block_offsets(
     params: &BTreeMap<String, ciborium::Value>,
     encoded_bytes_len: usize,
 ) -> Result<()> {
@@ -712,7 +712,7 @@ fn validate_szip_block_offsets(
     Ok(())
 }
 
-fn validate_no_szip_offsets_for_non_szip(desc: &DataObjectDescriptor) -> Result<()> {
+pub(crate) fn validate_no_szip_offsets_for_non_szip(desc: &DataObjectDescriptor) -> Result<()> {
     if desc.compression != "szip" && desc.params.contains_key("szip_block_offsets") {
         return Err(TensogramError::Metadata(format!(
             "szip_block_offsets provided but compression is '{}', not 'szip'",

--- a/crates/tensogram-core/src/lib.rs
+++ b/crates/tensogram-core/src/lib.rs
@@ -15,7 +15,7 @@ pub use decode::{
     decode, decode_descriptors, decode_metadata, decode_object, decode_range, DecodeOptions,
 };
 pub use dtype::Dtype;
-pub use encode::{encode, EncodeOptions};
+pub use encode::{encode, encode_pre_encoded, EncodeOptions};
 pub use error::{Result, TensogramError};
 pub use file::TensogramFile;
 pub use framing::{scan, scan_file};

--- a/crates/tensogram-core/src/streaming.rs
+++ b/crates/tensogram-core/src/streaming.rs
@@ -2,7 +2,8 @@ use std::collections::BTreeMap;
 use std::io::Write;
 
 use crate::encode::{
-    build_pipeline_config, populate_base_entries, populate_reserved_provenance, validate_object,
+    build_pipeline_config, populate_base_entries, populate_reserved_provenance,
+    validate_no_szip_offsets_for_non_szip, validate_object, validate_szip_block_offsets,
     EncodeOptions,
 };
 use crate::error::{Result, TensogramError};
@@ -123,12 +124,13 @@ impl<W: Write> StreamingEncoder<W> {
     ///
     /// The `metadata` map becomes `base[0]` in a `GlobalMetadata` CBOR
     /// wrapper.  Must be followed by exactly one
-    /// [`write_object`](Self::write_object) call before another
-    /// `write_preceder` or [`finish`](Self::finish).
+    /// [`write_object`](Self::write_object) or
+    /// [`write_object_pre_encoded`](Self::write_object_pre_encoded) call
+    /// before another `write_preceder` or [`finish`](Self::finish).
     pub fn write_preceder(&mut self, metadata: BTreeMap<String, ciborium::Value>) -> Result<()> {
         if self.pending_preceder {
             return Err(TensogramError::Framing(
-                "write_preceder called twice without an intervening write_object".to_string(),
+                "write_preceder called twice without an intervening write_object/write_object_pre_encoded".to_string(),
             ));
         }
 
@@ -232,6 +234,13 @@ impl<W: Write> StreamingEncoder<W> {
         // Validate descriptor pipeline configuration without encoding.
         build_pipeline_config(descriptor, num_elements, descriptor.dtype)?;
 
+        // Validate szip metadata — same checks as buffered encode_pre_encoded.
+        validate_no_szip_offsets_for_non_szip(descriptor)?;
+        if descriptor.compression == "szip" && descriptor.params.contains_key("szip_block_offsets")
+        {
+            validate_szip_block_offsets(&descriptor.params, pre_encoded_bytes.len())?;
+        }
+
         self.write_object_inner(descriptor.clone(), pre_encoded_bytes)
     }
 
@@ -300,7 +309,7 @@ impl<W: Write> StreamingEncoder<W> {
     pub fn finish(mut self) -> Result<W> {
         if self.pending_preceder {
             return Err(TensogramError::Framing(
-                "dangling PrecederMetadata: finish called without a following write_object"
+                "dangling PrecederMetadata: finish called without a following write_object/write_object_pre_encoded"
                     .to_string(),
             ));
         }

--- a/crates/tensogram-core/src/streaming.rs
+++ b/crates/tensogram-core/src/streaming.rs
@@ -194,9 +194,60 @@ impl<W: Write> StreamingEncoder<W> {
             );
         }
 
+        self.write_object_inner(final_desc, &result.encoded_bytes)
+    }
+
+    /// Write a pre-encoded data object frame directly.
+    ///
+    /// Unlike [`write_object`](Self::write_object), this method does **not**
+    /// run the encoding pipeline — `pre_encoded_bytes` are written to the
+    /// stream as-is.  The descriptor must accurately describe the encoding
+    /// that was already applied (encoding, filter, compression, params) so
+    /// that decoders can reconstruct the original payload.
+    ///
+    /// This method participates in the same preceder consumption logic as
+    /// [`write_object`](Self::write_object) and can be freely intermixed
+    /// with it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the descriptor is invalid or the frame cannot be
+    /// written to the underlying writer.
+    #[tracing::instrument(skip(self, descriptor, pre_encoded_bytes))]
+    pub fn write_object_pre_encoded(
+        &mut self,
+        descriptor: &DataObjectDescriptor,
+        pre_encoded_bytes: &[u8],
+    ) -> Result<()> {
+        validate_object(descriptor, pre_encoded_bytes.len())?;
+
+        let shape_product = descriptor
+            .shape
+            .iter()
+            .try_fold(1u64, |acc, &x| acc.checked_mul(x))
+            .ok_or_else(|| TensogramError::Metadata("shape product overflow".to_string()))?;
+        let num_elements = usize::try_from(shape_product)
+            .map_err(|_| TensogramError::Metadata("element count overflows usize".to_string()))?;
+
+        // Validate descriptor pipeline configuration without encoding.
+        build_pipeline_config(descriptor, num_elements, descriptor.dtype)?;
+
+        self.write_object_inner(descriptor.clone(), pre_encoded_bytes)
+    }
+
+    /// Shared inner implementation for both [`write_object`](Self::write_object) and
+    /// [`write_object_pre_encoded`](Self::write_object_pre_encoded).
+    ///
+    /// Computes the hash, builds the data object frame, updates all bookkeeping,
+    /// consumes any pending preceder, and writes the frame to the stream.
+    fn write_object_inner(
+        &mut self,
+        mut final_desc: DataObjectDescriptor,
+        encoded_bytes: &[u8],
+    ) -> Result<()> {
         // Compute hash
         let hash_entry = if let Some(algorithm) = self.hash_algorithm {
-            let hash_value = compute_hash(&result.encoded_bytes, algorithm);
+            let hash_value = compute_hash(encoded_bytes, algorithm);
             let hash_type = algorithm.as_str().to_string();
             let entry = Some((hash_type.clone(), hash_value.clone()));
             final_desc.hash = Some(HashDescriptor {
@@ -210,11 +261,11 @@ impl<W: Write> StreamingEncoder<W> {
 
         // Build the data object frame bytes
         let frame_bytes =
-            crate::framing::encode_data_object_frame(&final_desc, &result.encoded_bytes, false)?;
+            crate::framing::encode_data_object_frame(&final_desc, encoded_bytes, false)?;
 
         // Record offset before writing
         self.object_offsets.push(self.bytes_written);
-        self.object_lengths.push(result.encoded_bytes.len() as u64);
+        self.object_lengths.push(encoded_bytes.len() as u64);
         self.hash_entries.push(hash_entry);
         // Retain only the descriptor for footer metadata population.
         // The encoded payload has already been written to the stream;
@@ -939,6 +990,74 @@ mod tests {
                 "rogue key from preceder's _reserved_ should have been stripped"
             );
         }
+    }
+
+    // ── write_object_pre_encoded tests ───────────────────────────────────
+
+    #[test]
+    fn test_streaming_mixed_mode_pre_encoded() {
+        // write_object (raw), write_object_pre_encoded, write_object (raw) — decode all 3.
+        let meta = GlobalMetadata::default();
+
+        let desc0 = make_descriptor(vec![4]);
+        let desc2 = make_descriptor(vec![6]);
+        // Pre-encoded object: encoding="none" so pre-encoded bytes == raw bytes.
+        let desc1 = make_descriptor(vec![5]);
+
+        let data0 = vec![1u8; 4 * 4];
+        let pre_encoded1 = vec![2u8; 5 * 4]; // treated as already-encoded
+        let data2 = vec![3u8; 6 * 4];
+
+        let buf = Vec::new();
+        let mut enc = StreamingEncoder::new(buf, &meta, &EncodeOptions::default()).unwrap();
+        enc.write_object(&desc0, &data0).unwrap();
+        enc.write_object_pre_encoded(&desc1, &pre_encoded1).unwrap();
+        enc.write_object(&desc2, &data2).unwrap();
+        assert_eq!(enc.object_count(), 3);
+        let result = enc.finish().unwrap();
+
+        let (_, objects) = decode(&result, &DecodeOptions::default()).unwrap();
+        assert_eq!(objects.len(), 3);
+        // Don't compare raw message bytes (provenance is non-deterministic).
+        // Compare decoded payloads.
+        assert_eq!(objects[0].1, data0, "object 0 payload mismatch");
+        assert_eq!(objects[1].1, pre_encoded1, "object 1 payload mismatch");
+        assert_eq!(objects[2].1, data2, "object 2 payload mismatch");
+    }
+
+    #[test]
+    fn test_streaming_preceder_then_pre_encoded() {
+        // write_preceder followed by write_object_pre_encoded — preceder metadata
+        // should appear in base[0] after decode.
+        let meta = GlobalMetadata::default();
+        let desc = make_descriptor(vec![4]);
+        let pre_encoded = vec![42u8; 4 * 4];
+
+        let mut prec = BTreeMap::new();
+        prec.insert(
+            "mars".to_string(),
+            ciborium::Value::Map(vec![(
+                ciborium::Value::Text("param".to_string()),
+                ciborium::Value::Text("2t".to_string()),
+            )]),
+        );
+
+        let buf = Vec::new();
+        let mut enc = StreamingEncoder::new(buf, &meta, &EncodeOptions::default()).unwrap();
+        enc.write_preceder(prec).unwrap();
+        enc.write_object_pre_encoded(&desc, &pre_encoded).unwrap();
+        let result = enc.finish().unwrap();
+
+        let (decoded_meta, objects) = decode(&result, &DecodeOptions::default()).unwrap();
+        assert_eq!(objects.len(), 1);
+        // Payload must round-trip correctly.
+        assert_eq!(objects[0].1, pre_encoded, "pre-encoded payload mismatch");
+        // Preceder mars key should be in base[0].
+        let mars = decoded_meta.base[0].get("mars");
+        assert!(
+            mars.is_some(),
+            "mars key from preceder should be in base[0]"
+        );
     }
 
     #[test]

--- a/crates/tensogram-core/tests/cross_language_pre_encoded.rs
+++ b/crates/tensogram-core/tests/cross_language_pre_encoded.rs
@@ -1,0 +1,193 @@
+//! Cross-language SHA256 golden test for `encode_pre_encoded()`.
+//!
+//! This test verifies that encoding the **same** pre-encoded payload via Rust,
+//! Python, and C++ `encode_pre_encoded()` produces decoded payloads whose
+//! SHA-256 hashes are identical. Because provenance fields (UUID, timestamp)
+//! differ across encode calls, we compare decoded-payload hashes, **not** raw
+//! wire bytes.
+//!
+//! The test driver:
+//! 1. Generates a deterministic float64[1024] input.
+//! 2. Encodes via Rust `encode_pre_encoded()` → decodes → SHA-256.
+//! 3. Spawns a Python helper that does the same → reads its SHA-256 from stdout.
+//! 4. Spawns a C++ helper that does the same → reads its SHA-256 from stdout.
+//! 5. Asserts all three SHA-256 values are equal.
+//!
+//! The test is gated: if the Python venv or C++ helper binary is unavailable
+//! the corresponding sub-test is skipped with a warning (not failed).
+
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use tensogram_core::{
+    decode, encode_pre_encoded, ByteOrder, DataObjectDescriptor, Dtype, EncodeOptions,
+    GlobalMetadata,
+};
+
+// ── Deterministic input ────────────────────────────────────────────────────
+
+/// Generate 1024 deterministic float64 values.
+fn deterministic_f64_1024() -> Vec<f64> {
+    (0..1024).map(|i| 200.0 + (i as f64) * 0.125).collect()
+}
+
+/// Little-endian bytes for a slice of f64.
+fn f64_to_le_bytes(values: &[f64]) -> Vec<u8> {
+    values.iter().flat_map(|v| v.to_le_bytes()).collect()
+}
+
+/// SHA-256 hex string of a byte slice.
+fn sha256_hex(data: &[u8]) -> String {
+    let hash = Sha256::digest(data);
+    hash.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+// ── Rust encode + decode ───────────────────────────────────────────────────
+
+/// Encode the deterministic payload via Rust `encode_pre_encoded`, decode,
+/// and return the SHA-256 hex string of the decoded payload bytes.
+fn rust_encode_decode_sha256() -> String {
+    let values = deterministic_f64_1024();
+    let raw_bytes = f64_to_le_bytes(&values);
+
+    // Build descriptor for encoding="none" (raw pass-through).
+    let desc = DataObjectDescriptor {
+        obj_type: "ntensor".to_string(),
+        ndim: 1,
+        shape: vec![1024],
+        strides: vec![1],
+        dtype: Dtype::Float64,
+        byte_order: ByteOrder::Little,
+        encoding: "none".to_string(),
+        filter: "none".to_string(),
+        compression: "none".to_string(),
+        params: BTreeMap::new(),
+        hash: None,
+    };
+
+    let meta = GlobalMetadata::default();
+    let opts = EncodeOptions::default();
+
+    let wire =
+        encode_pre_encoded(&meta, &[(&desc, &raw_bytes)], &opts).expect("Rust encode_pre_encoded");
+
+    // Decode and extract the payload.
+    let (_meta, objects) = decode(&wire, &Default::default()).expect("Rust decode");
+    assert_eq!(objects.len(), 1);
+    let (_desc, payload) = &objects[0];
+    sha256_hex(payload)
+}
+
+// ── Helper spawning ────────────────────────────────────────────────────────
+
+/// Find the project root from CARGO_MANIFEST_DIR.
+fn project_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR for this crate is crates/tensogram-core
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("project root")
+        .to_path_buf()
+}
+
+/// Spawn the Python helper; returns Ok(sha256_hex) or Err(skip reason).
+fn python_sha256() -> Result<String, String> {
+    let root = project_root();
+    let venv_python = root.join(".venv/bin/python");
+    if !venv_python.exists() {
+        return Err(format!(
+            "Python venv not found at {}",
+            venv_python.display()
+        ));
+    }
+
+    let helper = root.join("tests/python/cross_language_pre_encoded_helper.py");
+    if !helper.exists() {
+        return Err(format!("Python helper not found at {}", helper.display()));
+    }
+
+    let output = std::process::Command::new(&venv_python)
+        .arg(&helper)
+        .env("PYTHONDONTWRITEBYTECODE", "1")
+        .output()
+        .map_err(|e| format!("Failed to spawn Python: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("Python helper failed: {stderr}"));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let sha = stdout.trim().to_string();
+    if sha.len() != 64 {
+        return Err(format!("Python output not a valid SHA-256 hex: '{sha}'"));
+    }
+    Ok(sha)
+}
+
+/// Spawn the C++ helper; returns Ok(sha256_hex) or Err(skip reason).
+fn cpp_sha256() -> Result<String, String> {
+    let root = project_root();
+    let helper = root.join("build/cross_language_pre_encoded_helper");
+    if !helper.exists() {
+        return Err(format!(
+            "C++ helper not found at {}; build it first",
+            helper.display()
+        ));
+    }
+
+    let output = std::process::Command::new(&helper)
+        .env("DYLD_LIBRARY_PATH", root.join("target/release"))
+        .output()
+        .map_err(|e| format!("Failed to spawn C++ helper: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("C++ helper failed: {stderr}"));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let sha = stdout.trim().to_string();
+    if sha.len() != 64 {
+        return Err(format!("C++ output not a valid SHA-256 hex: '{sha}'"));
+    }
+    Ok(sha)
+}
+
+// ── Test ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn cross_language_pre_encoded_sha256() {
+    let rust_sha = rust_encode_decode_sha256();
+    eprintln!("Rust  SHA-256: {rust_sha}");
+
+    // Python
+    match python_sha256() {
+        Ok(py_sha) => {
+            eprintln!("Python SHA-256: {py_sha}");
+            assert_eq!(
+                rust_sha, py_sha,
+                "Rust and Python decoded-payload SHA-256 differ"
+            );
+        }
+        Err(reason) => {
+            eprintln!("SKIP Python: {reason}");
+        }
+    }
+
+    // C++
+    match cpp_sha256() {
+        Ok(cpp_sha) => {
+            eprintln!("C++   SHA-256: {cpp_sha}");
+            assert_eq!(
+                rust_sha, cpp_sha,
+                "Rust and C++ decoded-payload SHA-256 differ"
+            );
+        }
+        Err(reason) => {
+            eprintln!("SKIP C++: {reason}");
+        }
+    }
+}

--- a/crates/tensogram-core/tests/cross_language_pre_encoded.rs
+++ b/crates/tensogram-core/tests/cross_language_pre_encoded.rs
@@ -138,8 +138,24 @@ fn cpp_sha256() -> Result<String, String> {
         ));
     }
 
-    let output = std::process::Command::new(&helper)
-        .env("DYLD_LIBRARY_PATH", root.join("target/release"))
+    let library_dir = root.join("target/release");
+    let append_library_dir = |var_name: &str| -> Result<std::ffi::OsString, String> {
+        let mut paths = vec![library_dir.clone()];
+        if let Some(existing) = std::env::var_os(var_name) {
+            paths.extend(std::env::split_paths(&existing));
+        }
+        std::env::join_paths(paths)
+            .map_err(|e| format!("Failed to construct {var_name} for C++ helper: {e}"))
+    };
+
+    let mut command = std::process::Command::new(&helper);
+    command.env(
+        "DYLD_LIBRARY_PATH",
+        append_library_dir("DYLD_LIBRARY_PATH")?,
+    );
+    command.env("LD_LIBRARY_PATH", append_library_dir("LD_LIBRARY_PATH")?);
+
+    let output = command
         .output()
         .map_err(|e| format!("Failed to spawn C++ helper: {e}"))?;
 

--- a/crates/tensogram-core/tests/integration_pre_encoded.rs
+++ b/crates/tensogram-core/tests/integration_pre_encoded.rs
@@ -1,0 +1,850 @@
+//! Integration tests for `encode_pre_encoded()`.
+//!
+//! These tests cover happy-path round-trips, all encoding/compression
+//! variants, edge cases, and rejection branches of the pre-encoded encode
+//! API. Wire bytes are NOT compared directly because provenance fields
+//! (`_reserved_.uuid`, `_reserved_.time`) are non-deterministic — instead
+//! we compare a SHA-256 hash over (descriptor CBOR + decoded payload).
+//!
+//! Round-trip pattern:
+//! 1. Encode raw data via `encode()`.
+//! 2. Use `framing::decode_message` to extract the **encoded payload bytes**
+//!    (the on-wire post-pipeline bytes — NOT the post-decode raw bytes).
+//! 3. Feed those bytes back into `encode_pre_encoded()` along with the same
+//!    descriptor.
+//! 4. Decode both messages with `decode()` and compare via `decoded_sha256`.
+//!
+//! Both messages must produce identical decoded payloads since the library
+//! deterministically hashes the same encoded bytes (`xxh3` → same hash) and
+//! the same pipeline applied to the same encoded bytes yields the same
+//! decoded payload.
+
+use std::collections::BTreeMap;
+
+use tensogram_core::framing;
+use tensogram_core::{
+    decode, decode_range, encode, encode_pre_encoded, ByteOrder, DataObjectDescriptor,
+    DecodeOptions, Dtype, EncodeOptions, GlobalMetadata, HashDescriptor, StreamingEncoder,
+};
+use tensogram_encodings::simple_packing;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// SHA-256 hash of (CBOR-encoded descriptor || payload).
+///
+/// Used for comparing two decoded objects. We strip `_reserved_` from the
+/// descriptor's `params` defensively in case the library ever adds it
+/// there (currently it does not — `_reserved_` lives in metadata, not
+/// descriptor — but hashing must be stable across encoder versions).
+fn decoded_sha256(desc: &DataObjectDescriptor, payload: &[u8]) -> [u8; 32] {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    let mut desc_clone = desc.clone();
+    // Defensive: ensure no reserved keys leak into the hash.
+    desc_clone.params.remove("_reserved_");
+    let mut cbor = Vec::new();
+    ciborium::into_writer(&desc_clone, &mut cbor).expect("encode descriptor for hashing");
+    hasher.update(&cbor);
+    hasher.update(payload);
+    hasher.finalize().into()
+}
+
+/// Convert a slice of `f64` to its big-endian byte representation.
+fn f64_to_be_bytes(values: &[f64]) -> Vec<u8> {
+    values.iter().flat_map(|v| v.to_be_bytes()).collect()
+}
+
+/// Convert a slice of `f32` to its big-endian byte representation.
+fn f32_to_be_bytes(values: &[f32]) -> Vec<u8> {
+    values.iter().flat_map(|v| v.to_be_bytes()).collect()
+}
+
+/// Build a `simple_packing`-only descriptor (no compression).
+fn make_simple_packing_desc(
+    num_values: u64,
+    p: &simple_packing::SimplePackingParams,
+) -> DataObjectDescriptor {
+    let mut params = BTreeMap::new();
+    params.insert(
+        "reference_value".to_string(),
+        ciborium::Value::Float(p.reference_value),
+    );
+    params.insert(
+        "binary_scale_factor".to_string(),
+        ciborium::Value::Integer((p.binary_scale_factor as i64).into()),
+    );
+    params.insert(
+        "decimal_scale_factor".to_string(),
+        ciborium::Value::Integer((p.decimal_scale_factor as i64).into()),
+    );
+    params.insert(
+        "bits_per_value".to_string(),
+        ciborium::Value::Integer((p.bits_per_value as i64).into()),
+    );
+    DataObjectDescriptor {
+        obj_type: "ntensor".to_string(),
+        ndim: 1,
+        shape: vec![num_values],
+        strides: vec![1],
+        dtype: Dtype::Float64,
+        byte_order: ByteOrder::Big,
+        encoding: "simple_packing".to_string(),
+        filter: "none".to_string(),
+        compression: "none".to_string(),
+        params,
+        hash: None,
+    }
+}
+
+/// Build a `simple_packing` + `szip` descriptor.
+fn make_szip_simple_packing_desc(
+    num_values: u64,
+    p: &simple_packing::SimplePackingParams,
+) -> DataObjectDescriptor {
+    let mut params = BTreeMap::new();
+    params.insert(
+        "reference_value".to_string(),
+        ciborium::Value::Float(p.reference_value),
+    );
+    params.insert(
+        "binary_scale_factor".to_string(),
+        ciborium::Value::Integer((p.binary_scale_factor as i64).into()),
+    );
+    params.insert(
+        "decimal_scale_factor".to_string(),
+        ciborium::Value::Integer((p.decimal_scale_factor as i64).into()),
+    );
+    params.insert(
+        "bits_per_value".to_string(),
+        ciborium::Value::Integer((p.bits_per_value as i64).into()),
+    );
+    params.insert("szip_rsi".to_string(), ciborium::Value::Integer(128.into()));
+    params.insert(
+        "szip_block_size".to_string(),
+        ciborium::Value::Integer(16.into()),
+    );
+    params.insert(
+        "szip_flags".to_string(),
+        ciborium::Value::Integer(8_i64.into()),
+    );
+    DataObjectDescriptor {
+        obj_type: "ntensor".to_string(),
+        ndim: 1,
+        shape: vec![num_values],
+        strides: vec![1],
+        dtype: Dtype::Float64,
+        byte_order: ByteOrder::Big,
+        encoding: "simple_packing".to_string(),
+        filter: "none".to_string(),
+        compression: "szip".to_string(),
+        params,
+        hash: None,
+    }
+}
+
+/// Build a raw (encoding=none) descriptor with the given compression name and params.
+fn make_raw_desc(
+    num_values: u64,
+    dtype: Dtype,
+    compression: &str,
+    params: BTreeMap<String, ciborium::Value>,
+) -> DataObjectDescriptor {
+    DataObjectDescriptor {
+        obj_type: "ntensor".to_string(),
+        ndim: 1,
+        shape: vec![num_values],
+        strides: vec![1],
+        dtype,
+        byte_order: ByteOrder::Big,
+        encoding: "none".to_string(),
+        filter: "none".to_string(),
+        compression: compression.to_string(),
+        params,
+        hash: None,
+    }
+}
+
+/// Encode raw bytes via `encode()`, then return the (descriptor, encoded payload bytes)
+/// pair from the resulting wire message. The payload is the on-wire post-pipeline bytes
+/// suitable for feeding back into `encode_pre_encoded`.
+fn encode_then_extract_payload(
+    meta: &GlobalMetadata,
+    desc: &DataObjectDescriptor,
+    raw: &[u8],
+    options: &EncodeOptions,
+) -> (Vec<u8>, DataObjectDescriptor, Vec<u8>) {
+    let msg = encode(meta, &[(desc, raw)], options).expect("encode raw");
+    // Materialize descriptor + payload into owned values so the borrow on `msg`
+    // is released before we move `msg` into the return tuple.
+    let (extracted_desc, payload_vec) = {
+        let dec = framing::decode_message(&msg).expect("decode message");
+        assert_eq!(dec.objects.len(), 1);
+        let (d, payload_slice, _offset) = &dec.objects[0];
+        (d.clone(), payload_slice.to_vec())
+    };
+    (msg, extracted_desc, payload_vec)
+}
+
+/// Run a full pre-encoded round-trip and return both decoded results
+/// for hash comparison.
+fn round_trip_via_pre_encoded(
+    meta: &GlobalMetadata,
+    desc: &DataObjectDescriptor,
+    raw: &[u8],
+) -> (DataObjectDescriptor, Vec<u8>, DataObjectDescriptor, Vec<u8>) {
+    let opts = EncodeOptions::default();
+    let (msg1, extracted_desc, encoded_payload) =
+        encode_then_extract_payload(meta, desc, raw, &opts);
+
+    // Decode msg1 (the original encoded message)
+    let (_, decoded1) = decode(&msg1, &DecodeOptions::default()).expect("decode msg1");
+    let (d1, p1) = decoded1.into_iter().next().expect("at least one object");
+
+    // Re-encode via pre-encoded path with the extracted encoded payload bytes.
+    let msg2 = encode_pre_encoded(meta, &[(&extracted_desc, &encoded_payload)], &opts)
+        .expect("encode_pre_encoded");
+
+    // Decode msg2
+    let (_, decoded2) = decode(&msg2, &DecodeOptions::default()).expect("decode msg2");
+    let (d2, p2) = decoded2.into_iter().next().expect("at least one object");
+
+    (d1, p1, d2, p2)
+}
+
+// ── Round-trip tests ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_encode_pre_encoded_roundtrip_simple_packing() {
+    let values: Vec<f64> = (0..1024).map(|i| 250.0 + i as f64 * 0.01).collect();
+    let raw = f64_to_be_bytes(&values);
+    let p = simple_packing::compute_params(&values, 16, 0).expect("compute simple_packing");
+    let desc = make_simple_packing_desc(1024, &p);
+    let meta = GlobalMetadata::default();
+
+    let (d1, p1, d2, p2) = round_trip_via_pre_encoded(&meta, &desc, &raw);
+
+    let h1 = decoded_sha256(&d1, &p1);
+    let h2 = decoded_sha256(&d2, &p2);
+    assert_eq!(h1, h2, "decoded payloads must match (simple_packing)");
+}
+
+#[test]
+fn test_encode_pre_encoded_roundtrip_simple_packing_szip() {
+    let values: Vec<f64> = (0..4096).map(|i| 250.0 + i as f64 * 0.1).collect();
+    let raw = f64_to_be_bytes(&values);
+    let p = simple_packing::compute_params(&values, 16, 0).expect("compute simple_packing");
+    let desc = make_szip_simple_packing_desc(4096, &p);
+    let meta = GlobalMetadata::default();
+
+    let (d1, p1, d2, p2) = round_trip_via_pre_encoded(&meta, &desc, &raw);
+
+    // szip_block_offsets must survive in d2 — they were carried forward from
+    // d1 (which received them from the raw encode pipeline) into the
+    // pre-encoded path and back through decode.
+    assert!(
+        d2.params.contains_key("szip_block_offsets"),
+        "szip_block_offsets must survive in pre-encoded re-decoded descriptor",
+    );
+
+    let h1 = decoded_sha256(&d1, &p1);
+    let h2 = decoded_sha256(&d2, &p2);
+    assert_eq!(h1, h2, "decoded payloads must match (simple_packing+szip)");
+}
+
+// IMPORTANT: `validate_object()` enforces `bytes_len == shape * dtype`
+// when `encoding == "none"`, regardless of compression. This means
+// `encode_pre_encoded` with raw (encoding="none") + non-trivial
+// compression cannot accept already-compressed bytes — the size check
+// will fail. To exercise pre-encoded with these compressions, we use
+// `simple_packing` as the encoding wrapper, which bypasses the size
+// check (per the inherited invariant in encode.rs).
+
+/// Build a `simple_packing` + `<compression>` descriptor with raw szip-style
+/// rsi/block_size/flags omitted (so build_pipeline_config goes through the
+/// requested compression branch).
+fn make_simple_packing_compressed_desc(
+    num_values: u64,
+    p: &simple_packing::SimplePackingParams,
+    compression: &str,
+    extra_params: BTreeMap<String, ciborium::Value>,
+) -> DataObjectDescriptor {
+    let mut desc = make_simple_packing_desc(num_values, p);
+    desc.compression = compression.to_string();
+    for (k, v) in extra_params {
+        desc.params.insert(k, v);
+    }
+    desc
+}
+
+#[cfg(feature = "zstd")]
+#[test]
+fn test_encode_pre_encoded_roundtrip_zstd() {
+    let values: Vec<f64> = (0..1024).map(|i| 200.0 + i as f64 * 0.01).collect();
+    let raw = f64_to_be_bytes(&values);
+    let p = simple_packing::compute_params(&values, 16, 0).expect("compute simple_packing");
+    let mut extra = BTreeMap::new();
+    extra.insert(
+        "zstd_level".to_string(),
+        ciborium::Value::Integer(3_i64.into()),
+    );
+    let desc = make_simple_packing_compressed_desc(1024, &p, "zstd", extra);
+    let meta = GlobalMetadata::default();
+
+    let (d1, p1, d2, p2) = round_trip_via_pre_encoded(&meta, &desc, &raw);
+
+    let h1 = decoded_sha256(&d1, &p1);
+    let h2 = decoded_sha256(&d2, &p2);
+    assert_eq!(h1, h2, "decoded payloads must match (simple_packing+zstd)");
+}
+
+#[cfg(feature = "lz4")]
+#[test]
+fn test_encode_pre_encoded_roundtrip_lz4() {
+    let values: Vec<f64> = (0..1024).map(|i| 100.0 + i as f64 * 0.5).collect();
+    let raw = f64_to_be_bytes(&values);
+    let p = simple_packing::compute_params(&values, 16, 0).expect("compute simple_packing");
+    let desc = make_simple_packing_compressed_desc(1024, &p, "lz4", BTreeMap::new());
+    let meta = GlobalMetadata::default();
+
+    let (d1, p1, d2, p2) = round_trip_via_pre_encoded(&meta, &desc, &raw);
+
+    let h1 = decoded_sha256(&d1, &p1);
+    let h2 = decoded_sha256(&d2, &p2);
+    assert_eq!(h1, h2, "decoded payloads must match (simple_packing+lz4)");
+}
+
+#[cfg(feature = "blosc2")]
+#[test]
+fn test_encode_pre_encoded_roundtrip_blosc2() {
+    let values: Vec<f64> = (0..1024).map(|i| 50.0 + i as f64 * 0.25).collect();
+    let raw = f64_to_be_bytes(&values);
+    let p = simple_packing::compute_params(&values, 16, 0).expect("compute simple_packing");
+    let mut extra = BTreeMap::new();
+    extra.insert(
+        "blosc2_codec".to_string(),
+        ciborium::Value::Text("zstd".to_string()),
+    );
+    extra.insert(
+        "blosc2_clevel".to_string(),
+        ciborium::Value::Integer(5_i64.into()),
+    );
+    let desc = make_simple_packing_compressed_desc(1024, &p, "blosc2", extra);
+    let meta = GlobalMetadata::default();
+
+    let (d1, p1, d2, p2) = round_trip_via_pre_encoded(&meta, &desc, &raw);
+
+    let h1 = decoded_sha256(&d1, &p1);
+    let h2 = decoded_sha256(&d2, &p2);
+    assert_eq!(
+        h1, h2,
+        "decoded payloads must match (simple_packing+blosc2)"
+    );
+}
+
+// zfp and sz3 expect raw float buffers and do not compose with simple_packing
+// (which produces packed integer bit-streams). We document the API constraint
+// instead: passing already-compressed zfp/sz3 bytes via encode_pre_encoded
+// with `encoding="none"` is rejected by `validate_object` because the
+// compressed byte length cannot equal `shape * dtype` for non-trivial inputs.
+
+#[cfg(feature = "zfp")]
+#[test]
+fn test_encode_pre_encoded_roundtrip_zfp_fixed_rate() {
+    let values: Vec<f32> = (0..1024).map(|i| (i as f32) * 0.01).collect();
+    let raw = f32_to_be_bytes(&values);
+    let mut params = BTreeMap::new();
+    params.insert(
+        "zfp_mode".to_string(),
+        ciborium::Value::Text("fixed_rate".to_string()),
+    );
+    params.insert("zfp_rate".to_string(), ciborium::Value::Float(8.0));
+    let desc = make_raw_desc(1024, Dtype::Float32, "zfp", params);
+    let meta = GlobalMetadata::default();
+    let opts = EncodeOptions::default();
+
+    // Get the actually-compressed bytes from a normal encode.
+    let (_msg, extracted_desc, encoded_payload) =
+        encode_then_extract_payload(&meta, &desc, &raw, &opts);
+    // Pre-encoded with the same encoding="none" descriptor must FAIL because
+    // the compressed payload length will not equal raw shape*dtype bytes.
+    let result = encode_pre_encoded(&meta, &[(&extracted_desc, &encoded_payload)], &opts);
+    assert!(
+        result.is_err(),
+        "pre-encoded with encoding=none + compressed bytes must be rejected"
+    );
+    let err = result.expect_err("err").to_string();
+    assert!(
+        err.contains("does not match expected"),
+        "error should mention size mismatch, got: {err}"
+    );
+}
+
+#[cfg(feature = "sz3")]
+#[test]
+fn test_encode_pre_encoded_roundtrip_sz3_abs() {
+    let values: Vec<f32> = (0..1024).map(|i| 100.0 + (i as f32) * 0.1).collect();
+    let raw = f32_to_be_bytes(&values);
+    let mut params = BTreeMap::new();
+    params.insert(
+        "sz3_error_bound_mode".to_string(),
+        ciborium::Value::Text("abs".to_string()),
+    );
+    params.insert("sz3_error_bound".to_string(), ciborium::Value::Float(0.01));
+    let desc = make_raw_desc(1024, Dtype::Float32, "sz3", params);
+    let meta = GlobalMetadata::default();
+    let opts = EncodeOptions::default();
+
+    // Same constraint as zfp: compressed sz3 bytes do not match raw size,
+    // and encoding="none" path rejects them.
+    let (_msg, extracted_desc, encoded_payload) =
+        encode_then_extract_payload(&meta, &desc, &raw, &opts);
+    let result = encode_pre_encoded(&meta, &[(&extracted_desc, &encoded_payload)], &opts);
+    assert!(
+        result.is_err(),
+        "pre-encoded with encoding=none + sz3-compressed bytes must be rejected"
+    );
+    let err = result.expect_err("err").to_string();
+    assert!(
+        err.contains("does not match expected"),
+        "error should mention size mismatch, got: {err}"
+    );
+}
+
+// ── decode_range with caller-provided szip_block_offsets ─────────────────────
+
+#[cfg(feature = "szip")]
+#[test]
+fn test_encode_pre_encoded_with_szip_decode_range() {
+    let values: Vec<f64> = (0..4096).map(|i| 100.0 + i as f64 * 0.5).collect();
+    let raw = f64_to_be_bytes(&values);
+    let p = simple_packing::compute_params(&values, 16, 0).expect("compute simple_packing");
+    let desc = make_szip_simple_packing_desc(4096, &p);
+    let meta = GlobalMetadata::default();
+
+    // Round-trip via pre-encoded path with offsets carried over.
+    let opts = EncodeOptions::default();
+    let (_msg1, extracted_desc, encoded_payload) =
+        encode_then_extract_payload(&meta, &desc, &raw, &opts);
+    assert!(
+        extracted_desc.params.contains_key("szip_block_offsets"),
+        "raw encode of szip must populate szip_block_offsets"
+    );
+
+    let msg2 = encode_pre_encoded(&meta, &[(&extracted_desc, &encoded_payload)], &opts)
+        .expect("encode_pre_encoded");
+
+    // Full decode of the pre-encoded message
+    let (_, full_objects) = decode(&msg2, &DecodeOptions::default()).expect("decode full");
+    let full_payload = &full_objects[0].1;
+    let full_values: Vec<f64> = full_payload
+        .chunks_exact(8)
+        .map(|c| f64::from_be_bytes(c.try_into().expect("8 bytes")))
+        .collect();
+    assert_eq!(full_values.len(), 4096);
+
+    // Partial decode: 500 elements starting at index 100.
+    let parts =
+        decode_range(&msg2, 0, &[(100, 500)], &DecodeOptions::default()).expect("decode_range");
+    assert_eq!(parts.len(), 1, "one range → one part");
+    let part_values: Vec<f64> = parts[0]
+        .chunks_exact(8)
+        .map(|c| f64::from_be_bytes(c.try_into().expect("8 bytes")))
+        .collect();
+    assert_eq!(part_values.len(), 500);
+
+    // Compare against slice of full decode (within simple_packing tolerance).
+    for (i, (full, partial)) in full_values[100..600]
+        .iter()
+        .zip(part_values.iter())
+        .enumerate()
+    {
+        assert!(
+            (full - partial).abs() < 0.01,
+            "value mismatch at offset {i}: full={full}, partial={partial}"
+        );
+    }
+}
+
+#[cfg(feature = "szip")]
+#[test]
+fn test_encode_pre_encoded_decode_range_fails_without_offsets() {
+    let values: Vec<f64> = (0..4096).map(|i| 50.0 + i as f64 * 0.25).collect();
+    let raw = f64_to_be_bytes(&values);
+    let p = simple_packing::compute_params(&values, 16, 0).expect("compute simple_packing");
+    let desc = make_szip_simple_packing_desc(4096, &p);
+    let meta = GlobalMetadata::default();
+    let opts = EncodeOptions::default();
+
+    // Encode raw to obtain valid szip-compressed payload bytes.
+    let (_msg, mut extracted_desc, encoded_payload) =
+        encode_then_extract_payload(&meta, &desc, &raw, &opts);
+    // Strip the offsets — the pre-encoded path allows szip without offsets.
+    extracted_desc.params.remove("szip_block_offsets");
+    assert!(!extracted_desc.params.contains_key("szip_block_offsets"));
+
+    let msg2 = encode_pre_encoded(&meta, &[(&extracted_desc, &encoded_payload)], &opts)
+        .expect("encode_pre_encoded must succeed without offsets");
+
+    // Full decode still works (it doesn't need block offsets).
+    let _ = decode(&msg2, &DecodeOptions::default()).expect("full decode should succeed");
+
+    // But decode_range must fail because it requires offsets.
+    let result = decode_range(&msg2, 0, &[(0, 100)], &DecodeOptions::default());
+    assert!(
+        result.is_err(),
+        "decode_range without szip_block_offsets must fail"
+    );
+    let err = result.expect_err("must err").to_string();
+    assert!(
+        err.contains("szip_block_offsets"),
+        "error should mention szip_block_offsets, got: {err}"
+    );
+}
+
+// ── Hash overwrite ───────────────────────────────────────────────────────────
+
+#[test]
+fn test_encode_pre_encoded_overwrites_caller_hash() {
+    let values: Vec<f32> = (0..256).map(|i| i as f32).collect();
+    let raw = f32_to_be_bytes(&values);
+    let garbage_hash = HashDescriptor {
+        hash_type: "xxh3".to_string(),
+        value: "deadbeefcafebabe".to_string(),
+    };
+    let mut desc = make_raw_desc(256, Dtype::Float32, "none", BTreeMap::new());
+    desc.hash = Some(garbage_hash);
+
+    let meta = GlobalMetadata::default();
+    let opts = EncodeOptions::default();
+    let msg = encode_pre_encoded(&meta, &[(&desc, &raw)], &opts).expect("encode_pre_encoded");
+
+    let (_, objects) = decode(&msg, &DecodeOptions::default()).expect("decode");
+    let embedded = objects[0].0.hash.as_ref().expect("hash present");
+    assert_eq!(embedded.hash_type, "xxh3", "hash type should be xxh3");
+    assert_ne!(
+        embedded.value, "deadbeefcafebabe",
+        "garbage hash must be overwritten by library"
+    );
+
+    // The library hashes the encoded payload bytes, which for encoding=none
+    // are exactly the bytes the caller passed in.
+    let expected = tensogram_core::compute_hash(&raw, tensogram_core::HashAlgorithm::Xxh3);
+    assert_eq!(
+        embedded.value, expected,
+        "embedded hash must equal xxh3 of payload bytes"
+    );
+}
+
+// ── Rejection branches ───────────────────────────────────────────────────────
+
+#[test]
+fn test_encode_pre_encoded_rejects_emit_preceders() {
+    let raw = vec![0u8; 16]; // 4 × float32
+    let desc = make_raw_desc(4, Dtype::Float32, "none", BTreeMap::new());
+    let meta = GlobalMetadata::default();
+    let opts = EncodeOptions {
+        hash_algorithm: Some(tensogram_core::HashAlgorithm::Xxh3),
+        emit_preceders: true,
+    };
+    let result = encode_pre_encoded(&meta, &[(&desc, &raw)], &opts);
+    assert!(result.is_err(), "emit_preceders=true must be rejected");
+    let err = result.expect_err("err").to_string();
+    assert!(
+        err.contains("emit_preceders"),
+        "error should mention emit_preceders, got: {err}"
+    );
+}
+
+#[test]
+fn test_encode_pre_encoded_rejects_caller_reserved() {
+    let raw = vec![0u8; 16];
+    let desc = make_raw_desc(4, Dtype::Float32, "none", BTreeMap::new());
+    let mut reserved = BTreeMap::new();
+    reserved.insert(
+        "uuid".to_string(),
+        ciborium::Value::Text("client-set".to_string()),
+    );
+    let meta = GlobalMetadata {
+        version: 2,
+        reserved,
+        ..Default::default()
+    };
+    let result = encode_pre_encoded(&meta, &[(&desc, &raw)], &EncodeOptions::default());
+    assert!(result.is_err(), "caller-set _reserved_ must be rejected");
+    let err = result.expect_err("err").to_string();
+    assert!(
+        err.contains("_reserved_"),
+        "error should mention _reserved_, got: {err}"
+    );
+}
+
+#[test]
+fn test_encode_pre_encoded_rejects_szip_offsets_for_non_szip() {
+    let raw = vec![0u8; 16];
+    let mut params = BTreeMap::new();
+    // Provide szip_block_offsets but compression is zstd → must fail.
+    params.insert(
+        "szip_block_offsets".to_string(),
+        ciborium::Value::Array(vec![ciborium::Value::Integer(0_i64.into())]),
+    );
+    params.insert(
+        "zstd_level".to_string(),
+        ciborium::Value::Integer(3_i64.into()),
+    );
+    let desc = make_raw_desc(4, Dtype::Float32, "zstd", params);
+    let meta = GlobalMetadata::default();
+    let result = encode_pre_encoded(&meta, &[(&desc, &raw)], &EncodeOptions::default());
+    assert!(
+        result.is_err(),
+        "szip_block_offsets with non-szip compression must be rejected"
+    );
+    let err = result.expect_err("err").to_string();
+    assert!(
+        err.contains("szip_block_offsets"),
+        "error should mention szip_block_offsets, got: {err}"
+    );
+}
+
+#[cfg(feature = "szip")]
+#[test]
+fn test_encode_pre_encoded_rejects_non_monotonic_offsets() {
+    // Build any szip descriptor (won't actually run szip pipeline since
+    // pre-encoded mode skips encoding) and inject bad offsets.
+    let dummy_raw = vec![0u8; 4096];
+    let p = simple_packing::SimplePackingParams {
+        reference_value: 0.0,
+        binary_scale_factor: 0,
+        decimal_scale_factor: 0,
+        bits_per_value: 16,
+    };
+    let mut desc = make_szip_simple_packing_desc(512, &p);
+    desc.params.insert(
+        "szip_block_offsets".to_string(),
+        ciborium::Value::Array(vec![
+            ciborium::Value::Integer(0_i64.into()),
+            ciborium::Value::Integer(100_i64.into()),
+            ciborium::Value::Integer(50_i64.into()), // not strictly increasing
+        ]),
+    );
+    let meta = GlobalMetadata::default();
+    let result = encode_pre_encoded(&meta, &[(&desc, &dummy_raw)], &EncodeOptions::default());
+    assert!(
+        result.is_err(),
+        "non-monotonic szip_block_offsets must be rejected"
+    );
+    let err = result.expect_err("err").to_string();
+    assert!(
+        err.contains("strictly increasing") || err.contains("szip_block_offsets"),
+        "error should mention monotonicity, got: {err}"
+    );
+}
+
+#[cfg(feature = "szip")]
+#[test]
+fn test_encode_pre_encoded_rejects_offset_beyond_buffer() {
+    let dummy_raw = vec![0u8; 16]; // 16 bytes = 128 bits
+    let p = simple_packing::SimplePackingParams {
+        reference_value: 0.0,
+        binary_scale_factor: 0,
+        decimal_scale_factor: 0,
+        bits_per_value: 16,
+    };
+    let mut desc = make_szip_simple_packing_desc(8, &p);
+    // Bit-bound is 128; offset 999 must overflow it.
+    desc.params.insert(
+        "szip_block_offsets".to_string(),
+        ciborium::Value::Array(vec![
+            ciborium::Value::Integer(0_i64.into()),
+            ciborium::Value::Integer(999_i64.into()),
+        ]),
+    );
+    let meta = GlobalMetadata::default();
+    let result = encode_pre_encoded(&meta, &[(&desc, &dummy_raw)], &EncodeOptions::default());
+    assert!(result.is_err(), "offset beyond bit bound must be rejected");
+    let err = result.expect_err("err").to_string();
+    assert!(
+        err.contains("bit bound") || err.contains("exceeds"),
+        "error should mention bound violation, got: {err}"
+    );
+}
+
+// ── Edge cases ───────────────────────────────────────────────────────────────
+
+#[test]
+fn test_encode_pre_encoded_zero_objects() {
+    let meta = GlobalMetadata::default();
+    let msg = encode_pre_encoded(&meta, &[], &EncodeOptions::default())
+        .expect("zero-object encode_pre_encoded must succeed");
+    let (decoded_meta, objects) =
+        decode(&msg, &DecodeOptions::default()).expect("decode empty message");
+    assert_eq!(objects.len(), 0, "should decode to zero objects");
+    assert_eq!(decoded_meta.version, 2);
+}
+
+#[test]
+fn test_encode_pre_encoded_zero_element_shape() {
+    // shape [0, 5] → product 0 → expected_bytes 0 → empty payload is valid.
+    let desc = DataObjectDescriptor {
+        obj_type: "ntensor".to_string(),
+        ndim: 2,
+        shape: vec![0, 5],
+        strides: vec![5, 1],
+        dtype: Dtype::Float32,
+        byte_order: ByteOrder::Big,
+        encoding: "none".to_string(),
+        filter: "none".to_string(),
+        compression: "none".to_string(),
+        params: BTreeMap::new(),
+        hash: None,
+    };
+    let meta = GlobalMetadata::default();
+    let msg = encode_pre_encoded(&meta, &[(&desc, &[])], &EncodeOptions::default())
+        .expect("zero-element shape must succeed");
+    let (_, objects) = decode(&msg, &DecodeOptions::default()).expect("decode");
+    assert_eq!(objects.len(), 1);
+    assert_eq!(objects[0].0.shape, vec![0, 5]);
+    assert!(objects[0].1.is_empty(), "payload must be empty");
+}
+
+#[test]
+fn test_encode_pre_encoded_provenance_populated() {
+    let raw = vec![0u8; 16]; // 4 × float32
+    let desc = make_raw_desc(4, Dtype::Float32, "none", BTreeMap::new());
+    let meta = GlobalMetadata::default();
+    let msg = encode_pre_encoded(&meta, &[(&desc, &raw)], &EncodeOptions::default())
+        .expect("encode_pre_encoded");
+    let (decoded_meta, _) = decode(&msg, &DecodeOptions::default()).expect("decode");
+
+    // _reserved_ should have encoder, time, uuid populated.
+    let reserved = &decoded_meta.reserved;
+    assert!(reserved.contains_key("encoder"), "encoder missing");
+    assert!(reserved.contains_key("time"), "time missing");
+    assert!(reserved.contains_key("uuid"), "uuid missing");
+
+    // encoder.name should be "tensogram"
+    if let Some(ciborium::Value::Map(pairs)) = reserved.get("encoder") {
+        let name_pair = pairs
+            .iter()
+            .find(|(k, _)| *k == ciborium::Value::Text("name".to_string()));
+        assert!(
+            matches!(name_pair, Some((_, ciborium::Value::Text(s))) if s == "tensogram"),
+            "encoder.name must be 'tensogram'"
+        );
+    } else {
+        panic!("encoder must be a map");
+    }
+
+    // time should be a non-empty string
+    if let Some(ciborium::Value::Text(t)) = reserved.get("time") {
+        assert!(!t.is_empty(), "time must not be empty");
+    } else {
+        panic!("time must be a string");
+    }
+
+    // uuid should be a non-empty string
+    if let Some(ciborium::Value::Text(u)) = reserved.get("uuid") {
+        assert!(!u.is_empty(), "uuid must not be empty");
+    } else {
+        panic!("uuid must be a string");
+    }
+}
+
+#[test]
+fn test_encode_pre_encoded_tensor_metadata_populated() {
+    let raw = vec![0u8; 3 * 4 * 4]; // 12 × float32
+    let desc = DataObjectDescriptor {
+        obj_type: "ntensor".to_string(),
+        ndim: 2,
+        shape: vec![3, 4],
+        strides: vec![4, 1],
+        dtype: Dtype::Float32,
+        byte_order: ByteOrder::Big,
+        encoding: "none".to_string(),
+        filter: "none".to_string(),
+        compression: "none".to_string(),
+        params: BTreeMap::new(),
+        hash: None,
+    };
+    let meta = GlobalMetadata::default();
+    let msg = encode_pre_encoded(&meta, &[(&desc, &raw)], &EncodeOptions::default())
+        .expect("encode_pre_encoded");
+    let (decoded_meta, _) = decode(&msg, &DecodeOptions::default()).expect("decode");
+
+    let base0 = &decoded_meta.base[0];
+    let reserved = base0
+        .get("_reserved_")
+        .expect("_reserved_ missing in base[0]");
+    if let ciborium::Value::Map(pairs) = reserved {
+        let tensor_entry = pairs
+            .iter()
+            .find(|(k, _)| *k == ciborium::Value::Text("tensor".to_string()));
+        let tensor_map = match tensor_entry {
+            Some((_, ciborium::Value::Map(m))) => m,
+            _ => panic!("tensor missing or not a map"),
+        };
+        let mut keys: Vec<String> = tensor_map
+            .iter()
+            .filter_map(|(k, _)| {
+                if let ciborium::Value::Text(s) = k {
+                    Some(s.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        keys.sort();
+        assert_eq!(
+            keys,
+            vec![
+                "dtype".to_string(),
+                "ndim".to_string(),
+                "shape".to_string(),
+                "strides".to_string(),
+            ]
+        );
+        // Verify dtype is float32
+        let dtype_pair = tensor_map
+            .iter()
+            .find(|(k, _)| *k == ciborium::Value::Text("dtype".to_string()));
+        assert!(
+            matches!(dtype_pair, Some((_, ciborium::Value::Text(s))) if s == "float32"),
+            "dtype must be float32"
+        );
+    } else {
+        panic!("_reserved_ must be a map");
+    }
+}
+
+// ── Streaming integration ────────────────────────────────────────────────────
+
+#[test]
+fn test_streaming_mixed_mode_pre_encoded() {
+    // Streaming: write_object (raw), write_object_pre_encoded, write_object (raw).
+    let meta = GlobalMetadata::default();
+    let opts = EncodeOptions::default();
+
+    let desc0 = make_raw_desc(4, Dtype::Float32, "none", BTreeMap::new());
+    let desc1 = make_raw_desc(5, Dtype::Float32, "none", BTreeMap::new());
+    let desc2 = make_raw_desc(6, Dtype::Float32, "none", BTreeMap::new());
+
+    let data0 = vec![1u8; 4 * 4];
+    let pre_encoded1 = vec![2u8; 5 * 4]; // bytes are treated as already-encoded
+    let data2 = vec![3u8; 6 * 4];
+
+    let buf: Vec<u8> = Vec::new();
+    let mut enc = StreamingEncoder::new(buf, &meta, &opts).expect("create streaming encoder");
+    enc.write_object(&desc0, &data0).expect("write 0 (raw)");
+    enc.write_object_pre_encoded(&desc1, &pre_encoded1)
+        .expect("write 1 (pre-encoded)");
+    enc.write_object(&desc2, &data2).expect("write 2 (raw)");
+    let result = enc.finish().expect("finish");
+
+    let (_, objects) = decode(&result, &DecodeOptions::default()).expect("decode streaming");
+    assert_eq!(objects.len(), 3, "must decode 3 objects");
+    assert_eq!(objects[0].1, data0, "object 0 raw payload mismatch");
+    assert_eq!(
+        objects[1].1, pre_encoded1,
+        "object 1 pre-encoded payload mismatch"
+    );
+    assert_eq!(objects[2].1, data2, "object 2 raw payload mismatch");
+}

--- a/crates/tensogram-core/tests/integration_pre_encoded.rs
+++ b/crates/tensogram-core/tests/integration_pre_encoded.rs
@@ -848,3 +848,360 @@ fn test_streaming_mixed_mode_pre_encoded() {
     );
     assert_eq!(objects[2].1, data2, "object 2 raw payload mismatch");
 }
+
+// ── Additional edge-case tests ───────────────────────────────────────────────
+
+#[test]
+fn test_encode_pre_encoded_single_element() {
+    // Shape=[1]: single-element array round-trip.
+    let desc = DataObjectDescriptor {
+        obj_type: "ntensor".to_string(),
+        ndim: 1,
+        shape: vec![1],
+        strides: vec![1],
+        dtype: Dtype::Float32,
+        byte_order: ByteOrder::Big,
+        encoding: "none".to_string(),
+        filter: "none".to_string(),
+        compression: "none".to_string(),
+        params: BTreeMap::new(),
+        hash: None,
+    };
+    let raw = 42.0f32.to_be_bytes().to_vec();
+    let meta = GlobalMetadata::default();
+    let msg = encode_pre_encoded(&meta, &[(&desc, &raw)], &EncodeOptions::default())
+        .expect("single element encode_pre_encoded");
+    let (_, objects) = decode(&msg, &DecodeOptions::default()).expect("decode");
+    assert_eq!(objects.len(), 1);
+    assert_eq!(objects[0].0.shape, vec![1]);
+    let val = f32::from_be_bytes(objects[0].1[..4].try_into().unwrap());
+    assert!((val - 42.0).abs() < f32::EPSILON, "value mismatch: {val}");
+}
+
+#[test]
+fn test_encode_pre_encoded_2d_array() {
+    // 2D shape [3, 4] encoding=none round-trip.
+    let desc = DataObjectDescriptor {
+        obj_type: "ntensor".to_string(),
+        ndim: 2,
+        shape: vec![3, 4],
+        strides: vec![4, 1],
+        dtype: Dtype::Float32,
+        byte_order: ByteOrder::Big,
+        encoding: "none".to_string(),
+        filter: "none".to_string(),
+        compression: "none".to_string(),
+        params: BTreeMap::new(),
+        hash: None,
+    };
+    let values: Vec<f32> = (0..12).map(|i| i as f32 * 1.5).collect();
+    let raw = f32_to_be_bytes(&values);
+    let meta = GlobalMetadata::default();
+    let msg = encode_pre_encoded(&meta, &[(&desc, &raw)], &EncodeOptions::default())
+        .expect("2D encode_pre_encoded");
+    let (_, objects) = decode(&msg, &DecodeOptions::default()).expect("decode");
+    assert_eq!(objects[0].0.shape, vec![3, 4]);
+    assert_eq!(objects[0].0.ndim, 2);
+    assert_eq!(objects[0].1, raw, "2D payload round-trip");
+}
+
+#[test]
+fn test_encode_pre_encoded_ndim0_scalar() {
+    // ndim=0 scalar: shape=[], strides=[].
+    let desc = DataObjectDescriptor {
+        obj_type: "ntensor".to_string(),
+        ndim: 0,
+        shape: vec![],
+        strides: vec![],
+        dtype: Dtype::Float64,
+        byte_order: ByteOrder::Big,
+        encoding: "none".to_string(),
+        filter: "none".to_string(),
+        compression: "none".to_string(),
+        params: BTreeMap::new(),
+        hash: None,
+    };
+    // A scalar has shape product = 1 (empty product), so expected bytes = 1 * 8 = 8.
+    let raw = std::f64::consts::PI.to_be_bytes().to_vec();
+    let meta = GlobalMetadata::default();
+    let msg = encode_pre_encoded(&meta, &[(&desc, &raw)], &EncodeOptions::default())
+        .expect("scalar encode_pre_encoded");
+    let (_, objects) = decode(&msg, &DecodeOptions::default()).expect("decode");
+    assert_eq!(objects[0].0.ndim, 0);
+    assert!(objects[0].0.shape.is_empty());
+    let val = f64::from_be_bytes(objects[0].1[..8].try_into().unwrap());
+    assert!((val - std::f64::consts::PI).abs() < f64::EPSILON);
+}
+
+#[test]
+fn test_encode_pre_encoded_rejects_empty_obj_type() {
+    let desc = DataObjectDescriptor {
+        obj_type: "".to_string(),
+        ndim: 1,
+        shape: vec![4],
+        strides: vec![1],
+        dtype: Dtype::Float32,
+        byte_order: ByteOrder::Big,
+        encoding: "none".to_string(),
+        filter: "none".to_string(),
+        compression: "none".to_string(),
+        params: BTreeMap::new(),
+        hash: None,
+    };
+    let raw = vec![0u8; 16];
+    let meta = GlobalMetadata::default();
+    let result = encode_pre_encoded(&meta, &[(&desc, &raw)], &EncodeOptions::default());
+    assert!(result.is_err(), "empty obj_type must be rejected");
+    let err = result.expect_err("err").to_string();
+    assert!(
+        err.contains("obj_type"),
+        "error should mention obj_type, got: {err}"
+    );
+}
+
+#[test]
+fn test_encode_pre_encoded_encoding_none_data_too_short() {
+    // encoding=none with data shorter than shape*dtype → rejected.
+    let desc = make_raw_desc(10, Dtype::Float32, "none", BTreeMap::new());
+    let raw = vec![0u8; 20]; // 20 bytes, need 40 for 10 × float32
+    let meta = GlobalMetadata::default();
+    let result = encode_pre_encoded(&meta, &[(&desc, &raw)], &EncodeOptions::default());
+    assert!(result.is_err(), "data too short must be rejected");
+    let err = result.expect_err("err").to_string();
+    assert!(
+        err.contains("does not match expected"),
+        "error should mention size mismatch, got: {err}"
+    );
+}
+
+#[test]
+fn test_encode_pre_encoded_encoding_none_data_too_long() {
+    // encoding=none with data longer than shape*dtype → rejected.
+    let desc = make_raw_desc(4, Dtype::Float32, "none", BTreeMap::new());
+    let raw = vec![0u8; 32]; // 32 bytes, need 16 for 4 × float32
+    let meta = GlobalMetadata::default();
+    let result = encode_pre_encoded(&meta, &[(&desc, &raw)], &EncodeOptions::default());
+    assert!(result.is_err(), "data too long must be rejected");
+    let err = result.expect_err("err").to_string();
+    assert!(
+        err.contains("does not match expected"),
+        "error should mention size mismatch, got: {err}"
+    );
+}
+
+#[cfg(feature = "szip")]
+#[test]
+fn test_encode_pre_encoded_szip_single_offset() {
+    // szip_block_offsets = [0] (single entry) should be accepted by encode.
+    // NOTE: we do NOT decode because the dummy payload is not valid szip data.
+    let p = simple_packing::SimplePackingParams {
+        reference_value: 0.0,
+        binary_scale_factor: 0,
+        decimal_scale_factor: 0,
+        bits_per_value: 16,
+    };
+    let mut desc = make_szip_simple_packing_desc(64, &p);
+    desc.params.insert(
+        "szip_block_offsets".to_string(),
+        ciborium::Value::Array(vec![ciborium::Value::Integer(0_i64.into())]),
+    );
+    let dummy = vec![0u8; 128]; // some payload bytes
+    let meta = GlobalMetadata::default();
+    let _msg = encode_pre_encoded(&meta, &[(&desc, &dummy)], &EncodeOptions::default())
+        .expect("single offset [0] must succeed");
+    // Encode succeeded — structural validation passed.
+}
+
+#[cfg(feature = "szip")]
+#[test]
+fn test_encode_pre_encoded_szip_offset_at_exact_bit_boundary() {
+    // Offset at exactly bytes_len * 8 should be accepted (boundary case).
+    // NOTE: we do NOT decode because the dummy payload is not valid szip data.
+    let p = simple_packing::SimplePackingParams {
+        reference_value: 0.0,
+        binary_scale_factor: 0,
+        decimal_scale_factor: 0,
+        bits_per_value: 16,
+    };
+    let dummy = vec![0u8; 32]; // 32 bytes = 256 bits
+    let mut desc = make_szip_simple_packing_desc(16, &p);
+    desc.params.insert(
+        "szip_block_offsets".to_string(),
+        ciborium::Value::Array(vec![
+            ciborium::Value::Integer(0_i64.into()),
+            ciborium::Value::Integer(128_i64.into()),
+            ciborium::Value::Integer(256_i64.into()), // exactly at boundary
+        ]),
+    );
+    let meta = GlobalMetadata::default();
+    let _msg = encode_pre_encoded(&meta, &[(&desc, &dummy)], &EncodeOptions::default())
+        .expect("offset at exact bit boundary must succeed");
+    // Encode succeeded — structural validation passed.
+}
+
+#[test]
+fn test_encode_pre_encoded_extra_params_survive() {
+    // Unknown params in the descriptor should survive round-trip.
+    let mut params = BTreeMap::new();
+    params.insert(
+        "custom_key".to_string(),
+        ciborium::Value::Text("custom_value".to_string()),
+    );
+    params.insert(
+        "numeric_param".to_string(),
+        ciborium::Value::Integer(42_i64.into()),
+    );
+    let desc = make_raw_desc(4, Dtype::Float32, "none", params);
+    let raw = vec![0u8; 16];
+    let meta = GlobalMetadata::default();
+    let msg = encode_pre_encoded(&meta, &[(&desc, &raw)], &EncodeOptions::default())
+        .expect("extra params must succeed");
+    let (_, objects) = decode(&msg, &DecodeOptions::default()).expect("decode");
+    let out_params = &objects[0].0.params;
+    assert_eq!(
+        out_params.get("custom_key"),
+        Some(&ciborium::Value::Text("custom_value".to_string())),
+    );
+    assert_eq!(
+        out_params.get("numeric_param"),
+        Some(&ciborium::Value::Integer(42_i64.into())),
+    );
+}
+
+#[test]
+fn test_encode_pre_encoded_no_hash() {
+    // hash_algorithm=None: no hash in output.
+    let raw = vec![0u8; 16];
+    let desc = make_raw_desc(4, Dtype::Float32, "none", BTreeMap::new());
+    let meta = GlobalMetadata::default();
+    let opts = EncodeOptions {
+        hash_algorithm: None,
+        emit_preceders: false,
+    };
+    let msg = encode_pre_encoded(&meta, &[(&desc, &raw)], &opts)
+        .expect("encode_pre_encoded with no hash");
+    let (_, objects) = decode(&msg, &DecodeOptions::default()).expect("decode");
+    assert!(objects[0].0.hash.is_none(), "hash must be None");
+}
+
+#[test]
+fn test_encode_pre_encoded_multiple_objects_different_dtypes() {
+    // Two objects with different dtypes in one message.
+    let desc_f32 = make_raw_desc(4, Dtype::Float32, "none", BTreeMap::new());
+    let desc_f64 = DataObjectDescriptor {
+        obj_type: "ntensor".to_string(),
+        ndim: 1,
+        shape: vec![3],
+        strides: vec![1],
+        dtype: Dtype::Float64,
+        byte_order: ByteOrder::Big,
+        encoding: "none".to_string(),
+        filter: "none".to_string(),
+        compression: "none".to_string(),
+        params: BTreeMap::new(),
+        hash: None,
+    };
+    let raw_f32 = vec![1u8; 16]; // 4 × float32
+    let raw_f64 = vec![2u8; 24]; // 3 × float64
+    let meta = GlobalMetadata::default();
+    let msg = encode_pre_encoded(
+        &meta,
+        &[(&desc_f32, &raw_f32[..]), (&desc_f64, &raw_f64[..])],
+        &EncodeOptions::default(),
+    )
+    .expect("multi-dtype encode_pre_encoded");
+    let (_, objects) = decode(&msg, &DecodeOptions::default()).expect("decode");
+    assert_eq!(objects.len(), 2);
+    assert_eq!(objects[0].0.dtype, Dtype::Float32);
+    assert_eq!(objects[1].0.dtype, Dtype::Float64);
+    assert_eq!(objects[0].1, raw_f32);
+    assert_eq!(objects[1].1, raw_f64);
+}
+
+#[test]
+fn test_encode_pre_encoded_ndim_shape_mismatch_rejected() {
+    // ndim=2 but shape has 1 element → rejected.
+    let desc = DataObjectDescriptor {
+        obj_type: "ntensor".to_string(),
+        ndim: 2,
+        shape: vec![4],
+        strides: vec![1],
+        dtype: Dtype::Float32,
+        byte_order: ByteOrder::Big,
+        encoding: "none".to_string(),
+        filter: "none".to_string(),
+        compression: "none".to_string(),
+        params: BTreeMap::new(),
+        hash: None,
+    };
+    let raw = vec![0u8; 16];
+    let meta = GlobalMetadata::default();
+    let result = encode_pre_encoded(&meta, &[(&desc, &raw)], &EncodeOptions::default());
+    assert!(result.is_err(), "ndim/shape mismatch must be rejected");
+    let err = result.expect_err("err").to_string();
+    assert!(
+        err.contains("ndim") && err.contains("shape"),
+        "error should mention ndim/shape mismatch, got: {err}"
+    );
+}
+
+#[test]
+fn test_encode_pre_encoded_strides_shape_mismatch_rejected() {
+    // strides.len() != shape.len() → rejected.
+    let desc = DataObjectDescriptor {
+        obj_type: "ntensor".to_string(),
+        ndim: 1,
+        shape: vec![4],
+        strides: vec![1, 1], // wrong length
+        dtype: Dtype::Float32,
+        byte_order: ByteOrder::Big,
+        encoding: "none".to_string(),
+        filter: "none".to_string(),
+        compression: "none".to_string(),
+        params: BTreeMap::new(),
+        hash: None,
+    };
+    let raw = vec![0u8; 16];
+    let meta = GlobalMetadata::default();
+    let result = encode_pre_encoded(&meta, &[(&desc, &raw)], &EncodeOptions::default());
+    assert!(result.is_err(), "strides/shape mismatch must be rejected");
+    let err = result.expect_err("err").to_string();
+    assert!(
+        err.contains("strides") && err.contains("shape"),
+        "error should mention strides/shape mismatch, got: {err}"
+    );
+}
+
+#[test]
+fn test_streaming_pre_encoded_with_preceder() {
+    // Streaming: write_object_pre_encoded after writing a preceder.
+    let meta = GlobalMetadata::default();
+    let opts = EncodeOptions {
+        hash_algorithm: Some(tensogram_core::HashAlgorithm::Xxh3),
+        emit_preceders: true,
+    };
+
+    let desc = make_raw_desc(4, Dtype::Float32, "none", BTreeMap::new());
+    let raw = vec![42u8; 16]; // 4 × float32
+
+    let buf: Vec<u8> = Vec::new();
+    let mut enc = StreamingEncoder::new(buf, &meta, &opts).expect("create streaming encoder");
+
+    // Write a preceder (metadata-only, no data payload).
+    let preceder_meta: BTreeMap<String, ciborium::Value> = BTreeMap::new();
+    enc.write_preceder(preceder_meta).expect("write preceder");
+
+    // Then write the pre-encoded object
+    enc.write_object_pre_encoded(&desc, &raw)
+        .expect("write pre-encoded after preceder");
+
+    let result = enc.finish().expect("finish");
+    let (_, objects) = decode(&result, &DecodeOptions::default()).expect("decode");
+    // Preceder is transparent to decode — only the main object is returned.
+    assert_eq!(
+        objects.len(),
+        1,
+        "preceder + 1 pre-encoded object → 1 decoded"
+    );
+    assert_eq!(objects[0].1, raw);
+}

--- a/crates/tensogram-ffi/src/lib.rs
+++ b/crates/tensogram-ffi/src/lib.rs
@@ -32,9 +32,9 @@ use std::ptr;
 use std::slice;
 
 use tensogram_core::{
-    decode, decode_metadata, decode_object, decode_range, encode, scan, DataObjectDescriptor,
-    DecodeOptions, EncodeOptions, GlobalMetadata, HashAlgorithm, StreamingEncoder, TensogramError,
-    TensogramFile, RESERVED_KEY,
+    decode, decode_metadata, decode_object, decode_range, encode, encode_pre_encoded, scan,
+    DataObjectDescriptor, DecodeOptions, EncodeOptions, GlobalMetadata, HashAlgorithm,
+    StreamingEncoder, TensogramError, TensogramFile, RESERVED_KEY,
 };
 
 // ---------------------------------------------------------------------------
@@ -508,6 +508,96 @@ pub extern "C" fn tgm_encode(
         .collect();
 
     match encode(&parsed.global_metadata, &pairs, &parsed.options) {
+        Ok(bytes) => {
+            // Rebuild via boxed slice to guarantee capacity == len for tgm_bytes_free.
+            let mut bytes = bytes.into_boxed_slice().into_vec();
+            let result = TgmBytes {
+                data: bytes.as_mut_ptr(),
+                len: bytes.len(),
+            };
+            std::mem::forget(bytes); // ownership transferred to C
+            unsafe {
+                *out = result;
+            }
+            TgmError::Ok
+        }
+        Err(e) => {
+            set_last_error(&e.to_string());
+            to_error_code(&e)
+        }
+    }
+}
+
+/// Encode a Tensogram message from JSON metadata and pre-encoded payload bytes.
+///
+/// Like `tgm_encode`, but each `data_ptrs[i]` slice must already be encoded
+/// according to the matching descriptor's `encoding` / `filter` / `compression`
+/// pipeline. The library does not run the encoding pipeline again — it writes
+/// the caller-provided bytes directly into the wire-format payload after
+/// validating that the descriptor's pipeline configuration is well-formed.
+///
+/// `metadata_json`: same flat JSON schema as `tgm_encode` (`version`,
+///   `descriptors`, optional `base`, plus arbitrary extra top-level keys).
+///
+/// `data_ptrs` / `data_lens`: arrays of length `num_objects` pointing at
+///   already-encoded payload bytes (one entry per descriptor).
+///
+/// `hash_algo`: null-terminated string ("xxh3") or NULL for no hash. The
+///   library always recomputes the hash over the caller's bytes; any
+///   `hash` field embedded in the descriptor JSON is ignored and overwritten.
+///
+/// Notes for compression-aware decoding:
+/// - For `szip` compression, callers SHOULD include `szip_block_offsets`
+///   (a list of bit offsets into the compressed payload) inside the
+///   matching descriptor's params so that `tgm_decode_range` can locate
+///   szip block boundaries without rescanning the compressed stream.
+/// - Other pipeline params (e.g. `simple_packing` reference value, scale
+///   factors) must also be present in the descriptor — they are not
+///   inferred from the bytes.
+///
+/// On success returns `TgmError::Ok` and fills `out` with the encoded message.
+/// The caller must free `out` with `tgm_bytes_free`.
+#[no_mangle]
+pub extern "C" fn tgm_encode_pre_encoded(
+    metadata_json: *const c_char,
+    data_ptrs: *const *const u8,
+    data_lens: *const usize,
+    num_objects: usize,
+    hash_algo: *const c_char,
+    out: *mut TgmBytes,
+) -> TgmError {
+    if metadata_json.is_null() || out.is_null() {
+        set_last_error("null argument");
+        return TgmError::InvalidArg;
+    }
+
+    let json_str = match unsafe { CStr::from_ptr(metadata_json) }.to_str() {
+        Ok(s) => s,
+        Err(e) => {
+            set_last_error(&format!("invalid UTF-8 in metadata_json: {e}"));
+            return TgmError::InvalidArg;
+        }
+    };
+
+    let parsed = match unsafe {
+        parse_encode_args(json_str, data_ptrs, data_lens, num_objects, hash_algo)
+    } {
+        Ok(p) => p,
+        Err((code, msg)) => {
+            set_last_error(&msg);
+            return code;
+        }
+    };
+
+    // Build (descriptor, pre-encoded data) pairs for the pre-encoded API.
+    let pairs: Vec<(&DataObjectDescriptor, &[u8])> = parsed
+        .descriptors
+        .iter()
+        .zip(parsed.data_slices.iter())
+        .map(|(d, s)| (d, *s))
+        .collect();
+
+    match encode_pre_encoded(&parsed.global_metadata, &pairs, &parsed.options) {
         Ok(bytes) => {
             // Rebuild via boxed slice to guarantee capacity == len for tgm_bytes_free.
             let mut bytes = bytes.into_boxed_slice().into_vec();
@@ -2643,6 +2733,71 @@ pub extern "C" fn tgm_streaming_encoder_write(
 
     match encoder.inner.as_mut() {
         Some(inner) => match inner.write_object(&descriptor, data_slice) {
+            Ok(()) => TgmError::Ok,
+            Err(e) => {
+                set_last_error(&e.to_string());
+                to_error_code(&e)
+            }
+        },
+        None => {
+            set_last_error("streaming encoder already finished");
+            TgmError::InvalidArg
+        }
+    }
+}
+
+/// Write a single pre-encoded data object to the streaming encoder.
+///
+/// Like `tgm_streaming_encoder_write`, but `data` must already be encoded
+/// according to the descriptor's pipeline (`encoding` / `filter` /
+/// `compression`). The library does not run the encoding pipeline — it
+/// validates the descriptor's pipeline configuration and writes the bytes
+/// as-is into a data object frame. The hash (if configured on the encoder)
+/// is recomputed over the caller's bytes.
+///
+/// `descriptor_json`: same JSON schema as `tgm_streaming_encoder_write`.
+///
+/// For `szip` compression, callers SHOULD include `szip_block_offsets`
+/// (bit offsets, not byte offsets) in the descriptor's params so that
+/// `tgm_decode_range` can locate compressed block boundaries later.
+/// Other pipeline params (e.g. `simple_packing` reference value, scale
+/// factors) must also be present in the descriptor.
+///
+/// Any `hash` field embedded in the descriptor JSON is ignored — the
+/// library always recomputes the hash from the caller's bytes.
+#[no_mangle]
+pub extern "C" fn tgm_streaming_encoder_write_pre_encoded(
+    enc: *mut TgmStreamingEncoder,
+    descriptor_json: *const c_char,
+    data: *const u8,
+    data_len: usize,
+) -> TgmError {
+    if enc.is_null() || descriptor_json.is_null() || data.is_null() {
+        set_last_error("null argument");
+        return TgmError::InvalidArg;
+    }
+
+    let json_str = match unsafe { CStr::from_ptr(descriptor_json) }.to_str() {
+        Ok(s) => s,
+        Err(e) => {
+            set_last_error(&format!("invalid UTF-8 in descriptor_json: {e}"));
+            return TgmError::InvalidArg;
+        }
+    };
+
+    let descriptor: DataObjectDescriptor = match serde_json::from_str(json_str) {
+        Ok(d) => d,
+        Err(e) => {
+            set_last_error(&format!("failed to parse descriptor JSON: {e}"));
+            return TgmError::Metadata;
+        }
+    };
+
+    let data_slice = unsafe { slice::from_raw_parts(data, data_len) };
+    let encoder = unsafe { &mut *enc };
+
+    match encoder.inner.as_mut() {
+        Some(inner) => match inner.write_object_pre_encoded(&descriptor, data_slice) {
             Ok(()) => TgmError::Ok,
             Err(e) => {
                 set_last_error(&e.to_string());

--- a/crates/tensogram-ffi/tensogram.h
+++ b/crates/tensogram-ffi/tensogram.h
@@ -117,6 +117,44 @@ tgm_error tgm_encode(const char *metadata_json,
                      tgm_bytes_t *out);
 
 /**
+ * Encode a Tensogram message from JSON metadata and pre-encoded payload bytes.
+ *
+ * Like `tgm_encode`, but each `data_ptrs[i]` slice must already be encoded
+ * according to the matching descriptor's `encoding` / `filter` / `compression`
+ * pipeline. The library does not run the encoding pipeline again — it writes
+ * the caller-provided bytes directly into the wire-format payload after
+ * validating that the descriptor's pipeline configuration is well-formed.
+ *
+ * `metadata_json`: same flat JSON schema as `tgm_encode` (`version`,
+ *   `descriptors`, optional `base`, plus arbitrary extra top-level keys).
+ *
+ * `data_ptrs` / `data_lens`: arrays of length `num_objects` pointing at
+ *   already-encoded payload bytes (one entry per descriptor).
+ *
+ * `hash_algo`: null-terminated string ("xxh3") or NULL for no hash. The
+ *   library always recomputes the hash over the caller's bytes; any
+ *   `hash` field embedded in the descriptor JSON is ignored and overwritten.
+ *
+ * Notes for compression-aware decoding:
+ * - For `szip` compression, callers SHOULD include `szip_block_offsets`
+ *   (a list of bit offsets into the compressed payload) inside the
+ *   matching descriptor's params so that `tgm_decode_range` can locate
+ *   szip block boundaries without rescanning the compressed stream.
+ * - Other pipeline params (e.g. `simple_packing` reference value, scale
+ *   factors) must also be present in the descriptor — they are not
+ *   inferred from the bytes.
+ *
+ * On success returns `TgmError::Ok` and fills `out` with the encoded message.
+ * The caller must free `out` with `tgm_bytes_free`.
+ */
+tgm_error tgm_encode_pre_encoded(const char *metadata_json,
+                                 const uint8_t *const *data_ptrs,
+                                 const size_t *data_lens,
+                                 size_t num_objects,
+                                 const char *hash_algo,
+                                 tgm_bytes_t *out);
+
+/**
  * Decode a complete message (global metadata + all object payloads).
  *
  * `buf` / `buf_len`: the wire-format message bytes.
@@ -532,6 +570,32 @@ tgm_error tgm_streaming_encoder_write(tgm_streaming_encoder_t *enc,
                                       const char *descriptor_json,
                                       const uint8_t *data,
                                       size_t data_len);
+
+/**
+ * Write a single pre-encoded data object to the streaming encoder.
+ *
+ * Like `tgm_streaming_encoder_write`, but `data` must already be encoded
+ * according to the descriptor's pipeline (`encoding` / `filter` /
+ * `compression`). The library does not run the encoding pipeline — it
+ * validates the descriptor's pipeline configuration and writes the bytes
+ * as-is into a data object frame. The hash (if configured on the encoder)
+ * is recomputed over the caller's bytes.
+ *
+ * `descriptor_json`: same JSON schema as `tgm_streaming_encoder_write`.
+ *
+ * For `szip` compression, callers SHOULD include `szip_block_offsets`
+ * (bit offsets, not byte offsets) in the descriptor's params so that
+ * `tgm_decode_range` can locate compressed block boundaries later.
+ * Other pipeline params (e.g. `simple_packing` reference value, scale
+ * factors) must also be present in the descriptor.
+ *
+ * Any `hash` field embedded in the descriptor JSON is ignored — the
+ * library always recomputes the hash from the caller's bytes.
+ */
+tgm_error tgm_streaming_encoder_write_pre_encoded(tgm_streaming_encoder_t *enc,
+                                                  const char *descriptor_json,
+                                                  const uint8_t *data,
+                                                  size_t data_len);
 
 /**
  * Return the number of objects written so far.

--- a/crates/tensogram-python/src/lib.rs
+++ b/crates/tensogram-python/src/lib.rs
@@ -957,15 +957,16 @@ impl PyStreamingEncoder {
     fn write_object_pre_encoded(
         &mut self,
         descriptor: &Bound<'_, PyDict>,
-        data: &Bound<'_, PyBytes>,
+        data: &Bound<'_, pyo3::PyAny>,
     ) -> PyResult<()> {
         let desc = dict_to_data_object_descriptor(descriptor)?;
+        let bytes = data.extract::<Vec<u8>>()?;
         let inner = self
             .inner
             .as_mut()
             .ok_or_else(|| PyRuntimeError::new_err("StreamingEncoder already finished"))?;
         inner
-            .write_object_pre_encoded(&desc, data.as_bytes())
+            .write_object_pre_encoded(&desc, &bytes)
             .map_err(to_py_err)
     }
 

--- a/crates/tensogram-python/src/lib.rs
+++ b/crates/tensogram-python/src/lib.rs
@@ -1118,10 +1118,15 @@ fn extract_pre_encoded_pairs(
         let data_item = tuple.get_item(1)?;
         // Only accept bytes-like objects, not numpy arrays.
         let data = data_item.extract::<Vec<u8>>().map_err(|_| {
-            PyValueError::new_err(
-                "encode_pre_encoded requires bytes data, not numpy arrays — \
+            let type_name = data_item
+                .get_type()
+                .name()
+                .map(|n| n.to_string())
+                .unwrap_or_else(|_| "<unknown>".to_string());
+            PyValueError::new_err(format!(
+                "encode_pre_encoded requires bytes data (got {type_name}) — \
                  the payload must already be in its final wire form",
-            )
+            ))
         })?;
         result.push((desc, data));
     }

--- a/crates/tensogram-python/src/lib.rs
+++ b/crates/tensogram-python/src/lib.rs
@@ -960,14 +960,21 @@ impl PyStreamingEncoder {
         data: &Bound<'_, pyo3::PyAny>,
     ) -> PyResult<()> {
         let desc = dict_to_data_object_descriptor(descriptor)?;
-        let bytes = data.extract::<Vec<u8>>()?;
         let inner = self
             .inner
             .as_mut()
             .ok_or_else(|| PyRuntimeError::new_err("StreamingEncoder already finished"))?;
-        inner
-            .write_object_pre_encoded(&desc, &bytes)
-            .map_err(to_py_err)
+        // Zero-copy fast path for PyBytes; fall back to extract for bytearray / memoryview.
+        if let Ok(py_bytes) = data.downcast::<PyBytes>() {
+            inner
+                .write_object_pre_encoded(&desc, py_bytes.as_bytes())
+                .map_err(to_py_err)
+        } else {
+            let bytes = data.extract::<Vec<u8>>()?;
+            inner
+                .write_object_pre_encoded(&desc, &bytes)
+                .map_err(to_py_err)
+        }
     }
 
     /// Finalize the stream and return the complete wire-format ``bytes``.

--- a/crates/tensogram-python/src/lib.rs
+++ b/crates/tensogram-python/src/lib.rs
@@ -633,7 +633,7 @@ fn py_encode_pre_encoded<'py>(
     hash: Option<&str>,
 ) -> PyResult<Bound<'py, PyBytes>> {
     let global_meta = dict_to_global_metadata(global_meta_dict)?;
-    let pairs = extract_descriptor_data_pairs(py, descriptors_and_data)?;
+    let pairs = extract_pre_encoded_pairs(descriptors_and_data)?;
     let refs: Vec<(&DataObjectDescriptor, &[u8])> =
         pairs.iter().map(|(d, b)| (d, b.as_slice())).collect();
 
@@ -1091,6 +1091,41 @@ fn extract_single_data_item(item: &Bound<'_, pyo3::PyAny>) -> PyResult<Vec<u8>> 
         return Ok(b);
     }
     Err(PyValueError::new_err("data must be a numpy array or bytes"))
+}
+
+/// Extract a list of (descriptor, raw_bytes) pairs for `encode_pre_encoded`.
+///
+/// Unlike [`extract_descriptor_data_pairs`] this function **only** accepts
+/// `bytes`-like objects as the data element — numpy arrays are rejected because
+/// pre-encoded payloads are already in their final wire form.
+fn extract_pre_encoded_pairs(
+    pairs_list: &Bound<'_, PyList>,
+) -> PyResult<Vec<(DataObjectDescriptor, Vec<u8>)>> {
+    let mut result = Vec::new();
+    for item in pairs_list.iter() {
+        let tuple = item.downcast::<pyo3::types::PyTuple>().map_err(|_| {
+            PyValueError::new_err("each element must be a (descriptor_dict, bytes) tuple")
+        })?;
+        if tuple.len() != 2 {
+            return Err(PyValueError::new_err(
+                "each element must be a (descriptor_dict, bytes) tuple of length 2",
+            ));
+        }
+        let desc_dict = tuple.get_item(0)?.downcast_into::<PyDict>().map_err(|_| {
+            PyValueError::new_err("first element of each pair must be a descriptor dict")
+        })?;
+        let desc = dict_to_data_object_descriptor(&desc_dict)?;
+        let data_item = tuple.get_item(1)?;
+        // Only accept bytes-like objects, not numpy arrays.
+        let data = data_item.extract::<Vec<u8>>().map_err(|_| {
+            PyValueError::new_err(
+                "encode_pre_encoded requires bytes data, not numpy arrays — \
+                 the payload must already be in its final wire form",
+            )
+        })?;
+        result.push((desc, data));
+    }
+    Ok(result)
 }
 
 /// Convert decoded data objects to a Python list of (descriptor, ndarray) tuples.

--- a/crates/tensogram-python/src/lib.rs
+++ b/crates/tensogram-python/src/lib.rs
@@ -11,9 +11,9 @@ use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList};
 
 use tensogram_core::{
-    decode, decode_descriptors, decode_metadata, decode_object, decode_range, encode, scan,
-    ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions, GlobalMetadata,
-    HashAlgorithm, TensogramError, TensogramFile, RESERVED_KEY,
+    decode, decode_descriptors, decode_metadata, decode_object, decode_range, encode,
+    encode_pre_encoded, scan, ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions,
+    GlobalMetadata, HashAlgorithm, StreamingEncoder, TensogramError, TensogramFile, RESERVED_KEY,
 };
 
 // ---------------------------------------------------------------------------
@@ -605,6 +605,43 @@ fn py_encode<'py>(
     Ok(PyBytes::new(py, &msg))
 }
 
+/// Encode already-encoded payloads into a Tensogram wire-format message.
+///
+/// Unlike :func:`encode`, this function does **not** run the encoding pipeline
+/// (encoding/filter/compression/szip).  Each *data* element must be a
+/// ``bytes`` object already carrying the encoded payload that matches the
+/// descriptor's declared ``encoding`` / ``filter`` / ``compression`` and any
+/// codec-specific ``params`` (e.g. ``szip_block_offsets``).  The library still
+/// computes and stamps the payload hash.
+///
+/// Args:
+///     global_meta_dict: ``{"version": 2, ...}`` with any extra keys.
+///     descriptors_and_data: list of ``(descriptor_dict, bytes)`` pairs.  The
+///         second element of each pair **must** be a ``bytes``-like object —
+///         numpy arrays are rejected because pre-encoded payloads are
+///         already in their final wire form.
+///     hash: ``"xxh3"`` (default) or ``None`` to skip integrity hashing.
+///
+/// Returns:
+///     ``bytes`` — the complete wire-format message.
+#[pyfunction]
+#[pyo3(name = "encode_pre_encoded", signature = (global_meta_dict, descriptors_and_data, hash=Some("xxh3")))]
+fn py_encode_pre_encoded<'py>(
+    py: Python<'py>,
+    global_meta_dict: &Bound<'_, PyDict>,
+    descriptors_and_data: &Bound<'_, PyList>,
+    hash: Option<&str>,
+) -> PyResult<Bound<'py, PyBytes>> {
+    let global_meta = dict_to_global_metadata(global_meta_dict)?;
+    let pairs = extract_descriptor_data_pairs(py, descriptors_and_data)?;
+    let refs: Vec<(&DataObjectDescriptor, &[u8])> =
+        pairs.iter().map(|(d, b)| (d, b.as_slice())).collect();
+
+    let options = make_encode_options(hash)?;
+    let msg = encode_pre_encoded(&global_meta, &refs, &options).map_err(to_py_err)?;
+    Ok(PyBytes::new(py, &msg))
+}
+
 /// Decode a wire-format message → ``Message(metadata, objects)``.
 ///
 /// Set *verify_hash* to ``True`` to verify payload integrity.
@@ -851,12 +888,108 @@ fn compute_packing_params(
 }
 
 // ---------------------------------------------------------------------------
+// PyStreamingEncoder — wraps StreamingEncoder<Vec<u8>>
+// ---------------------------------------------------------------------------
+
+/// Progressive, frame-at-a-time encoder backed by an in-memory ``bytes`` buffer.
+///
+/// Unlike :func:`encode`, which builds a complete message in one shot, the
+/// streaming encoder writes each object frame as soon as
+/// :meth:`write_object` (or :meth:`write_object_pre_encoded`) is called.
+/// Call :meth:`finish` to flush the footer frames + postamble and retrieve the
+/// complete wire-format message.
+///
+/// Example::
+///
+///     enc = tensogram.StreamingEncoder({"version": 2})
+///     enc.write_object({"type": "ntensor", "shape": [4], "dtype": "float32"},
+///                      np.ones(4, dtype=np.float32))
+///     msg = enc.finish()
+#[pyclass(name = "StreamingEncoder")]
+struct PyStreamingEncoder {
+    inner: Option<StreamingEncoder<Vec<u8>>>,
+}
+
+#[pymethods]
+impl PyStreamingEncoder {
+    /// Begin a new streaming message.
+    ///
+    /// Args:
+    ///     global_meta_dict: ``{"version": 2, ...}`` with any extra keys.
+    ///     hash: ``"xxh3"`` (default) or ``None`` to skip integrity hashing.
+    #[new]
+    #[pyo3(signature = (global_meta_dict, hash=Some("xxh3")))]
+    fn new(global_meta_dict: &Bound<'_, PyDict>, hash: Option<&str>) -> PyResult<Self> {
+        let global_meta = dict_to_global_metadata(global_meta_dict)?;
+        let options = make_encode_options(hash)?;
+        let inner = StreamingEncoder::new(Vec::new(), &global_meta, &options).map_err(to_py_err)?;
+        Ok(Self { inner: Some(inner) })
+    }
+
+    /// Encode and write a single data object frame.
+    ///
+    /// Args:
+    ///     descriptor: dict with ``type``/``shape``/``dtype`` plus encoding
+    ///         pipeline fields (``encoding``, ``filter``, ``compression``,
+    ///         ``params``, etc.).
+    ///     data: numpy array or ``bytes``-like object carrying the raw
+    ///         native-endian payload to encode.
+    fn write_object(
+        &mut self,
+        descriptor: &Bound<'_, PyDict>,
+        data: &Bound<'_, pyo3::PyAny>,
+    ) -> PyResult<()> {
+        let desc = dict_to_data_object_descriptor(descriptor)?;
+        let bytes = extract_single_data_item(data)?;
+        let inner = self
+            .inner
+            .as_mut()
+            .ok_or_else(|| PyRuntimeError::new_err("StreamingEncoder already finished"))?;
+        inner.write_object(&desc, &bytes).map_err(to_py_err)
+    }
+
+    /// Write a pre-encoded data object frame directly (no pipeline).
+    ///
+    /// ``data`` must already contain the encoded payload matching the
+    /// descriptor's ``encoding`` / ``filter`` / ``compression`` / ``params``
+    /// (e.g. ``szip_block_offsets`` as a ``list[int]``).  The library still
+    /// computes and stamps the payload hash.
+    fn write_object_pre_encoded(
+        &mut self,
+        descriptor: &Bound<'_, PyDict>,
+        data: &Bound<'_, PyBytes>,
+    ) -> PyResult<()> {
+        let desc = dict_to_data_object_descriptor(descriptor)?;
+        let inner = self
+            .inner
+            .as_mut()
+            .ok_or_else(|| PyRuntimeError::new_err("StreamingEncoder already finished"))?;
+        inner
+            .write_object_pre_encoded(&desc, data.as_bytes())
+            .map_err(to_py_err)
+    }
+
+    /// Finalize the stream and return the complete wire-format ``bytes``.
+    ///
+    /// Subsequent calls on this encoder raise ``RuntimeError``.
+    fn finish<'py>(&mut self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
+        let inner = self
+            .inner
+            .take()
+            .ok_or_else(|| PyRuntimeError::new_err("StreamingEncoder already finished"))?;
+        let buf = inner.finish().map_err(to_py_err)?;
+        Ok(PyBytes::new(py, &buf))
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Module definition
 // ---------------------------------------------------------------------------
 
 #[pymodule]
 fn tensogram(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_encode, m)?)?;
+    m.add_function(wrap_pyfunction!(py_encode_pre_encoded, m)?)?;
     m.add_function(wrap_pyfunction!(py_decode, m)?)?;
     m.add_function(wrap_pyfunction!(py_decode_metadata, m)?)?;
     m.add_function(wrap_pyfunction!(py_decode_descriptors, m)?)?;
@@ -870,6 +1003,7 @@ fn tensogram(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyTensogramFile>()?;
     m.add_class::<PyFileIter>()?;
     m.add_class::<PyBufferIter>()?;
+    m.add_class::<PyStreamingEncoder>()?;
     Ok(())
 }
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -26,6 +26,7 @@
 
 - [Quick Start](guide/quickstart.md)
 - [Encoding Data](guide/encoding.md)
+- [Pre-Encoded Data API (Advanced)](guide/encode-pre-encoded.md)
 - [Decoding Data](guide/decoding.md)
 - [Working with Files](guide/file-api.md)
 - [Iterators](guide/iterators.md)

--- a/docs/src/concepts/pipeline.md
+++ b/docs/src/concepts/pipeline.md
@@ -36,7 +36,7 @@ flowchart TD
     style Decode fill:#fce4ec,stroke:#c62828,color:#c62828
 ```
 
-Each stage is **independently configurable per object** via fields in the `DataObjectDescriptor`. Set a stage to `"none"` to skip it.
+Each stage is **independently configurable per object** via fields in the `DataObjectDescriptor`. Set a stage to `"none"` to skip it. For callers with already-encoded payloads, a pipeline-bypass option exists via `encode_pre_encoded` (see [Pre-encoded Payloads](../guide/encode-pre-encoded.md)).
 
 ## Stage 1: Encoding
 

--- a/docs/src/encodings/compression.md
+++ b/docs/src/encodings/compression.md
@@ -40,7 +40,7 @@ pub trait Compressor {
 
 Szip implements CCSDS 121.0-B-3, a lossless compressor designed for scientific data. It works on integer data and exploits the block structure of packed values.
 
-**Random access**: Szip records RSI (Reference Sample Interval) block boundaries during encoding. These offsets are stored in metadata as `szip_block_offsets`, enabling seek-to-block partial decode via `decompress_range`.
+**Random access**: Szip records RSI (Reference Sample Interval) block boundaries during encoding. These offsets are stored in metadata as `szip_block_offsets`, enabling seek-to-block partial decode via `decompress_range`. When using `encode_pre_encoded`, the caller must provide these bit-precise block offsets themselves to enable random access (see [Pre-encoded Payloads](../guide/encode-pre-encoded.md)).
 
 | Parameter | Type | Description |
 |---|---|---|

--- a/docs/src/format/cbor-metadata.md
+++ b/docs/src/format/cbor-metadata.md
@@ -236,7 +236,7 @@ The `params` field in `DataObjectDescriptor` is for encoding parameters only (e.
 | `szip_rsi` | uint | Reference sample interval |
 | `szip_block_size` | uint | Block size (typically 8 or 16) |
 | `szip_flags` | uint | AEC encoding flags |
-| `szip_block_offsets` | array of uint | Bit offsets of RSI block boundaries (computed during encoding) |
+| `szip_block_offsets` | array of uint | Bit offsets of RSI block boundaries (computed by the library or provided via `encode_pre_encoded`, see [Pre-encoded Payloads](../guide/encode-pre-encoded.md)) |
 
 **zstd:**
 

--- a/docs/src/guide/decoding.md
+++ b/docs/src/guide/decoding.md
@@ -127,6 +127,8 @@ print(arr.shape)          # (75,)
 > `(offset, count)` pairs that `decode_range` expects, so you rarely need to
 > compute flattened offsets by hand when working through xarray.
 
+> **Pre-encoded messages:** Messages produced via `encode_pre_encoded` only support `decode_range` if the caller provided the necessary bit-precise `szip_block_offsets` (see [Pre-encoded Payloads](./encode-pre-encoded.md)).
+
 > **Edge case:** `decode_range` works with all encoding+compression combinations that support random access: uncompressed data, `simple_packing` (bit extraction), `szip` (RSI block seeking), `blosc2` (chunk access), and `zfp` fixed-rate mode. It returns an error for the `shuffle` filter (byte rearrangement breaks contiguous sample ranges) and for stream compressors (`zstd`, `lz4`, `sz3`) that don't support partial decode.
 
 ## DecodeOptions

--- a/docs/src/guide/encode-pre-encoded.md
+++ b/docs/src/guide/encode-pre-encoded.md
@@ -175,8 +175,10 @@ library does NOT validate or flip byte order. The bytes must be in the byte
 order declared in the descriptor's `byte_order` field.
 
 For example, if `byte_order="big"` and `encoding="none"`, the caller must
-provide big-endian bytes. The decoder will interpret them according to the
-declared byte order.
+provide big-endian bytes. On decode, the payload bytes are returned **verbatim**
+for `encoding="none"`; callers and language bindings that interpret those bytes
+as numeric values must use the declared `byte_order` (or byteswap as needed)
+rather than assuming native endianness.
 
 When using other encodings (`simple_packing`, etc.), byte order is handled
 by the encoding/decoding pipeline, so the `byte_order` field describes the

--- a/docs/src/guide/encode-pre-encoded.md
+++ b/docs/src/guide/encode-pre-encoded.md
@@ -168,6 +168,76 @@ flowchart LR
 
 The pre-encoded path skips the pipeline entirely. The wire format is identical.
 
+## Byte order responsibility
+
+When using `encoding="none"`, the caller's bytes are stored **verbatim** — the
+library does NOT validate or flip byte order. The bytes must be in the byte
+order declared in the descriptor's `byte_order` field.
+
+For example, if `byte_order="big"` and `encoding="none"`, the caller must
+provide big-endian bytes. The decoder will interpret them according to the
+declared byte order.
+
+When using other encodings (`simple_packing`, etc.), byte order is handled
+by the encoding/decoding pipeline, so the `byte_order` field describes the
+*decoded* output format.
+
+## Streaming API
+
+`StreamingEncoder::write_object_pre_encoded()` is the streaming counterpart of
+`encode_pre_encoded()`. It writes a single pre-encoded object to the stream.
+It can be interleaved freely with `write_object()` (normal encode) calls.
+
+### Rust
+```rust
+let mut enc = StreamingEncoder::new(output, &metadata, &options)?;
+enc.write_object_pre_encoded(&descriptor, &pre_encoded_bytes)?;
+enc.finish()?;
+```
+
+### Python
+```python
+enc = tensogram.StreamingEncoder({"version": 2})
+enc.write_object_pre_encoded(descriptor_dict, raw_bytes)
+msg = enc.finish()
+```
+
+### C++
+```cpp
+tensogram::streaming_encoder enc(path, metadata_json);
+enc.write_object_pre_encoded(descriptor_json, data_ptr, data_len);
+enc.finish();
+```
+
+## Error reference
+
+`encode_pre_encoded` can raise the following errors:
+
+| Error condition | Message contains |
+|---|---|
+| `obj_type` is empty | `"obj_type must not be empty"` |
+| `ndim` doesn't match `shape.len()` | `"ndim … does not match shape.len()"` |
+| `strides.len()` doesn't match `shape.len()` | `"strides.len() … does not match shape.len()"` |
+| `encoding="none"` and data size wrong | `"data_len … does not match expected … bytes"` |
+| `emit_preceders=true` in buffered mode | `"emit_preceders is not supported"` |
+| Caller set `_reserved_` in metadata | `"_reserved_"` |
+| `szip_block_offsets` not starting at 0 | `"first offset must be 0"` |
+| `szip_block_offsets` not strictly increasing | `"strictly increasing"` |
+| `szip_block_offsets` exceeds bit bound | `"exceeds … bit bound"` |
+| `szip_block_offsets` with non-szip compression | `"szip_block_offsets provided but compression"` |
+| Unknown encoding string | `"encoding"` |
+| Unknown dtype | `"unknown dtype"` |
+
+## Strides convention
+
+The library treats strides as **opaque metadata** — it only validates that
+`strides.len() == shape.len()`. The convention differs between language bindings:
+
+- **Rust** tests use **element strides** (e.g., `[1]` for 1D, `[5, 1]` for shape `[4, 5]`)
+- **C++** tests use **byte strides** (e.g., `[4]` for float32, `[12, 4]` for shape `[2, 3]` float32)
+
+Both conventions work correctly since the library does not interpret stride values.
+
 ## Cross-references
 
 - [Encoding](encoding.md) — the normal `encode()` API

--- a/docs/src/guide/encode-pre-encoded.md
+++ b/docs/src/guide/encode-pre-encoded.md
@@ -1,0 +1,157 @@
+# Pre-Encoded Data API (Advanced)
+
+## When to use this API
+
+The `encode_pre_encoded` API is for **advanced callers** whose data is already
+encoded by an external pipeline (e.g., a GPU kernel that emits packed bytes,
+or a streaming receiver passing payloads through). It bypasses Tensogram's
+internal encoding pipeline and uses the supplied bytes verbatim.
+
+Do NOT use this API for ordinary encoding. Use `encode()` instead.
+
+## ⚠️ The bit-vs-byte trap
+
+> **WARNING**: When using `compression="szip"`, the `szip_block_offsets` parameter
+> contains **bit offsets**, not byte offsets. The first offset must be 0 and
+> every offset must satisfy `offset <= encoded_bytes_len * 8`. This matches
+> the libaec/szip wire format. See [cbor-metadata.md](../format/cbor-metadata.md#szip-block-offsets)
+> for the format reference.
+>
+> Getting this wrong is the #1 caller mistake. Tensogram validates the offsets
+> structurally (monotonicity, bounds) but cannot detect a byte-instead-of-bit
+> mistake until decode_range fails.
+
+## API surface
+
+### Rust
+```rust
+pub fn encode_pre_encoded(
+    metadata: &GlobalMetadata,
+    descriptors_and_data: &[(&DataObjectDescriptor, &[u8])],
+    options: &EncodeOptions,
+) -> Result<Vec<u8>, TensogramError>
+```
+
+### Python
+```python
+import tensogram
+
+msg: bytes = tensogram.encode_pre_encoded(
+    global_meta={"name": "demo"},
+    descriptors_and_data=[(descriptor_dict, raw_bytes)],
+    hash="xxh3",
+)
+```
+
+### C
+```c
+tgm_error tgm_encode_pre_encoded(
+    const char *metadata_json,
+    const uint8_t *const *data_ptrs,
+    const size_t *data_lens,
+    size_t num_objects,
+    const char *hash_algo,
+    tgm_bytes_t *out
+);
+```
+
+### C++
+```cpp
+std::vector<uint8_t> tensogram::encode_pre_encoded(
+    const GlobalMetadata &meta,
+    const std::vector<std::pair<DataObjectDescriptor, std::span<const uint8_t>>> &pairs,
+    const EncodeOptions &opts
+);
+```
+
+## Hash semantics
+
+The library **always recomputes** the hash of the pre-encoded bytes using
+the algorithm specified in `EncodeOptions.hash` (default `xxh3`). Any hash
+the caller stored on the descriptor is silently overwritten. This guarantees
+the wire format invariant `descriptor.hash == hash_algo(bytes)` always holds.
+
+## Provenance semantics
+
+The encoded message is byte-format-indistinguishable from one produced by
+`encode()`. The decoder cannot tell which API produced it. The provenance
+fields `_reserved_.encoder.name`, `_reserved_.time`, and `_reserved_.uuid`
+are populated identically.
+
+## Self-consistency checks
+
+Before encoding, the library validates:
+1. Caller has not set `EncodeOptions.emit_preceders` (rejected).
+2. Caller has not put `_reserved_` in their metadata (rejected).
+3. Each descriptor passes the standard `validate_object` checks.
+4. If `compression="szip"` and `szip_block_offsets` is supplied:
+   - It's a CBOR Array of u64.
+   - First offset is 0.
+   - Strictly monotonically increasing.
+   - All bit offsets `<= bytes_len * 8`.
+5. If `szip_block_offsets` is supplied but `compression != "szip"`, rejected.
+
+These are **structural** checks only. The library does NOT trial-decode the
+bytes to verify they actually decode correctly.
+
+## Worked example: simple_packing + szip with decode_range
+
+```rust
+use tensogram_core::{encode_pre_encoded, decode_range, GlobalMetadata, EncodeOptions};
+use std::collections::BTreeMap;
+
+// Pre-encoded bytes from a GPU kernel + szip block offsets in BITS
+let pre_encoded_bytes: Vec<u8> = /* from GPU */;
+let szip_offsets_bits: Vec<u64> = vec![0, 8192, 16384, /* ... */];
+
+let mut params: BTreeMap<String, ciborium::Value> = BTreeMap::new();
+params.insert("bits_per_value".into(), 24u64.into());
+params.insert("reference_value".into(), 0.0_f64.into());
+params.insert("scale".into(), 0.001_f64.into());
+params.insert("szip_block_offsets".into(),
+    ciborium::Value::Array(szip_offsets_bits.into_iter()
+        .map(|o| ciborium::Value::Integer(o.into()))
+        .collect()));
+
+let desc = DataObjectDescriptor {
+    name: "demo".into(),
+    encoding: "simple_packing".into(),
+    compression: "szip".into(),
+    shape: vec![1024, 1024],
+    dtype: "f32".into(),
+    params,
+    ..Default::default()
+};
+
+let msg = encode_pre_encoded(
+    &GlobalMetadata::default(),
+    &[(&desc, &pre_encoded_bytes)],
+    &EncodeOptions::default(),
+)?;
+
+// Now decode_range works because szip_block_offsets is present:
+let partial = decode_range(&msg, 0, /* range */ 0..512)?;
+```
+
+## How it works (mermaid)
+
+```mermaid
+flowchart LR
+    A[Caller bytes] -->|encode_pre_encoded| B[validate_object]
+    B --> C[validate_szip_block_offsets]
+    C --> D[Recompute hash]
+    D --> E[Wrap in CBOR framing]
+    E --> F[Wire message]
+    
+    G[Caller bytes] -.->|encode| H[Run pipeline]
+    H -.-> D
+```
+
+The pre-encoded path skips the pipeline entirely. The wire format is identical.
+
+## Cross-references
+
+- [Encoding](encoding.md) — the normal `encode()` API
+- [Decoding](decoding.md) — `decode_range` requirements for partial reads
+- [Compression](../encodings/compression.md) — szip details
+- [CBOR metadata](../format/cbor-metadata.md) — wire format reference

--- a/docs/src/guide/encode-pre-encoded.md
+++ b/docs/src/guide/encode-pre-encoded.md
@@ -37,7 +37,7 @@ pub fn encode_pre_encoded(
 import tensogram
 
 msg: bytes = tensogram.encode_pre_encoded(
-    global_meta={"name": "demo"},
+    global_meta_dict={"version": 2},
     descriptors_and_data=[(descriptor_dict, raw_bytes)],
     hash="xxh3",
 )
@@ -57,10 +57,10 @@ tgm_error tgm_encode_pre_encoded(
 
 ### C++
 ```cpp
-std::vector<uint8_t> tensogram::encode_pre_encoded(
-    const GlobalMetadata &meta,
-    const std::vector<std::pair<DataObjectDescriptor, std::span<const uint8_t>>> &pairs,
-    const EncodeOptions &opts
+std::vector<std::uint8_t> tensogram::encode_pre_encoded(
+    const std::string& metadata_json,
+    const std::vector<std::pair<const std::uint8_t*, std::size_t>>& objects,
+    const encode_options& opts = {}
 );
 ```
 
@@ -94,33 +94,53 @@ Before encoding, the library validates:
 These are **structural** checks only. The library does NOT trial-decode the
 bytes to verify they actually decode correctly.
 
+### Limitation: encoding="none" size check
+
+When `encoding="none"`, the `validate_object` check enforces
+`payload_len == shape_product * dtype_byte_width`. This means you cannot pass
+compression-only payloads (e.g., zstd-compressed raw bytes) with
+`encoding="none"` because the compressed size will not match the expected raw
+size. Wrap such payloads in at least `simple_packing` or another encoding.
+
 ## Worked example: simple_packing + szip with decode_range
 
 ```rust
-use tensogram_core::{encode_pre_encoded, decode_range, GlobalMetadata, EncodeOptions};
+use tensogram_core::{
+    encode_pre_encoded, DataObjectDescriptor, EncodeOptions,
+    GlobalMetadata, ByteOrder, Dtype,
+};
 use std::collections::BTreeMap;
+use ciborium::Value;
 
 // Pre-encoded bytes from a GPU kernel + szip block offsets in BITS
 let pre_encoded_bytes: Vec<u8> = /* from GPU */;
 let szip_offsets_bits: Vec<u64> = vec![0, 8192, 16384, /* ... */];
 
 let mut params: BTreeMap<String, ciborium::Value> = BTreeMap::new();
-params.insert("bits_per_value".into(), 24u64.into());
-params.insert("reference_value".into(), 0.0_f64.into());
-params.insert("scale".into(), 0.001_f64.into());
+params.insert("bits_per_value".into(), Value::Integer(24u64.into()));
+params.insert("reference_value".into(), Value::Float(0.0));
+params.insert("binary_scale_factor".into(), Value::Integer((-10i64).into()));
+params.insert("decimal_scale_factor".into(), Value::Integer(0i64.into()));
+params.insert("szip_rsi".into(), Value::Integer(128i64.into()));
+params.insert("szip_block_size".into(), Value::Integer(16i64.into()));
+params.insert("szip_flags".into(), Value::Integer(8i64.into()));
 params.insert("szip_block_offsets".into(),
-    ciborium::Value::Array(szip_offsets_bits.into_iter()
-        .map(|o| ciborium::Value::Integer(o.into()))
+    Value::Array(szip_offsets_bits.into_iter()
+        .map(|o| Value::Integer(o.into()))
         .collect()));
 
 let desc = DataObjectDescriptor {
-    name: "demo".into(),
-    encoding: "simple_packing".into(),
-    compression: "szip".into(),
+    obj_type: "ntensor".into(),
+    ndim: 2,
     shape: vec![1024, 1024],
-    dtype: "f32".into(),
+    strides: vec![1024, 1],
+    dtype: Dtype::Float32,
+    byte_order: ByteOrder::Big,
+    encoding: "simple_packing".into(),
+    filter: "none".into(),
+    compression: "szip".into(),
     params,
-    ..Default::default()
+    hash: None,
 };
 
 let msg = encode_pre_encoded(
@@ -129,8 +149,7 @@ let msg = encode_pre_encoded(
     &EncodeOptions::default(),
 )?;
 
-// Now decode_range works because szip_block_offsets is present:
-let partial = decode_range(&msg, 0, /* range */ 0..512)?;
+// decode_range works because szip_block_offsets is present.
 ```
 
 ## How it works (mermaid)

--- a/examples/cpp/11_encode_pre_encoded.cpp
+++ b/examples/cpp/11_encode_pre_encoded.cpp
@@ -176,7 +176,7 @@ int main() {
         // Pre-encoded simple_packing object
         std::string desc_sp =
             R"({"type":"ndarray","ndim":1,"shape":[)" + std::to_string(N) +
-            R"(],"strides":[8],"dtype":"float64","byte_order":"little",)"
+R"(],"strides":[8],"dtype":"float64","byte_order":"little",)"
             R"("encoding":"simple_packing","filter":"none","compression":"none",)"
             R"("bits_per_value":)" + std::to_string(bits_per_value) +
             R"(,"reference_value":)" + std::string(ref_buf) +

--- a/examples/cpp/11_encode_pre_encoded.cpp
+++ b/examples/cpp/11_encode_pre_encoded.cpp
@@ -1,0 +1,229 @@
+/// @file 11_encode_pre_encoded.cpp
+/// @brief Example 11 — Pre-encoded payloads using the C++ wrapper.
+///
+/// Demonstrates tensogram::encode_pre_encoded(), which lets callers hand
+/// already-encoded payload bytes to the library without re-running the
+/// encoding pipeline.
+///
+/// This is useful for GPU pipelines, HPC frameworks, or any system that
+/// produces encoded data outside the library — the caller packs the data
+/// themselves and Tensogram wraps it into the wire format.
+///
+/// Build:
+///   cmake -B build && cmake --build build
+///   Then compile manually (or add to your CMakeLists.txt):
+///   g++ -std=c++17 -I include -I crates/tensogram-ffi \
+///       examples/cpp/11_encode_pre_encoded.cpp \
+///       -L target/release -l tensogram_ffi \
+///       -framework CoreFoundation -framework Security \
+///       -framework SystemConfiguration -lc++ -lm \
+///       -o build/example_11
+
+#include <tensogram.hpp>
+
+extern "C" {
+#include "tensogram.h"
+}
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+// -----------------------------------------------------------------------
+// Manual bit-packing helper (MSB-first, big-endian bit order)
+// -----------------------------------------------------------------------
+
+static std::vector<std::uint8_t> bit_pack(const std::vector<std::uint64_t>& values,
+                                          int bits_per_value) {
+    std::size_t total_bits = values.size() * static_cast<std::size_t>(bits_per_value);
+    std::size_t total_bytes = (total_bits + 7) / 8;
+    std::vector<std::uint8_t> buf(total_bytes, 0);
+
+    std::size_t bit_pos = 0;
+    for (auto val : values) {
+        int remaining = bits_per_value;
+        while (remaining > 0) {
+            std::size_t byte_idx = bit_pos / 8;
+            int bit_offset = static_cast<int>(bit_pos % 8);
+            int space = 8 - bit_offset;
+            int write_bits = std::min(remaining, space);
+            int shift = remaining - write_bits;
+            auto bits = static_cast<std::uint8_t>(
+                (val >> shift) & ((1ULL << write_bits) - 1));
+            buf[byte_idx] |= static_cast<std::uint8_t>(bits << (space - write_bits));
+            bit_pos += static_cast<std::size_t>(write_bits);
+            remaining -= write_bits;
+        }
+    }
+    return buf;
+}
+
+int main() {
+    // ── 1. Synthesise pre-encoded payload (simple_packing) ─────────────
+
+    constexpr int N = 1000;
+    std::vector<double> temps(N);
+    for (int i = 0; i < N; ++i)
+        temps[i] = 249.15 + i * 0.1;
+    std::printf("Source: %d float64 values  raw=%zu bytes\n",
+                N, temps.size() * sizeof(double));
+
+    // Compute packing parameters via the C FFI helper
+    double reference_value = 0.0;
+    std::int32_t binary_scale_factor = 0;
+    constexpr std::uint32_t bits_per_value = 16;
+    constexpr std::int32_t decimal_scale_factor = 0;
+
+    tgm_error err = tgm_simple_packing_compute_params(
+        temps.data(), temps.size(),
+        bits_per_value, decimal_scale_factor,
+        &reference_value, &binary_scale_factor);
+    assert(err == TGM_ERROR_OK);
+
+    std::printf("Packing params: ref=%.4f  bsf=%d  dsf=%d  bpv=%u\n",
+                reference_value, binary_scale_factor,
+                decimal_scale_factor, bits_per_value);
+
+    // Manual quantisation: packed_int = round((value - ref) * 10^dsf / 2^bsf)
+    double scale = std::pow(10.0, decimal_scale_factor) /
+                   std::pow(2.0, binary_scale_factor);
+    std::vector<std::uint64_t> packed_ints(N);
+    for (int i = 0; i < N; ++i) {
+        packed_ints[i] = static_cast<std::uint64_t>(
+            std::round((temps[i] - reference_value) * scale));
+    }
+
+    auto packed_bytes = bit_pack(packed_ints, static_cast<int>(bits_per_value));
+    std::printf("Packed payload: %zu bytes  (%u bits x %d values)\n",
+                packed_bytes.size(), bits_per_value, N);
+
+    // ── 2. Build descriptor and encode_pre_encoded ─────────────────────
+
+    char ref_buf[64];
+    std::snprintf(ref_buf, sizeof(ref_buf), "%.17g", reference_value);
+
+    std::string json =
+        R"({"version":2,"descriptors":[{"type":"ndarray","ndim":1,"shape":[)" +
+        std::to_string(N) +
+        R"(],"strides":[8],"dtype":"float64","byte_order":"little",)"
+        R"("encoding":"simple_packing","filter":"none","compression":"none",)"
+        R"("bits_per_value":)" + std::to_string(bits_per_value) +
+        R"(,"reference_value":)" + std::string(ref_buf) +
+        R"(,"binary_scale_factor":)" + std::to_string(binary_scale_factor) +
+        R"(,"decimal_scale_factor":)" + std::to_string(decimal_scale_factor) +
+        R"(}]})";
+
+    std::vector<std::pair<const std::uint8_t*, std::size_t>> objects = {
+        {packed_bytes.data(), packed_bytes.size()}
+    };
+
+    auto message = tensogram::encode_pre_encoded(json, objects);
+    std::printf("Wire message: %zu bytes\n", message.size());
+
+    // ── 3. Decode and verify ───────────────────────────────────────────
+
+    auto msg = tensogram::decode(message.data(), message.size());
+    assert(msg.num_objects() == 1);
+
+    auto obj = msg.object(0);
+    assert(obj.dtype_string() == "float64");
+
+    const double* decoded = obj.data_as<double>();
+    const std::size_t count = obj.element_count<double>();
+    assert(count == static_cast<std::size_t>(N));
+
+    double max_err = 0.0;
+    for (int i = 0; i < N; ++i) {
+        double e = std::abs(temps[i] - decoded[i]);
+        if (e > max_err) max_err = e;
+    }
+    std::printf("Max quantisation error: %.6f\n", max_err);
+    assert(max_err < 0.01);
+
+    // ── 4. encoding=none variant ───────────────────────────────────────
+
+    std::vector<float> raw_data(50);
+    for (int i = 0; i < 50; ++i) raw_data[i] = static_cast<float>(i);
+
+    std::string raw_json =
+        R"({"version":2,"descriptors":[{"type":"ndarray","ndim":1,"shape":[50],)"
+        R"("strides":[4],"dtype":"float32","byte_order":"little",)"
+        R"("encoding":"none","filter":"none","compression":"none"}]})";
+
+    std::vector<std::pair<const std::uint8_t*, std::size_t>> raw_objects = {
+        {reinterpret_cast<const std::uint8_t*>(raw_data.data()),
+         raw_data.size() * sizeof(float)}
+    };
+
+    auto raw_msg = tensogram::encode_pre_encoded(raw_json, raw_objects);
+    auto raw_decoded = tensogram::decode(raw_msg.data(), raw_msg.size());
+    auto raw_obj = raw_decoded.object(0);
+    const float* rp = raw_obj.data_as<float>();
+    for (int i = 0; i < 50; ++i) {
+        assert(rp[i] == static_cast<float>(i));
+    }
+    std::printf("Raw encoding=none round-trip: OK\n");
+
+    // ── 5. StreamingEncoder variant ────────────────────────────────────
+
+    // Write to a temp file, then decode
+    const char* tmp_path = "/tmp/tensogram_example_11.tgm";
+    {
+        tensogram::streaming_encoder enc(tmp_path, R"({"version":2})");
+
+        // Pre-encoded simple_packing object
+        std::string desc_sp =
+            R"({"type":"ndarray","ndim":1,"shape":[)" + std::to_string(N) +
+            R"(],"strides":[8],"dtype":"float64","byte_order":"little",)"
+            R"("encoding":"simple_packing","filter":"none","compression":"none",)"
+            R"("bits_per_value":)" + std::to_string(bits_per_value) +
+            R"(,"reference_value":)" + std::string(ref_buf) +
+            R"(,"binary_scale_factor":)" + std::to_string(binary_scale_factor) +
+            R"(,"decimal_scale_factor":)" + std::to_string(decimal_scale_factor) +
+            R"(})";
+        enc.write_object_pre_encoded(desc_sp,
+                                     packed_bytes.data(), packed_bytes.size());
+
+        // Pre-encoded encoding=none object
+        std::string desc_raw =
+            R"({"type":"ndarray","ndim":1,"shape":[50],"strides":[4],)"
+            R"("dtype":"float32","byte_order":"little",)"
+            R"("encoding":"none","filter":"none","compression":"none"})";
+        enc.write_object_pre_encoded(desc_raw,
+                                     reinterpret_cast<const std::uint8_t*>(raw_data.data()),
+                                     raw_data.size() * sizeof(float));
+
+        enc.finish();
+    }
+
+    auto f = tensogram::file::open(tmp_path);
+    assert(f.message_count() == 1);
+    auto stream_msg = f.decode_message(0);
+    assert(stream_msg.num_objects() == 2);
+
+    // Verify simple_packing object
+    auto s0 = stream_msg.object(0);
+    const double* sp0 = s0.data_as<double>();
+    double s_max_err = 0.0;
+    for (int i = 0; i < N; ++i) {
+        double e = std::abs(temps[i] - sp0[i]);
+        if (e > s_max_err) s_max_err = e;
+    }
+    assert(s_max_err < 0.01);
+
+    // Verify encoding=none object
+    auto s1 = stream_msg.object(1);
+    const float* sp1 = s1.data_as<float>();
+    for (int i = 0; i < 50; ++i) {
+        assert(sp1[i] == static_cast<float>(i));
+    }
+    std::printf("Streaming pre-encoded: OK\n");
+
+    // Clean up temp file
+    std::remove(tmp_path);
+
+    std::printf("\nOK: all pre-encoded round-trips succeeded\n");
+    return 0;
+}

--- a/examples/cpp/11_encode_pre_encoded.cpp
+++ b/examples/cpp/11_encode_pre_encoded.cpp
@@ -14,7 +14,7 @@
 ///   Then compile manually (or add to your CMakeLists.txt):
 ///   g++ -std=c++17 -I include -I crates/tensogram-ffi \
 ///       examples/cpp/11_encode_pre_encoded.cpp \
-///       -L target/release -l tensogram_ffi \
+///       -L target/release -ltensogram_ffi \
 ///       -framework CoreFoundation -framework Security \
 ///       -framework SystemConfiguration -lc++ -lm \
 ///       -o build/example_11

--- a/examples/python/11_encode_pre_encoded.py
+++ b/examples/python/11_encode_pre_encoded.py
@@ -1,0 +1,146 @@
+"""Example 11 — Pre-encoded payloads (Python)
+
+Demonstrates tensogram.encode_pre_encoded(), which lets callers hand
+already-encoded payload bytes to the library without re-running the
+encoding pipeline.
+
+This is useful for GPU pipelines, HPC frameworks, or any system that
+produces encoded data outside the library — the caller packs the data
+themselves and Tensogram wraps it into the wire format.
+
+IMPORTANT — bit-vs-byte gotcha:
+  szip_block_offsets in the descriptor are BIT offsets, not byte offsets.
+  For example, if a compressed block starts at byte 16, the offset is 128
+  (= 16 * 8). Getting this wrong silently breaks decode_range().
+
+NOTE: Requires building tensogram-python first:
+    cd crates/tensogram-python && maturin develop
+"""
+
+import numpy as np
+import tensogram
+
+# ── 1. Synthesise pre-encoded payload (simple_packing) ──────────────────────
+
+n = 1000
+temps = np.linspace(249.15, 349.05, n, dtype=np.float64)
+print(f"Source: {n} float64 values  raw={temps.nbytes} bytes")
+
+# Compute packing parameters via the library helper
+params = tensogram.compute_packing_params(
+    temps, bits_per_value=16, decimal_scale_factor=0
+)
+ref_val = params["reference_value"]
+bsf = params["binary_scale_factor"]
+dsf = params["decimal_scale_factor"]
+bpv = params["bits_per_value"]
+
+print(f"Packing params: ref={ref_val:.4f}  bsf={bsf}  dsf={dsf}  bpv={bpv}")
+
+# Manual simple packing in Python:
+#   packed_int = round((value - ref_val) * 10^dsf / 2^bsf)
+#   then bit-pack into a byte stream
+scale = (10.0**dsf) / (2.0**bsf)
+packed_ints = np.round((temps - ref_val) * scale).astype(np.uint64)
+
+
+def bit_pack(values: np.ndarray, bits_per_value: int) -> bytes:
+    """Pack integers into a bit stream (big-endian bit order, MSB first)."""
+    total_bits = len(values) * bits_per_value
+    total_bytes = (total_bits + 7) // 8
+    buf = bytearray(total_bytes)
+
+    bit_pos = 0
+    for val in values:
+        remaining = bits_per_value
+        v = int(val)
+        while remaining > 0:
+            byte_idx = bit_pos // 8
+            bit_offset = bit_pos % 8
+            space = 8 - bit_offset
+            write_bits = min(remaining, space)
+            shift = remaining - write_bits
+            bits = (v >> shift) & ((1 << write_bits) - 1)
+            buf[byte_idx] |= bits << (space - write_bits)
+            bit_pos += write_bits
+            remaining -= write_bits
+
+    return bytes(buf)
+
+
+packed_bytes = bit_pack(packed_ints, bpv)
+print(f"Packed payload: {len(packed_bytes)} bytes  ({bpv} bits x {n} values)")
+
+# ── 2. Build descriptor and encode ──────────────────────────────────────────
+
+metadata = {"version": 2, "source": "pre-encoded example"}
+descriptor = {
+    "type": "ntensor",
+    "shape": [n],
+    "dtype": "float64",
+    "byte_order": "little",
+    "encoding": "simple_packing",
+    "filter": "none",
+    "compression": "none",
+    **params,
+}
+
+message = bytes(tensogram.encode_pre_encoded(metadata, [(descriptor, packed_bytes)]))
+print(f"Wire message: {len(message)} bytes")
+
+# ── 3. Decode and verify ────────────────────────────────────────────────────
+
+msg = tensogram.decode(message)
+desc_out, decoded = msg.objects[0]
+
+max_err = float(np.abs(temps - decoded).max())
+print(f"Max quantisation error: {max_err:.6f}")
+assert max_err < 0.01, f"error {max_err} exceeds tolerance"
+assert decoded.dtype == np.float64
+assert decoded.shape == (n,)
+assert msg.metadata["source"] == "pre-encoded example"
+
+# ── 4. encoding=none variant ────────────────────────────────────────────────
+#
+# The simplest case: raw payload bytes, no encoding applied.
+
+raw_data = np.arange(50, dtype=np.float32)
+raw_bytes = raw_data.tobytes()
+
+raw_desc = {
+    "type": "ntensor",
+    "shape": [50],
+    "dtype": "float32",
+    "byte_order": "little",
+    "encoding": "none",
+    "filter": "none",
+    "compression": "none",
+}
+
+msg_raw = bytes(tensogram.encode_pre_encoded({"version": 2}, [(raw_desc, raw_bytes)]))
+_, objs_raw = tensogram.decode(msg_raw)
+_, decoded_raw = objs_raw[0]
+np.testing.assert_array_equal(decoded_raw, raw_data)
+print("Raw encoding=none round-trip: OK")
+
+# ── 5. StreamingEncoder variant ─────────────────────────────────────────────
+#
+# The streaming encoder also supports write_object_pre_encoded().
+
+enc = tensogram.StreamingEncoder({"version": 2})
+enc.write_object_pre_encoded(descriptor, packed_bytes)
+enc.write_object_pre_encoded(raw_desc, raw_bytes)
+stream_msg = bytes(enc.finish())
+
+_, stream_objs = tensogram.decode(stream_msg)
+assert len(stream_objs) == 2
+
+_, s0 = stream_objs[0]
+assert np.abs(temps - s0).max() < 0.01
+
+_, s1 = stream_objs[1]
+np.testing.assert_array_equal(s1, raw_data)
+print("Streaming pre-encoded: OK")
+
+# ── Done ────────────────────────────────────────────────────────────────────
+print("\nOK: all pre-encoded round-trips succeeded")

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tensogram-examples"
+name = "tensogram-rust-examples"
 version = "0.6.0"
 edition = "2021"
 publish = false
@@ -39,6 +39,10 @@ path = "src/bin/08_decode_variants.rs"
 [[bin]]
 name = "09_file_api"
 path = "src/bin/09_file_api.rs"
+
+[[bin]]
+name = "11_encode_pre_encoded"
+path = "src/bin/11_encode_pre_encoded.rs"
 
 [dependencies]
 tensogram-core = { path = "../../crates/tensogram-core" }

--- a/examples/rust/src/bin/11_encode_pre_encoded.rs
+++ b/examples/rust/src/bin/11_encode_pre_encoded.rs
@@ -1,0 +1,108 @@
+//! Example 11 — encode_pre_encoded round-trip
+//!
+//! Demonstrates the GPU-pipeline pattern: a pre-packed buffer is produced first,
+//! its descriptor declares the applied encoding/compression, and then the bytes
+//! are handed directly to `encode_pre_encoded()`.
+//!
+//! IMPORTANT: `szip_block_offsets` are BIT offsets, not byte offsets.
+
+use std::collections::BTreeMap;
+
+use ciborium::Value;
+use tensogram_core::{
+    decode, encode_pre_encoded, ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype,
+    EncodeOptions, GlobalMetadata,
+};
+use tensogram_encodings::pipeline::{CompressionType, EncodingType, FilterType, PipelineConfig};
+use tensogram_encodings::{pipeline, simple_packing};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 1. Source data: a simple 1D float64 signal.
+    let values: Vec<f64> = (0..1024).map(|i| 250.0 + (i as f64) * 0.25).collect();
+    let raw_bytes: Vec<u8> = values.iter().flat_map(|v| v.to_be_bytes()).collect();
+
+    // 2. Build descriptor params for simple_packing + szip.
+    let bits_per_value = 16u32;
+    let packing = simple_packing::compute_params(&values, bits_per_value, 0)?;
+
+    let mut params = BTreeMap::new();
+    params.insert(
+        "reference_value".to_string(),
+        Value::Float(packing.reference_value),
+    );
+    params.insert(
+        "binary_scale_factor".to_string(),
+        Value::Integer((packing.binary_scale_factor as i64).into()),
+    );
+    params.insert(
+        "decimal_scale_factor".to_string(),
+        Value::Integer((packing.decimal_scale_factor as i64).into()),
+    );
+    params.insert(
+        "bits_per_value".to_string(),
+        Value::Integer((packing.bits_per_value as i64).into()),
+    );
+    params.insert("szip_rsi".to_string(), Value::Integer(128.into()));
+    params.insert("szip_block_size".to_string(), Value::Integer(16.into()));
+    params.insert("szip_flags".to_string(), Value::Integer(8_i64.into()));
+
+    let desc = DataObjectDescriptor {
+        obj_type: "ntensor".to_string(),
+        ndim: 1,
+        shape: vec![values.len() as u64],
+        strides: vec![1],
+        dtype: Dtype::Float64,
+        byte_order: ByteOrder::Big,
+        encoding: "simple_packing".to_string(),
+        filter: "none".to_string(),
+        compression: "szip".to_string(),
+        params,
+        hash: None,
+    };
+
+    // 3. Fake the GPU pipeline by running the internal forward pipeline once.
+    //    This gives us realistic pre-packed bytes without using any external GPU code.
+    let config = PipelineConfig {
+        encoding: EncodingType::SimplePacking(packing.clone()),
+        filter: FilterType::None,
+        compression: CompressionType::Szip {
+            rsi: 128,
+            block_size: 16,
+            flags: 8,
+            bits_per_sample: bits_per_value,
+        },
+        num_values: values.len(),
+        byte_order: ByteOrder::Big,
+        dtype_byte_width: 8,
+    };
+    let packed = pipeline::encode_pipeline(&raw_bytes, &config)?;
+    let packed_bytes = packed.encoded_bytes;
+    let packed_desc = desc.clone();
+    let _ = packed.block_offsets;
+
+    // 4. Feed the pre-encoded bytes directly to the API under test.
+    let meta = GlobalMetadata::default();
+    let options = EncodeOptions::default();
+    let message = encode_pre_encoded(&meta, &[(&packed_desc, packed_bytes.as_slice())], &options)?;
+
+    // 5. Decode the message and verify the round-trip.
+    let (decoded_meta, decoded_objects) = decode(&message, &DecodeOptions::default())?;
+    let (decoded_desc, decoded_payload) = decoded_objects
+        .first()
+        .ok_or_else(|| std::io::Error::other("missing decoded object"))?;
+
+    assert_eq!(decoded_meta.version, 2);
+    assert_eq!(decoded_desc.encoding, "simple_packing");
+    assert_eq!(decoded_desc.compression, "szip");
+    assert_eq!(
+        decoded_payload,
+        raw_bytes.as_slice(),
+        "round-trip must recover the source bytes"
+    );
+
+    println!(
+        "OK: encode_pre_encoded round-trip succeeded ({} bytes)",
+        message.len()
+    );
+    Ok(())
+}

--- a/include/tensogram.hpp
+++ b/include/tensogram.hpp
@@ -780,6 +780,26 @@ public:
             handle_.get(), descriptor_json.c_str(), data, len));
     }
 
+    /// Write a single pre-encoded data object.
+    ///
+    /// Like write_object(), but @p data must already be encoded according
+    /// to the descriptor's pipeline (`encoding` / `filter` / `compression`).
+    /// The library does not run the encoding pipeline — it validates the
+    /// descriptor's pipeline configuration and writes the bytes as-is.
+    /// The hash (if configured on the encoder) is recomputed over the
+    /// caller's bytes.
+    ///
+    /// For `szip` compression, the caller SHOULD include
+    /// `szip_block_offsets` (bit offsets) in the descriptor's params so
+    /// that `decode_range()` can locate compressed block boundaries.
+    /// Other pipeline params (e.g. `simple_packing` reference value,
+    /// scale factors) must also be present in the descriptor.
+    void write_object_pre_encoded(const std::string& descriptor_json,
+                                   const std::uint8_t* data, std::size_t len) {
+        detail::check(tgm_streaming_encoder_write_pre_encoded(
+            handle_.get(), descriptor_json.c_str(), data, len));
+    }
+
     /// Number of objects written so far.
     [[nodiscard]] std::size_t object_count() const {
         return tgm_streaming_encoder_count(handle_.get());
@@ -828,6 +848,53 @@ private:
     detail::check(tgm_encode(metadata_json.c_str(),
                               sg.ptrs.data(), sg.lens.data(), objects.size(),
                               hash, &bytes));
+    std::vector<std::uint8_t> result(bytes.data, bytes.data + bytes.len);
+    tgm_bytes_free(bytes);
+    return result;
+}
+
+/// Encode a Tensogram message from JSON metadata and pre-encoded payload bytes.
+///
+/// Like encode(), but each entry in @p objects must already be encoded
+/// according to the matching descriptor's `encoding` / `filter` /
+/// `compression` pipeline. The library does not run the encoding pipeline
+/// again — it writes the caller-provided bytes directly into the wire-format
+/// payload after validating that the descriptor's pipeline configuration
+/// is well-formed.
+///
+/// The library always recomputes the hash over the caller's bytes; any
+/// `hash` field embedded in the descriptor JSON is ignored and overwritten.
+///
+/// For `szip` compression, callers SHOULD include `szip_block_offsets`
+/// (bit offsets into the compressed payload) inside the matching
+/// descriptor's params so that `decode_range()` can locate szip block
+/// boundaries without rescanning the compressed stream. Other pipeline
+/// params (e.g. `simple_packing` reference value, scale factors) must
+/// also be present in the descriptor — they are not inferred from the
+/// bytes.
+///
+/// The resulting wire format is identical to what encode() produces — a
+/// decoder cannot distinguish the two sources.
+///
+/// @param metadata_json  Same JSON schema as encode() (`version`,
+///                       `descriptors`, optional `base`, plus arbitrary
+///                       extra top-level keys).
+/// @param objects        Vector of (pointer, length) pairs pointing at
+///                       already-encoded payload bytes — one per descriptor
+///                       entry.
+/// @param opts           Encoding options (hash algorithm, etc.).
+/// @return The encoded message as a byte vector.
+[[nodiscard]] inline std::vector<std::uint8_t> encode_pre_encoded(
+    const std::string& metadata_json,
+    const std::vector<std::pair<const std::uint8_t*, std::size_t>>& objects,
+    const encode_options& opts = {})
+{
+    detail::scatter_gather sg(objects);
+    const char* hash = opts.hash_algo.empty() ? nullptr : opts.hash_algo.c_str();
+    tgm_bytes_t bytes{};
+    detail::check(tgm_encode_pre_encoded(metadata_json.c_str(),
+                                          sg.ptrs.data(), sg.lens.data(),
+                                          objects.size(), hash, &bytes));
     std::vector<std::uint8_t> result(bytes.data, bytes.data + bytes.len);
     tgm_bytes_free(bytes);
     return result;

--- a/include/tensogram.hpp
+++ b/include/tensogram.hpp
@@ -766,8 +766,9 @@ public:
     /// @p metadata_json is a JSON object with per-object metadata keys
     /// (e.g. `{"mars":{"param":"2t"}, "units":"K"}`).
     ///
-    /// Must be followed by exactly one write_object() call before
-    /// another write_preceder() or finish().
+    /// Must be followed by exactly one write_object() or
+    /// write_object_pre_encoded() call before another write_preceder()
+    /// or finish().
     void write_preceder(const std::string& metadata_json) {
         detail::check(tgm_streaming_encoder_write_preceder(
             handle_.get(), metadata_json.c_str()));

--- a/plans/DONE.md
+++ b/plans/DONE.md
@@ -7,7 +7,7 @@
 
 - **Version:** 0.6.0
 - **Workspace:** 6 default crates + 2 optional (Python, GRIB) + 2 separate packages (xarray, zarr)
-- **Tests:** 1008 total (283 Rust + 226 Python + 181 xarray + 204 Zarr + 105 C++ + 7 GRIB new + 2 streamer)
+- **Tests:** 1008+ total (283+ Rust + 245 Python + 181 xarray + 204 Zarr + 117 C++ + 7 GRIB new + 2 streamer)
 - **Quality:** 0 clippy warnings, 90.5% Rust line coverage
 
 ## tensogram-benchmarks
@@ -35,6 +35,8 @@ Unit, integration, adversarial, and edge-case tests.
 - `dtype.rs` — All 15 dtypes (float16/32/64, bfloat16, complex64/128, int/uint 8-64, bitmask)
 - `hash.rs` — xxh3 hashing + verification (xxh3 only)
 - `encode.rs` — Full encode pipeline: validate → build pipeline config → encode per object → hash → assemble frames. Auto-populates `base[i]._reserved_.tensor` entries. Validates that client code does not write to `_reserved_`.
+  - `encode_pre_encoded()` — Bypass the encoding pipeline for already-encoded payloads. Accepts pre-packed bytes with a descriptor declaring encoding/filter/compression. Validates object structure (shape, dtype, szip block offsets) but skips the pipeline. Available across all bindings: Rust, Python, C FFI, C++.
+  - `StreamingEncoder::write_object_pre_encoded()` — Streaming variant for progressive encode of pre-encoded objects.
 - `decode.rs` — `decode()`, `decode_metadata()`, `decode_object()`, `decode_range()` (split results by default, `join` parameter)
 - `file.rs` — `TensogramFile`: open, create, lazy scan, append, seek-based random access
 - `iter.rs` — `MessageIter` (zero-copy buffer), `ObjectIter` (lazy per-object decode), `FileMessageIter` (seek-based file), `objects_metadata()` (descriptor-only)
@@ -79,17 +81,19 @@ Tested indirectly via C++ wrapper (105 tests).
 - Error codes: `TGM_ERROR_OK` through `TGM_ERROR_END_OF_ITER`
 - Thread-local error messages via `tgm_last_error()`
 - Iterator API: `tgm_buffer_iter_*`, `tgm_file_iter_*`, `tgm_object_iter_*`
-- Streaming encoder: `tgm_streaming_encoder_create/write/write_preceder/count/finish/free`
+- Streaming encoder: `tgm_streaming_encoder_create/write/write_preceder/write_pre_encoded/count/finish/free`
 - Auto-generated `tensogram.h` (~544 lines) via cbindgen
 - Panic safety: `panic = "abort"` in both release and dev profiles
 - Vec capacity UB fixed (shrink_to_fit before forget), null pointer validation
 
 ## C++ Wrapper
 
-105 GoogleTest tests across 10 files.
+117 GoogleTest tests across 11 files.
 
 - `include/tensogram.hpp` — single-header C++17 wrapper (~934 lines)
 - RAII classes: `message`, `metadata`, `file`, `buffer_iterator`, `file_iterator`, `object_iterator`, `streaming_encoder`
+- `encode_pre_encoded()` — free function for already-encoded payloads
+- `streaming_encoder::write_object_pre_encoded()` — streaming variant
 - Typed exception hierarchy: `error` → `framing_error`, `metadata_error`, etc.
 - `decoded_object` view with `data_as<T>()`, `element_count<T>()`
 - Range-based for via `message::iterator`
@@ -102,6 +106,8 @@ Tested indirectly via C++ wrapper (105 tests).
 
 - Full Python API with NumPy integration
 - `encode()`, `decode()`, `decode_metadata()`, `decode_object()`, `decode_range()`, `scan()`
+- `encode_pre_encoded()` — bypass pipeline for already-encoded payloads (bytes input, not numpy arrays)
+- `StreamingEncoder` — progressive encode to file with `write_object()` and `write_object_pre_encoded()`
 - `iter_messages()` — iterate decoded messages from a byte buffer
 - `Message` namedtuple — `.metadata` and `.objects` attribute access, tuple unpacking
 - `TensogramFile` with context manager, `len()`, iterator
@@ -137,14 +143,14 @@ Tested indirectly via C++ wrapper (105 tests).
 
 ## Examples
 
-### Rust (11 runnable, workspace member)
-01 encode_decode, 02 mars_metadata, 03 simple_packing, 04 shuffle_filter, 05 multi_object, 06 hash_verification, 07 scan_buffer, 08 decode_variants, 09 file_api, 10 iterators, 11 streaming
+### Rust (12 runnable, workspace member)
+01 encode_decode, 02 mars_metadata, 03 simple_packing, 04 shuffle_filter, 05 multi_object, 06 hash_verification, 07 scan_buffer, 08 decode_variants, 09 file_api, 10 iterators, 11 streaming, 11 encode_pre_encoded
 
-### C++ (5 examples, C++ wrapper API)
-01 encode_decode, 02 mars_metadata, 03 simple_packing, 04 file_api, 05 iterators
+### C++ (6 examples, C++ wrapper API)
+01 encode_decode, 02 mars_metadata, 03 simple_packing, 04 file_api, 05 iterators, 11 encode_pre_encoded
 
-### Python (11 examples)
-01 encode_decode, 02 mars_metadata, 03 simple_packing, 04 multi_object, 05 file_api, 06 hash_and_errors, 07 iterators, 08 xarray_integration, 08 zarr_backend, 09 dask_distributed, 09 streaming_consumer
+### Python (12 examples)
+01 encode_decode, 02 mars_metadata, 03 simple_packing, 04 multi_object, 05 file_api, 06 hash_and_errors, 07 iterators, 08 xarray_integration, 08 zarr_backend, 09 dask_distributed, 09 streaming_consumer, 11 encode_pre_encoded
 
 ## Documentation (mdbook)
 

--- a/plans/TODO.md
+++ b/plans/TODO.md
@@ -5,11 +5,7 @@ For speculative ideas, see `IDEAS.md`.
 
 ## API
 
-- [ ] *api-pre-encoded*:
-  - add API for caller to pass pre encoded buffer and other details of compression
-  - this is and advanced usability function, rarely needed except when caller code has access to alternative, possibly more optmised, for encoding (eg a GPU kernel).
-  - research ecmwf/eccodes has a similar api function
-  - for complex encoders (eg szip) the caller may need to pass complex information, for example the RSI blocks (if wanting to enable the decode_range functionality)
+- [x] ~~api-pre-encoded~~ → `encode.rs:encode_pre_encoded()` + bindings (Python, C FFI, C++) + `docs/src/guide/encode-pre-encoded.md` + benchmarks + examples
 
 - [x] ~~Populate `reserved` metadata field with provenance information~~ → `encode.rs:populate_reserved_provenance()`
 

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(tensogram_tests
     test_simple_packing.cpp
     test_streaming.cpp
     test_multi_dtype.cpp
+    test_encode_pre_encoded.cpp
 )
 
 target_include_directories(tensogram_tests PRIVATE

--- a/tests/cpp/cross_language_pre_encoded_helper.cpp
+++ b/tests/cpp/cross_language_pre_encoded_helper.cpp
@@ -1,0 +1,78 @@
+/// @file cross_language_pre_encoded_helper.cpp
+/// @brief Cross-language SHA256 golden test helper (C++ side).
+///
+/// Generates the SAME deterministic float64[1024] payload as the Rust driver,
+/// encodes via tensogram::encode_pre_encoded(), decodes, and prints the
+/// SHA-256 hex digest of the decoded payload to stdout.
+///
+/// Build:
+///   g++ -std=c++17 -I include -I crates/tensogram-ffi \
+///       tests/cpp/cross_language_pre_encoded_helper.cpp \
+///       -L target/release -ltensogram_ffi \
+///       -framework CoreFoundation -framework Security \
+///       -framework SystemConfiguration -lc++ -lm \
+///       -o build/cross_language_pre_encoded_helper
+
+#include <tensogram.hpp>
+
+extern "C" {
+#include "tensogram.h"
+}
+
+// CommonCrypto for SHA-256 on macOS
+#include <CommonCrypto/CommonDigest.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+static std::string sha256_hex(const std::uint8_t* data, std::size_t len) {
+    unsigned char hash[CC_SHA256_DIGEST_LENGTH];
+    CC_SHA256(data, static_cast<CC_LONG>(len), hash);
+    char hex[CC_SHA256_DIGEST_LENGTH * 2 + 1];
+    for (int i = 0; i < CC_SHA256_DIGEST_LENGTH; ++i) {
+        std::snprintf(hex + i * 2, 3, "%02x", hash[i]);
+    }
+    return std::string(hex, CC_SHA256_DIGEST_LENGTH * 2);
+}
+
+int main() {
+    // Same deterministic input as the Rust driver: 1024 float64 values.
+    constexpr int N = 1024;
+    std::vector<double> values(N);
+    for (int i = 0; i < N; ++i) {
+        values[i] = 200.0 + static_cast<double>(i) * 0.125;
+    }
+
+    // Raw LE bytes (double is already LE on ARM Mac and x86).
+    auto* raw_bytes = reinterpret_cast<const std::uint8_t*>(values.data());
+    std::size_t raw_len = N * sizeof(double);
+
+    // Build descriptor JSON for encoding="none" (raw pass-through).
+    std::string json =
+        R"({"version":2,"descriptors":[{"type":"ndarray","ndim":1,"shape":[1024],)"
+        R"("strides":[8],"dtype":"float64","byte_order":"little",)"
+        R"("encoding":"none","filter":"none","compression":"none"}]})";
+
+    std::vector<std::pair<const std::uint8_t*, std::size_t>> objects = {
+        {raw_bytes, raw_len}
+    };
+
+    auto wire = tensogram::encode_pre_encoded(json, objects);
+
+    // Decode and extract payload.
+    auto msg = tensogram::decode(wire.data(), wire.size());
+    if (msg.num_objects() != 1) {
+        std::fprintf(stderr, "Expected 1 object, got %zu\n", msg.num_objects());
+        return 1;
+    }
+
+    auto obj = msg.object(0);
+    auto sha = sha256_hex(obj.data(), obj.data_size());
+
+    // Print ONLY the hex digest to stdout (no newline, no extra text).
+    std::printf("%s", sha.c_str());
+    return 0;
+}

--- a/tests/cpp/cross_language_pre_encoded_helper.cpp
+++ b/tests/cpp/cross_language_pre_encoded_helper.cpp
@@ -46,9 +46,16 @@ int main() {
         values[i] = 200.0 + static_cast<double>(i) * 0.125;
     }
 
-    // Raw LE bytes (double is already LE on ARM Mac and x86).
-    auto* raw_bytes = reinterpret_cast<const std::uint8_t*>(values.data());
-    std::size_t raw_len = N * sizeof(double);
+    // Serialize to little-endian bytes regardless of host endianness.
+    std::vector<std::uint8_t> raw_bytes(N * sizeof(double));
+    for (int i = 0; i < N; ++i) {
+        std::uint64_t bits;
+        std::memcpy(&bits, &values[i], sizeof(double));
+        for (int j = 0; j < 8; ++j) {
+            raw_bytes[i * 8 + j] = static_cast<std::uint8_t>(bits >> (j * 8));
+        }
+    }
+    std::size_t raw_len = raw_bytes.size();
 
     // Build descriptor JSON for encoding="none" (raw pass-through).
     std::string json =
@@ -57,7 +64,7 @@ int main() {
         R"("encoding":"none","filter":"none","compression":"none"}]})";
 
     std::vector<std::pair<const std::uint8_t*, std::size_t>> objects = {
-        {raw_bytes, raw_len}
+        {raw_bytes.data(), raw_len}
     };
 
     auto wire = tensogram::encode_pre_encoded(json, objects);

--- a/tests/cpp/cross_language_pre_encoded_helper.cpp
+++ b/tests/cpp/cross_language_pre_encoded_helper.cpp
@@ -40,18 +40,18 @@ static std::string sha256_hex(const std::uint8_t* data, std::size_t len) {
 
 int main() {
     // Same deterministic input as the Rust driver: 1024 float64 values.
-    constexpr int N = 1024;
+    constexpr std::size_t N = 1024;
     std::vector<double> values(N);
-    for (int i = 0; i < N; ++i) {
+    for (std::size_t i = 0; i < N; ++i) {
         values[i] = 200.0 + static_cast<double>(i) * 0.125;
     }
 
     // Serialize to little-endian bytes regardless of host endianness.
     std::vector<std::uint8_t> raw_bytes(N * sizeof(double));
-    for (int i = 0; i < N; ++i) {
+    for (std::size_t i = 0; i < N; ++i) {
         std::uint64_t bits;
         std::memcpy(&bits, &values[i], sizeof(double));
-        for (int j = 0; j < 8; ++j) {
+        for (std::size_t j = 0; j < 8; ++j) {
             raw_bytes[i * 8 + j] = static_cast<std::uint8_t>(bits >> (j * 8));
         }
     }

--- a/tests/cpp/test_encode_pre_encoded.cpp
+++ b/tests/cpp/test_encode_pre_encoded.cpp
@@ -1,0 +1,335 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 ECMWF
+//
+// GoogleTest coverage for encode_pre_encoded() and
+// streaming_encoder::write_object_pre_encoded().
+
+#include <gtest/gtest.h>
+#include <tensogram.hpp>
+#include "test_helpers.hpp"
+
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <numeric>
+#include <string>
+#include <vector>
+
+using test_helpers::TempFile;
+
+// -----------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------
+
+/// Build a v2 JSON metadata+descriptor string for a 1-D encoding=none message.
+static std::string encoding_none_json(std::size_t count,
+                                      const std::string& dtype = "float32",
+                                      const std::string& byte_order = "little") {
+    return R"({"version":2,"descriptors":[{"type":"ndarray","ndim":1,"shape":[)" +
+           std::to_string(count) +
+           R"(],"strides":[)" +
+           std::to_string(dtype == "float64" ? 8
+                          : dtype == "int64" ? 8
+                          : dtype == "int32" ? 4
+                          : dtype == "uint8" ? 1
+                          : 4) +
+           R"(],"dtype":")" + dtype +
+           R"(","byte_order":")" + byte_order +
+           R"(","encoding":"none","filter":"none","compression":"none"}]})";
+}
+
+/// Build a v2 JSON string for simple_packing.
+static std::string simple_packing_json(std::size_t count,
+                                       double reference_value,
+                                       int binary_scale_factor,
+                                       int decimal_scale_factor,
+                                       int bits_per_value) {
+    return R"({"version":2,"descriptors":[{"type":"ndarray","ndim":1,"shape":[)" +
+           std::to_string(count) +
+           R"(],"strides":[8],"dtype":"float64","byte_order":"little",)"
+           R"("encoding":"simple_packing","filter":"none","compression":"none",)"
+           R"("reference_value":)" + std::to_string(reference_value) +
+           R"(,"binary_scale_factor":)" + std::to_string(binary_scale_factor) +
+           R"(,"decimal_scale_factor":)" + std::to_string(decimal_scale_factor) +
+           R"(,"bits_per_value":)" + std::to_string(bits_per_value) +
+           R"(}]})";
+}
+
+/// Manually bit-pack integers (MSB-first, big-endian bit order).
+static std::vector<std::uint8_t> bit_pack(const std::vector<std::uint64_t>& values,
+                                          int bits_per_value) {
+    std::size_t total_bits = values.size() * static_cast<std::size_t>(bits_per_value);
+    std::size_t total_bytes = (total_bits + 7) / 8;
+    std::vector<std::uint8_t> buf(total_bytes, 0);
+
+    std::size_t bit_pos = 0;
+    for (auto val : values) {
+        int remaining = bits_per_value;
+        while (remaining > 0) {
+            std::size_t byte_idx = bit_pos / 8;
+            int bit_offset = static_cast<int>(bit_pos % 8);
+            int space = 8 - bit_offset;
+            int write_bits = std::min(remaining, space);
+
+            int shift = remaining - write_bits;
+            auto bits = static_cast<std::uint8_t>((val >> shift) & ((1ULL << write_bits) - 1));
+
+            buf[byte_idx] |= static_cast<std::uint8_t>(bits << (space - write_bits));
+            bit_pos += static_cast<std::size_t>(write_bits);
+            remaining -= write_bits;
+        }
+    }
+    return buf;
+}
+
+// -----------------------------------------------------------------------
+// Test 1: encoding=none round-trip
+// -----------------------------------------------------------------------
+
+TEST(EncodePreEncodedTest, EncodingNoneFloat32RoundTrip) {
+    std::vector<float> values = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+    auto json = encoding_none_json(values.size());
+
+    std::vector<std::pair<const std::uint8_t*, std::size_t>> objects = {
+        {reinterpret_cast<const std::uint8_t*>(values.data()),
+         values.size() * sizeof(float)}
+    };
+    auto encoded = tensogram::encode_pre_encoded(json, objects);
+    ASSERT_FALSE(encoded.empty());
+
+    auto msg = tensogram::decode(encoded.data(), encoded.size());
+    EXPECT_EQ(msg.num_objects(), 1u);
+
+    auto obj = msg.object(0);
+    EXPECT_EQ(obj.dtype_string(), "float32");
+    EXPECT_EQ(obj.element_count<float>(), values.size());
+
+    const float* p = obj.data_as<float>();
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        EXPECT_FLOAT_EQ(p[i], values[i]);
+    }
+}
+
+// -----------------------------------------------------------------------
+// Test 2: encoding=none int32 round-trip
+// -----------------------------------------------------------------------
+
+TEST(EncodePreEncodedTest, EncodingNoneInt32RoundTrip) {
+    std::vector<std::int32_t> values = {-100, 0, 42, 1000, -1};
+    auto json = encoding_none_json(values.size(), "int32");
+
+    std::vector<std::pair<const std::uint8_t*, std::size_t>> objects = {
+        {reinterpret_cast<const std::uint8_t*>(values.data()),
+         values.size() * sizeof(std::int32_t)}
+    };
+    auto encoded = tensogram::encode_pre_encoded(json, objects);
+    ASSERT_FALSE(encoded.empty());
+
+    auto msg = tensogram::decode(encoded.data(), encoded.size());
+    EXPECT_EQ(msg.num_objects(), 1u);
+
+    auto obj = msg.object(0);
+    EXPECT_EQ(obj.dtype_string(), "int32");
+
+    const auto* p = obj.data_as<std::int32_t>();
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        EXPECT_EQ(p[i], values[i]);
+    }
+}
+
+// -----------------------------------------------------------------------
+// Test 3: simple_packing round-trip
+// -----------------------------------------------------------------------
+
+TEST(EncodePreEncodedTest, SimplePackingRoundTrip) {
+    // Generate 100 temperature-like values
+    constexpr std::size_t N = 100;
+    std::vector<double> values(N);
+    for (std::size_t i = 0; i < N; ++i) {
+        values[i] = 250.0 + static_cast<double>(i) * 1.0;
+    }
+
+    // Packing parameters (manually chosen for these values)
+    double ref_val = 250.0;
+    int bsf = -9;   // binary_scale_factor
+    int dsf = 0;    // decimal_scale_factor
+    int bpv = 16;   // bits_per_value
+
+    // Quantise
+    double scale = std::pow(10.0, dsf) / std::pow(2.0, bsf);
+    std::vector<std::uint64_t> packed_ints(N);
+    for (std::size_t i = 0; i < N; ++i) {
+        packed_ints[i] = static_cast<std::uint64_t>(
+            std::round((values[i] - ref_val) * scale));
+    }
+
+    auto packed_bytes = bit_pack(packed_ints, bpv);
+    auto json = simple_packing_json(N, ref_val, bsf, dsf, bpv);
+
+    std::vector<std::pair<const std::uint8_t*, std::size_t>> objects = {
+        {packed_bytes.data(), packed_bytes.size()}
+    };
+    auto encoded = tensogram::encode_pre_encoded(json, objects);
+    ASSERT_FALSE(encoded.empty());
+
+    auto msg = tensogram::decode(encoded.data(), encoded.size());
+    EXPECT_EQ(msg.num_objects(), 1u);
+
+    auto obj = msg.object(0);
+    EXPECT_EQ(obj.dtype_string(), "float64");
+
+    const double* p = obj.data_as<double>();
+    double max_err = 0.0;
+    for (std::size_t i = 0; i < N; ++i) {
+        max_err = std::max(max_err, std::abs(p[i] - values[i]));
+    }
+    EXPECT_LT(max_err, 0.01) << "Max quantisation error: " << max_err;
+}
+
+// -----------------------------------------------------------------------
+// Test 4: multiple objects
+// -----------------------------------------------------------------------
+
+TEST(EncodePreEncodedTest, MultipleObjects) {
+    std::vector<float> a = {1.0f, 2.0f, 3.0f};
+    std::vector<float> b = {10.0f, 20.0f};
+
+    std::string json = R"({"version":2,"descriptors":[)"
+        R"({"type":"ndarray","ndim":1,"shape":[3],"strides":[4],)"
+        R"("dtype":"float32","byte_order":"little",)"
+        R"("encoding":"none","filter":"none","compression":"none"},)"
+        R"({"type":"ndarray","ndim":1,"shape":[2],"strides":[4],)"
+        R"("dtype":"float32","byte_order":"little",)"
+        R"("encoding":"none","filter":"none","compression":"none"}]})";
+
+    std::vector<std::pair<const std::uint8_t*, std::size_t>> objects = {
+        {reinterpret_cast<const std::uint8_t*>(a.data()), a.size() * sizeof(float)},
+        {reinterpret_cast<const std::uint8_t*>(b.data()), b.size() * sizeof(float)},
+    };
+    auto encoded = tensogram::encode_pre_encoded(json, objects);
+    ASSERT_FALSE(encoded.empty());
+
+    auto msg = tensogram::decode(encoded.data(), encoded.size());
+    EXPECT_EQ(msg.num_objects(), 2u);
+
+    auto obj0 = msg.object(0);
+    EXPECT_EQ(obj0.element_count<float>(), 3u);
+    const float* p0 = obj0.data_as<float>();
+    EXPECT_FLOAT_EQ(p0[0], 1.0f);
+    EXPECT_FLOAT_EQ(p0[1], 2.0f);
+    EXPECT_FLOAT_EQ(p0[2], 3.0f);
+
+    auto obj1 = msg.object(1);
+    EXPECT_EQ(obj1.element_count<float>(), 2u);
+    const float* p1 = obj1.data_as<float>();
+    EXPECT_FLOAT_EQ(p1[0], 10.0f);
+    EXPECT_FLOAT_EQ(p1[1], 20.0f);
+}
+
+// -----------------------------------------------------------------------
+// Test 5: invalid descriptor rejection
+// -----------------------------------------------------------------------
+
+TEST(EncodePreEncodedTest, RejectsUnknownEncoding) {
+    std::string json = R"({"version":2,"descriptors":[{"type":"ndarray","ndim":1,"shape":[4],)"
+        R"("strides":[4],"dtype":"float32","byte_order":"little",)"
+        R"("encoding":"bogus","filter":"none","compression":"none"}]})";
+
+    std::vector<std::uint8_t> data(16, 0);
+    std::vector<std::pair<const std::uint8_t*, std::size_t>> objects = {
+        {data.data(), data.size()}
+    };
+
+    EXPECT_THROW(tensogram::encode_pre_encoded(json, objects), tensogram::error);
+}
+
+// -----------------------------------------------------------------------
+// Test 6: zero objects
+// -----------------------------------------------------------------------
+
+TEST(EncodePreEncodedTest, ZeroObjects) {
+    std::string json = R"({"version":2,"descriptors":[]})";
+    std::vector<std::pair<const std::uint8_t*, std::size_t>> objects;
+
+    auto encoded = tensogram::encode_pre_encoded(json, objects);
+    ASSERT_FALSE(encoded.empty());
+
+    auto msg = tensogram::decode(encoded.data(), encoded.size());
+    EXPECT_EQ(msg.num_objects(), 0u);
+}
+
+// -----------------------------------------------------------------------
+// Test 7: streaming encoder with write_object_pre_encoded
+// -----------------------------------------------------------------------
+
+TEST(EncodePreEncodedTest, StreamingMixedMode) {
+    TempFile tmp;
+    std::string meta = R"({"version":2})";
+
+    {
+        tensogram::streaming_encoder enc(tmp.path, meta);
+
+        // Object 0: normal encode
+        std::vector<float> a = {1.0f, 2.0f, 3.0f};
+        std::string desc_a = R"({"type":"ndarray","ndim":1,"shape":[3],"strides":[4],)"
+            R"("dtype":"float32","byte_order":"little","encoding":"none",)"
+            R"("filter":"none","compression":"none"})";
+        enc.write_object(desc_a,
+                         reinterpret_cast<const std::uint8_t*>(a.data()),
+                         a.size() * sizeof(float));
+
+        // Object 1: pre-encoded (raw bytes, encoding=none)
+        std::vector<float> b = {10.0f, 20.0f};
+        std::string desc_b = R"({"type":"ndarray","ndim":1,"shape":[2],"strides":[4],)"
+            R"("dtype":"float32","byte_order":"little","encoding":"none",)"
+            R"("filter":"none","compression":"none"})";
+        enc.write_object_pre_encoded(desc_b,
+                                     reinterpret_cast<const std::uint8_t*>(b.data()),
+                                     b.size() * sizeof(float));
+
+        enc.finish();
+    }
+
+    // Open the file and decode
+    auto f = tensogram::file::open(tmp.path);
+    ASSERT_EQ(f.message_count(), 1u);
+
+    auto msg = f.decode_message(0);
+    ASSERT_EQ(msg.num_objects(), 2u);
+
+    auto obj0 = msg.object(0);
+    EXPECT_EQ(obj0.element_count<float>(), 3u);
+    const float* p0 = obj0.data_as<float>();
+    EXPECT_FLOAT_EQ(p0[0], 1.0f);
+    EXPECT_FLOAT_EQ(p0[1], 2.0f);
+    EXPECT_FLOAT_EQ(p0[2], 3.0f);
+
+    auto obj1 = msg.object(1);
+    EXPECT_EQ(obj1.element_count<float>(), 2u);
+    const float* p1 = obj1.data_as<float>();
+    EXPECT_FLOAT_EQ(p1[0], 10.0f);
+    EXPECT_FLOAT_EQ(p1[1], 20.0f);
+}
+
+// -----------------------------------------------------------------------
+// Test 8: hash is recomputed (not from caller)
+// -----------------------------------------------------------------------
+
+TEST(EncodePreEncodedTest, HashIsRecomputed) {
+    std::vector<float> values = {1.0f, 2.0f, 3.0f};
+    auto json = encoding_none_json(values.size());
+
+    std::vector<std::pair<const std::uint8_t*, std::size_t>> objects = {
+        {reinterpret_cast<const std::uint8_t*>(values.data()),
+         values.size() * sizeof(float)}
+    };
+
+    // Encode with hash
+    auto encoded = tensogram::encode_pre_encoded(json, objects);
+    ASSERT_FALSE(encoded.empty());
+
+    // Verify hash succeeds on decode
+    tensogram::decode_options opts;
+    opts.verify_hash = true;
+    EXPECT_NO_THROW(tensogram::decode(encoded.data(), encoded.size(), opts));
+}

--- a/tests/cpp/test_encode_pre_encoded.cpp
+++ b/tests/cpp/test_encode_pre_encoded.cpp
@@ -21,11 +21,11 @@ using test_helpers::TempFile;
 // Helpers
 // -----------------------------------------------------------------------
 
-/// Build a v2 JSON metadata+descriptor string for a 1-D encoding=none message.
-static std::string encoding_none_json(std::size_t count,
-                                      const std::string& dtype = "float32",
-                                      const std::string& byte_order = "little") {
-    return R"({"version":2,"descriptors":[{"type":"ndarray","ndim":1,"shape":[)" +
+/// Build a bare descriptor JSON for a 1-D encoding=none object (no envelope).
+static std::string descriptor_json(std::size_t count,
+                                   const std::string& dtype = "float32",
+                                   const std::string& byte_order = "little") {
+    return R"({"type":"ndarray","ndim":1,"shape":[)" +
            std::to_string(count) +
            R"(],"strides":[)" +
            std::to_string(dtype == "float64" ? 8
@@ -35,7 +35,14 @@ static std::string encoding_none_json(std::size_t count,
                           : 4) +
            R"(],"dtype":")" + dtype +
            R"(","byte_order":")" + byte_order +
-           R"(","encoding":"none","filter":"none","compression":"none"}]})";
+           R"(","encoding":"none","filter":"none","compression":"none"})";
+}
+
+/// Build a v2 JSON metadata+descriptor string for a 1-D encoding=none message.
+static std::string encoding_none_json(std::size_t count,
+                                      const std::string& dtype = "float32",
+                                      const std::string& byte_order = "little") {
+    return R"({"version":2,"descriptors":[)" + descriptor_json(count, dtype, byte_order) + R"(]})";
 }
 
 /// Build a v2 JSON string for simple_packing.
@@ -332,4 +339,144 @@ TEST(EncodePreEncodedTest, HashIsRecomputed) {
     tensogram::decode_options opts;
     opts.verify_hash = true;
     EXPECT_NO_THROW(tensogram::decode(encoded.data(), encoded.size(), opts));
+}
+
+// -----------------------------------------------------------------------
+// Additional edge-case tests
+// -----------------------------------------------------------------------
+
+TEST(EncodePreEncodedTest, MalformedJsonDescriptor) {
+    std::string json = R"({"version":2,"descriptors":[MALFORMED_JSON]})";
+    std::vector<float> values = {1.0f, 2.0f};
+    std::vector<std::pair<const std::uint8_t*, std::size_t>> objects = {
+        {reinterpret_cast<const std::uint8_t*>(values.data()),
+         values.size() * sizeof(float)}
+    };
+    EXPECT_ANY_THROW(tensogram::encode_pre_encoded(json, objects));
+}
+
+TEST(EncodePreEncodedTest, EmptyJsonDescriptor) {
+    std::string json = R"({})";
+    std::vector<float> values = {1.0f};
+    std::vector<std::pair<const std::uint8_t*, std::size_t>> objects = {
+        {reinterpret_cast<const std::uint8_t*>(values.data()),
+         values.size() * sizeof(float)}
+    };
+    EXPECT_ANY_THROW(tensogram::encode_pre_encoded(json, objects));
+}
+
+TEST(EncodePreEncodedTest, DataSizeMismatch) {
+    // encoding=none, shape=[10] float32 = 40 bytes expected, but pass only 20.
+    std::string json = encoding_none_json(10, "float32");
+    std::vector<std::uint8_t> short_data(20, 0);
+    std::vector<std::pair<const std::uint8_t*, std::size_t>> objects = {
+        {short_data.data(), short_data.size()}
+    };
+    EXPECT_ANY_THROW(tensogram::encode_pre_encoded(json, objects));
+}
+
+TEST(EncodePreEncodedTest, RoundTrip2D) {
+    // 2D array [2, 3] of float32 (24 bytes)
+    std::string json =
+        R"({"version":2,"descriptors":[{"type":"ndarray","ndim":2,"shape":[2,3],)"
+        R"("strides":[12,4],"dtype":"float32","byte_order":"little",)"
+        R"("encoding":"none","filter":"none","compression":"none"}]})";
+
+    std::vector<float> values = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+    std::vector<std::pair<const std::uint8_t*, std::size_t>> objects = {
+        {reinterpret_cast<const std::uint8_t*>(values.data()),
+         values.size() * sizeof(float)}
+    };
+
+    auto encoded = tensogram::encode_pre_encoded(json, objects);
+    ASSERT_FALSE(encoded.empty());
+
+    auto msg = tensogram::decode(encoded.data(), encoded.size());
+    ASSERT_EQ(msg.num_objects(), 1u);
+
+    auto obj = msg.object(0);
+    EXPECT_EQ(obj.element_count<float>(), 6u);
+    const float* p = obj.data_as<float>();
+    EXPECT_FLOAT_EQ(p[0], 1.0f);
+    EXPECT_FLOAT_EQ(p[5], 6.0f);
+}
+
+TEST(EncodePreEncodedTest, StreamingPreEncodedOnly) {
+    // Streaming encoder with ONLY pre-encoded writes (no write_object).
+    TempFile tmp;
+    std::string meta = R"({"version":2})";
+
+    {
+        tensogram::streaming_encoder enc(tmp.path, meta);
+
+        std::vector<float> a = {10.0f, 20.0f, 30.0f, 40.0f};
+        std::string desc_a = descriptor_json(a.size());
+
+        enc.write_object_pre_encoded(desc_a,
+                                     reinterpret_cast<const std::uint8_t*>(a.data()),
+                                     a.size() * sizeof(float));
+        enc.finish();
+    }
+
+    auto f = tensogram::file::open(tmp.path);
+    ASSERT_EQ(f.message_count(), 1u);
+    auto msg = f.decode_message(0);
+    ASSERT_EQ(msg.num_objects(), 1u);
+
+    auto obj = msg.object(0);
+    EXPECT_EQ(obj.element_count<float>(), 4u);
+    const float* p = obj.data_as<float>();
+    EXPECT_FLOAT_EQ(p[0], 10.0f);
+    EXPECT_FLOAT_EQ(p[3], 40.0f);
+}
+
+TEST(EncodePreEncodedTest, StreamingMultiplePreEncoded) {
+    // Streaming encoder with multiple pre-encoded objects.
+    TempFile tmp;
+    std::string meta = R"({"version":2})";
+
+    {
+        tensogram::streaming_encoder enc(tmp.path, meta);
+
+        std::vector<float> a = {1.0f, 2.0f};
+        std::vector<double> b = {100.0, 200.0, 300.0};
+
+        std::string desc_a = descriptor_json(a.size(), "float32");
+        std::string desc_b = descriptor_json(b.size(), "float64");
+
+        enc.write_object_pre_encoded(desc_a,
+                                     reinterpret_cast<const std::uint8_t*>(a.data()),
+                                     a.size() * sizeof(float));
+        enc.write_object_pre_encoded(desc_b,
+                                     reinterpret_cast<const std::uint8_t*>(b.data()),
+                                     b.size() * sizeof(double));
+        enc.finish();
+    }
+
+    auto f = tensogram::file::open(tmp.path);
+    ASSERT_EQ(f.message_count(), 1u);
+    auto msg = f.decode_message(0);
+    ASSERT_EQ(msg.num_objects(), 2u);
+
+    auto obj0 = msg.object(0);
+    EXPECT_EQ(obj0.element_count<float>(), 2u);
+    EXPECT_FLOAT_EQ(obj0.data_as<float>()[0], 1.0f);
+
+    auto obj1 = msg.object(1);
+    EXPECT_EQ(obj1.element_count<double>(), 3u);
+    EXPECT_DOUBLE_EQ(obj1.data_as<double>()[2], 300.0);
+}
+
+TEST(EncodePreEncodedTest, SingleElement) {
+    // Single-element array.
+    std::string json = encoding_none_json(1, "float32");
+    float val = 42.0f;
+    std::vector<std::pair<const std::uint8_t*, std::size_t>> objects = {
+        {reinterpret_cast<const std::uint8_t*>(&val), sizeof(float)}
+    };
+
+    auto encoded = tensogram::encode_pre_encoded(json, objects);
+    auto msg = tensogram::decode(encoded.data(), encoded.size());
+    ASSERT_EQ(msg.num_objects(), 1u);
+    EXPECT_FLOAT_EQ(msg.object(0).data_as<float>()[0], 42.0f);
 }

--- a/tests/python/cross_language_pre_encoded_helper.py
+++ b/tests/python/cross_language_pre_encoded_helper.py
@@ -17,7 +17,7 @@ import tensogram
 def main() -> None:
     # Same deterministic input as the Rust driver.
     values = np.array([200.0 + i * 0.125 for i in range(1024)], dtype=np.float64)
-    raw_bytes = values.tobytes()  # little-endian on ARM Mac
+    raw_bytes = values.astype("<f8", copy=False).tobytes()  # explicit little-endian
 
     global_meta = {"version": 2}
     descriptor = {

--- a/tests/python/cross_language_pre_encoded_helper.py
+++ b/tests/python/cross_language_pre_encoded_helper.py
@@ -1,0 +1,49 @@
+"""Cross-language SHA256 golden test helper for encode_pre_encoded().
+
+Generates the SAME deterministic float64[1024] payload as the Rust driver,
+encodes via tensogram.encode_pre_encoded(), decodes, and prints the SHA-256
+hex digest of the decoded payload to stdout.
+
+The Rust test driver spawns this script and compares the output.
+"""
+
+import hashlib
+import sys
+
+import numpy as np
+import tensogram
+
+
+def main() -> None:
+    # Same deterministic input as the Rust driver.
+    values = np.array([200.0 + i * 0.125 for i in range(1024)], dtype=np.float64)
+    raw_bytes = values.tobytes()  # little-endian on ARM Mac
+
+    global_meta = {"version": 2}
+    descriptor = {
+        "type": "ndarray",
+        "ndim": 1,
+        "shape": [1024],
+        "strides": [8],
+        "dtype": "float64",
+        "byte_order": "little",
+        "encoding": "none",
+        "filter": "none",
+        "compression": "none",
+    }
+
+    wire = tensogram.encode_pre_encoded(global_meta, [(descriptor, raw_bytes)])
+
+    # Decode and extract payload.
+    msg = tensogram.decode(wire)
+    assert len(msg.objects) == 1, f"Expected 1 object, got {len(msg.objects)}"
+    _desc, payload_array = msg.objects[0]
+    # payload_array is a numpy array; get its raw bytes.
+    payload_bytes = payload_array.tobytes()
+
+    sha = hashlib.sha256(payload_bytes).hexdigest()
+    sys.stdout.write(sha)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/python/test_encode_pre_encoded.py
+++ b/tests/python/test_encode_pre_encoded.py
@@ -125,9 +125,7 @@ class TestEncodePreEncodedSimplePacking:
         temps = np.linspace(249.15, 349.05, n, dtype=np.float64)
 
         # Compute packing parameters via the library helper
-        params = tensogram.compute_packing_params(
-            temps, bits_per_value=16, decimal_scale_factor=0
-        )
+        params = tensogram.compute_packing_params(temps, bits_per_value=16, decimal_scale_factor=0)
         ref_val = params["reference_value"]
         bsf = params["binary_scale_factor"]
         dsf = params["decimal_scale_factor"]
@@ -164,9 +162,7 @@ class TestEncodePreEncodedSimplePacking:
         """Pre-encoded simple_packing produces same decoded payload as encode()."""
         n = 500
         temps = np.linspace(200.0, 300.0, n, dtype=np.float64)
-        params = tensogram.compute_packing_params(
-            temps, bits_per_value=16, decimal_scale_factor=0
-        )
+        params = tensogram.compute_packing_params(temps, bits_per_value=16, decimal_scale_factor=0)
 
         desc = make_descriptor(
             shape=[n],
@@ -206,14 +202,19 @@ class TestEncodePreEncodedSimplePacking:
 class TestEncodePreEncodedSzip:
     """Pre-encoded szip payloads with block offsets."""
 
-    def test_szip_with_block_offsets(self):
-        """Encode with simple_packing+szip, extract descriptor, re-encode."""
-        # Use a large enough array that szip actually produces blocks
+    def test_szip_with_block_offsets_via_pre_encoded(self):
+        """Encode with szip via encode(), extract descriptor, re-encode via encode_pre_encoded.
+
+        Since Python has no API to extract raw on-wire payload bytes directly,
+        we use encode() to get a valid szip message, then re-use the descriptor
+        (which includes szip_block_offsets) with manually packed bytes via
+        encode_pre_encoded().  The descriptor's block offsets won't match the
+        new payload, but the library must accept them structurally (validation
+        checks monotonicity and range, not payload correspondence).
+        """
         n = 10000
         temps = np.linspace(200.0, 300.0, n, dtype=np.float64)
-        params = tensogram.compute_packing_params(
-            temps, bits_per_value=16, decimal_scale_factor=0
-        )
+        params = tensogram.compute_packing_params(temps, bits_per_value=16, decimal_scale_factor=0)
 
         desc_szip = make_descriptor(
             shape=[n],
@@ -228,23 +229,106 @@ class TestEncodePreEncodedSzip:
         )
         meta = make_global_meta(2)
 
-        # Encode normally with szip compression
-        msg = bytes(tensogram.encode(meta, [(desc_szip, temps)]))
-
-        # Decode to verify the original encodes fine
-        _, objs_orig = tensogram.decode(msg)
+        # Step 1: Encode normally with szip compression to get valid block offsets
+        msg_orig = bytes(tensogram.encode(meta, [(desc_szip, temps)]))
+        _, objs_orig = tensogram.decode(msg_orig)
         desc_orig, decoded_orig = objs_orig[0]
         max_err = np.abs(temps - decoded_orig).max()
         assert max_err < 0.01
 
-        # Verify that szip_block_offsets are present in the decoded descriptor
+        # Verify szip_block_offsets are present
         p = desc_orig.params
         assert "szip_block_offsets" in p, "szip should produce block offsets"
+        offsets = p["szip_block_offsets"]
+        assert len(offsets) > 0, "should have at least one block offset"
 
-        # decode_range should work on the original message
-        result = tensogram.decode_range(msg, 0, [(100, 50)])
-        assert len(result) == 1
-        assert len(result[0]) == 50
+        # Step 2: Build a manually packed payload (simple_packing, no szip)
+        packed_bytes = simple_pack_python(
+            temps,
+            params["reference_value"],
+            params["binary_scale_factor"],
+            params["decimal_scale_factor"],
+            params["bits_per_value"],
+        )
+
+        # Step 3: Build a pre-encoded descriptor with valid szip_block_offsets
+        # Use the block offsets from the real szip encode — they're structurally
+        # valid (monotonically increasing, within range).
+        pre_desc = make_descriptor(
+            shape=[n],
+            dtype="float64",
+            byte_order="little",
+            encoding="simple_packing",
+            compression="szip",
+            szip_rsi=int(p.get("szip_rsi", 128)),
+            szip_block_size=int(p.get("szip_block_size", 16)),
+            szip_flags=int(p.get("szip_flags", 8)),
+            szip_block_offsets=[int(o) for o in offsets],
+            **params,
+        )
+
+        # Step 4: encode_pre_encoded must accept the descriptor with szip_block_offsets
+        msg_pre = bytes(tensogram.encode_pre_encoded(meta, [(pre_desc, packed_bytes)]))
+        assert len(msg_pre) > 0, "pre-encoded message should not be empty"
+
+        # Step 5: decode_descriptors to verify the offsets survived round-trip
+        _, descs = tensogram.decode_descriptors(msg_pre)
+        d = descs[0]
+        assert "szip_block_offsets" in d.params
+        assert d.params["szip_block_offsets"] == [int(o) for o in offsets]
+
+    def test_szip_block_offsets_non_monotonic_rejected(self):
+        """Non-monotonic szip_block_offsets must be rejected."""
+        n = 100
+        temps = np.linspace(200.0, 300.0, n, dtype=np.float64)
+        params = tensogram.compute_packing_params(temps, bits_per_value=16, decimal_scale_factor=0)
+        packed = simple_pack_python(
+            temps,
+            params["reference_value"],
+            params["binary_scale_factor"],
+            params["decimal_scale_factor"],
+            params["bits_per_value"],
+        )
+        desc = make_descriptor(
+            shape=[n],
+            dtype="float64",
+            byte_order="little",
+            encoding="simple_packing",
+            compression="szip",
+            szip_rsi=128,
+            szip_block_size=16,
+            szip_flags=8,
+            szip_block_offsets=[0, 200, 100],  # not monotonic
+            **params,
+        )
+        meta = make_global_meta(2)
+        with pytest.raises(ValueError, match="szip_block_offsets must be strictly increasing"):
+            tensogram.encode_pre_encoded(meta, [(desc, packed)])
+
+    def test_szip_block_offsets_with_non_szip_rejected(self):
+        """szip_block_offsets with non-szip compression must be rejected."""
+        n = 100
+        temps = np.linspace(200.0, 300.0, n, dtype=np.float64)
+        params = tensogram.compute_packing_params(temps, bits_per_value=16, decimal_scale_factor=0)
+        packed = simple_pack_python(
+            temps,
+            params["reference_value"],
+            params["binary_scale_factor"],
+            params["decimal_scale_factor"],
+            params["bits_per_value"],
+        )
+        desc = make_descriptor(
+            shape=[n],
+            dtype="float64",
+            byte_order="little",
+            encoding="simple_packing",
+            compression="zstd",
+            szip_block_offsets=[0, 100, 200],
+            **params,
+        )
+        meta = make_global_meta(2)
+        with pytest.raises(ValueError, match="szip_block_offsets provided but compression"):
+            tensogram.encode_pre_encoded(meta, [(desc, packed)])
 
 
 # ---------------------------------------------------------------------------
@@ -328,6 +412,14 @@ class TestEncodePreEncodedRejectsInvalid:
         meta = make_global_meta(2)
         with pytest.raises(ValueError, match="unknown dtype"):
             tensogram.encode_pre_encoded(meta, [(desc, data)])
+
+    def test_rejects_numpy_array_data(self):
+        """encode_pre_encoded must reject numpy arrays (requires bytes)."""
+        arr = np.arange(10, dtype=np.float32)
+        desc = make_descriptor(shape=[10], dtype="float32", byte_order="little")
+        meta = make_global_meta(2)
+        with pytest.raises((ValueError, TypeError)):
+            tensogram.encode_pre_encoded(meta, [(desc, arr)])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/python/test_encode_pre_encoded.py
+++ b/tests/python/test_encode_pre_encoded.py
@@ -664,3 +664,158 @@ class TestEncodePreEncodedEdgeCases:
         _, objects = tensogram.decode(msg)
         desc_out = objects[0][0]
         assert desc_out.params["my_custom_key"] == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Test: Additional edge cases for coverage
+# ---------------------------------------------------------------------------
+
+
+class TestEncodePreEncodedAdditionalEdgeCases:
+    """Additional edge cases for code coverage hardening."""
+
+    def test_bytearray_accepted(self):
+        """bytearray is accepted as data (PyO3 extracts Vec<u8> from it)."""
+        data = np.arange(8, dtype=np.float32)
+        raw = bytearray(data.tobytes())
+        desc = make_descriptor(shape=[8], dtype="float32", byte_order="little")
+        meta = make_global_meta(2)
+
+        msg = bytes(tensogram.encode_pre_encoded(meta, [(desc, raw)]))
+        _, objects = tensogram.decode(msg)
+        _, decoded = objects[0]
+        np.testing.assert_array_equal(decoded, data)
+
+    def test_memoryview_accepted(self):
+        """memoryview is accepted as data (PyO3 extracts Vec<u8> from it)."""
+        data = np.arange(8, dtype=np.float32)
+        raw = memoryview(data.tobytes())
+        desc = make_descriptor(shape=[8], dtype="float32", byte_order="little")
+        meta = make_global_meta(2)
+
+        msg = bytes(tensogram.encode_pre_encoded(meta, [(desc, raw)]))
+        _, objects = tensogram.decode(msg)
+        _, decoded = objects[0]
+        np.testing.assert_array_equal(decoded, data)
+
+    def test_empty_bytes_zero_element_shape(self):
+        """Empty bytes with shape=[0] succeeds."""
+        desc = make_descriptor(shape=[0], dtype="float32", byte_order="little")
+        meta = make_global_meta(2)
+
+        msg = bytes(tensogram.encode_pre_encoded(meta, [(desc, b"")]))
+        _, objects = tensogram.decode(msg)
+        _, decoded = objects[0]
+        assert decoded.shape == (0,)
+        assert decoded.dtype == np.float32
+
+    def test_non_tuple_in_list_raises(self):
+        """Non-tuple element in the data list raises ValueError."""
+        meta = make_global_meta(2)
+        with pytest.raises((ValueError, TypeError)):
+            tensogram.encode_pre_encoded(meta, ["not a tuple"])
+
+    def test_non_dict_descriptor_raises(self):
+        """Non-dict as descriptor raises ValueError."""
+        meta = make_global_meta(2)
+        with pytest.raises((ValueError, TypeError)):
+            tensogram.encode_pre_encoded(meta, [("not_a_dict", b"\x00" * 4)])
+
+    def test_tuple_wrong_length_raises(self):
+        """Tuple with wrong length raises ValueError."""
+        meta = make_global_meta(2)
+        with pytest.raises((ValueError, TypeError)):
+            tensogram.encode_pre_encoded(meta, [({}, b"\x00", "extra")])
+
+    def test_rejects_numpy_with_type_in_error(self):
+        """encode_pre_encoded error message includes the rejected type name."""
+        arr = np.arange(10, dtype=np.float32)
+        desc = make_descriptor(shape=[10], dtype="float32", byte_order="little")
+        meta = make_global_meta(2)
+        with pytest.raises((ValueError, TypeError), match=r"ndarray|numpy|got"):
+            tensogram.encode_pre_encoded(meta, [(desc, arr)])
+
+    def test_rejects_int_data_with_type_in_error(self):
+        """Passing an int as data shows the type name in the error."""
+        desc = make_descriptor(shape=[1], dtype="float32", byte_order="little")
+        meta = make_global_meta(2)
+        with pytest.raises((ValueError, TypeError), match=r"int|got"):
+            tensogram.encode_pre_encoded(meta, [(desc, 42)])
+
+    def test_rejects_none_data_with_type_in_error(self):
+        """Passing None as data shows the type name in the error."""
+        desc = make_descriptor(shape=[1], dtype="float32", byte_order="little")
+        meta = make_global_meta(2)
+        with pytest.raises((ValueError, TypeError), match=r"None|got"):
+            tensogram.encode_pre_encoded(meta, [(desc, None)])
+
+    def test_single_element_roundtrip(self):
+        """Single-element array round-trips correctly."""
+        data = np.array([42.0], dtype=np.float32)
+        raw = data.tobytes()
+        desc = make_descriptor(shape=[1], dtype="float32", byte_order="little")
+        meta = make_global_meta(2)
+
+        msg = bytes(tensogram.encode_pre_encoded(meta, [(desc, raw)]))
+        _, objects = tensogram.decode(msg)
+        _, decoded = objects[0]
+        np.testing.assert_array_equal(decoded, data)
+
+    def test_2d_array_roundtrip(self):
+        """2D array [3, 4] round-trips correctly."""
+        data = np.arange(12, dtype=np.float32).reshape(3, 4)
+        raw = data.tobytes()
+        desc = make_descriptor(shape=[3, 4], dtype="float32", byte_order="little")
+        # strides for row-major float32 2D
+        desc["strides"] = [16, 4]
+        meta = make_global_meta(2)
+
+        msg = bytes(tensogram.encode_pre_encoded(meta, [(desc, raw)]))
+        _, objects = tensogram.decode(msg)
+        _, decoded = objects[0]
+        np.testing.assert_array_equal(decoded.reshape(3, 4), data)
+
+    def test_streaming_write_after_finish_raises(self):
+        """write_object_pre_encoded after finish() raises RuntimeError."""
+        meta = make_global_meta(2)
+        enc = tensogram.StreamingEncoder(meta)
+        enc.finish()
+        desc = make_descriptor(shape=[4], dtype="float32", byte_order="little")
+        with pytest.raises(RuntimeError, match="already finished"):
+            enc.write_object_pre_encoded(desc, b"\x00" * 16)
+
+    def test_streaming_pre_encoded_multiple_objects(self):
+        """StreamingEncoder with multiple pre-encoded writes."""
+        meta = make_global_meta(2)
+        enc = tensogram.StreamingEncoder(meta)
+
+        a = np.arange(5, dtype=np.float32)
+        b = np.arange(3, dtype=np.int32)
+
+        desc_a = make_descriptor(shape=[5], dtype="float32", byte_order="little")
+        desc_b = make_descriptor(shape=[3], dtype="int32", byte_order="little")
+
+        enc.write_object_pre_encoded(desc_a, a.tobytes())
+        enc.write_object_pre_encoded(desc_b, b.tobytes())
+
+        msg = bytes(enc.finish())
+        _, objects = tensogram.decode(msg)
+        assert len(objects) == 2
+        _, d_a = objects[0]
+        _, d_b = objects[1]
+        np.testing.assert_array_equal(d_a, a)
+        np.testing.assert_array_equal(d_b, b)
+
+    def test_encoding_none_size_mismatch_too_short(self):
+        """encoding=none with data too short raises ValueError."""
+        desc = make_descriptor(shape=[10], dtype="float32", byte_order="little")
+        meta = make_global_meta(2)
+        with pytest.raises(ValueError, match="does not match expected"):
+            tensogram.encode_pre_encoded(meta, [(desc, b"\x00" * 20)])
+
+    def test_encoding_none_size_mismatch_too_long(self):
+        """encoding=none with data too long raises ValueError."""
+        desc = make_descriptor(shape=[4], dtype="float32", byte_order="little")
+        meta = make_global_meta(2)
+        with pytest.raises(ValueError, match="does not match expected"):
+            tensogram.encode_pre_encoded(meta, [(desc, b"\x00" * 32)])

--- a/tests/python/test_encode_pre_encoded.py
+++ b/tests/python/test_encode_pre_encoded.py
@@ -1,0 +1,574 @@
+"""Tests for encode_pre_encoded() and StreamingEncoder.write_object_pre_encoded().
+
+These tests exercise the pre-encoded encode path: callers hand already-encoded
+payload bytes (plus a matching descriptor) and the library wraps them into the
+wire format without re-running the encoding pipeline.
+
+Key invariants:
+  - The library always overwrites the descriptor's ``hash`` field with
+    ``xxh3(payload)`` — callers cannot inject a hash.
+  - Wire bytes are NOT compared directly because provenance fields
+    (``_reserved_.uuid``, ``_reserved_.time``) are non-deterministic.
+    Instead, decoded payloads are compared via ``hashlib.sha256``.
+  - ``szip_block_offsets`` are **BIT** offsets, not byte offsets.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+import numpy as np
+import pytest
+import tensogram
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_global_meta(version: int = 2, **extra: Any) -> dict[str, Any]:
+    """Build a global metadata dict."""
+    return {"version": version, **extra}
+
+
+def make_descriptor(
+    shape: list[int],
+    dtype: str = "float32",
+    byte_order: str = "little",
+    encoding: str = "none",
+    compression: str = "none",
+    filter_: str = "none",
+    **extra: Any,
+) -> dict[str, Any]:
+    """Build a DataObjectDescriptor dict."""
+    return {
+        "type": "ntensor",
+        "shape": shape,
+        "dtype": dtype,
+        "byte_order": byte_order,
+        "encoding": encoding,
+        "filter": filter_,
+        "compression": compression,
+        **extra,
+    }
+
+
+def decoded_sha256(desc: dict, payload: np.ndarray) -> str:
+    """SHA-256 over (descriptor repr + raw payload bytes).
+
+    Excludes hash and _reserved_ from the descriptor for stability.
+    """
+    h = hashlib.sha256()
+    # Sort keys for determinism; exclude volatile fields
+    stable = {k: v for k, v in sorted(desc.items()) if k not in ("hash", "_reserved_")}
+    h.update(repr(stable).encode())
+    h.update(payload.tobytes())
+    return h.hexdigest()
+
+
+def simple_pack_python(
+    values: np.ndarray,
+    ref_val: float,
+    bsf: int,
+    dsf: int,
+    bpv: int,
+) -> bytes:
+    """Manually quantise float64 values and bit-pack into bytes.
+
+    This reproduces the simple_packing encoding in pure Python so we can
+    build pre-encoded payloads without calling tensogram.encode().
+
+    Formula: packed_int = round((value - ref_val) * 10^dsf / 2^bsf)
+    """
+    scale = (10.0**dsf) / (2.0**bsf)
+    packed_ints = np.round((values - ref_val) * scale).astype(np.uint64)
+
+    # Bit-pack into a byte stream (big-endian bit order, MSB first)
+    total_bits = len(packed_ints) * bpv
+    total_bytes = (total_bits + 7) // 8
+    buf = bytearray(total_bytes)
+
+    bit_pos = 0
+    for val in packed_ints:
+        # Write bpv bits of val into buf starting at bit_pos
+        remaining = bpv
+        v = int(val)
+        while remaining > 0:
+            byte_idx = bit_pos // 8
+            bit_offset = bit_pos % 8
+            space = 8 - bit_offset
+            write_bits = min(remaining, space)
+
+            # Extract the top `write_bits` bits from the remaining value
+            shift = remaining - write_bits
+            bits = (v >> shift) & ((1 << write_bits) - 1)
+
+            buf[byte_idx] |= bits << (space - write_bits)
+            bit_pos += write_bits
+            remaining -= write_bits
+
+    return bytes(buf)
+
+
+# ---------------------------------------------------------------------------
+# Test 1: simple_packing round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestEncodePreEncodedSimplePacking:
+    """Pre-encoded simple_packing payloads decode correctly."""
+
+    def test_simple_packing_roundtrip(self):
+        """Manually pack float64 values, pass to encode_pre_encoded, decode."""
+        n = 1000
+        temps = np.linspace(249.15, 349.05, n, dtype=np.float64)
+
+        # Compute packing parameters via the library helper
+        params = tensogram.compute_packing_params(
+            temps, bits_per_value=16, decimal_scale_factor=0
+        )
+        ref_val = params["reference_value"]
+        bsf = params["binary_scale_factor"]
+        dsf = params["decimal_scale_factor"]
+        bpv = params["bits_per_value"]
+
+        # Manually pack in Python
+        packed_bytes = simple_pack_python(temps, ref_val, bsf, dsf, bpv)
+
+        # Build descriptor for pre-encoded path
+        # Use byte_order="little" (native on ARM Mac) because simple_packing
+        # bit-packing is byte-order-independent — only the reference value
+        # and scale factors matter for decoding.
+        desc = make_descriptor(
+            shape=[n],
+            dtype="float64",
+            byte_order="little",
+            encoding="simple_packing",
+            **params,
+        )
+        meta = make_global_meta(2)
+
+        # Encode via pre-encoded path
+        msg = bytes(tensogram.encode_pre_encoded(meta, [(desc, packed_bytes)]))
+
+        # Decode and verify lossy round-trip
+        _, objects = tensogram.decode(msg)
+        _, decoded = objects[0]
+        max_err = np.abs(temps - decoded).max()
+        assert max_err < 0.01, f"Max error {max_err} exceeds tolerance"
+        assert decoded.dtype == np.float64
+        assert decoded.shape == (n,)
+
+    def test_simple_packing_matches_encode(self):
+        """Pre-encoded simple_packing produces same decoded payload as encode()."""
+        n = 500
+        temps = np.linspace(200.0, 300.0, n, dtype=np.float64)
+        params = tensogram.compute_packing_params(
+            temps, bits_per_value=16, decimal_scale_factor=0
+        )
+
+        desc = make_descriptor(
+            shape=[n],
+            dtype="float64",
+            byte_order="little",
+            encoding="simple_packing",
+            **params,
+        )
+        meta = make_global_meta(2)
+
+        # Path A: normal encode
+        msg_a = bytes(tensogram.encode(meta, [(desc, temps)]))
+        _, objs_a = tensogram.decode(msg_a)
+        _, decoded_a = objs_a[0]
+
+        # Path B: manually pack then encode_pre_encoded
+        packed = simple_pack_python(
+            temps,
+            params["reference_value"],
+            params["binary_scale_factor"],
+            params["decimal_scale_factor"],
+            params["bits_per_value"],
+        )
+        msg_b = bytes(tensogram.encode_pre_encoded(meta, [(desc, packed)]))
+        _, objs_b = tensogram.decode(msg_b)
+        _, decoded_b = objs_b[0]
+
+        # Both paths should produce identical decoded payloads
+        np.testing.assert_array_equal(decoded_a, decoded_b)
+
+
+# ---------------------------------------------------------------------------
+# Test 2: szip with block offsets
+# ---------------------------------------------------------------------------
+
+
+class TestEncodePreEncodedSzip:
+    """Pre-encoded szip payloads with block offsets."""
+
+    def test_szip_with_block_offsets(self):
+        """Encode with simple_packing+szip, extract descriptor, re-encode."""
+        # Use a large enough array that szip actually produces blocks
+        n = 10000
+        temps = np.linspace(200.0, 300.0, n, dtype=np.float64)
+        params = tensogram.compute_packing_params(
+            temps, bits_per_value=16, decimal_scale_factor=0
+        )
+
+        desc_szip = make_descriptor(
+            shape=[n],
+            dtype="float64",
+            byte_order="little",
+            encoding="simple_packing",
+            compression="szip",
+            szip_rsi=128,
+            szip_block_size=16,
+            szip_flags=8,
+            **params,
+        )
+        meta = make_global_meta(2)
+
+        # Encode normally with szip compression
+        msg = bytes(tensogram.encode(meta, [(desc_szip, temps)]))
+
+        # Decode to verify the original encodes fine
+        _, objs_orig = tensogram.decode(msg)
+        desc_orig, decoded_orig = objs_orig[0]
+        max_err = np.abs(temps - decoded_orig).max()
+        assert max_err < 0.01
+
+        # Verify that szip_block_offsets are present in the decoded descriptor
+        p = desc_orig.params
+        assert "szip_block_offsets" in p, "szip should produce block offsets"
+
+        # decode_range should work on the original message
+        result = tensogram.decode_range(msg, 0, [(100, 50)])
+        assert len(result) == 1
+        assert len(result[0]) == 50
+
+
+# ---------------------------------------------------------------------------
+# Test 3: hash overwriting
+# ---------------------------------------------------------------------------
+
+
+class TestEncodePreEncodedHashOverwrite:
+    """Library always overwrites the caller's hash field."""
+
+    def test_overwrites_caller_hash(self):
+        """Even if the descriptor dict contains a 'hash' key, the library
+        recomputes it from the payload bytes."""
+        data = np.arange(20, dtype=np.float32)
+        raw_bytes = data.tobytes()
+
+        desc = make_descriptor(
+            shape=[20],
+            dtype="float32",
+            byte_order="little",
+            # Inject a fake hash that should be overwritten
+            hash={"type": "xxh3", "value": "deadbeef"},
+        )
+        meta = make_global_meta(2)
+
+        msg = bytes(tensogram.encode_pre_encoded(meta, [(desc, raw_bytes)]))
+
+        # Decode and check the hash is NOT our fake one
+        _, objects = tensogram.decode(msg, verify_hash=True)
+        desc_out, arr = objects[0]
+        np.testing.assert_array_equal(arr, data)
+
+        h = desc_out.hash
+        assert h is not None
+        assert h["type"] == "xxh3"
+        # The library computed a real hash, not our injected fake
+        assert h["value"] != "deadbeef"
+        assert len(h["value"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# Test 4: invalid descriptor rejection
+# ---------------------------------------------------------------------------
+
+
+class TestEncodePreEncodedRejectsInvalid:
+    """Invalid descriptors are rejected with an exception."""
+
+    def test_rejects_unknown_encoding(self):
+        """Unknown encoding string raises ValueError."""
+        data = b"\x00" * 40
+        desc = make_descriptor(
+            shape=[10],
+            dtype="float32",
+            byte_order="little",
+            encoding="bogus_encoding",
+        )
+        meta = make_global_meta(2)
+        with pytest.raises(ValueError, match="encoding"):
+            tensogram.encode_pre_encoded(meta, [(desc, data)])
+
+    def test_rejects_missing_version(self):
+        """Missing version in global metadata raises ValueError."""
+        data = b"\x00" * 40
+        desc = make_descriptor(shape=[10], dtype="float32")
+        with pytest.raises(ValueError, match="version"):
+            tensogram.encode_pre_encoded({}, [(desc, data)])
+
+    def test_rejects_missing_shape(self):
+        """Missing shape in descriptor raises ValueError."""
+        data = b"\x00" * 40
+        desc = {"type": "ntensor", "dtype": "float32"}
+        meta = make_global_meta(2)
+        with pytest.raises(ValueError, match="shape"):
+            tensogram.encode_pre_encoded(meta, [(desc, data)])
+
+    def test_rejects_unknown_dtype(self):
+        """Unknown dtype string raises ValueError."""
+        data = b"\x00" * 40
+        desc = make_descriptor(shape=[10], dtype="complex256")
+        meta = make_global_meta(2)
+        with pytest.raises(ValueError, match="unknown dtype"):
+            tensogram.encode_pre_encoded(meta, [(desc, data)])
+
+
+# ---------------------------------------------------------------------------
+# Test 5: zero objects
+# ---------------------------------------------------------------------------
+
+
+class TestEncodePreEncodedZeroObjects:
+    """Encoding with zero data objects."""
+
+    def test_zero_objects(self):
+        """Pre-encoding an empty list of objects produces a valid message."""
+        meta = make_global_meta(2, note="empty")
+        msg = bytes(tensogram.encode_pre_encoded(meta, []))
+        decoded_meta, objects = tensogram.decode(msg)
+        assert len(objects) == 0
+        assert decoded_meta["note"] == "empty"
+
+
+# ---------------------------------------------------------------------------
+# Test 6: StreamingEncoder mixed mode
+# ---------------------------------------------------------------------------
+
+
+class TestStreamingEncoderPreEncoded:
+    """StreamingEncoder.write_object_pre_encoded interleaved with write_object."""
+
+    def test_mixed_mode(self):
+        """Alternate write_object (normal) and write_object_pre_encoded."""
+        meta = make_global_meta(2)
+        enc = tensogram.StreamingEncoder(meta)
+
+        # Object 0: normal encode
+        arr0 = np.arange(10, dtype=np.float32)
+        desc0 = make_descriptor(shape=[10], dtype="float32", byte_order="little")
+        enc.write_object(desc0, arr0)
+
+        # Object 1: pre-encoded (raw bytes, encoding=none)
+        arr1 = np.arange(5, dtype=np.int32)
+        raw1 = arr1.tobytes()
+        desc1 = make_descriptor(
+            shape=[5],
+            dtype="int32",
+            byte_order="little",
+        )
+        enc.write_object_pre_encoded(desc1, raw1)
+
+        # Object 2: normal encode again
+        arr2 = np.full(3, 42, dtype=np.uint8)
+        desc2 = make_descriptor(shape=[3], dtype="uint8")
+        enc.write_object(desc2, arr2)
+
+        msg = bytes(enc.finish())
+
+        # Decode and verify all three objects
+        _, objects = tensogram.decode(msg)
+        assert len(objects) == 3
+
+        _, d0 = objects[0]
+        np.testing.assert_array_equal(d0, arr0)
+
+        _, d1 = objects[1]
+        np.testing.assert_array_equal(d1, arr1)
+
+        _, d2 = objects[2]
+        np.testing.assert_array_equal(d2, arr2)
+
+    def test_streaming_pre_encoded_only(self):
+        """StreamingEncoder with only pre-encoded writes."""
+        meta = make_global_meta(2)
+        enc = tensogram.StreamingEncoder(meta)
+
+        arr = np.arange(20, dtype=np.float64)
+        raw = arr.tobytes()
+        desc = make_descriptor(
+            shape=[20],
+            dtype="float64",
+            byte_order="little",
+        )
+        enc.write_object_pre_encoded(desc, raw)
+
+        msg = bytes(enc.finish())
+        _, objects = tensogram.decode(msg)
+        assert len(objects) == 1
+        _, decoded = objects[0]
+        np.testing.assert_array_equal(decoded, arr)
+
+    def test_streaming_finish_twice_raises(self):
+        """Calling finish() twice on a StreamingEncoder raises RuntimeError."""
+        meta = make_global_meta(2)
+        enc = tensogram.StreamingEncoder(meta)
+        enc.finish()
+        with pytest.raises(RuntimeError, match="already finished"):
+            enc.finish()
+
+
+# ---------------------------------------------------------------------------
+# Test 7: szip_block_offsets rejected for non-szip compression
+# ---------------------------------------------------------------------------
+
+
+class TestEncodePreEncodedRejectsSzipOffsetsForNonSzip:
+    """szip_block_offsets in descriptor when compression != 'szip' → error."""
+
+    def test_rejects_szip_offsets_for_non_szip(self):
+        """Passing szip_block_offsets with compression='none' should raise."""
+        data = b"\x00" * 40
+        desc = make_descriptor(
+            shape=[10],
+            dtype="float32",
+            byte_order="little",
+            szip_block_offsets=[0, 80, 160],
+        )
+        meta = make_global_meta(2)
+        with pytest.raises(ValueError, match="szip_block_offsets"):
+            tensogram.encode_pre_encoded(meta, [(desc, data)])
+
+
+# Additional edge-case tests
+# ---------------------------------------------------------------------------
+
+
+class TestEncodePreEncodedEdgeCases:
+    """Additional edge cases for pre-encoded encoding."""
+
+    def test_encoding_none_roundtrip(self):
+        """encoding=none with raw bytes round-trips correctly."""
+        data = np.arange(100, dtype=np.float32)
+        raw = data.tobytes()
+
+        desc = make_descriptor(
+            shape=[100],
+            dtype="float32",
+            byte_order="little",
+        )
+        meta = make_global_meta(2)
+        msg = bytes(tensogram.encode_pre_encoded(meta, [(desc, raw)]))
+
+        _, objects = tensogram.decode(msg)
+        _, decoded = objects[0]
+        np.testing.assert_array_equal(decoded, data)
+
+    def test_encoding_none_multiple_objects(self):
+        """Pre-encode multiple objects with encoding=none."""
+        a = np.arange(10, dtype=np.float32)
+        b = np.arange(5, dtype=np.int64)
+
+        desc_a = make_descriptor(
+            shape=[10],
+            dtype="float32",
+            byte_order="little",
+        )
+        desc_b = make_descriptor(
+            shape=[5],
+            dtype="int64",
+            byte_order="little",
+        )
+        meta = make_global_meta(2)
+
+        msg = bytes(
+            tensogram.encode_pre_encoded(
+                meta,
+                [(desc_a, a.tobytes()), (desc_b, b.tobytes())],
+            )
+        )
+
+        _, objects = tensogram.decode(msg)
+        assert len(objects) == 2
+        _, d_a = objects[0]
+        _, d_b = objects[1]
+        np.testing.assert_array_equal(d_a, a)
+        np.testing.assert_array_equal(d_b, b)
+
+    def test_no_hash(self):
+        """Pre-encode with hash=None succeeds."""
+        data = np.ones(10, dtype=np.float32)
+        raw = data.tobytes()
+        desc = make_descriptor(shape=[10], dtype="float32", byte_order="little")
+        meta = make_global_meta(2)
+
+        msg = bytes(tensogram.encode_pre_encoded(meta, [(desc, raw)], hash=None))
+        _, objects = tensogram.decode(msg)
+        _, decoded = objects[0]
+        np.testing.assert_array_equal(decoded, data)
+        desc_out = objects[0][0]
+        assert desc_out.hash is None
+
+    def test_big_endian_encoding_none(self):
+        """Big-endian encoding=none pre-encoded: decode returns raw bytes as-is.
+
+        When ``encoding=none`` is used with ``byte_order=big``, the library
+        stores the payload bytes verbatim.  The Python decoder currently
+        returns bytes in native (little-endian) interpretation, so the
+        caller is responsible for byte-swapping.  This test verifies the
+        bytes survive the round-trip (content preserved), even though the
+        numpy dtype interpretation needs manual swapping.
+        """
+        data = np.arange(10, dtype=np.float32)
+        # Big-endian bytes: swap byte order
+        raw_be = data.byteswap().tobytes()
+
+        desc = make_descriptor(
+            shape=[10],
+            dtype="float32",
+            byte_order="big",
+        )
+        meta = make_global_meta(2)
+        msg = bytes(tensogram.encode_pre_encoded(meta, [(desc, raw_be)]))
+
+        _, objects = tensogram.decode(msg)
+        _, decoded = objects[0]
+
+        # The raw bytes survive — manually swap to verify content
+        swapped = decoded.byteswap()
+        np.testing.assert_array_equal(swapped, data)
+
+    def test_metadata_preserved(self):
+        """Extra metadata keys survive encode_pre_encoded round-trip."""
+        data = np.ones(5, dtype=np.float32)
+        raw = data.tobytes()
+        desc = make_descriptor(shape=[5], dtype="float32", byte_order="little")
+        meta = make_global_meta(2, experiment="test-01", step=42)
+
+        msg = bytes(tensogram.encode_pre_encoded(meta, [(desc, raw)]))
+        decoded_meta, _ = tensogram.decode(msg)
+        assert decoded_meta["experiment"] == "test-01"
+        assert decoded_meta["step"] == 42
+
+    def test_descriptor_params_preserved(self):
+        """Custom params in the descriptor survive round-trip."""
+        data = np.ones(5, dtype=np.float32)
+        raw = data.tobytes()
+        desc = make_descriptor(
+            shape=[5],
+            dtype="float32",
+            byte_order="little",
+            my_custom_key="hello",
+        )
+        meta = make_global_meta(2)
+
+        msg = bytes(tensogram.encode_pre_encoded(meta, [(desc, raw)]))
+        _, objects = tensogram.decode(msg)
+        desc_out = objects[0][0]
+        assert desc_out.params["my_custom_key"] == "hello"


### PR DESCRIPTION
Adds the `encode_pre_encoded()` API and `StreamingEncoder::write_object_pre_encoded()` method that accept caller-supplied already-encoded/compressed payload bytes, bypassing the encoding/compression pipeline while reusing all CBOR framing, hash computation, and provenance emission.

### Use case

GPU pipelines, HPC frameworks, and any system that produces encoded data outside the library can now wrap their payloads into Tensogram messages without re-encoding.

### Surface area

- **Rust**: `tensogram_core::encode_pre_encoded()` + `StreamingEncoder::write_object_pre_encoded()`
- **Python**: `tensogram.encode_pre_encoded()` + `tensogram.StreamingEncoder.write_object_pre_encoded()`
- **C FFI**: `tgm_encode_pre_encoded()` + `tgm_streaming_encoder_write_pre_encoded()`
- **C++**: `tensogram::encode_pre_encoded()` + `streaming_encoder::write_object_pre_encoded()`

### Validation

- Reuses `validate_object()` for descriptor self-consistency (size check gated on `encoding == "none"`)
- Adds `validate_szip_block_offsets()` enforcing bit-offset monotonicity, first==0, bounds checks
- Adds `validate_no_szip_offsets_for_non_szip()` to reject misuse
- Library always overwrites `descriptor.hash` (caller hash silently replaced)

### Test coverage

- **Rust**: 34 integration tests across all encoding/compression combos, self-consistency rejection paths, `decode_range` with caller-provided block offsets, mixed streaming flows
- **Python**: 37 tests covering type coercion (bytes/bytearray/memoryview), bad descriptors, encoding mismatches, streaming, error paths
- **C++**: 15 GoogleTest cases covering `encoding=none`, simple_packing, multi-object, hash recomputation, streaming pre-encoded
- **Cross-language SHA-256 golden test**: deterministic `float64[1024]` encoded via all 3 bindings, decoded SHA-256 must match across Rust/Python/C++

### Performance

Criterion benchmark on 16M float64 with simple_packing 24-bit + szip:

- `encode()` full pipeline: ~75.5 ms (1.65 GiB/s)
- `encode_pre_encoded()` framing-only: ~11.1 ms (11.27 GiB/s)
- **~6.8x speedup** when caller already has encoded bytes

### Documentation

- New mdbook page: `docs/src/guide/encode-pre-encoded.md`
- Cross-references added to cbor-metadata, compression, pipeline, decoding guides
- Bit-vs-byte WARNING for `szip_block_offsets`
- Byte-order section: decode returns bytes verbatim for `encoding="none"`, callers byteswap as needed
- Streaming usage, error reference, and stride handling sections

### Examples

Example 11 added in all 3 languages (`examples/{rust,python,cpp}/11_encode_pre_encoded`) demonstrating manual simple_packing quantisation, bit-packing, and the pre-encoded round-trip.

### Review history

This PR went through three review passes including external reviewer feedback. All issues resolved:

- **First pass**: T1-T20 implementation across Rust core, Python, FFI, C++, tests, docs, examples, benchmark
- **Second pass**: szip validation parity in streaming, Python `extract_pre_encoded_pairs`, doc accuracy fixes
- **Third pass (reviewer)**: `PyAny` acceptance for streaming, portable LE serialization in cross-language helpers, Linux `LD_LIBRARY_PATH`, byte-order doc clarification
