### PR TITLE
Feature/improve benchmarks

### DIFF
--- a/benchmarks/src/bin/codec_matrix.rs
+++ b/benchmarks/src/bin/codec_matrix.rs
@@ -1,24 +1,23 @@
 use clap::Parser;
 
-/// Benchmark all encoder × compressor × bit-width combinations.
-///
-/// Runs the full tensogram encoding pipeline for every valid combination,
-/// measuring encode/decode throughput and compressed size against the
-/// `none+none` baseline.
 #[derive(Parser, Debug)]
 #[command(
     name = "codec-matrix",
-    about = "Benchmark all encoder × compressor × bit-width combinations"
+    about = "Benchmark all encoder \u{d7} compressor \u{d7} bit-width combinations"
 )]
 struct Args {
     /// Number of float64 values to encode per benchmark run.
-    /// Always rounded up to the next multiple of 4 (at most 3 extra values) for szip alignment.
+    /// Rounded up to the next multiple of 4 for szip alignment.
     #[arg(long, default_value = "16000000")]
     num_points: usize,
 
-    /// Number of timed iterations (median is reported).
-    #[arg(long, default_value = "5")]
+    /// Number of timed iterations (median reported).
+    #[arg(long, default_value = "10")]
     iterations: usize,
+
+    /// Number of warm-up iterations (discarded).
+    #[arg(long, default_value = "3")]
+    warmup: usize,
 
     /// Random seed for deterministic data generation.
     #[arg(long, default_value = "42")]
@@ -27,8 +26,17 @@ struct Args {
 
 fn main() {
     let args = Args::parse();
-    match tensogram_benchmarks::run_codec_matrix(args.num_points, args.iterations, args.seed) {
-        Ok(()) => {}
+    match tensogram_benchmarks::run_codec_matrix(
+        args.num_points,
+        args.iterations,
+        args.warmup,
+        args.seed,
+    ) {
+        Ok(run) => {
+            if !run.all_passed() {
+                std::process::exit(1);
+            }
+        }
         Err(e) => {
             eprintln!("Error: {e}");
             std::process::exit(1);

--- a/benchmarks/src/bin/grib_comparison.rs
+++ b/benchmarks/src/bin/grib_comparison.rs
@@ -1,10 +1,5 @@
 use clap::Parser;
 
-/// Compare ecCodes CCSDS packing against Tensogram simple_packing+szip.
-///
-/// Benchmarks encoding and decoding of 10M float64 values (packed to 24 bit)
-/// using ecCodes `grid_ccsds` as the reference and tensogram as the candidate.
-/// Requires the `eccodes` feature and the ecCodes C library to be installed.
 #[derive(Parser, Debug)]
 #[command(
     name = "grib-comparison",
@@ -15,9 +10,13 @@ struct Args {
     #[arg(long, default_value = "10000000")]
     num_points: usize,
 
-    /// Number of timed iterations (median is reported).
-    #[arg(long, default_value = "5")]
+    /// Number of timed iterations (median reported).
+    #[arg(long, default_value = "10")]
     iterations: usize,
+
+    /// Number of warm-up iterations (discarded).
+    #[arg(long, default_value = "3")]
+    warmup: usize,
 
     /// Random seed for deterministic data generation.
     #[arg(long, default_value = "42")]
@@ -26,8 +25,17 @@ struct Args {
 
 fn main() {
     let args = Args::parse();
-    match tensogram_benchmarks::run_grib_comparison(args.num_points, args.iterations, args.seed) {
-        Ok(()) => {}
+    match tensogram_benchmarks::run_grib_comparison(
+        args.num_points,
+        args.iterations,
+        args.warmup,
+        args.seed,
+    ) {
+        Ok(run) => {
+            if !run.all_passed() {
+                std::process::exit(1);
+            }
+        }
         Err(e) => {
             eprintln!("Error: {e}");
             std::process::exit(1);

--- a/benchmarks/src/codec_matrix.rs
+++ b/benchmarks/src/codec_matrix.rs
@@ -1,43 +1,35 @@
-//! Codec matrix benchmark — all encoder × compressor × bit-width combinations.
-//!
-//! Generates a synthetic weather field, runs every valid pipeline combination,
-//! and reports encode time, decode time, compressed size, and compression ratio
-//! against the `none+none` baseline.
-
 use std::time::Instant;
 
-use tensogram_encodings::pipeline::{decode_pipeline, encode_pipeline};
+use tensogram_encodings::pipeline::{decode_pipeline, encode_pipeline, encode_pipeline_f64};
 use tensogram_encodings::simple_packing::compute_params;
 use tensogram_encodings::{
     Blosc2Codec, ByteOrder, CompressionType, EncodingType, FilterType, PipelineConfig,
     Sz3ErrorBound, ZfpMode,
 };
 
+use crate::constants::AEC_DATA_PREPROCESS;
 use crate::datagen::generate_weather_field;
-use crate::report::{median_ns, ns_to_ms, BenchmarkResult};
-use crate::BenchmarkError;
+use crate::report::{compute_fidelity, compute_timing_stats, BenchmarkResult};
+use crate::{BenchmarkError, BenchmarkRun, CaseFailure};
 
-// AEC_DATA_PREPROCESS flag value (defined in libaec-sys as 1).
-// Using the raw constant avoids adding libaec-sys as a direct dependency.
-const AEC_DATA_PREPROCESS: u32 = 1;
+// ── Case descriptor ──────────────────────────────────────────────────────────
 
-// ── Case descriptor ───────────────────────────────────────────────────────────
-
-/// A single benchmark case: a pipeline configuration and a display name.
 struct Case {
     name: String,
     config: PipelineConfig,
+    /// For SimplePacking: bit width for re-deriving params each iteration.
+    sp_bits: Option<u32>,
+    is_lossy: bool,
 }
 
-// ── Config helpers ────────────────────────────────────────────────────────────
+// ── Config helpers ───────────────────────────────────────────────────────────
 
-/// Construct a benchmark case with the shared pipeline defaults
-/// (no filter, little-endian, f64).
 fn make_case(
     name: impl Into<String>,
     encoding: EncodingType,
     compression: CompressionType,
     num_values: usize,
+    is_lossy: bool,
 ) -> Case {
     Case {
         name: name.into(),
@@ -49,10 +41,11 @@ fn make_case(
             byte_order: ByteOrder::Little,
             dtype_byte_width: 8,
         },
+        sp_bits: None,
+        is_lossy,
     }
 }
 
-/// Construct a simple-packing case: compute packing params, then build the case.
 fn sp_case(
     bits: u32,
     compressor_name: &str,
@@ -61,43 +54,46 @@ fn sp_case(
     values: &[f64],
 ) -> Result<Case, BenchmarkError> {
     let params = compute_params(values, bits, 0)
-        .map_err(|e| BenchmarkError(format!("sp({bits}) params: {e}")))?;
-    Ok(make_case(
+        .map_err(|e| BenchmarkError::Pipeline(format!("sp({bits}) params: {e}")))?;
+    let mut case = make_case(
         format!("sp({bits})+{compressor_name}"),
         EncodingType::SimplePacking(params),
         compression,
         num_values,
-    ))
+        true,
+    );
+    case.sp_bits = Some(bits);
+    Ok(case)
 }
 
-// ── Case builder ──────────────────────────────────────────────────────────────
+// ── Case builder ─────────────────────────────────────────────────────────────
 
-/// Build all benchmark cases in display order.
-///
-/// The `none+none` case is always first — it serves as the reference.
 fn build_cases(n: usize, values: &[f64]) -> Result<Vec<Case>, BenchmarkError> {
     let mut c = Vec::with_capacity(24);
 
-    // ── Baseline ──────────────────────────────────────────────────────────────
+    // ── Baseline ─────────────────────────────────────────────────────────────
     c.push(make_case(
         "none+none",
         EncodingType::None,
         CompressionType::None,
         n,
+        false,
     ));
 
-    // ── Raw f64 + lossless compressors (no encoding) ──────────────────────────
+    // ── Raw f64 + lossless compressors ───────────────────────────────────────
     c.push(make_case(
         "none+zstd(3)",
         EncodingType::None,
         CompressionType::Zstd { level: 3 },
         n,
+        false,
     ));
     c.push(make_case(
         "none+lz4",
         EncodingType::None,
         CompressionType::Lz4,
         n,
+        false,
     ));
     c.push(make_case(
         "none+blosc2(blosclz)",
@@ -108,8 +104,8 @@ fn build_cases(n: usize, values: &[f64]) -> Result<Vec<Case>, BenchmarkError> {
             typesize: 8,
         },
         n,
+        false,
     ));
-    // libaec supports up to 32-bit samples; treat raw f64 bytes as two 32-bit samples each.
     c.push(make_case(
         "none+szip(32)",
         EncodingType::None,
@@ -120,9 +116,10 @@ fn build_cases(n: usize, values: &[f64]) -> Result<Vec<Case>, BenchmarkError> {
             bits_per_sample: 32,
         },
         n,
+        false,
     ));
 
-    // ── simple_packing at 16/24/32 bits + each lossless compressor ────────────
+    // ── simple_packing at 16/24/32 bits + each lossless compressor ───────────
     for bits in [16u32, 24, 32] {
         c.push(sp_case(bits, "none", CompressionType::None, n, values)?);
         c.push(sp_case(
@@ -161,7 +158,7 @@ fn build_cases(n: usize, values: &[f64]) -> Result<Vec<Case>, BenchmarkError> {
         )?);
     }
 
-    // ── Lossy floating-point compressors ──────────────────────────────────────
+    // ── Lossy floating-point compressors ─────────────────────────────────────
     for rate in [16.0f64, 24.0, 32.0] {
         c.push(make_case(
             format!("none+zfp(rate={rate})"),
@@ -170,6 +167,7 @@ fn build_cases(n: usize, values: &[f64]) -> Result<Vec<Case>, BenchmarkError> {
                 mode: ZfpMode::FixedRate { rate },
             },
             n,
+            true,
         ));
     }
     c.push(make_case(
@@ -179,117 +177,182 @@ fn build_cases(n: usize, values: &[f64]) -> Result<Vec<Case>, BenchmarkError> {
             error_bound: Sz3ErrorBound::Absolute(0.01),
         },
         n,
+        true,
     ));
 
     Ok(c)
 }
 
-// ── Timing ────────────────────────────────────────────────────────────────────
+// ── Timing ───────────────────────────────────────────────────────────────────
 
-/// Run one benchmark case: warm up, then time `iterations` encode+decode cycles.
-///
-/// Returns a `BenchmarkResult` with median encode/decode times.
 fn run_case(
     case: &Case,
     data_bytes: &[u8],
+    values: &[f64],
     original_bytes: usize,
     iterations: usize,
+    warmup: usize,
 ) -> Result<BenchmarkResult, BenchmarkError> {
-    let map_err = |e: tensogram_encodings::pipeline::PipelineError| -> BenchmarkError {
-        BenchmarkError(e.to_string())
+    // For SP cases, compute_params is included in the encode timing.
+    let build_config = |recompute_params: bool| -> Result<PipelineConfig, BenchmarkError> {
+        if let Some(bits) = case.sp_bits {
+            if recompute_params {
+                let params = compute_params(values, bits, 0)
+                    .map_err(|e| BenchmarkError::Pipeline(format!("sp({bits}) params: {e}")))?;
+                Ok(PipelineConfig {
+                    encoding: EncodingType::SimplePacking(params),
+                    filter: case.config.filter.clone(),
+                    compression: case.config.compression.clone(),
+                    num_values: case.config.num_values,
+                    byte_order: case.config.byte_order,
+                    dtype_byte_width: case.config.dtype_byte_width,
+                })
+            } else {
+                Ok(case.config.clone())
+            }
+        } else {
+            Ok(case.config.clone())
+        }
     };
 
-    // Warm-up iteration (result discarded).
-    let warm = encode_pipeline(data_bytes, &case.config).map_err(map_err)?;
-    drop(decode_pipeline(&warm.encoded_bytes, &case.config).map_err(map_err)?);
+    let use_f64_path = case.sp_bits.is_some();
+
+    for _ in 0..warmup {
+        let config = build_config(true)?;
+        let encoded = if use_f64_path {
+            encode_pipeline_f64(values, &config)?
+        } else {
+            encode_pipeline(data_bytes, &config)?
+        };
+        let _ = decode_pipeline(&encoded.encoded_bytes, &config)?;
+    }
 
     let mut encode_ns = Vec::with_capacity(iterations);
     let mut decode_ns = Vec::with_capacity(iterations);
-    let mut compressed_bytes = warm.encoded_bytes.len();
+    let mut compressed_sizes: Vec<usize> = Vec::with_capacity(iterations);
+    let mut last_decoded: Vec<u8> = Vec::new();
 
     for _ in 0..iterations {
         let t0 = Instant::now();
-        let result = encode_pipeline(data_bytes, &case.config).map_err(map_err)?;
+        let config = build_config(true)?;
+        let result = if use_f64_path {
+            encode_pipeline_f64(values, &config)?
+        } else {
+            encode_pipeline(data_bytes, &config)?
+        };
         encode_ns.push(t0.elapsed().as_nanos() as u64);
 
-        compressed_bytes = result.encoded_bytes.len();
+        compressed_sizes.push(result.encoded_bytes.len());
 
         let t0 = Instant::now();
-        drop(decode_pipeline(&result.encoded_bytes, &case.config).map_err(map_err)?);
+        let decoded = decode_pipeline(&result.encoded_bytes, &config)?;
         decode_ns.push(t0.elapsed().as_nanos() as u64);
+
+        last_decoded = decoded;
     }
+
+    let fidelity = compute_fidelity(data_bytes, &last_decoded, case.is_lossy);
+    if matches!(fidelity, crate::report::Fidelity::Unchecked) {
+        return Err(BenchmarkError::Pipeline(format!(
+            "fidelity could not be computed for '{}' (unexpected decode output length)",
+            case.name
+        )));
+    }
+    if !case.is_lossy && !matches!(fidelity, crate::report::Fidelity::Exact) {
+        return Err(BenchmarkError::Pipeline(format!(
+            "lossless case '{}' did not round-trip exactly: {fidelity:?}",
+            case.name
+        )));
+    }
+
+    let compressed_bytes = compressed_sizes
+        .last()
+        .copied()
+        .expect("iterations validated > 0");
+    let compressed_bytes_varied = compressed_sizes.windows(2).any(|w| w[0] != w[1]);
 
     Ok(BenchmarkResult {
         name: case.name.clone(),
-        encode_ms: ns_to_ms(median_ns(&mut encode_ns)),
-        decode_ms: ns_to_ms(median_ns(&mut decode_ns)),
+        encode: compute_timing_stats(&mut encode_ns),
+        decode: compute_timing_stats(&mut decode_ns),
         compressed_bytes,
         original_bytes,
+        compressed_bytes_varied,
+        fidelity,
     })
 }
 
-// ── Public API ────────────────────────────────────────────────────────────────
+// ── Public API ───────────────────────────────────────────────────────────────
 
-/// Run all codec matrix benchmarks and return results.
-///
-/// Results are ordered with `none+none` first (the reference row).
-/// Called by the binary entry point and by integration tests.
-///
-/// # Note on `num_points` padding
-/// The actual number of values encoded is rounded up to the next multiple of 4
-/// (by at most 3 values) for szip alignment. The reported sizes and the
-/// `original_bytes` field in each result reflect this padded count.
-pub fn run_codec_matrix_results(
+pub fn run_codec_matrix(
     num_points: usize,
     iterations: usize,
+    warmup: usize,
     seed: u64,
-) -> Result<Vec<BenchmarkResult>, BenchmarkError> {
+) -> Result<BenchmarkRun, BenchmarkError> {
     if num_points == 0 {
-        return Err(BenchmarkError("num_points must be > 0".to_string()));
+        return Err(BenchmarkError::Validation(
+            "num_points must be > 0".to_string(),
+        ));
     }
     if iterations == 0 {
-        return Err(BenchmarkError("iterations must be > 0".to_string()));
+        return Err(BenchmarkError::Validation(
+            "iterations must be > 0".to_string(),
+        ));
+    }
+    if warmup == 0 {
+        return Err(BenchmarkError::Validation("warmup must be > 0".to_string()));
     }
 
-    // Round up to the next multiple of 4 so szip cases work at any bit width.
-    // libaec promotes 24-bit samples to 4-byte containers, requiring the packed
-    // byte count to be a multiple of 4.  Padding by at most 3 values has no
-    // measurable impact on benchmark accuracy at production sizes.
+    // Round up to next multiple of 4 for szip alignment (at most 3 extra values).
     let num_points = num_points.next_multiple_of(4);
 
     eprintln!("Generating {num_points} weather-like float64 values (seed={seed})...");
     let values = generate_weather_field(num_points, seed);
-    // Little-endian bytes (native on x86/ARM64 — matches ZFP/SZ3 expectations).
     let data_bytes: Vec<u8> = values.iter().flat_map(|v| v.to_le_bytes()).collect();
     let original_bytes = data_bytes.len();
 
     let cases = build_cases(num_points, &values)?;
+    let total_cases = cases.len();
     eprintln!(
-        "Running {} cases ({iterations} iterations each)...",
-        cases.len()
+        "Running {total_cases} cases ({warmup} warmup + {iterations} timed iterations each)..."
     );
 
-    let mut results = Vec::with_capacity(cases.len());
+    let mut results = Vec::with_capacity(total_cases);
+    let mut failures = Vec::new();
+
     for (i, case) in cases.iter().enumerate() {
-        eprint!("  [{:2}/{}] {:<35}", i + 1, cases.len(), &case.name);
-        match run_case(case, &data_bytes, original_bytes, iterations) {
+        eprint!("  [{:2}/{}] {:<35}", i + 1, total_cases, &case.name);
+        match run_case(
+            case,
+            &data_bytes,
+            &values,
+            original_bytes,
+            iterations,
+            warmup,
+        ) {
             Ok(r) => {
-                eprintln!(" done ({:.1} ms encode)", r.encode_ms);
+                eprintln!(
+                    " {:.1} ms enc, {:.1} ms dec, {:.1}%",
+                    r.encode.median_ms,
+                    r.decode.median_ms,
+                    r.ratio_pct()
+                );
                 results.push(r);
             }
             Err(e) => {
-                // Report failures without aborting the entire benchmark.
                 eprintln!(" FAILED: {e}");
-                results.push(BenchmarkResult {
-                    name: format!("{} [ERROR]", case.name),
-                    encode_ms: 0.0,
-                    decode_ms: 0.0,
-                    compressed_bytes: 0,
-                    original_bytes,
+                failures.push(CaseFailure {
+                    name: case.name.clone(),
+                    error: e.to_string(),
                 });
             }
         }
     }
 
-    Ok(results)
+    Ok(BenchmarkRun {
+        results,
+        failures,
+        total_cases,
+    })
 }

--- a/benchmarks/src/constants.rs
+++ b/benchmarks/src/constants.rs
@@ -1,0 +1,3 @@
+/// libaec's AEC_DATA_PREPROCESS flag (value 8). Defined here to avoid
+/// pulling in libaec-sys as a direct dependency.
+pub const AEC_DATA_PREPROCESS: u32 = 8;

--- a/benchmarks/src/grib_comparison.rs
+++ b/benchmarks/src/grib_comparison.rs
@@ -1,40 +1,17 @@
-//! GRIB vs Tensogram comparison benchmark.
-//!
-//! Compares ecCodes CCSDS (GRIB grid_ccsds) packing against Tensogram
-//! `simple_packing(24)+szip` on 10M float64 values (24-bit precision).
-//!
-//! ecCodes is the reference. Requires the ecCodes C library installed and the
-//! `eccodes` Cargo feature enabled.
-//!
-//! # Timing model
-//! - **GRIB encode**: time spent in `codes_set_double_array("values", ...)`,
-//!   which performs the actual quantisation and compression.
-//! - **GRIB decode**: time to create a GRIB handle from raw bytes plus
-//!   `codes_get_double_array("values", ...)`, mirroring tensogram's
-//!   full decode path.
-//! - **Tensogram encode**: `encode_pipeline(bytes, config)`.
-//! - **Tensogram decode**: `decode_pipeline(encoded, config)`.
-
 use std::ffi::CString;
 use std::os::raw::{c_int, c_long, c_void};
 use std::time::Instant;
 
-use tensogram_encodings::pipeline::{decode_pipeline, encode_pipeline};
+use tensogram_encodings::pipeline::{decode_pipeline, encode_pipeline_f64};
 use tensogram_encodings::simple_packing::compute_params;
 use tensogram_encodings::{ByteOrder, CompressionType, EncodingType, FilterType, PipelineConfig};
 
+use crate::constants::AEC_DATA_PREPROCESS;
 use crate::datagen::generate_weather_field;
-use crate::report::{median_ns, ns_to_ms, BenchmarkResult};
-use crate::BenchmarkError;
+use crate::report::{compute_fidelity, compute_timing_stats, BenchmarkResult};
+use crate::{BenchmarkError, BenchmarkRun, CaseFailure};
 
-// AEC_DATA_PREPROCESS constant (value = 1 in libaec).
-const AEC_DATA_PREPROCESS: u32 = 1;
-
-// ── ecCodes C API (raw) ───────────────────────────────────────────────────────
-//
-// We declare just the subset needed for this benchmark. Linking to
-// `libeccodes` is provided by the benchmark crate's build configuration
-// (for example, `build.rs`), not by direct use of the `eccodes` crate here.
+// ── ecCodes C API (raw) ──────────────────────────────────────────────────────
 
 extern "C" {
     fn codes_grib_handle_new_from_samples(ctx: *mut c_void, name: *const i8) -> *mut c_void;
@@ -70,9 +47,8 @@ extern "C" {
     ) -> c_int;
 }
 
-// ── RAII handle wrapper ───────────────────────────────────────────────────────
+// ── RAII handle wrapper ──────────────────────────────────────────────────────
 
-/// RAII wrapper around `codes_handle*`.
 struct GribHandle(*mut c_void);
 
 impl Drop for GribHandle {
@@ -84,14 +60,13 @@ impl Drop for GribHandle {
 }
 
 impl GribHandle {
-    /// Create a handle from an ecCodes sample template by name.
     fn from_samples(name: &str) -> Result<Self, BenchmarkError> {
         let name_c = CString::new(name)
-            .map_err(|e| BenchmarkError(format!("invalid sample name '{name}': {e}")))?;
+            .map_err(|e| BenchmarkError::Pipeline(format!("invalid sample name '{name}': {e}")))?;
         let h =
             unsafe { codes_grib_handle_new_from_samples(std::ptr::null_mut(), name_c.as_ptr()) };
         if h.is_null() {
-            Err(BenchmarkError(format!(
+            Err(BenchmarkError::Pipeline(format!(
                 "codes_grib_handle_new_from_samples({name}) returned null; \
                  check ECCODES_SAMPLES_PATH or ecCodes installation"
             )))
@@ -100,7 +75,6 @@ impl GribHandle {
         }
     }
 
-    /// Create a handle by copying raw GRIB message bytes.
     fn from_message_copy(msg: &[u8]) -> Result<Self, BenchmarkError> {
         let h = unsafe {
             codes_handle_new_from_message_copy(
@@ -110,7 +84,7 @@ impl GribHandle {
             )
         };
         if h.is_null() {
-            Err(BenchmarkError(
+            Err(BenchmarkError::Pipeline(
                 "codes_handle_new_from_message_copy returned null".to_string(),
             ))
         } else {
@@ -119,11 +93,11 @@ impl GribHandle {
     }
 
     fn set_long(&self, key: &str, val: i64) -> Result<(), BenchmarkError> {
-        let key_c =
-            CString::new(key).map_err(|e| BenchmarkError(format!("invalid key '{key}': {e}")))?;
+        let key_c = CString::new(key)
+            .map_err(|e| BenchmarkError::Pipeline(format!("invalid key '{key}': {e}")))?;
         let rc = unsafe { codes_set_long(self.0, key_c.as_ptr(), val as c_long) };
         if rc != 0 {
-            Err(BenchmarkError(format!(
+            Err(BenchmarkError::Pipeline(format!(
                 "codes_set_long({key}, {val}) returned {rc}"
             )))
         } else {
@@ -132,14 +106,15 @@ impl GribHandle {
     }
 
     fn set_string(&self, key: &str, val: &str) -> Result<(), BenchmarkError> {
-        let key_c =
-            CString::new(key).map_err(|e| BenchmarkError(format!("invalid key '{key}': {e}")))?;
-        let val_c = CString::new(val)
-            .map_err(|e| BenchmarkError(format!("invalid value '{val}' for key '{key}': {e}")))?;
+        let key_c = CString::new(key)
+            .map_err(|e| BenchmarkError::Pipeline(format!("invalid key '{key}': {e}")))?;
+        let val_c = CString::new(val).map_err(|e| {
+            BenchmarkError::Pipeline(format!("invalid value '{val}' for key '{key}': {e}"))
+        })?;
         let mut len = val.len() + 1;
         let rc = unsafe { codes_set_string(self.0, key_c.as_ptr(), val_c.as_ptr(), &mut len) };
         if rc != 0 {
-            Err(BenchmarkError(format!(
+            Err(BenchmarkError::Pipeline(format!(
                 "codes_set_string({key}, {val}) returned {rc}"
             )))
         } else {
@@ -147,16 +122,13 @@ impl GribHandle {
         }
     }
 
-    /// Encode (pack) `vals` into this GRIB message.  This is the timed operation.
     fn set_values(&self, vals: &[f64]) -> Result<(), BenchmarkError> {
-        // "values" is a static ASCII string — CString::new cannot fail here,
-        // but we propagate the error for consistency.
         let key_c = CString::new("values")
-            .map_err(|e| BenchmarkError(format!("invalid key 'values': {e}")))?;
+            .map_err(|e| BenchmarkError::Pipeline(format!("invalid key 'values': {e}")))?;
         let rc =
             unsafe { codes_set_double_array(self.0, key_c.as_ptr(), vals.as_ptr(), vals.len()) };
         if rc != 0 {
-            Err(BenchmarkError(format!(
+            Err(BenchmarkError::Pipeline(format!(
                 "codes_set_double_array(values, len={}) returned {rc}",
                 vals.len()
             )))
@@ -165,16 +137,15 @@ impl GribHandle {
         }
     }
 
-    /// Decode (unpack) values from this GRIB message.  This is the timed operation.
     fn get_values(&self, n: usize) -> Result<Vec<f64>, BenchmarkError> {
         let key_c = CString::new("values")
-            .map_err(|e| BenchmarkError(format!("invalid key 'values': {e}")))?;
+            .map_err(|e| BenchmarkError::Pipeline(format!("invalid key 'values': {e}")))?;
         let mut buf = vec![0.0f64; n];
         let mut len = n;
         let rc =
             unsafe { codes_get_double_array(self.0, key_c.as_ptr(), buf.as_mut_ptr(), &mut len) };
         if rc != 0 {
-            Err(BenchmarkError(format!(
+            Err(BenchmarkError::Pipeline(format!(
                 "codes_get_double_array(values) returned {rc}"
             )))
         } else {
@@ -183,25 +154,22 @@ impl GribHandle {
         }
     }
 
-    /// Copy the raw GRIB message bytes into an owned buffer.
     fn message_bytes(&self) -> Result<Vec<u8>, BenchmarkError> {
         let mut ptr: *const c_void = std::ptr::null();
         let mut size: usize = 0;
         let rc = unsafe { codes_get_message(self.0, &mut ptr, &mut size) };
         if rc != 0 || ptr.is_null() {
-            return Err(BenchmarkError(format!("codes_get_message returned {rc}")));
+            return Err(BenchmarkError::Pipeline(format!(
+                "codes_get_message returned {rc}"
+            )));
         }
-        // The pointer is valid for the lifetime of the handle; copy to owned bytes.
         let bytes = unsafe { std::slice::from_raw_parts(ptr as *const u8, size) };
         Ok(bytes.to_vec())
     }
 }
 
-// ── Grid utilities ────────────────────────────────────────────────────────────
+// ── Grid utilities ───────────────────────────────────────────────────────────
 
-/// Find (ni, nj) such that ni × nj == n (exact), preferring nearly-square grids.
-///
-/// Returns (1, n) as a fallback for prime n.
 fn factorize(n: usize) -> (usize, usize) {
     let root = (n as f64).sqrt() as usize;
     for i in (1..=root).rev() {
@@ -213,10 +181,6 @@ fn factorize(n: usize) -> (usize, usize) {
     (1, n)
 }
 
-/// Configure a GRIB2 handle for N data points on a regular lat-lon grid.
-///
-/// Sets packingType and bitsPerValue before returning — caller should then
-/// call `set_values()` to pack the actual data.
 fn setup_grib_handle(
     n: usize,
     packing_type: &str,
@@ -226,9 +190,7 @@ fn setup_grib_handle(
 
     let (ni, nj) = factorize(n);
 
-    // Configure a regular lat-lon grid covering ±80° lat, 0-360° lon.
-    // Exact bounds matter less than correctness for packing benchmarks.
-    let i_inc = 360_000_000i64 / ni as i64; // microdegrees
+    let i_inc = 360_000_000i64 / ni as i64;
     let j_inc = 160_000_000i64 / nj as i64;
 
     h.set_string("gridType", "regular_ll")?;
@@ -245,169 +207,213 @@ fn setup_grib_handle(
     h.set_long("jDirectionIncrement", j_inc)?;
 
     h.set_long("bitsPerValue", bits_per_value)?;
-    // Set packingType last — some packing types require grid to be set first.
     h.set_string("packingType", packing_type)?;
 
     Ok(h)
 }
 
-// ── GRIB timing ───────────────────────────────────────────────────────────────
+// ── GRIB timing (end-to-end: setup + pack/unpack + serialize) ────────────────
 
-/// Time GRIB encode+decode for a given packing type.
-///
-/// Warm-up run discarded; then `iterations` timed runs.
 fn time_grib(
     values: &[f64],
     packing_type: &str,
     bits_per_value: i64,
     iterations: usize,
+    warmup: usize,
     original_bytes: usize,
 ) -> Result<BenchmarkResult, BenchmarkError> {
     let n = values.len();
 
-    // ── Warm-up ──────────────────────────────────────────────────────────────
-    let warm_h = setup_grib_handle(n, packing_type, bits_per_value)?;
-    warm_h.set_values(values)?;
-    let warm_bytes = warm_h.message_bytes()?;
-    let warm_dec = GribHandle::from_message_copy(&warm_bytes)?;
-    warm_dec.get_values(n)?;
-    let compressed_bytes = warm_bytes.len();
+    for _ in 0..warmup {
+        let h = setup_grib_handle(n, packing_type, bits_per_value)?;
+        h.set_values(values)?;
+        let msg = h.message_bytes()?;
+        let dec_h = GribHandle::from_message_copy(&msg)?;
+        let _ = dec_h.get_values(n)?;
+    }
 
-    // ── Timed iterations ─────────────────────────────────────────────────────
+    // End-to-end encode: handle setup + set_values + message_bytes.
+    // End-to-end decode: from_message_copy + get_values.
     let mut encode_ns = Vec::with_capacity(iterations);
     let mut decode_ns = Vec::with_capacity(iterations);
+    let mut compressed_sizes: Vec<usize> = Vec::with_capacity(iterations);
+    let mut last_decoded_vals: Vec<f64> = Vec::new();
 
     for _ in 0..iterations {
-        // Encode: create handle + pack values (set_values is the bottleneck).
-        let h = setup_grib_handle(n, packing_type, bits_per_value)?;
         let t0 = Instant::now();
+        let h = setup_grib_handle(n, packing_type, bits_per_value)?;
         h.set_values(values)?;
+        let msg = h.message_bytes()?;
         encode_ns.push(t0.elapsed().as_nanos() as u64);
 
-        let msg = h.message_bytes()?;
+        compressed_sizes.push(msg.len());
 
-        // Decode: parse handle from bytes + unpack values.
         let t0 = Instant::now();
         let dec_h = GribHandle::from_message_copy(&msg)?;
-        dec_h.get_values(n)?;
+        last_decoded_vals = dec_h.get_values(n)?;
         decode_ns.push(t0.elapsed().as_nanos() as u64);
     }
 
+    let orig_bytes: Vec<u8> = values.iter().flat_map(|v| v.to_le_bytes()).collect();
+    let dec_bytes: Vec<u8> = last_decoded_vals
+        .iter()
+        .flat_map(|v| v.to_le_bytes())
+        .collect();
+    let fidelity = compute_fidelity(&orig_bytes, &dec_bytes, true);
+    if matches!(fidelity, crate::report::Fidelity::Unchecked) {
+        return Err(BenchmarkError::Pipeline(
+            "fidelity could not be computed (unexpected decode output length)".to_string(),
+        ));
+    }
+
+    let compressed_bytes = compressed_sizes
+        .last()
+        .copied()
+        .expect("iterations validated > 0");
+    let compressed_bytes_varied = compressed_sizes.windows(2).any(|w| w[0] != w[1]);
+
     Ok(BenchmarkResult {
-        name: String::new(), // caller fills this in
-        encode_ms: ns_to_ms(median_ns(&mut encode_ns)),
-        decode_ms: ns_to_ms(median_ns(&mut decode_ns)),
+        name: String::new(),
+        encode: compute_timing_stats(&mut encode_ns),
+        decode: compute_timing_stats(&mut decode_ns),
         compressed_bytes,
         original_bytes,
+        compressed_bytes_varied,
+        fidelity,
     })
 }
 
-// ── Tensogram timing ──────────────────────────────────────────────────────────
+// ── Tensogram timing (end-to-end: compute_params + encode/decode pipeline) ───
 
 fn time_tensogram_sp_szip(
     values: &[f64],
     bits: u32,
     iterations: usize,
+    warmup: usize,
     original_bytes: usize,
 ) -> Result<BenchmarkResult, BenchmarkError> {
-    let num_points = values.len();
     let data_bytes: Vec<u8> = values.iter().flat_map(|v| v.to_le_bytes()).collect();
+    let num_points = values.len();
 
-    let params = compute_params(values, bits, 0)
-        .map_err(|e| BenchmarkError(format!("compute_params({bits}): {e}")))?;
-
-    let config = PipelineConfig {
-        encoding: EncodingType::SimplePacking(params),
-        filter: FilterType::None,
-        compression: CompressionType::Szip {
-            rsi: 128,
-            block_size: 16,
-            flags: AEC_DATA_PREPROCESS,
-            bits_per_sample: bits,
-        },
-        num_values: num_points,
-        byte_order: ByteOrder::Little,
-        dtype_byte_width: 8,
+    let build_config = |vals: &[f64]| -> Result<PipelineConfig, BenchmarkError> {
+        let params = compute_params(vals, bits, 0)
+            .map_err(|e| BenchmarkError::Pipeline(format!("compute_params({bits}): {e}")))?;
+        Ok(PipelineConfig {
+            encoding: EncodingType::SimplePacking(params),
+            filter: FilterType::None,
+            compression: CompressionType::Szip {
+                rsi: 128,
+                block_size: 16,
+                flags: AEC_DATA_PREPROCESS,
+                bits_per_sample: bits,
+            },
+            num_values: num_points,
+            byte_order: ByteOrder::Little,
+            dtype_byte_width: 8,
+        })
     };
 
-    let map_err = |e: tensogram_encodings::pipeline::PipelineError| -> BenchmarkError {
-        BenchmarkError(e.to_string())
-    };
-
-    // Warm-up
-    let warm = encode_pipeline(&data_bytes, &config).map_err(map_err)?;
-    decode_pipeline(&warm.encoded_bytes, &config).map_err(map_err)?;
+    for _ in 0..warmup {
+        let config = build_config(values)?;
+        let encoded = encode_pipeline_f64(values, &config)?;
+        let _ = decode_pipeline(&encoded.encoded_bytes, &config)?;
+    }
 
     let mut encode_ns = Vec::with_capacity(iterations);
     let mut decode_ns = Vec::with_capacity(iterations);
-    let compressed_bytes = warm.encoded_bytes.len();
+    let mut compressed_sizes: Vec<usize> = Vec::with_capacity(iterations);
+    let mut last_decoded: Vec<u8> = Vec::new();
 
     for _ in 0..iterations {
         let t0 = Instant::now();
-        let result = encode_pipeline(&data_bytes, &config).map_err(map_err)?;
+        let config = build_config(values)?;
+        let result = encode_pipeline_f64(values, &config)?;
         encode_ns.push(t0.elapsed().as_nanos() as u64);
 
+        compressed_sizes.push(result.encoded_bytes.len());
+
         let t0 = Instant::now();
-        decode_pipeline(&result.encoded_bytes, &config).map_err(map_err)?;
+        let decoded = decode_pipeline(&result.encoded_bytes, &config)?;
         decode_ns.push(t0.elapsed().as_nanos() as u64);
+
+        last_decoded = decoded;
     }
 
+    let fidelity = compute_fidelity(&data_bytes, &last_decoded, true);
+    if matches!(fidelity, crate::report::Fidelity::Unchecked) {
+        return Err(BenchmarkError::Pipeline(
+            "fidelity could not be computed (unexpected decode output length)".to_string(),
+        ));
+    }
+
+    let compressed_bytes = compressed_sizes
+        .last()
+        .copied()
+        .expect("iterations validated > 0");
+    let compressed_bytes_varied = compressed_sizes.windows(2).any(|w| w[0] != w[1]);
+
     Ok(BenchmarkResult {
-        name: String::new(), // caller fills this in
-        encode_ms: ns_to_ms(median_ns(&mut encode_ns)),
-        decode_ms: ns_to_ms(median_ns(&mut decode_ns)),
+        name: String::new(),
+        encode: compute_timing_stats(&mut encode_ns),
+        decode: compute_timing_stats(&mut decode_ns),
         compressed_bytes,
         original_bytes,
+        compressed_bytes_varied,
+        fidelity,
     })
 }
 
-// ── Public API ────────────────────────────────────────────────────────────────
+// ── Public API ───────────────────────────────────────────────────────────────
 
-/// Run the GRIB comparison benchmark and return results.
-///
-/// The first result is `"eccodes grid_ccsds"` (the reference).
-/// Called by the binary entry point and by integration tests.
-pub fn run_grib_comparison_results(
+pub fn run_grib_comparison(
     num_points: usize,
     iterations: usize,
+    warmup: usize,
     seed: u64,
-) -> Result<Vec<BenchmarkResult>, BenchmarkError> {
+) -> Result<BenchmarkRun, BenchmarkError> {
     if num_points == 0 {
-        return Err(BenchmarkError("num_points must be > 0".to_string()));
+        return Err(BenchmarkError::Validation(
+            "num_points must be > 0".to_string(),
+        ));
     }
     if iterations == 0 {
-        return Err(BenchmarkError("iterations must be > 0".to_string()));
+        return Err(BenchmarkError::Validation(
+            "iterations must be > 0".to_string(),
+        ));
+    }
+    if warmup == 0 {
+        return Err(BenchmarkError::Validation("warmup must be > 0".to_string()));
     }
 
     eprintln!("Generating {num_points} weather-like float64 values (seed={seed})...");
     let values = generate_weather_field(num_points, seed);
-    let original_bytes = num_points * 8; // 8 bytes per f64
+    let original_bytes = num_points * 8;
 
-    let mut results = Vec::new();
-    let bits = 24;
+    let bits = 24i64;
+    let total_cases = 3;
+    let mut results = Vec::with_capacity(total_cases);
+    let mut failures = Vec::new();
 
-    /// Collect a benchmark result, logging progress and handling errors
-    /// without aborting the full run.
     fn collect(
         name: &str,
         result: Result<BenchmarkResult, BenchmarkError>,
-        original_bytes: usize,
-        out: &mut Vec<BenchmarkResult>,
+        results: &mut Vec<BenchmarkResult>,
+        failures: &mut Vec<CaseFailure>,
     ) {
         match result {
             Ok(mut r) => {
                 r.name = name.to_string();
-                eprintln!(" done ({:.1} ms encode)", r.encode_ms);
-                out.push(r);
+                eprintln!(
+                    " {:.1} ms enc, {:.1} ms dec",
+                    r.encode.median_ms, r.decode.median_ms
+                );
+                results.push(r);
             }
             Err(e) => {
                 eprintln!(" FAILED: {e}");
-                out.push(BenchmarkResult {
-                    name: format!("{name} [ERROR]"),
-                    encode_ms: 0.0,
-                    decode_ms: 0.0,
-                    compressed_bytes: 0,
-                    original_bytes,
+                failures.push(CaseFailure {
+                    name: name.to_string(),
+                    error: e.to_string(),
                 });
             }
         }
@@ -416,26 +422,44 @@ pub fn run_grib_comparison_results(
     eprint!("  eccodes grid_ccsds (24-bit)...");
     collect(
         "eccodes grid_ccsds",
-        time_grib(&values, "grid_ccsds", bits, iterations, original_bytes),
-        original_bytes,
+        time_grib(
+            &values,
+            "grid_ccsds",
+            bits,
+            iterations,
+            warmup,
+            original_bytes,
+        ),
         &mut results,
+        &mut failures,
     );
 
     eprint!("  eccodes grid_simple (24-bit)...");
     collect(
         "eccodes grid_simple",
-        time_grib(&values, "grid_simple", bits, iterations, original_bytes),
-        original_bytes,
+        time_grib(
+            &values,
+            "grid_simple",
+            bits,
+            iterations,
+            warmup,
+            original_bytes,
+        ),
         &mut results,
+        &mut failures,
     );
 
     eprint!("  tensogram sp(24)+szip...");
     collect(
         "tensogram sp(24)+szip",
-        time_tensogram_sp_szip(&values, bits as u32, iterations, original_bytes),
-        original_bytes,
+        time_tensogram_sp_szip(&values, bits as u32, iterations, warmup, original_bytes),
         &mut results,
+        &mut failures,
     );
 
-    Ok(results)
+    Ok(BenchmarkRun {
+        results,
+        failures,
+        total_cases,
+    })
 }

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -1,68 +1,92 @@
-// Tensogram benchmark library.
-//
-// The `run_*` functions are the public entry points called by the binaries.
-
 pub mod codec_matrix;
+pub mod constants;
 pub mod datagen;
 pub mod report;
 
-/// Error type for benchmark operations.
 #[derive(Debug)]
-pub struct BenchmarkError(pub String);
+pub enum BenchmarkError {
+    Validation(String),
+    Pipeline(String),
+}
 
 impl std::fmt::Display for BenchmarkError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+        match self {
+            BenchmarkError::Validation(msg) => write!(f, "validation: {msg}"),
+            BenchmarkError::Pipeline(msg) => write!(f, "pipeline: {msg}"),
+        }
     }
 }
 
 impl std::error::Error for BenchmarkError {}
 
-impl From<String> for BenchmarkError {
-    fn from(s: String) -> Self {
-        BenchmarkError(s)
+impl From<tensogram_encodings::pipeline::PipelineError> for BenchmarkError {
+    fn from(e: tensogram_encodings::pipeline::PipelineError) -> Self {
+        BenchmarkError::Pipeline(e.to_string())
     }
 }
 
-/// Run the codec matrix benchmark and print results to stdout.
-///
-/// Called by the `codec-matrix` binary.
+#[derive(Debug, Clone)]
+pub struct CaseFailure {
+    pub name: String,
+    pub error: String,
+}
+
+impl std::fmt::Display for CaseFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.name, self.error)
+    }
+}
+
+#[derive(Debug)]
+pub struct BenchmarkRun {
+    pub results: Vec<report::BenchmarkResult>,
+    pub failures: Vec<CaseFailure>,
+    pub total_cases: usize,
+}
+
+impl BenchmarkRun {
+    pub fn all_passed(&self) -> bool {
+        self.failures.is_empty()
+    }
+}
+
 pub fn run_codec_matrix(
     num_points: usize,
     iterations: usize,
+    warmup: usize,
     seed: u64,
-) -> Result<(), BenchmarkError> {
-    let results = codec_matrix::run_codec_matrix_results(num_points, iterations, seed)?;
+) -> Result<BenchmarkRun, BenchmarkError> {
+    let run = codec_matrix::run_codec_matrix(num_points, iterations, warmup, seed)?;
 
-    // Derive actual count from results: original_bytes / 8 bytes per f64.
-    // This reflects the rounded-up value (num_points may have been padded to
-    // the next multiple of 4 for szip alignment).
-    let actual_count = results.first().map_or(num_points, |r| r.original_bytes / 8);
+    let actual_count = run
+        .results
+        .first()
+        .map_or(num_points, |r| r.original_bytes / 8);
     let title = format!(
-        "Tensogram Codec Matrix ({actual_count} float64 values, {iterations} iterations, median)"
+        "Tensogram Codec Matrix ({actual_count} float64 values, \
+         {iterations} iterations, {warmup} warmup, median)"
     );
-    report::print_table(&results, "none+none", &title);
-    Ok(())
+    report::print_report(&run, "none+none", &title);
+    Ok(run)
 }
 
-/// Run the GRIB comparison benchmark and print results to stdout.
-///
-/// Called by the `grib-comparison` binary. Requires the `eccodes` C library.
 #[cfg(feature = "eccodes")]
 pub fn run_grib_comparison(
     num_points: usize,
     iterations: usize,
+    warmup: usize,
     seed: u64,
-) -> Result<(), BenchmarkError> {
-    let results = grib_comparison::run_grib_comparison_results(num_points, iterations, seed)?;
+) -> Result<BenchmarkRun, BenchmarkError> {
+    let run = grib_comparison::run_grib_comparison(num_points, iterations, warmup, seed)?;
 
     let title = format!(
-        "GRIB vs Tensogram Comparison ({num_points} float64 values, 24 bit, {iterations} iterations)"
+        "GRIB vs Tensogram Comparison ({num_points} float64 values, 24 bit, \
+         {iterations} iterations, {warmup} warmup)"
     );
-    report::print_table(&results, "eccodes grid_ccsds", &title);
-    Ok(())
+    report::print_report(&run, "eccodes grid_ccsds", &title);
+    Ok(run)
 }
 
-// grib_comparison module declared only when eccodes feature is active.
 #[cfg(feature = "eccodes")]
 pub mod grib_comparison;

--- a/benchmarks/src/report.rs
+++ b/benchmarks/src/report.rs
@@ -39,10 +39,12 @@ pub fn compute_timing_stats(samples: &mut [u64]) -> TimingStats {
         };
     }
     samples.sort_unstable();
+    // Safe: emptiness is guarded above, so both first and last element exist.
+    let last_idx = samples.len() - 1;
     TimingStats {
         median_ms: ns_to_ms(median_of_sorted(samples)),
         min_ms: ns_to_ms(samples[0]),
-        max_ms: ns_to_ms(*samples.last().unwrap()),
+        max_ms: ns_to_ms(samples[last_idx]),
     }
 }
 

--- a/benchmarks/src/report.rs
+++ b/benchmarks/src/report.rs
@@ -1,31 +1,144 @@
-//! ASCII table reporter for benchmark results.
-//!
-//! Formats a list of [`BenchmarkResult`] values into a human-readable table
-//! with reference-relative comparison columns. The reference row is marked
-//! with `[REF]` and the "vs Ref" columns show how many times faster or slower
-//! each variant is compared to the reference.
+use crate::BenchmarkRun;
 
-// ── Types ─────────────────────────────────────────────────────────────────────
+// ── Fidelity ─────────────────────────────────────────────────────────────────
 
-/// Timing and size results for one benchmark run.
+#[derive(Debug, Clone)]
+pub enum Fidelity {
+    Exact,
+    Lossy { linf: f64, l1: f64, l2: f64 },
+    Unchecked,
+}
+
+impl std::fmt::Display for Fidelity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Fidelity::Exact => write!(f, "exact"),
+            Fidelity::Lossy { linf, l1, l2 } => {
+                write!(f, "Linf={linf:.2e} L1={l1:.2e} L2={l2:.2e}")
+            }
+            Fidelity::Unchecked => write!(f, "\u{2014}"),
+        }
+    }
+}
+
+// ── Timing ───────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct TimingStats {
+    pub median_ms: f64,
+    pub min_ms: f64,
+    pub max_ms: f64,
+}
+
+pub fn compute_timing_stats(samples: &mut [u64]) -> TimingStats {
+    if samples.is_empty() {
+        return TimingStats {
+            median_ms: 0.0,
+            min_ms: 0.0,
+            max_ms: 0.0,
+        };
+    }
+    samples.sort_unstable();
+    TimingStats {
+        median_ms: ns_to_ms(median_of_sorted(samples)),
+        min_ms: ns_to_ms(samples[0]),
+        max_ms: ns_to_ms(*samples.last().unwrap()),
+    }
+}
+
+/// Median of a pre-sorted slice. Returns 0 for empty input.
+fn median_of_sorted(sorted: &[u64]) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let mid = sorted.len() / 2;
+    if sorted.len().is_multiple_of(2) {
+        ((sorted[mid - 1] as u128 + sorted[mid] as u128) / 2) as u64
+    } else {
+        sorted[mid]
+    }
+}
+
+#[cfg(test)]
+fn median_ns(samples: &mut [u64]) -> u64 {
+    if samples.is_empty() {
+        return 0;
+    }
+    samples.sort_unstable();
+    median_of_sorted(samples)
+}
+
+pub fn ns_to_ms(ns: u64) -> f64 {
+    ns as f64 / 1_000_000.0
+}
+
+// ── Fidelity computation ─────────────────────────────────────────────────────
+
+/// Compare decoded output to original input bytes (little-endian f64).
+///
+/// `is_lossy` controls the expectation: lossy codecs report error metrics,
+/// lossless codecs that mismatch are treated as lossy (bug indicator).
+pub fn compute_fidelity(original_bytes: &[u8], decoded_bytes: &[u8], is_lossy: bool) -> Fidelity {
+    let orig_len = original_bytes.len();
+    let dec_len = decoded_bytes.len();
+
+    if orig_len == 0
+        || !orig_len.is_multiple_of(8)
+        || dec_len < orig_len
+        || !dec_len.is_multiple_of(8)
+    {
+        return Fidelity::Unchecked;
+    }
+
+    let n = orig_len / 8;
+
+    let bytes_match = original_bytes[..n * 8] == decoded_bytes[..n * 8];
+
+    if !is_lossy && bytes_match {
+        return Fidelity::Exact;
+    }
+
+    let mut max_abs_error: f64 = 0.0;
+    let mut sum_abs_error: f64 = 0.0;
+    let mut sum_sq_error: f64 = 0.0;
+
+    for (orig_chunk, dec_chunk) in original_bytes
+        .chunks_exact(8)
+        .zip(decoded_bytes.chunks_exact(8))
+    {
+        let orig = f64::from_le_bytes(orig_chunk.try_into().unwrap_or([0; 8]));
+        let dec = f64::from_le_bytes(dec_chunk.try_into().unwrap_or([0; 8]));
+        let err = (orig - dec).abs();
+        max_abs_error = max_abs_error.max(err);
+        sum_abs_error += err;
+        sum_sq_error += err * err;
+    }
+
+    if bytes_match {
+        Fidelity::Exact
+    } else {
+        Fidelity::Lossy {
+            linf: max_abs_error,
+            l1: sum_abs_error / n as f64,
+            l2: (sum_sq_error / n as f64).sqrt(),
+        }
+    }
+}
+
+// ── Result ───────────────────────────────────────────────────────────────────
+
 #[derive(Debug, Clone)]
 pub struct BenchmarkResult {
-    /// Short display name, e.g. `"none+none"` or `"sp(24)+szip"`.
     pub name: String,
-    /// Median encode time across all iterations, in milliseconds.
-    pub encode_ms: f64,
-    /// Median decode time across all iterations, in milliseconds.
-    pub decode_ms: f64,
-    /// Compressed payload size in bytes.
+    pub encode: TimingStats,
+    pub decode: TimingStats,
     pub compressed_bytes: usize,
-    /// Original (uncompressed) payload size in bytes.
     pub original_bytes: usize,
+    pub compressed_bytes_varied: bool,
+    pub fidelity: Fidelity,
 }
 
 impl BenchmarkResult {
-    /// Compression ratio as a percentage: 100 % × compressed / original.
-    ///
-    /// Returns 100.0 when original_bytes is zero.
     pub fn ratio_pct(&self) -> f64 {
         if self.original_bytes == 0 {
             return 100.0;
@@ -33,110 +146,84 @@ impl BenchmarkResult {
         100.0 * self.compressed_bytes as f64 / self.original_bytes as f64
     }
 
-    /// Compressed size in kibibytes.
     pub fn size_kib(&self) -> f64 {
         self.compressed_bytes as f64 / 1024.0
     }
-}
 
-// ── Timing helpers ────────────────────────────────────────────────────────────
-
-/// Compute the median of a mutable slice of durations (in nanoseconds).
-///
-/// Returns 0 if the slice is empty.
-pub fn median_ns(samples: &mut [u64]) -> u64 {
-    if samples.is_empty() {
-        return 0;
+    /// Encode throughput in MB/s (uncompressed input size / median encode time).
+    pub fn encode_throughput_mbs(&self) -> f64 {
+        if self.encode.median_ms <= 0.0 {
+            return 0.0;
+        }
+        let mb = self.original_bytes as f64 / (1024.0 * 1024.0);
+        let secs = self.encode.median_ms / 1000.0;
+        mb / secs
     }
-    samples.sort_unstable();
-    let mid = samples.len() / 2;
-    if samples.len().is_multiple_of(2) {
-        // Average of the two middle values (avoids overflow via u128).
-        ((samples[mid - 1] as u128 + samples[mid] as u128) / 2) as u64
-    } else {
-        samples[mid]
+
+    /// Decode throughput in MB/s (uncompressed output size / median decode time).
+    pub fn decode_throughput_mbs(&self) -> f64 {
+        if self.decode.median_ms <= 0.0 {
+            return 0.0;
+        }
+        let mb = self.original_bytes as f64 / (1024.0 * 1024.0);
+        let secs = self.decode.median_ms / 1000.0;
+        mb / secs
     }
 }
 
-/// Convert nanoseconds to milliseconds.
-pub fn ns_to_ms(ns: u64) -> f64 {
-    ns as f64 / 1_000_000.0
-}
+// ── Table formatting ─────────────────────────────────────────────────────────
 
-// ── Table formatting ──────────────────────────────────────────────────────────
-
-/// Format benchmark results as an ASCII table string.
-///
-/// `reference_name` must match the `.name` field of exactly one result; that
-/// row is marked `[REF]` and used as the baseline for the "vs Ref" columns.
-/// If no matching row is found the function still produces a valid table and
-/// keeps the reference-relative columns, filling their cells with `N/A`.
 pub fn format_table(results: &[BenchmarkResult], reference_name: &str, title: &str) -> String {
-    // Find the reference row.
     let ref_result = results.iter().find(|r| r.name == reference_name);
 
-    // Build display rows: (name, encode_ms, decode_ms, ratio, kib, vs_enc, vs_dec)
     struct Row {
         name: String,
         encode_ms: String,
         decode_ms: String,
+        enc_mbs: String,
+        dec_mbs: String,
         ratio_pct: String,
         size_kib: String,
-        vs_enc: String,
-        vs_dec: String,
+        fidelity: String,
     }
 
     let rows: Vec<Row> = results
         .iter()
         .map(|r| {
-            let is_ref = r.name == reference_name;
-            let display_name = if is_ref {
+            let display_name = if r.name == reference_name {
                 format!("{} [REF]", r.name)
             } else {
                 r.name.clone()
             };
 
-            let vs_enc = match ref_result {
-                Some(ref_r) if ref_r.encode_ms > 0.0 => {
-                    format!("{:.2}x", r.encode_ms / ref_r.encode_ms)
-                }
-                Some(_) => "N/A".to_string(),
-                None => "N/A".to_string(),
-            };
-            let vs_dec = match ref_result {
-                Some(ref_r) if ref_r.decode_ms > 0.0 => {
-                    format!("{:.2}x", r.decode_ms / ref_r.decode_ms)
-                }
-                Some(_) => "N/A".to_string(),
-                None => "N/A".to_string(),
-            };
+            let size_note = if r.compressed_bytes_varied { "~" } else { "" };
 
             Row {
                 name: display_name,
-                encode_ms: format!("{:.3}", r.encode_ms),
-                decode_ms: format!("{:.3}", r.decode_ms),
-                ratio_pct: format!("{:.2}", r.ratio_pct()),
-                size_kib: format!("{:.1}", r.size_kib()),
-                vs_enc,
-                vs_dec,
+                encode_ms: format!("{:.3}", r.encode.median_ms),
+                decode_ms: format!("{:.3}", r.decode.median_ms),
+                enc_mbs: format!("{:.1}", r.encode_throughput_mbs()),
+                dec_mbs: format!("{:.1}", r.decode_throughput_mbs()),
+                ratio_pct: format!("{}{:.2}", size_note, r.ratio_pct()),
+                size_kib: format!("{}{:.1}", size_note, r.size_kib()),
+                fidelity: r.fidelity.to_string(),
             }
         })
         .collect();
 
-    // Column headers
     let headers = [
         "Combo",
-        "Encode (ms)",
-        "Decode (ms)",
+        "Enc (ms)",
+        "Dec (ms)",
+        "Enc MB/s",
+        "Dec MB/s",
         "Ratio (%)",
         "Size (KiB)",
-        "vs Ref Enc",
-        "vs Ref Dec",
+        "Fidelity",
     ];
 
-    // Compute column widths from max of header and data.
-    let widths: [usize; 7] = {
-        let mut w = [0usize; 7];
+    let widths: [usize; 8] = {
+        let mut w = [0usize; 8];
         for (i, h) in headers.iter().enumerate() {
             w[i] = h.len();
         }
@@ -145,10 +232,11 @@ pub fn format_table(results: &[BenchmarkResult], reference_name: &str, title: &s
                 row.name.as_str(),
                 row.encode_ms.as_str(),
                 row.decode_ms.as_str(),
+                row.enc_mbs.as_str(),
+                row.dec_mbs.as_str(),
                 row.ratio_pct.as_str(),
                 row.size_kib.as_str(),
-                row.vs_enc.as_str(),
-                row.vs_dec.as_str(),
+                row.fidelity.as_str(),
             ];
             for (i, cell) in cells.iter().enumerate() {
                 w[i] = w[i].max(cell.len());
@@ -159,17 +247,22 @@ pub fn format_table(results: &[BenchmarkResult], reference_name: &str, title: &s
 
     let mut out = String::new();
 
-    // Title line
     out.push_str(title);
     out.push('\n');
-
-    // Reference line
-    out.push_str(&format!("Reference: {reference_name}\n"));
+    if let Some(rr) = ref_result {
+        out.push_str(&format!(
+            "Reference: {} ({:.1} MB/s enc, {:.1} MB/s dec)\n",
+            reference_name,
+            rr.encode_throughput_mbs(),
+            rr.decode_throughput_mbs()
+        ));
+    } else {
+        out.push_str(&format!("Reference: {reference_name}\n"));
+    }
     out.push('\n');
 
-    // Header row
-    let header_line = format!(
-        " {:<w0$} | {:>w1$} | {:>w2$} | {:>w3$} | {:>w4$} | {:>w5$} | {:>w6$}",
+    out.push_str(&format!(
+        " {:<w0$} | {:>w1$} | {:>w2$} | {:>w3$} | {:>w4$} | {:>w5$} | {:>w6$} | {:>w7$}",
         headers[0],
         headers[1],
         headers[2],
@@ -177,6 +270,7 @@ pub fn format_table(results: &[BenchmarkResult], reference_name: &str, title: &s
         headers[4],
         headers[5],
         headers[6],
+        headers[7],
         w0 = widths[0],
         w1 = widths[1],
         w2 = widths[2],
@@ -184,11 +278,10 @@ pub fn format_table(results: &[BenchmarkResult], reference_name: &str, title: &s
         w4 = widths[4],
         w5 = widths[5],
         w6 = widths[6],
-    );
-    out.push_str(&header_line);
+        w7 = widths[7],
+    ));
     out.push('\n');
 
-    // Separator
     let sep: String = widths
         .iter()
         .enumerate()
@@ -198,17 +291,17 @@ pub fn format_table(results: &[BenchmarkResult], reference_name: &str, title: &s
     out.push_str(&sep);
     out.push('\n');
 
-    // Data rows
     for row in &rows {
-        let line = format!(
-            " {:<w0$} | {:>w1$} | {:>w2$} | {:>w3$} | {:>w4$} | {:>w5$} | {:>w6$}",
+        out.push_str(&format!(
+            " {:<w0$} | {:>w1$} | {:>w2$} | {:>w3$} | {:>w4$} | {:>w5$} | {:>w6$} | {:>w7$}",
             row.name,
             row.encode_ms,
             row.decode_ms,
+            row.enc_mbs,
+            row.dec_mbs,
             row.ratio_pct,
             row.size_kib,
-            row.vs_enc,
-            row.vs_dec,
+            row.fidelity,
             w0 = widths[0],
             w1 = widths[1],
             w2 = widths[2],
@@ -216,220 +309,358 @@ pub fn format_table(results: &[BenchmarkResult], reference_name: &str, title: &s
             w4 = widths[4],
             w5 = widths[5],
             w6 = widths[6],
-        );
-        out.push_str(&line);
+            w7 = widths[7],
+        ));
         out.push('\n');
     }
 
     out
 }
 
-/// Print benchmark results to stdout.
-pub fn print_table(results: &[BenchmarkResult], reference_name: &str, title: &str) {
-    print!("{}", format_table(results, reference_name, title));
+/// Print full benchmark report: table, failures, and summary.
+pub fn print_report(run: &BenchmarkRun, reference_name: &str, title: &str) {
+    print!("{}", format_table(&run.results, reference_name, title));
+
+    if !run.failures.is_empty() {
+        eprintln!("\nFailed cases ({}):", run.failures.len());
+        for f in &run.failures {
+            eprintln!("  \u{2717} {f}");
+        }
+    }
+
+    let vary_count = run
+        .results
+        .iter()
+        .filter(|r| r.compressed_bytes_varied)
+        .count();
+    if vary_count > 0 {
+        eprintln!(
+            "\nNote: {vary_count} case(s) had variable compressed sizes across iterations (marked ~)."
+        );
+    }
+
+    eprintln!(
+        "\nSummary: {} attempted, {} succeeded, {} failed",
+        run.total_cases,
+        run.results.len(),
+        run.failures.len()
+    );
 }
 
-// ── Tests ─────────────────────────────────────────────────────────────────────
+// ── Tests ────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn make_stats(median: f64) -> TimingStats {
+        TimingStats {
+            median_ms: median,
+            min_ms: median * 0.9,
+            max_ms: median * 1.1,
+        }
+    }
+
     fn make_results() -> Vec<BenchmarkResult> {
         vec![
             BenchmarkResult {
                 name: "none+none".to_string(),
-                encode_ms: 0.5,
-                decode_ms: 0.3,
+                encode: make_stats(0.5),
+                decode: make_stats(0.3),
                 compressed_bytes: 8000,
                 original_bytes: 8000,
+                compressed_bytes_varied: false,
+                fidelity: Fidelity::Exact,
             },
             BenchmarkResult {
                 name: "sp(24)+szip".to_string(),
-                encode_ms: 10.0,
-                decode_ms: 5.0,
+                encode: make_stats(10.0),
+                decode: make_stats(5.0),
                 compressed_bytes: 3000,
                 original_bytes: 8000,
+                compressed_bytes_varied: false,
+                fidelity: Fidelity::Lossy {
+                    linf: 0.01,
+                    l1: 0.005,
+                    l2: 0.003,
+                },
             },
         ]
     }
 
     #[test]
-    fn test_reference_marked() {
+    fn reference_marked() {
         let results = make_results();
         let table = format_table(&results, "none+none", "Test");
-        assert!(
-            table.contains("[REF]"),
-            "reference row must be marked [REF]"
-        );
-        assert!(
-            table.contains("none+none [REF]"),
-            "reference name must appear with [REF] suffix"
-        );
+        assert!(table.contains("[REF]"));
+        assert!(table.contains("none+none [REF]"));
     }
 
     #[test]
-    fn test_headers_present() {
+    fn headers_present() {
         let results = make_results();
         let table = format_table(&results, "none+none", "Test");
-        assert!(table.contains("Encode (ms)"), "header Encode (ms) missing");
-        assert!(table.contains("Decode (ms)"), "header Decode (ms) missing");
-        assert!(table.contains("Ratio (%)"), "header Ratio (%) missing");
-        assert!(table.contains("Size (KiB)"), "header Size (KiB) missing");
-        assert!(table.contains("vs Ref Enc"), "header vs Ref Enc missing");
+        assert!(table.contains("Enc (ms)"));
+        assert!(table.contains("Dec (ms)"));
+        assert!(table.contains("Enc MB/s"));
+        assert!(table.contains("Ratio (%)"));
+        assert!(table.contains("Fidelity"));
     }
 
     #[test]
-    fn test_reference_line() {
+    fn reference_line() {
         let results = make_results();
         let table = format_table(&results, "none+none", "Test");
-        assert!(
-            table.contains("Reference: none+none"),
-            "reference line missing"
-        );
+        assert!(table.contains("Reference: none+none"));
     }
 
     #[test]
-    fn test_ratio_calculation() {
+    fn ratio_calculation() {
         let r = BenchmarkResult {
             name: "x".to_string(),
-            encode_ms: 1.0,
-            decode_ms: 1.0,
+            encode: make_stats(1.0),
+            decode: make_stats(1.0),
             compressed_bytes: 3000,
             original_bytes: 8000,
+            compressed_bytes_varied: false,
+            fidelity: Fidelity::Exact,
         };
         let ratio = r.ratio_pct();
-        // 3000/8000 = 37.5%
         assert!((ratio - 37.5).abs() < 0.001, "ratio {ratio} != 37.5");
     }
 
     #[test]
-    fn test_zero_original_bytes() {
+    fn zero_original_bytes() {
         let r = BenchmarkResult {
             name: "x".to_string(),
-            encode_ms: 1.0,
-            decode_ms: 1.0,
+            encode: make_stats(1.0),
+            decode: make_stats(1.0),
             compressed_bytes: 0,
             original_bytes: 0,
+            compressed_bytes_varied: false,
+            fidelity: Fidelity::Exact,
         };
-        // Must not divide by zero.
-        let ratio = r.ratio_pct();
-        assert_eq!(ratio, 100.0);
+        assert_eq!(r.ratio_pct(), 100.0);
     }
 
     #[test]
-    fn test_zero_reference_time() {
-        let results = vec![
-            BenchmarkResult {
-                name: "ref".to_string(),
-                encode_ms: 0.0, // zero reference time
-                decode_ms: 0.0,
-                compressed_bytes: 100,
-                original_bytes: 100,
-            },
-            BenchmarkResult {
-                name: "other".to_string(),
-                encode_ms: 5.0,
-                decode_ms: 3.0,
-                compressed_bytes: 50,
-                original_bytes: 100,
-            },
-        ];
-        let table = format_table(&results, "ref", "Test");
-        // Should contain N/A for vs-ref columns when reference time is zero.
-        assert!(
-            table.contains("N/A"),
-            "N/A expected when reference time is zero"
-        );
+    fn throughput_calculation() {
+        let r = BenchmarkResult {
+            name: "x".to_string(),
+            encode: make_stats(1000.0), // 1 second
+            decode: make_stats(500.0),  // 0.5 seconds
+            compressed_bytes: 0,
+            original_bytes: 1024 * 1024, // 1 MiB
+            compressed_bytes_varied: false,
+            fidelity: Fidelity::Exact,
+        };
+        assert!((r.encode_throughput_mbs() - 1.0).abs() < 0.001);
+        assert!((r.decode_throughput_mbs() - 2.0).abs() < 0.001);
     }
 
     #[test]
-    fn test_median_ns_odd() {
+    fn zero_time_throughput() {
+        let r = BenchmarkResult {
+            name: "x".to_string(),
+            encode: make_stats(0.0),
+            decode: make_stats(0.0),
+            compressed_bytes: 0,
+            original_bytes: 1024,
+            compressed_bytes_varied: false,
+            fidelity: Fidelity::Exact,
+        };
+        assert_eq!(r.encode_throughput_mbs(), 0.0);
+        assert_eq!(r.decode_throughput_mbs(), 0.0);
+    }
+
+    #[test]
+    fn fidelity_display() {
+        assert_eq!(format!("{}", Fidelity::Exact), "exact");
+        assert_eq!(format!("{}", Fidelity::Unchecked), "\u{2014}");
+        let lossy = Fidelity::Lossy {
+            linf: 0.01,
+            l1: 0.005,
+            l2: 0.003,
+        };
+        let s = format!("{lossy}");
+        assert!(s.starts_with("Linf="));
+    }
+
+    #[test]
+    fn compute_fidelity_exact() {
+        let data = [1.0f64, 2.0, 3.0];
+        let bytes: Vec<u8> = data.iter().flat_map(|v| v.to_le_bytes()).collect();
+        let fidelity = compute_fidelity(&bytes, &bytes, false);
+        assert!(matches!(fidelity, Fidelity::Exact));
+    }
+
+    #[test]
+    fn compute_fidelity_lossy() {
+        let orig = [1.0f64, 2.0, 3.0];
+        let decoded = [1.01f64, 2.02, 3.03];
+        let orig_bytes: Vec<u8> = orig.iter().flat_map(|v| v.to_le_bytes()).collect();
+        let dec_bytes: Vec<u8> = decoded.iter().flat_map(|v| v.to_le_bytes()).collect();
+        let fidelity = compute_fidelity(&orig_bytes, &dec_bytes, true);
+        match fidelity {
+            Fidelity::Lossy { linf, l1, l2 } => {
+                assert!(linf > 0.0);
+                assert!(l1 > 0.0);
+                assert!(l2 > 0.0);
+                assert!((linf - 0.03).abs() < 0.001);
+            }
+            _ => panic!("expected Lossy fidelity"),
+        }
+    }
+
+    #[test]
+    fn compute_fidelity_empty() {
+        let fidelity = compute_fidelity(&[], &[], false);
+        assert!(matches!(fidelity, Fidelity::Unchecked));
+    }
+
+    #[test]
+    fn compute_fidelity_misaligned_input() {
+        let fidelity = compute_fidelity(&[0u8; 7], &[0u8; 7], false);
+        assert!(matches!(fidelity, Fidelity::Unchecked));
+    }
+
+    #[test]
+    fn compute_fidelity_decoded_too_short() {
+        let orig = [1.0f64];
+        let orig_bytes: Vec<u8> = orig.iter().flat_map(|v| v.to_le_bytes()).collect();
+        let fidelity = compute_fidelity(&orig_bytes, &[0u8; 4], false);
+        assert!(matches!(fidelity, Fidelity::Unchecked));
+    }
+
+    #[test]
+    fn compute_fidelity_lossy_returns_exact_when_identical() {
+        let data = [1.0f64, 2.0, 3.0];
+        let bytes: Vec<u8> = data.iter().flat_map(|v| v.to_le_bytes()).collect();
+        let fidelity = compute_fidelity(&bytes, &bytes, true);
+        assert!(matches!(fidelity, Fidelity::Exact));
+    }
+
+    #[test]
+    fn median_ns_odd() {
         let mut s = [3u64, 1, 4, 1, 5];
         assert_eq!(median_ns(&mut s), 3);
     }
 
     #[test]
-    fn test_median_ns_even() {
+    fn median_ns_even() {
         let mut s = [1u64, 2, 3, 4];
-        assert_eq!(median_ns(&mut s), 2); // (2+3)/2 = 2
+        assert_eq!(median_ns(&mut s), 2);
     }
 
     #[test]
-    fn test_median_ns_single() {
+    fn median_ns_single() {
         let mut s = [42u64];
         assert_eq!(median_ns(&mut s), 42);
     }
 
     #[test]
-    fn test_median_ns_empty() {
+    fn median_ns_empty() {
         let mut s: [u64; 0] = [];
         assert_eq!(median_ns(&mut s), 0);
     }
 
     #[test]
-    fn test_median_ns_large_values() {
-        // Two u64::MAX values — the u128 addition must not overflow.
+    fn median_ns_large_values() {
         let mut s = [u64::MAX, u64::MAX];
-        let m = median_ns(&mut s);
-        assert_eq!(m, u64::MAX);
+        assert_eq!(median_ns(&mut s), u64::MAX);
     }
 
     #[test]
-    fn test_median_ns_two_elements() {
+    fn median_ns_two_elements() {
         let mut s = [10u64, 20];
-        // (10+20)/2 = 15
         assert_eq!(median_ns(&mut s), 15);
     }
 
     #[test]
-    fn test_ns_to_ms() {
+    fn ns_to_ms_conversion() {
         assert!((ns_to_ms(1_000_000) - 1.0).abs() < f64::EPSILON);
         assert!((ns_to_ms(0) - 0.0).abs() < f64::EPSILON);
         assert!((ns_to_ms(500_000) - 0.5).abs() < f64::EPSILON);
     }
 
     #[test]
-    fn test_size_kib() {
+    fn size_kib() {
         let r = BenchmarkResult {
             name: "x".to_string(),
-            encode_ms: 1.0,
-            decode_ms: 1.0,
+            encode: make_stats(1.0),
+            decode: make_stats(1.0),
             compressed_bytes: 2048,
             original_bytes: 4096,
+            compressed_bytes_varied: false,
+            fidelity: Fidelity::Exact,
         };
         assert!((r.size_kib() - 2.0).abs() < f64::EPSILON);
     }
 
     #[test]
-    fn test_ratio_above_100() {
-        // Compression expansion: compressed > original (e.g. LZ4 on random data).
+    fn ratio_above_100() {
         let r = BenchmarkResult {
             name: "x".to_string(),
-            encode_ms: 1.0,
-            decode_ms: 1.0,
+            encode: make_stats(1.0),
+            decode: make_stats(1.0),
             compressed_bytes: 10000,
             original_bytes: 8000,
+            compressed_bytes_varied: false,
+            fidelity: Fidelity::Exact,
         };
         let ratio = r.ratio_pct();
         assert!((ratio - 125.0).abs() < 0.001, "expected 125%, got {ratio}");
     }
 
     #[test]
-    fn test_format_table_empty_results() {
+    fn format_table_empty_results() {
         let table = format_table(&[], "ref", "Empty");
-        // Must not panic. Header and separator should still appear.
-        assert!(table.contains("Combo"), "header missing for empty table");
-        assert!(table.contains("Empty"), "title missing for empty table");
+        assert!(table.contains("Combo"));
+        assert!(table.contains("Empty"));
     }
 
     #[test]
-    fn test_format_table_vs_ref_values() {
-        let results = make_results();
-        let table = format_table(&results, "none+none", "Test");
-        // Reference row should show 1.00x for both vs-ref columns.
-        assert!(table.contains("1.00x"), "reference row must show 1.00x");
-        // sp(24)+szip: encode 10.0 / 0.5 = 20.00x
-        assert!(table.contains("20.00x"), "expected 20.00x vs-ref encode");
+    fn varied_size_marker() {
+        let results = vec![BenchmarkResult {
+            name: "varied".to_string(),
+            encode: make_stats(1.0),
+            decode: make_stats(1.0),
+            compressed_bytes: 1000,
+            original_bytes: 2000,
+            compressed_bytes_varied: true,
+            fidelity: Fidelity::Exact,
+        }];
+        let table = format_table(&results, "varied", "Test");
+        assert!(table.contains("~"), "varied sizes should be marked with ~");
+    }
+
+    #[test]
+    fn timing_stats_from_samples() {
+        let mut samples = [100_000u64, 200_000, 300_000, 400_000, 500_000];
+        let stats = compute_timing_stats(&mut samples);
+        assert!((stats.median_ms - 0.3).abs() < 0.001);
+        assert!((stats.min_ms - 0.1).abs() < 0.001);
+        assert!((stats.max_ms - 0.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn timing_stats_empty() {
+        let stats = compute_timing_stats(&mut []);
+        assert_eq!(stats.median_ms, 0.0);
+        assert_eq!(stats.min_ms, 0.0);
+        assert_eq!(stats.max_ms, 0.0);
+    }
+
+    #[test]
+    fn print_report_with_failures() {
+        let run = BenchmarkRun {
+            results: make_results(),
+            failures: vec![crate::CaseFailure {
+                name: "broken+codec".to_string(),
+                error: "unsupported".to_string(),
+            }],
+            total_cases: 3,
+        };
+        print_report(&run, "none+none", "Test");
     }
 }

--- a/benchmarks/tests/smoke.rs
+++ b/benchmarks/tests/smoke.rs
@@ -1,31 +1,35 @@
-//! Smoke tests for the tensogram-benchmarks crate.
-//!
-//! These tests use small data sizes (1000 points, 1 iteration) so they
-//! run in milliseconds on CI, verifying that each benchmark module compiles,
-//! runs, and produces well-formed output without errors.
-
-use tensogram_benchmarks::codec_matrix::run_codec_matrix_results;
+use tensogram_benchmarks::codec_matrix::run_codec_matrix;
 use tensogram_benchmarks::datagen::generate_weather_field;
-use tensogram_benchmarks::report::{format_table, BenchmarkResult};
+use tensogram_benchmarks::report::{
+    compute_fidelity, format_table, BenchmarkResult, Fidelity, TimingStats,
+};
 
-// ── datagen ───────────────────────────────────────────────────────────────────
+fn make_stats(ms: f64) -> TimingStats {
+    TimingStats {
+        median_ms: ms,
+        min_ms: ms * 0.9,
+        max_ms: ms * 1.1,
+    }
+}
+
+// ── datagen ──────────────────────────────────────────────────────────────────
 
 #[test]
-fn test_datagen_determinism() {
+fn datagen_determinism() {
     let a = generate_weather_field(1000, 42);
     let b = generate_weather_field(1000, 42);
     assert_eq!(a, b, "same seed must produce identical output");
 }
 
 #[test]
-fn test_datagen_different_seeds_differ() {
+fn datagen_different_seeds_differ() {
     let a = generate_weather_field(1000, 1);
     let b = generate_weather_field(1000, 2);
     assert_ne!(a, b, "different seeds must produce different output");
 }
 
 #[test]
-fn test_datagen_exact_length() {
+fn datagen_exact_length() {
     for n in [0usize, 1, 100, 999, 1000, 1024] {
         let v = generate_weather_field(n, 42);
         assert_eq!(v.len(), n, "length mismatch for n={n}");
@@ -33,7 +37,7 @@ fn test_datagen_exact_length() {
 }
 
 #[test]
-fn test_datagen_physical_range() {
+fn datagen_physical_range() {
     let v = generate_weather_field(1000, 42);
     for (i, &val) in v.iter().enumerate() {
         assert!(val.is_finite(), "non-finite value at index {i}: {val}");
@@ -44,194 +48,235 @@ fn test_datagen_physical_range() {
     }
 }
 
-// ── report ────────────────────────────────────────────────────────────────────
+// ── report ───────────────────────────────────────────────────────────────────
 
 #[test]
-fn test_report_formatting() {
+fn report_formatting() {
     let results = vec![
         BenchmarkResult {
             name: "none+none".to_string(),
-            encode_ms: 1.0,
-            decode_ms: 0.5,
+            encode: make_stats(1.0),
+            decode: make_stats(0.5),
             compressed_bytes: 8000,
             original_bytes: 8000,
+            compressed_bytes_varied: false,
+            fidelity: Fidelity::Exact,
         },
         BenchmarkResult {
             name: "sp(24)+szip".to_string(),
-            encode_ms: 20.0,
-            decode_ms: 15.0,
+            encode: make_stats(20.0),
+            decode: make_stats(15.0),
             compressed_bytes: 3000,
             original_bytes: 8000,
+            compressed_bytes_varied: false,
+            fidelity: Fidelity::Lossy {
+                linf: 0.01,
+                l1: 0.005,
+                l2: 0.003,
+            },
         },
     ];
     let table = format_table(&results, "none+none", "Test title");
 
-    assert!(
-        table.contains("[REF]"),
-        "reference row must be marked [REF]"
-    );
-    assert!(
-        table.contains("none+none [REF]"),
-        "reference name must have [REF] suffix"
-    );
-    assert!(table.contains("Encode (ms)"), "header missing");
-    assert!(table.contains("Ratio (%)"), "ratio column missing");
-    assert!(
-        table.contains("Reference: none+none"),
-        "reference line missing"
-    );
-    assert!(table.contains("Test title"), "title missing");
-    // sp(24)+szip should show 37.5% ratio (3000/8000)
-    assert!(table.contains("37.50"), "expected 37.50% ratio");
+    assert!(table.contains("[REF]"));
+    assert!(table.contains("none+none [REF]"));
+    assert!(table.contains("Enc (ms)"));
+    assert!(table.contains("Ratio (%)"));
+    assert!(table.contains("Fidelity"));
+    assert!(table.contains("Reference: none+none"));
+    assert!(table.contains("Test title"));
+    assert!(table.contains("37.50"));
+    assert!(table.contains("exact"));
 }
 
 #[test]
-fn test_report_ref_not_found() {
-    // Table should still render even if reference_name doesn't match any result.
+fn report_ref_not_found() {
     let results = vec![BenchmarkResult {
         name: "only".to_string(),
-        encode_ms: 1.0,
-        decode_ms: 1.0,
+        encode: make_stats(1.0),
+        decode: make_stats(1.0),
         compressed_bytes: 100,
         original_bytes: 100,
+        compressed_bytes_varied: false,
+        fidelity: Fidelity::Exact,
     }];
     let table = format_table(&results, "missing_ref", "Test");
-    // Must not panic and must contain the column headers.
-    assert!(table.contains("Encode (ms)"));
-    assert!(table.contains("N/A")); // vs-ref columns should be N/A
+    assert!(table.contains("Enc (ms)"));
 }
 
-// ── codec_matrix ──────────────────────────────────────────────────────────────
+// ── fidelity ─────────────────────────────────────────────────────────────────
 
 #[test]
-fn test_codec_matrix_smoke() {
-    // Run with 1000 points and 1 iteration — completes in < 5 seconds.
-    let results =
-        run_codec_matrix_results(1000, 1, 42).expect("codec matrix must not return an error");
+fn fidelity_exact_roundtrip() {
+    let data = [1.0f64, 2.0, 3.0];
+    let bytes: Vec<u8> = data.iter().flat_map(|v| v.to_le_bytes()).collect();
+    let fidelity = compute_fidelity(&bytes, &bytes, false);
+    assert!(matches!(fidelity, Fidelity::Exact));
+}
 
-    // Should produce 24 results (one per combo).
-    assert_eq!(results.len(), 24, "expected 24 benchmark results");
+#[test]
+fn fidelity_lossy_reports_error() {
+    let orig = [1.0f64, 2.0, 3.0];
+    let decoded = [1.01f64, 2.0, 3.0];
+    let orig_bytes: Vec<u8> = orig.iter().flat_map(|v| v.to_le_bytes()).collect();
+    let dec_bytes: Vec<u8> = decoded.iter().flat_map(|v| v.to_le_bytes()).collect();
+    let fidelity = compute_fidelity(&orig_bytes, &dec_bytes, true);
+    match fidelity {
+        Fidelity::Lossy { linf, l1, l2 } => {
+            assert!(linf > 0.0);
+            assert!(l1 > 0.0);
+            assert!(l2 > 0.0);
+            assert!((linf - 0.01).abs() < 1e-10);
+        }
+        _ => panic!("expected Lossy fidelity"),
+    }
+}
 
-    // First result is the reference (none+none).
+// ── codec_matrix ─────────────────────────────────────────────────────────────
+
+#[test]
+fn codec_matrix_smoke() {
+    let run = run_codec_matrix(1000, 1, 1, 42).expect("codec matrix must not error");
+
+    assert_eq!(run.total_cases, 24, "expected 24 total cases attempted");
     assert_eq!(
-        results[0].name, "none+none",
-        "first result must be the reference"
+        run.results.len() + run.failures.len(),
+        run.total_cases,
+        "results + failures must equal total_cases"
     );
 
-    // All results must have positive original_bytes.
-    for r in &results {
+    assert!(
+        run.failures.is_empty(),
+        "unexpected failures: {:?}",
+        run.failures
+    );
+
+    assert_eq!(
+        run.results[0].name, "none+none",
+        "first result must be reference"
+    );
+
+    for r in &run.results {
         assert!(
             r.original_bytes > 0,
             "original_bytes must be > 0 for '{}'",
             r.name
         );
     }
-
-    // None of the results should be ERROR-tagged (compression should succeed
-    // for all 24 combos on this size of data).
-    for r in &results {
-        assert!(
-            !r.name.contains("[ERROR]"),
-            "unexpected error in result: '{}'",
-            r.name
-        );
-    }
-
-    // Compression ratios: sp(16) should give a ratio below 35%.
-    let sp16 = results
-        .iter()
-        .find(|r| r.name == "sp(16)+none")
-        .expect("sp(16)+none result missing");
-    assert!(
-        sp16.ratio_pct() < 35.0,
-        "sp(16) ratio {} should be below 35%",
-        sp16.ratio_pct()
-    );
 }
 
 #[test]
-fn test_codec_matrix_result_names_unique() {
-    let results = run_codec_matrix_results(500, 1, 0).expect("must not error");
-    let mut names: Vec<&str> = results.iter().map(|r| r.name.as_str()).collect();
+fn codec_matrix_fidelity() {
+    let run = run_codec_matrix(1000, 1, 1, 42).expect("must succeed");
+
+    for r in &run.results {
+        match &r.fidelity {
+            Fidelity::Exact => {}
+            Fidelity::Lossy { linf, l1, l2 } => {
+                assert!(linf.is_finite(), "non-finite Linf for '{}'", r.name);
+                assert!(l1.is_finite(), "non-finite L1 for '{}'", r.name);
+                assert!(l2.is_finite(), "non-finite L2 for '{}'", r.name);
+                assert!(*linf >= 0.0);
+                assert!(*l1 >= 0.0);
+                assert!(*l2 >= 0.0);
+            }
+            Fidelity::Unchecked => panic!("fidelity must be checked for '{}'", r.name),
+        }
+    }
+
+    let lossless_names = [
+        "none+none",
+        "none+zstd(3)",
+        "none+lz4",
+        "none+blosc2(blosclz)",
+        "none+szip(32)",
+    ];
+    for name in lossless_names {
+        if let Some(r) = run.results.iter().find(|r| r.name == name) {
+            assert!(
+                matches!(r.fidelity, Fidelity::Exact),
+                "expected exact fidelity for lossless codec '{name}', got {:?}",
+                r.fidelity
+            );
+        }
+    }
+}
+
+#[test]
+fn codec_matrix_result_names_unique() {
+    let run = run_codec_matrix(500, 1, 1, 0).expect("must not error");
+    let mut names: Vec<&str> = run.results.iter().map(|r| r.name.as_str()).collect();
     names.sort_unstable();
     names.dedup();
     assert_eq!(
         names.len(),
-        results.len(),
+        run.results.len(),
         "duplicate result names detected"
     );
 }
 
-// ── edge cases ────────────────────────────────────────────────────────────────
+// ── edge cases ───────────────────────────────────────────────────────────────
 
 #[test]
-fn test_codec_matrix_zero_points_returns_err() {
-    let result = run_codec_matrix_results(0, 1, 42);
+fn codec_matrix_zero_points_returns_err() {
+    let result = run_codec_matrix(0, 1, 1, 42);
     assert!(result.is_err(), "num_points=0 must return Err");
 }
 
 #[test]
-fn test_codec_matrix_zero_iterations_returns_err() {
-    let result = run_codec_matrix_results(100, 0, 42);
+fn codec_matrix_zero_iterations_returns_err() {
+    let result = run_codec_matrix(100, 0, 1, 42);
     assert!(result.is_err(), "iterations=0 must return Err");
 }
 
 #[test]
-fn test_codec_matrix_non_aligned_points() {
-    // 501 is not a multiple of 4.  The codec matrix rounds up internally
-    // so that szip cases never fail due to alignment.
-    let results = run_codec_matrix_results(501, 1, 42)
-        .expect("non-aligned num_points must succeed (rounded up)");
-    assert_eq!(results.len(), 24, "expected 24 results");
-    for r in &results {
-        assert!(
-            !r.name.contains("[ERROR]"),
-            "unexpected error for non-aligned size in '{}'",
-            r.name
-        );
-    }
+fn codec_matrix_zero_warmup_returns_err() {
+    let result = run_codec_matrix(100, 1, 0, 42);
+    assert!(result.is_err(), "warmup=0 must return Err");
 }
 
 #[test]
-fn test_codec_matrix_single_point() {
-    // num_points=1 rounds to 4. All 24 codecs should handle tiny data.
-    let results =
-        run_codec_matrix_results(1, 1, 42).expect("num_points=1 must succeed (rounded to 4)");
-    assert_eq!(results.len(), 24, "expected 24 results");
-    for r in &results {
-        assert!(
-            !r.name.contains("[ERROR]"),
-            "unexpected error for tiny data in '{}'",
-            r.name
-        );
-    }
-    // original_bytes should be 4 * 8 = 32 (padded to 4 values).
+fn codec_matrix_non_aligned_points() {
+    let run =
+        run_codec_matrix(501, 1, 1, 42).expect("non-aligned num_points must succeed (rounded up)");
+    assert_eq!(run.results.len(), 24, "expected 24 results");
+    assert!(
+        run.failures.is_empty(),
+        "unexpected failures: {:?}",
+        run.failures
+    );
+}
+
+#[test]
+fn codec_matrix_single_point() {
+    let run = run_codec_matrix(1, 1, 1, 42).expect("num_points=1 must succeed (rounded to 4)");
+    assert_eq!(run.results.len(), 24, "expected 24 results");
+    assert!(run.failures.is_empty());
     assert_eq!(
-        results[0].original_bytes, 32,
+        run.results[0].original_bytes, 32,
         "expected 32 bytes for 4 f64 values"
     );
 }
 
 #[test]
-fn test_codec_matrix_padded_original_bytes() {
-    // 501 rounds to 504. original_bytes = 504 * 8 = 4032.
-    let results = run_codec_matrix_results(501, 1, 42).expect("must succeed");
+fn codec_matrix_padded_original_bytes() {
+    let run = run_codec_matrix(501, 1, 1, 42).expect("must succeed");
     assert_eq!(
-        results[0].original_bytes,
+        run.results[0].original_bytes,
         504 * 8,
-        "original_bytes must reflect padded count (504 × 8)"
+        "original_bytes must reflect padded count (504 x 8)"
     );
 }
 
 #[test]
-fn test_codec_matrix_error_message_content() {
-    let err = run_codec_matrix_results(0, 1, 42).unwrap_err();
+fn codec_matrix_error_message_content() {
+    let err = run_codec_matrix(0, 1, 1, 42).unwrap_err();
     assert!(
         err.to_string().contains("num_points"),
         "error message should mention 'num_points': got '{err}'"
     );
 
-    let err = run_codec_matrix_results(100, 0, 42).unwrap_err();
+    let err = run_codec_matrix(100, 0, 1, 42).unwrap_err();
     assert!(
         err.to_string().contains("iterations"),
         "error message should mention 'iterations': got '{err}'"
@@ -241,74 +286,122 @@ fn test_codec_matrix_error_message_content() {
 // ── lib.rs entry points ──────────────────────────────────────────────────────
 
 #[test]
-fn test_run_codec_matrix_prints_table() {
-    // Just verify the top-level entry point doesn't panic.
-    tensogram_benchmarks::run_codec_matrix(100, 1, 42).expect("run_codec_matrix must not error");
+fn run_codec_matrix_prints_table() {
+    tensogram_benchmarks::run_codec_matrix(100, 1, 1, 42).expect("run_codec_matrix must not error");
 }
 
 #[test]
-fn test_benchmark_error_display() {
+fn benchmark_error_display() {
     use tensogram_benchmarks::BenchmarkError;
-    let e = BenchmarkError("test error".to_string());
-    assert_eq!(format!("{e}"), "test error");
+    let e = BenchmarkError::Validation("test error".to_string());
+    assert!(format!("{e}").contains("test error"));
 }
 
 #[test]
-fn test_benchmark_error_from_string() {
-    use tensogram_benchmarks::BenchmarkError;
-    let e: BenchmarkError = String::from("from string").into();
-    assert_eq!(e.0, "from string");
+fn benchmark_run_all_passed() {
+    use tensogram_benchmarks::BenchmarkRun;
+    let run = BenchmarkRun {
+        results: vec![],
+        failures: vec![],
+        total_cases: 0,
+    };
+    assert!(run.all_passed());
+}
+
+#[test]
+fn benchmark_run_has_failures() {
+    use tensogram_benchmarks::{BenchmarkRun, CaseFailure};
+    let run = BenchmarkRun {
+        results: vec![],
+        failures: vec![CaseFailure {
+            name: "test".to_string(),
+            error: "broke".to_string(),
+        }],
+        total_cases: 1,
+    };
+    assert!(!run.all_passed());
+}
+
+// ── compressed_bytes_varied ──────────────────────────────────────────────────
+
+#[test]
+fn codec_matrix_deterministic_sizes() {
+    let run = run_codec_matrix(1000, 3, 1, 42).expect("must succeed");
+    for r in &run.results {
+        assert!(
+            !r.compressed_bytes_varied,
+            "compressed size varied for '{}' — codec may be non-deterministic",
+            r.name
+        );
+    }
 }
 
 // ── grib_comparison (eccodes feature-gated) ──────────────────────────────────
 
 #[cfg(feature = "eccodes")]
 #[test]
-fn test_grib_comparison_zero_points_returns_err() {
-    use tensogram_benchmarks::grib_comparison::run_grib_comparison_results;
-    let result = run_grib_comparison_results(0, 1, 42);
+fn grib_comparison_zero_points_returns_err() {
+    use tensogram_benchmarks::grib_comparison::run_grib_comparison;
+    let result = run_grib_comparison(0, 1, 1, 42);
     assert!(result.is_err(), "num_points=0 must return Err");
 }
 
 #[cfg(feature = "eccodes")]
 #[test]
-fn test_grib_comparison_zero_iterations_returns_err() {
-    use tensogram_benchmarks::grib_comparison::run_grib_comparison_results;
-    let result = run_grib_comparison_results(100, 0, 42);
+fn grib_comparison_zero_iterations_returns_err() {
+    use tensogram_benchmarks::grib_comparison::run_grib_comparison;
+    let result = run_grib_comparison(100, 0, 1, 42);
     assert!(result.is_err(), "iterations=0 must return Err");
 }
 
 #[cfg(feature = "eccodes")]
 #[test]
-fn test_grib_comparison_smoke() {
-    use tensogram_benchmarks::grib_comparison::run_grib_comparison_results;
+fn grib_comparison_smoke() {
+    use tensogram_benchmarks::grib_comparison::run_grib_comparison;
 
-    let results = run_grib_comparison_results(1000, 1, 42).expect("grib comparison must not error");
+    let run = run_grib_comparison(1000, 1, 1, 42).expect("grib comparison must not error");
 
-    // Expect exactly 3 results.
-    assert_eq!(results.len(), 3, "expected 3 results");
-
-    // First result must be the eccodes CCSDS reference.
+    assert_eq!(run.total_cases, 3, "expected 3 total cases");
     assert_eq!(
-        results[0].name, "eccodes grid_ccsds",
-        "first result must be eccodes grid_ccsds"
+        run.results.len() + run.failures.len(),
+        run.total_cases,
+        "results + failures must equal total_cases"
+    );
+    assert!(
+        run.failures.is_empty(),
+        "unexpected failures: {:?}",
+        run.failures
     );
 
-    // No results should be ERROR-tagged.
-    for r in &results {
-        assert!(
-            !r.name.contains("[ERROR]"),
-            "unexpected error in grib result: '{}'",
-            r.name
-        );
-    }
+    assert_eq!(
+        run.results[0].name, "eccodes grid_ccsds",
+        "first result must be reference"
+    );
 
-    // All should have positive compressed_bytes.
-    for r in &results {
+    for r in &run.results {
         assert!(
             r.compressed_bytes > 0,
             "compressed_bytes must be > 0 for '{}'",
             r.name
         );
+    }
+}
+
+#[cfg(feature = "eccodes")]
+#[test]
+fn grib_comparison_fidelity() {
+    use tensogram_benchmarks::grib_comparison::run_grib_comparison;
+
+    let run = run_grib_comparison(1000, 1, 1, 42).expect("must succeed");
+    for r in &run.results {
+        match &r.fidelity {
+            Fidelity::Lossy { linf, l1, l2 } => {
+                assert!(linf.is_finite(), "non-finite Linf for '{}'", r.name);
+                assert!(l1.is_finite(), "non-finite L1 for '{}'", r.name);
+                assert!(l2.is_finite(), "non-finite L2 for '{}'", r.name);
+            }
+            Fidelity::Exact => {}
+            Fidelity::Unchecked => panic!("fidelity must be checked for '{}'", r.name),
+        }
     }
 }

--- a/crates/tensogram-encodings/src/libaec.rs
+++ b/crates/tensogram-encodings/src/libaec.rs
@@ -19,13 +19,30 @@ pub fn aec_compress(
     data: &[u8],
     params: &AecParams,
 ) -> Result<(Vec<u8>, Vec<u64>), CompressionError> {
+    aec_compress_impl(data, params, true)
+}
+
+pub fn aec_compress_no_offsets(
+    data: &[u8],
+    params: &AecParams,
+) -> Result<Vec<u8>, CompressionError> {
+    let (bytes, _) = aec_compress_impl(data, params, false)?;
+    Ok(bytes)
+}
+
+fn aec_compress_impl(
+    data: &[u8],
+    params: &AecParams,
+    track_offsets: bool,
+) -> Result<(Vec<u8>, Vec<u64>), CompressionError> {
     use libaec_sys::*;
 
     if data.is_empty() {
         return Ok((Vec::new(), Vec::new()));
     }
 
-    let sample_bytes = sample_byte_width(params.bits_per_sample);
+    let flags = effective_flags(params);
+    let sample_bytes = sample_byte_width(params.bits_per_sample, flags);
     if !data.len().is_multiple_of(sample_bytes) {
         return Err(CompressionError::Szip(format!(
             "data length {} is not a multiple of sample byte width {}",
@@ -35,8 +52,8 @@ pub fn aec_compress(
     }
 
     let num_samples = data.len() / sample_bytes;
-    // Worst case: compressed could be slightly larger than input
     let out_capacity = data.len() + data.len() / 4 + 256;
+
     let mut out = vec![0u8; out_capacity];
 
     unsafe {
@@ -48,15 +65,16 @@ pub fn aec_compress(
         strm.bits_per_sample = params.bits_per_sample;
         strm.block_size = params.block_size;
         strm.rsi = params.rsi;
-        strm.flags = params.flags;
+        strm.flags = flags;
 
         check_aec(aec_encode_init(&mut strm), "aec_encode_init")?;
 
-        // Enable RSI offset tracking
-        check_aec(
-            aec_encode_enable_offsets(&mut strm),
-            "aec_encode_enable_offsets",
-        )?;
+        if track_offsets {
+            check_aec(
+                aec_encode_enable_offsets(&mut strm),
+                "aec_encode_enable_offsets",
+            )?;
+        }
 
         let rc = aec_encode(&mut strm, AEC_FLUSH as _);
         if rc != AEC_OK as _ {
@@ -68,40 +86,42 @@ pub fn aec_compress(
 
         let compressed_len = out.len() - strm.avail_out;
 
-        // Retrieve RSI block offsets (bit offsets)
-        let mut offset_count: usize = 0;
-        check_aec_cleanup(
-            aec_encode_count_offsets(&mut strm, &mut offset_count),
-            "aec_encode_count_offsets",
-            || {
-                aec_encode_end(&mut strm);
-            },
-        )?;
-
-        let mut offsets = vec![0usize; offset_count];
-        if offset_count > 0 {
+        let bit_offsets = if track_offsets {
+            let mut offset_count: usize = 0;
             check_aec_cleanup(
-                aec_encode_get_offsets(&mut strm, offsets.as_mut_ptr(), offset_count),
-                "aec_encode_get_offsets",
+                aec_encode_count_offsets(&mut strm, &mut offset_count),
+                "aec_encode_count_offsets",
                 || {
                     aec_encode_end(&mut strm);
                 },
             )?;
-        }
+
+            let mut offsets = vec![0usize; offset_count];
+            if offset_count > 0 {
+                check_aec_cleanup(
+                    aec_encode_get_offsets(&mut strm, offsets.as_mut_ptr(), offset_count),
+                    "aec_encode_get_offsets",
+                    || {
+                        aec_encode_end(&mut strm);
+                    },
+                )?;
+            }
+
+            let bit_offsets: Vec<u64> = offsets.iter().map(|&o| o as u64).collect();
+            let samples_per_rsi = params.rsi as usize * params.block_size as usize;
+            let num_rsi_blocks = num_samples.div_ceil(samples_per_rsi);
+            if bit_offsets.len() > num_rsi_blocks {
+                bit_offsets[..num_rsi_blocks].to_vec()
+            } else {
+                bit_offsets
+            }
+        } else {
+            Vec::new()
+        };
 
         aec_encode_end(&mut strm);
 
         out.truncate(compressed_len);
-        let bit_offsets: Vec<u64> = offsets.iter().map(|&o| o as u64).collect();
-        // Filter out trailing zeros for streams with fewer RSI blocks than reported
-        let samples_per_rsi = params.rsi as usize * params.block_size as usize;
-        let num_rsi_blocks = num_samples.div_ceil(samples_per_rsi);
-        let bit_offsets = if bit_offsets.len() > num_rsi_blocks {
-            bit_offsets[..num_rsi_blocks].to_vec()
-        } else {
-            bit_offsets
-        };
-
         Ok((out, bit_offsets))
     }
 }
@@ -118,6 +138,7 @@ pub fn aec_decompress(
         return Ok(Vec::new());
     }
 
+    let flags = effective_flags(params);
     let mut out = vec![0u8; expected_size];
 
     unsafe {
@@ -129,7 +150,7 @@ pub fn aec_decompress(
         strm.bits_per_sample = params.bits_per_sample;
         strm.block_size = params.block_size;
         strm.rsi = params.rsi;
-        strm.flags = params.flags;
+        strm.flags = flags;
 
         check_aec(aec_decode_init(&mut strm), "aec_decode_init")?;
 
@@ -171,6 +192,7 @@ pub fn aec_decompress_range(
         ));
     }
 
+    let flags = effective_flags(params);
     let mut out = vec![0u8; byte_size];
     let offsets_usize: Vec<usize> = block_offsets.iter().map(|&o| o as usize).collect();
 
@@ -183,7 +205,7 @@ pub fn aec_decompress_range(
         strm.bits_per_sample = params.bits_per_sample;
         strm.block_size = params.block_size;
         strm.rsi = params.rsi;
-        strm.flags = params.flags;
+        strm.flags = flags;
 
         check_aec(aec_decode_init(&mut strm), "aec_decode_init")?;
 
@@ -209,11 +231,19 @@ pub fn aec_decompress_range(
     }
 }
 
-/// Compute the byte width of a sample given bits_per_sample.
-/// 3-byte samples are promoted to 4 bytes (libaec convention).
-fn sample_byte_width(bits_per_sample: u32) -> usize {
+/// Ensure AEC_DATA_3BYTE is set for 17-24 bit samples so libaec reads
+/// 3-byte containers instead of defaulting to 4-byte.
+fn effective_flags(params: &AecParams) -> u32 {
+    let mut flags = params.flags;
+    if params.bits_per_sample > 16 && params.bits_per_sample <= 24 {
+        flags |= libaec_sys::AEC_DATA_3BYTE;
+    }
+    flags
+}
+
+fn sample_byte_width(bits_per_sample: u32, flags: u32) -> usize {
     let nbytes = (bits_per_sample as usize).div_ceil(8);
-    if nbytes == 3 {
+    if nbytes == 3 && flags & libaec_sys::AEC_DATA_3BYTE == 0 {
         4
     } else {
         nbytes
@@ -276,6 +306,22 @@ mod tests {
         let values: Vec<u16> = (0..2048).map(|i| (i * 7 % 65536) as u16).collect();
         let data: Vec<u8> = values.iter().flat_map(|v| v.to_ne_bytes()).collect();
         let params = default_params(16);
+
+        let (compressed, offsets) = aec_compress(&data, &params).unwrap();
+        assert!(!compressed.is_empty());
+        assert!(!offsets.is_empty());
+
+        let decompressed = aec_decompress(&compressed, data.len(), &params).unwrap();
+        assert_eq!(decompressed, data);
+    }
+
+    #[test]
+    fn round_trip_u24_data() {
+        // 24-bit samples in 3-byte containers — requires AEC_DATA_3BYTE
+        // (automatically set by effective_flags for bits_per_sample 17-24).
+        let n = 4096;
+        let data: Vec<u8> = (0..n * 3).map(|i| (i % 256) as u8).collect();
+        let params = default_params(24);
 
         let (compressed, offsets) = aec_compress(&data, &params).unwrap();
         assert!(!compressed.is_empty());

--- a/crates/tensogram-encodings/src/pipeline.rs
+++ b/crates/tensogram-encodings/src/pipeline.rs
@@ -152,12 +152,20 @@ fn build_compressor(
             block_size,
             flags,
             bits_per_sample,
-        } => Ok(Some(Box::new(SzipCompressor {
-            rsi: *rsi,
-            block_size: *block_size,
-            flags: *flags,
-            bits_per_sample: *bits_per_sample,
-        }))),
+        } => {
+            let mut szip_flags = *flags;
+            // simple_packing output is MSB-first; tell libaec so its predictor
+            // sees bytes in the correct significance order.
+            if matches!(config.encoding, EncodingType::SimplePacking(_)) {
+                szip_flags |= libaec_sys::AEC_DATA_MSB;
+            }
+            Ok(Some(Box::new(SzipCompressor {
+                rsi: *rsi,
+                block_size: *block_size,
+                flags: szip_flags,
+                bits_per_sample: *bits_per_sample,
+            })))
+        }
         #[cfg(feature = "zstd")]
         CompressionType::Zstd { level } => Ok(Some(Box::new(ZstdCompressor { level: *level }))),
         #[cfg(feature = "lz4")]
@@ -210,6 +218,44 @@ pub fn encode_pipeline(
     };
 
     // Step 3: Compression
+    match build_compressor(&config.compression, config)? {
+        None => Ok(PipelineResult {
+            encoded_bytes: filtered.into_owned(),
+            block_offsets: None,
+        }),
+        Some(compressor) => {
+            let CompressResult {
+                data: compressed,
+                block_offsets,
+            } = compressor.compress(&filtered)?;
+            Ok(PipelineResult {
+                encoded_bytes: compressed,
+                block_offsets,
+            })
+        }
+    }
+}
+
+/// Encode from f64 values directly, avoiding the bytes→f64 conversion overhead
+/// that `encode_pipeline` pays when the caller already has typed values.
+#[tracing::instrument(skip(values, config), fields(num_values = values.len(), encoding = %config.encoding))]
+pub fn encode_pipeline_f64(
+    values: &[f64],
+    config: &PipelineConfig,
+) -> Result<PipelineResult, PipelineError> {
+    let encoded: Cow<'_, [u8]> = match &config.encoding {
+        EncodingType::None => Cow::Owned(f64_to_bytes(values, config.byte_order)),
+        EncodingType::SimplePacking(params) => Cow::Owned(simple_packing::encode(values, params)?),
+    };
+
+    let filtered: Cow<'_, [u8]> = match &config.filter {
+        FilterType::None => encoded,
+        FilterType::Shuffle { element_size } => Cow::Owned(
+            shuffle::shuffle(&encoded, *element_size)
+                .map_err(|e| PipelineError::Shuffle(e.to_string()))?,
+        ),
+    };
+
     match build_compressor(&config.compression, config)? {
         None => Ok(PipelineResult {
             encoded_bytes: filtered.into_owned(),

--- a/crates/tensogram-encodings/src/simple_packing.rs
+++ b/crates/tensogram-encodings/src/simple_packing.rs
@@ -8,6 +8,11 @@ pub enum PackingError {
     BitsPerValueTooLarge(u32),
     #[error("insufficient data: expected at least {expected} bytes, got {actual}")]
     InsufficientData { expected: usize, actual: usize },
+    #[error("output size overflow: {num_values} values × {bytes_per_value} bytes")]
+    OutputSizeOverflow {
+        num_values: usize,
+        bytes_per_value: usize,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -27,10 +32,6 @@ pub fn compute_params(
         return Err(PackingError::BitsPerValueTooLarge(bits_per_value));
     }
 
-    if let Some(i) = values.iter().position(|v| v.is_nan()) {
-        return Err(PackingError::NanValue(i));
-    }
-
     if values.is_empty() || bits_per_value == 0 {
         let reference_value = values.first().copied().unwrap_or(0.0);
         return Ok(SimplePackingParams {
@@ -41,11 +42,21 @@ pub fn compute_params(
         });
     }
 
-    let d_scale = 10f64.powi(decimal_scale_factor);
+    let mut min_val = f64::INFINITY;
+    let mut max_val = f64::NEG_INFINITY;
+    for (i, &v) in values.iter().enumerate() {
+        if v.is_nan() {
+            return Err(PackingError::NanValue(i));
+        }
+        if v < min_val {
+            min_val = v;
+        }
+        if v > max_val {
+            max_val = v;
+        }
+    }
 
-    // Scale values by decimal factor
-    let min_val = values.iter().copied().fold(f64::INFINITY, f64::min);
-    let max_val = values.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+    let d_scale = 10f64.powi(decimal_scale_factor);
 
     let reference_value = min_val;
     let range = (max_val - min_val) * d_scale;
@@ -72,47 +83,106 @@ pub fn compute_params(
 }
 
 /// Encode f64 values to packed integer bytes (MSB-first bit packing).
-/// Rejects NaN inputs.
+///
 pub fn encode(values: &[f64], params: &SimplePackingParams) -> Result<Vec<u8>, PackingError> {
     if params.bits_per_value > 64 {
         return Err(PackingError::BitsPerValueTooLarge(params.bits_per_value));
     }
-
     if let Some(i) = values.iter().position(|v| v.is_nan()) {
         return Err(PackingError::NanValue(i));
     }
-
-    // bits_per_value == 0: constant field, empty payload
     if params.bits_per_value == 0 {
         return Ok(Vec::new());
     }
 
     let bpv = params.bits_per_value;
-    let d_factor = 10f64.powi(params.decimal_scale_factor);
-    let e_factor = 2f64.powi(params.binary_scale_factor);
-
-    // Pack values to integers
-    // Forward: packed_int = round((value - reference_value) * 10^D / 2^E)
+    // packed_int = round((value - ref) * 10^D / 2^E)
+    //            = round((value - ref) * scale)
+    let scale = 10f64.powi(params.decimal_scale_factor) * 2f64.powi(-params.binary_scale_factor);
+    let refv = params.reference_value;
     let max_packed: u64 = if bpv >= 64 {
         u64::MAX
     } else {
         (1u64 << bpv) - 1
     };
 
-    let total_bits = values.len() as u64 * bpv as u64;
+    match bpv {
+        8 => encode_aligned::<1>(values, refv, scale, max_packed),
+        16 => encode_aligned::<2>(values, refv, scale, max_packed),
+        24 => encode_aligned::<3>(values, refv, scale, max_packed),
+        32 => encode_aligned::<4>(values, refv, scale, max_packed),
+        _ => encode_generic(values, refv, scale, max_packed, bpv),
+    }
+}
+
+fn encode_aligned<const N: usize>(
+    values: &[f64],
+    refv: f64,
+    scale: f64,
+    max_packed: u64,
+) -> Result<Vec<u8>, PackingError> {
+    let len = values
+        .len()
+        .checked_mul(N)
+        .ok_or(PackingError::OutputSizeOverflow {
+            num_values: values.len(),
+            bytes_per_value: N,
+        })?;
+    let mut out = vec![0u8; len];
+
+    for (chunk, &v) in out.chunks_exact_mut(N).zip(values) {
+        // Saturating f64→u64 cast handles negative values (→ 0).
+        // u64::min handles the rare +1 overshoot from rounding.
+        let q = (((v - refv) * scale).round() as u64).min(max_packed);
+        match N {
+            1 => {
+                chunk[0] = q as u8;
+            }
+            2 => {
+                chunk[0] = (q >> 8) as u8;
+                chunk[1] = q as u8;
+            }
+            3 => {
+                chunk[0] = (q >> 16) as u8;
+                chunk[1] = (q >> 8) as u8;
+                chunk[2] = q as u8;
+            }
+            4 => {
+                chunk[0] = (q >> 24) as u8;
+                chunk[1] = (q >> 16) as u8;
+                chunk[2] = (q >> 8) as u8;
+                chunk[3] = q as u8;
+            }
+            _ => unreachable!(),
+        }
+    }
+    Ok(out)
+}
+
+fn encode_generic(
+    values: &[f64],
+    refv: f64,
+    scale: f64,
+    max_packed: u64,
+    bpv: u32,
+) -> Result<Vec<u8>, PackingError> {
+    let total_bits =
+        (values.len() as u64)
+            .checked_mul(bpv as u64)
+            .ok_or(PackingError::OutputSizeOverflow {
+                num_values: values.len(),
+                bytes_per_value: (bpv as usize).div_ceil(8),
+            })?;
     let total_bytes =
-        usize::try_from(total_bits.div_ceil(8)).map_err(|_| PackingError::InsufficientData {
-            expected: usize::MAX,
-            actual: 0,
+        usize::try_from(total_bits.div_ceil(8)).map_err(|_| PackingError::OutputSizeOverflow {
+            num_values: values.len(),
+            bytes_per_value: (bpv as usize).div_ceil(8),
         })?;
     let mut output = vec![0u8; total_bytes];
 
     let mut bit_pos: u64 = 0;
     for &value in values {
-        let scaled = (value - params.reference_value) * d_factor / e_factor;
-        let packed = scaled.round().max(0.0).min(max_packed as f64) as u64;
-
-        // Write `bpv` bits at bit_pos, MSB-first
+        let packed = (((value - refv) * scale).round() as u64).min(max_packed);
         write_bits(&mut output, bit_pos, packed, bpv);
         bit_pos += bpv as u64;
     }
@@ -130,7 +200,6 @@ pub fn decode(
         return Err(PackingError::BitsPerValueTooLarge(params.bits_per_value));
     }
 
-    // bits_per_value == 0: all values equal reference_value
     if params.bits_per_value == 0 {
         return Ok(vec![params.reference_value; num_values]);
     }
@@ -145,21 +214,62 @@ pub fn decode(
         });
     }
 
-    let d_factor = 10f64.powi(-params.decimal_scale_factor);
-    let e_factor = 2f64.powi(params.binary_scale_factor);
+    let refv = params.reference_value;
+    // value = ref + 2^E * 10^(-D) * packed_int = ref + inv_scale * packed_int
+    let inv_scale =
+        2f64.powi(params.binary_scale_factor) * 10f64.powi(-params.decimal_scale_factor);
 
+    match bpv {
+        8 => Ok(decode_aligned::<1>(packed, num_values, refv, inv_scale)),
+        16 => Ok(decode_aligned::<2>(packed, num_values, refv, inv_scale)),
+        24 => Ok(decode_aligned::<3>(packed, num_values, refv, inv_scale)),
+        32 => Ok(decode_aligned::<4>(packed, num_values, refv, inv_scale)),
+        _ => Ok(decode_generic(packed, num_values, refv, inv_scale, bpv)),
+    }
+}
+
+fn decode_aligned<const N: usize>(
+    packed: &[u8],
+    num_values: usize,
+    refv: f64,
+    inv_scale: f64,
+) -> Vec<f64> {
+    let mut values = Vec::with_capacity(num_values);
+
+    for chunk in packed[..num_values * N].chunks_exact(N) {
+        let packed_int: u64 = match N {
+            1 => chunk[0] as u64,
+            2 => ((chunk[0] as u64) << 8) | chunk[1] as u64,
+            3 => ((chunk[0] as u64) << 16) | ((chunk[1] as u64) << 8) | chunk[2] as u64,
+            4 => {
+                ((chunk[0] as u64) << 24)
+                    | ((chunk[1] as u64) << 16)
+                    | ((chunk[2] as u64) << 8)
+                    | chunk[3] as u64
+            }
+            _ => unreachable!(),
+        };
+        values.push(refv + inv_scale * packed_int as f64);
+    }
+    values
+}
+
+fn decode_generic(
+    packed: &[u8],
+    num_values: usize,
+    refv: f64,
+    inv_scale: f64,
+    bpv: u32,
+) -> Vec<f64> {
     let mut values = Vec::with_capacity(num_values);
     let mut bit_pos: u64 = 0;
 
     for _ in 0..num_values {
         let packed_int = read_bits(packed, bit_pos, bpv);
-        // Reverse: value = reference_value + 2^E * 10^(-D) * packed_int
-        let value = params.reference_value + e_factor * d_factor * packed_int as f64;
-        values.push(value);
+        values.push(refv + inv_scale * packed_int as f64);
         bit_pos += bpv as u64;
     }
-
-    Ok(values)
+    values
 }
 
 /// Decode a range of packed values starting at an arbitrary bit offset.
@@ -213,11 +323,40 @@ fn write_bits(buf: &mut [u8], bit_offset: u64, value: u64, nbits: u32) {
     if nbits == 0 {
         return;
     }
+
+    if bit_offset.is_multiple_of(8) {
+        let idx = (bit_offset / 8) as usize;
+        match nbits {
+            8 => {
+                buf[idx] = value as u8;
+                return;
+            }
+            16 => {
+                buf[idx] = (value >> 8) as u8;
+                buf[idx + 1] = value as u8;
+                return;
+            }
+            24 => {
+                buf[idx] = (value >> 16) as u8;
+                buf[idx + 1] = (value >> 8) as u8;
+                buf[idx + 2] = value as u8;
+                return;
+            }
+            32 => {
+                buf[idx] = (value >> 24) as u8;
+                buf[idx + 1] = (value >> 16) as u8;
+                buf[idx + 2] = (value >> 8) as u8;
+                buf[idx + 3] = value as u8;
+                return;
+            }
+            _ => {}
+        }
+    }
+
     let mut remaining = nbits;
     let mut pos = bit_offset as usize;
     let mut val = value;
 
-    // Bits available in the first byte
     let first_avail = 8 - (pos % 8);
     if remaining <= first_avail as u32 {
         // Entire value fits in one byte
@@ -325,7 +464,16 @@ mod tests {
     }
 
     #[test]
-    fn test_nan_rejection() {
+    fn test_nan_rejection_in_compute_params() {
+        let values = vec![1.0, f64::NAN, 3.0];
+        assert!(matches!(
+            compute_params(&values, 16, 0),
+            Err(PackingError::NanValue(1))
+        ));
+    }
+
+    #[test]
+    fn test_nan_rejection_in_encode() {
         let values = vec![1.0, f64::NAN, 3.0];
         let params = SimplePackingParams {
             reference_value: 0.0,

--- a/docs/src/guide/benchmark-results.md
+++ b/docs/src/guide/benchmark-results.md
@@ -1,84 +1,150 @@
 # Benchmark Results
 
-This page is a snapshot of benchmark results recorded on a specific machine at a specific date.
-For methodology, flag descriptions, and how to re-run the benchmarks yourself, see [Benchmarks](benchmarks.md).
+This page is a snapshot of benchmark results recorded on a specific machine.
+For methodology, flags, and how to re-run, see [Benchmarks](benchmarks.md).
 
-> **Note:** Absolute timing values (`Encode (ms)`, `Decode (ms)`, `vs Ref` columns) are
-> machine-specific and will differ on other hardware. The `Ratio (%)` and `Size (KiB)` columns
-> are derived from compressed byte counts and are portable across machines.
+> **Note:** Timing and throughput are machine-specific. Compression ratios,
+> sizes, and fidelity metrics are determined by the codec and are reproducible.
 
 ## Run metadata
 
 | Field | Value |
 |-------|-------|
-| **Date** | 2026-04-07 |
+| **Date** | 2026-04-08 |
 | **Tensogram version** | 0.6.0 |
-| **Machine** | MacBook Pro (Mac16,1) |
-| **Chip** | Apple M4, 10 cores (4 Performance + 6 Efficiency) |
-| **Memory** | 16 GB |
-| **OS** | macOS 26.3.1 (Build 25D2128) |
-| **Rust** | rustc 1.94.1 (e408947bf 2026-03-25) |
-| **ecCodes** | 2.46.0 (Homebrew) |
+| **CPU** | Intel Core i9-10850K @ 3.60 GHz, 10 cores / 20 threads |
+| **OS** | Linux 6.19.10 (CachyOS) x86_64 |
+| **Rust** | rustc 1.94.0 |
+| **ecCodes** | 2.46.0 |
+| **Methodology** | 10 timed iterations, 3 warmup, median reported |
 
 ## Codec Matrix
 
-**Command:**
-```
-cargo run --release -p tensogram-benchmarks --bin codec-matrix \
-    -- --num-points 16000000 --iterations 5 --seed 42
-```
+16 million float64 values (122 MiB). The test data is a synthetic temperature-like
+field with values in the range 250–310.
 
-**Results** (24 combinations, 16 000 000 float64 values, 5 iterations, median):
+#### How fidelity is measured
 
-```
-Tensogram Codec Matrix (16000000 float64 values, 5 iterations, median)
-Reference: none+none
+After each encode→decode round-trip, the decoded values are compared to the
+original. Three error norms are reported, all absolute in the same units as
+the input:
 
- Combo                  | Encode (ms) | Decode (ms) | Ratio (%) | Size (KiB) | vs Ref Enc | vs Ref Dec
-------------------------+--------------+--------------+------------+-------------+-------------+-------------
- none+none [REF]        |       3.075 |       4.825 |    100.00 |   125000.0 |      1.00x |      1.00x
- none+zstd(3)           |     124.317 |     110.565 |     90.30 |   112870.0 |     40.42x |     22.91x
- none+lz4               |      14.860 |      17.728 |    100.39 |   125490.2 |      4.83x |      3.67x
- none+blosc2(blosclz)   |      51.608 |       8.807 |     75.22 |    94023.5 |     16.78x |      1.83x
- none+szip(32)          |      62.116 |     230.228 |    100.96 |   126202.8 |     20.20x |     47.71x
- sp(16)+none            |      28.108 |      28.126 |     25.00 |    31250.0 |      9.14x |      5.83x
- sp(16)+zstd(3)         |      62.453 |      46.609 |     24.35 |    30437.5 |     20.31x |      9.66x
- sp(16)+lz4             |      30.858 |      30.103 |     25.10 |    31372.6 |     10.03x |      6.24x
- sp(16)+blosc2(blosclz) |     116.136 |      42.672 |     20.28 |    25354.9 |     37.76x |      8.84x
- sp(16)+szip            |      50.469 |      90.414 |     25.39 |    31736.8 |     16.41x |     18.74x
- sp(24)+none            |      33.928 |      31.987 |     37.50 |    46875.0 |     11.03x |      6.63x
- sp(24)+zstd(3)         |      76.825 |      51.890 |     37.18 |    46477.1 |     24.98x |     10.75x
- sp(24)+lz4             |      37.208 |      33.731 |     37.65 |    47058.8 |     12.10x |      6.99x
- sp(24)+blosc2(blosclz) |     137.165 |      55.272 |     32.78 |    40980.9 |     44.60x |     11.45x
- sp(24)+szip            |      53.804 |     112.939 |     28.49 |    35614.0 |     17.49x |     23.40x
- sp(32)+none            |      40.802 |      36.103 |     50.00 |    62500.0 |     13.27x |      7.48x
- sp(32)+zstd(3)         |     115.953 |      54.272 |     49.81 |    62264.9 |     37.70x |     11.25x
- sp(32)+lz4             |      45.954 |      41.120 |     50.20 |    62745.1 |     14.94x |      8.52x
- sp(32)+blosc2(blosclz) |     139.815 |      52.611 |     45.29 |    56606.8 |     45.46x |     10.90x
- sp(32)+szip            |      72.659 |     151.333 |     50.49 |    63109.1 |     23.63x |     31.36x
- none+zfp(rate=16)      |     214.038 |     296.643 |     25.00 |    31250.0 |     69.60x |     61.47x
- none+zfp(rate=24)      |     246.089 |     470.858 |     37.50 |    46875.0 |     80.02x |     97.58x
- none+zfp(rate=32)      |     282.528 |     593.183 |     50.00 |    62500.0 |     91.87x |    122.93x
- none+sz3(abs=0.01)     |     133.714 |     142.765 |      6.46 |     8069.4 |     43.48x |     29.59x
-```
+- **Linf** — the largest error for any single value. Answers: *"what is the
+  worst case?"*
+- **L1** — the average error across all values. Answers: *"how far off are
+  values on average?"*
+- **L2 (RMSE)** — root mean square error. Like L1 but penalizes large outliers
+  more heavily. Answers: *"how large are the typical errors, weighted toward
+  the worst ones?"*
+
+For lossless codecs all three are zero.
+
+### Lossless compressors on raw floats
+
+No encoding step — raw 64-bit floats compressed directly. Decoded values are
+bit-identical to the original.
+
+| Method | Enc (ms) | Dec (ms) | Enc MB/s | Dec MB/s | Ratio | Size (MiB) |
+|--------|----------|----------|----------|----------|-------|------------|
+| no compression **[REF]** | 35.2 | 35.0 | 3466 | 3489 | 100% | 122.1 |
+| zstd level 3 | 178.9 | 113.8 | 682 | 1073 | 90.3% | 110.2 |
+| LZ4 | 41.5 | 37.5 | 2942 | 3251 | 100.4% | 122.5 |
+| Blosc2 | 160.6 | 63.9 | 760 | 1912 | 75.2% | 91.8 |
+| szip | 186.4 | 316.5 | 655 | 386 | 100.9% | 123.2 |
+
+Raw 64-bit floats have high entropy, so most lossless compressors cannot reduce
+their size. LZ4 and szip slightly expand the data. Blosc2 is the exception — its
+byte-shuffle step exposes compressible patterns (75%).
+
+### SimplePacking (quantization) + lossless compressors
+
+Values are quantized to N bits, then compressed. Fidelity depends only on the
+bit width, not on the compressor — see the fidelity table below.
+
+| Method | Enc (ms) | Dec (ms) | Enc MB/s | Dec MB/s | Ratio | Size (MiB) |
+|--------|----------|----------|----------|----------|-------|------------|
+| 16-bit only | 88.7 | 73.3 | 1376 | 1665 | 25.0% | 30.5 |
+| 16-bit + zstd | 138.6 | 87.6 | 881 | 1393 | 24.4% | 29.7 |
+| 16-bit + LZ4 | 98.9 | 74.4 | 1234 | 1640 | 25.1% | 30.6 |
+| 16-bit + Blosc2 | 221.3 | 91.9 | 552 | 1329 | 20.3% | 24.8 |
+| 16-bit + szip | 158.6 | 187.8 | 770 | 650 | 14.6% | 17.8 |
+| 24-bit only | 99.9 | 78.3 | 1222 | 1560 | 37.5% | 45.8 |
+| 24-bit + zstd | 170.8 | 102.5 | 715 | 1191 | 37.2% | 45.4 |
+| 24-bit + LZ4 | 117.0 | 91.8 | 1044 | 1329 | 37.7% | 46.0 |
+| 24-bit + Blosc2 | 265.2 | 135.9 | 460 | 898 | 32.8% | 40.0 |
+| 24-bit + szip | 191.8 | 230.1 | 637 | 531 | 27.2% | 33.2 |
+| 32-bit only | 99.3 | 73.4 | 1229 | 1664 | 50.0% | 61.0 |
+| 32-bit + zstd | 192.6 | 100.0 | 634 | 1221 | 49.8% | 60.8 |
+| 32-bit + LZ4 | 121.7 | 91.8 | 1003 | 1330 | 50.2% | 61.3 |
+| 32-bit + Blosc2 | 279.5 | 124.0 | 437 | 985 | 45.3% | 55.3 |
+| 32-bit + szip | 203.2 | 268.6 | 601 | 455 | 39.7% | 48.4 |
+
+#### Fidelity by bit width
+
+| Bit width | Linf (max abs) | L1 (mean abs) | L2 (RMSE) |
+|-----------|----------------|---------------|-----------|
+| 16 bits | 4.9 × 10⁻⁴ | 2.4 × 10⁻⁴ | 2.8 × 10⁻⁴ |
+| 24 bits | 1.9 × 10⁻⁶ | 9.5 × 10⁻⁷ | 1.1 × 10⁻⁶ |
+| 32 bits | 7.5 × 10⁻⁹ | 3.7 × 10⁻⁹ | 4.3 × 10⁻⁹ |
+
+For context: with input values around 280, a Linf of 1.9 × 10⁻⁶ means the worst-case
+relative error at 24 bits is roughly 7 parts per billion.
+
+### Lossy floating-point compressors
+
+These operate directly on raw f64 bytes without quantization.
+
+| Method | Enc (ms) | Dec (ms) | Enc MB/s | Dec MB/s | Ratio | Size (MiB) |
+|--------|----------|----------|----------|----------|-------|------------|
+| ZFP rate 16 | 493.5 | 507.3 | 247 | 241 | 25.0% | 30.5 |
+| ZFP rate 24 | 621.8 | 743.4 | 196 | 164 | 37.5% | 45.8 |
+| ZFP rate 32 | 717.5 | 920.0 | 170 | 133 | 50.0% | 61.0 |
+| SZ3 abs 0.01 | 464.1 | 276.2 | 263 | 442 | 6.5% | 7.9 |
+
+#### Fidelity by lossy codec
+
+| Method | Linf (max abs) | L1 (mean abs) | L2 (RMSE) |
+|--------|----------------|---------------|-----------|
+| ZFP rate 16 | 1.3 × 10⁻² | 1.6 × 10⁻³ | 2.0 × 10⁻³ |
+| ZFP rate 24 | 5.6 × 10⁻⁵ | 6.1 × 10⁻⁶ | 7.9 × 10⁻⁶ |
+| ZFP rate 32 | 1.9 × 10⁻⁷ | 2.4 × 10⁻⁸ | 3.1 × 10⁻⁸ |
+| SZ3 abs 0.01 | 1.0 × 10⁻² | 5.0 × 10⁻³ | 5.8 × 10⁻³ |
+
+### Notable observations
+
+- **16-bit + szip** achieves the best compression ratio (14.6%) among the
+  SimplePacking combinations.
+- **SZ3** achieves the smallest output overall (6.5%) with a max error of 0.01.
+  If your application tolerates that error bound, this gives the best compression
+  in this benchmark.
+- In this benchmark, higher ZFP rates gave proportionally smaller errors.
+  ZFP fixed-rate modes always hit their target ratio exactly (25% / 37.5% / 50%).
 
 ## GRIB Comparison
 
-**Command:**
-```
-cargo run --release -p tensogram-benchmarks --bin grib-comparison --features eccodes \
-    -- --num-points 10000000 --iterations 5 --seed 42
-```
+[GRIB](https://en.wikipedia.org/wiki/GRIB) is the standard binary format used in
+operational weather forecasting. The most widely used GRIB encoder is
+[ecCodes](https://confluence.ecmwf.int/display/ECC) from ECMWF.
 
-**Results** (10 000 000 float64 values, 24-bit packing, 5 iterations, median):
+This benchmark compares Tensogram's 24-bit SimplePacking + szip against ecCodes'
+built-in packing methods on the same data. Both sides are timed end-to-end: from a
+float64 array to serialized compressed bytes (encode), and back (decode).
 
-```
-GRIB vs Tensogram Comparison (10000000 float64 values, 24 bit, 5 iterations)
-Reference: eccodes grid_ccsds
+10 million float64 values (76 MiB), 24-bit packing. Different dataset size from the
+codec matrix above.
 
- Combo                    | Encode (ms) | Decode (ms) | Ratio (%) | Size (KiB) | vs Ref Enc | vs Ref Dec
---------------------------+--------------+--------------+------------+-------------+-------------+-------------
- eccodes grid_ccsds [REF] |      45.559 |      83.248 |     27.20 |    21247.1 |      1.00x |      1.00x
- eccodes grid_simple      |      30.993 |       7.678 |     37.50 |    29297.0 |      0.68x |      0.09x
- tensogram sp(24)+szip    |      36.137 |      72.323 |     28.49 |    22258.8 |      0.79x |      0.87x
-```
+| Method | Enc (ms) | Dec (ms) | Enc MB/s | Dec MB/s | Ratio | Size (MiB) |
+|--------|----------|----------|----------|----------|-------|------------|
+| ecCodes CCSDS **[REF]** | 84.7 | 139.1 | 900 | 549 | 27.2% | 20.7 |
+| ecCodes simple packing | 67.0 | 39.0 | 1139 | 1954 | 37.5% | 28.6 |
+| Tensogram 24-bit + szip | 114.2 | 136.5 | 668 | 559 | 27.4% | 20.9 |
+
+All three methods produce identical fidelity: Linf = 1.9 × 10⁻⁶,
+L1 = 9.5 × 10⁻⁷, L2 = 1.1 × 10⁻⁶.
+
+### Notable observations
+
+- **Tensogram and ecCodes CCSDS achieve nearly identical compression** (27.4% vs 27.2%)
+  and identical fidelity at 24 bits.
+- **Tensogram encode is 1.3× slower** (114 vs 85 ms); decode is slightly faster (137 vs 139 ms).
+- **ecCodes simple packing** decodes fastest (39 ms) but produces a larger file (37.5% vs 27%).

--- a/docs/src/guide/benchmarks.md
+++ b/docs/src/guide/benchmarks.md
@@ -1,26 +1,14 @@
 # Benchmarks
 
-The `benchmarks/` crate provides reproducible, tabular performance comparisons for
-all encoding/compression pipeline combinations. It lives in the repository and can
-be re-run at any time to measure the effect of changes to the core encoding paths.
-
-## Design Rationale
-
-The benchmark suite is a standalone binary rather than a Criterion harness for two
-reasons:
-
-1. **Custom reporting** — the TODO spec requires formatted comparison tables with
-   compression ratios, sizes in KiB, and reference-relative speedup factors. Criterion
-   is purpose-built for statistical regression detection (mean ± stddev), not tabular
-   multi-metric comparison.
-2. **Zero extra dependencies** — a standalone binary with `std::time::Instant` adds
-   no compilation overhead to the workspace and is fully controlled.
+Tensogram ships with a benchmark suite that measures all encoding and compression
+combinations on synthetic data. It produces tabular comparisons of speed, compressed
+size, and decode fidelity. The benchmarks can be re-run at any time to measure the
+effect of changes.
 
 ## Codec Matrix Benchmark
 
-Runs all valid encoder × compressor × bit-width combinations on 16 million synthetic
-float64 values and reports encode time, decode time, compressed size, and compression
-ratio against the `none+none` baseline.
+Tests all valid encoder × compressor × bit-width combinations on 16 million
+synthetic float64 values.
 
 ### Quick start
 
@@ -33,61 +21,62 @@ Override parameters with CLI flags:
 ```bash
 cargo run --release -p tensogram-benchmarks --bin codec-matrix -- \
     --num-points 16000000 \
-    --iterations 5 \
+    --iterations 10 \
+    --warmup 3 \
     --seed 42
 ```
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--num-points` | 16 000 000 | Number of float64 values to encode; always rounded up to the next multiple of 4 (up to 3 extra values) for szip alignment |
-| `--iterations` | 5 | Timed iterations per combo (median reported) |
+| `--num-points` | 16 000 000 | Number of float64 values to encode |
+| `--iterations` | 10 | Timed iterations per combination (median reported) |
+| `--warmup` | 3 | Warm-up iterations (discarded) |
 | `--seed` | 42 | PRNG seed for deterministic data generation |
 
 ### Combinations measured
 
 | Group | Description | Count |
 |-------|-------------|-------|
-| Baseline | `none+none` (raw f64 bytes, no compression) | 1 |
-| Raw + lossless | `none+{zstd,lz4,blosc2,szip}` | 4 |
-| SimplePacking + lossless | `sp(B)+{none,zstd,lz4,blosc2,szip}` at B=16, 24, 32 bits | 15 |
-| Lossy float | `none+zfp(rate=16/24/32)`, `none+sz3(abs=0.01)` | 4 |
+| Baseline | No encoding, no compression | 1 |
+| Lossless compressors | Raw floats compressed with zstd, LZ4, Blosc2, or szip | 4 |
+| SimplePacking + lossless | Quantized to 16, 24, or 32 bits, then compressed with each of the above (or no compressor) | 15 |
+| Lossy codecs | ZFP (fixed rate 16/24/32) and SZ3 (absolute error 0.01) | 4 |
 | **Total** | | **24** |
 
-### Example output
+For actual results, see [Benchmark Results](benchmark-results.md).
 
-```
-Tensogram Codec Matrix (16000000 float64 values, 5 iterations, median)
-Reference: none+none
+### How to read the results
 
- Combo                  | Encode (ms) | Decode (ms) | Ratio (%) | Size (KiB) | vs Ref Enc | vs Ref Dec
-------------------------+-------------+-------------+-----------+------------+------------+-----------
- none+none [REF]        |       4.123 |       3.891 |    100.00 |  125000.0  |      1.00x |      1.00x
- none+zstd(3)           |     312.456 |      52.100 |     72.30 |   90375.0  |     75.79x |     13.39x
- none+lz4               |      58.234 |       8.100 |     98.20 |  122750.0  |     14.12x |      2.08x
- sp(16)+none            |      95.200 |     185.400 |     25.00 |   31250.0  |     23.09x |     47.65x
- sp(24)+szip            |      70.100 |     175.200 |     28.50 |   35625.0  |     17.00x |     45.03x
- none+zfp(rate=24)      |      52.300 |     155.100 |     37.50 |   46875.0  |     12.69x |     39.86x
- ...
-```
+The results page splits each benchmark into a **performance table** (timing,
+throughput, compressed size) and a **fidelity table** (error norms for lossy codecs).
 
-### Interpreting the output
+| Column | Meaning | Better is |
+|--------|---------|-----------|
+| **Method** | Encoder + compressor. E.g. "24-bit + szip" means values are quantized to 24 bits then compressed with szip. **[REF]** marks the baseline. | — |
+| **Enc / Dec (ms)** | Median encode / decode time. | Lower |
+| **Enc / Dec MB/s** | Throughput: uncompressed size ÷ median time. | Higher |
+| **Ratio** | Compressed size as percentage of original. 25% = compressed to ¼. Above 100% means the codec expanded the data. | Lower |
+| **Size (MiB)** | Compressed output size. | — |
+| **Linf** | Max absolute error (worst single value). | Smaller |
+| **L1** | Mean absolute error (average drift). | Smaller |
+| **L2** | Root mean square error (penalizes outliers). | Smaller |
 
-| Column | Meaning |
-|--------|---------|
-| `Encode (ms)` | Median time to compress the payload (wall clock, unloaded machine) |
-| `Decode (ms)` | Median time to decompress the payload |
-| `Ratio (%)` | `compressed_bytes / original_bytes × 100` — lower is better |
-| `Size (KiB)` | Compressed payload size |
-| `vs Ref Enc` | `this_encode_ms / reference_encode_ms` — values > 1.00× are slower than the reference |
-| `vs Ref Dec` | Same for decode |
+For lossless codecs all three error norms are zero.
+Errors are absolute, in the same units as the input data.
 
-The reference (`none+none`) is the throughput of copying raw float64 bytes through the
-pipeline without any encoding or compression. It sets the baseline latency floor.
+**Quick rules of thumb:**
+- If you need exact data back, use one of the lossless codecs.
+- If you can tolerate some loss, compare Ratio vs error norms for your use case.
+- Throughput (MB/s) is the most useful speed metric — it accounts for data size and
+  lets you compare across different payload sizes.
 
 ## GRIB Comparison Benchmark
 
-Compares ecCodes CCSDS packing (`grid_ccsds`, 24 bit) — the operational reference —
-against Tensogram `simple_packing(24)+szip` on 10 million float64 values.
+Compares Tensogram's 24-bit SimplePacking + szip against
+[ecCodes](https://confluence.ecmwf.int/display/ECC) (ECMWF's operational GRIB
+encoder) on 10 million float64 values. Both sides are timed symmetrically:
+encoding measures the full path from a float64 array to compressed bytes, and
+decoding measures the reverse.
 
 ### Requirements
 
@@ -103,7 +92,8 @@ cargo run --release -p tensogram-benchmarks --bin grib-comparison --features ecc
 ```bash
 cargo run --release -p tensogram-benchmarks --bin grib-comparison --features eccodes -- \
     --num-points 10000000 \
-    --iterations 5 \
+    --iterations 10 \
+    --warmup 3 \
     --seed 42
 ```
 
@@ -111,133 +101,76 @@ cargo run --release -p tensogram-benchmarks --bin grib-comparison --features ecc
 
 | Method | Description |
 |--------|-------------|
-| `eccodes grid_ccsds` **(reference)** | ecCodes CCSDS packing (CCSDS 121.0-B-3 via libaec) |
-| `eccodes grid_simple` | ecCodes simple packing (GRIB grid_simple, same bit depth) |
-| `tensogram sp(24)+szip` | Tensogram SimplePacking(24) + szip (same algorithm, different framing) |
+| ecCodes CCSDS **(reference)** | CCSDS packing — the standard used in operational weather data distribution |
+| ecCodes simple packing | Basic fixed-bit-width packing without entropy coding |
+| Tensogram 24-bit + szip | Tensogram's SimplePacking at 24 bits followed by szip entropy coding |
 
-### Timing model
-
-- **GRIB encode**: time of `codes_set_double_array("values", ...)` — the quantisation and packing call.
-- **GRIB decode**: time to create a handle from raw GRIB bytes + `codes_get_double_array("values", ...)`.
-- **Tensogram encode/decode**: `encode_pipeline` / `decode_pipeline` on the packed bit stream.
-
-### Example output
-
-```
-GRIB vs Tensogram Comparison (10000000 float64 values, 24 bit, 5 iterations)
-Reference: eccodes grid_ccsds
-
- Combo                    | Encode (ms) | Decode (ms) | Ratio (%) | Size (KiB)  | vs Ref Enc | vs Ref Dec
---------------------------+-------------+-------------+-----------+-------------+------------+-----------
- eccodes grid_ccsds [REF] |     312.000 |     245.000 |     37.50 |   36621.1   |      1.00x |      1.00x
- eccodes grid_simple      |     180.000 |     120.000 |     37.50 |   36621.1   |      0.58x |      0.49x
- tensogram sp(24)+szip    |     210.000 |     160.000 |     28.57 |   27915.1   |      0.67x |      0.65x
-```
+For actual results, see [Benchmark Results](benchmark-results.md).
 
 ## Benchmark pipeline flow
 
 ```mermaid
-flowchart LR
-    subgraph datagen
-        G[generate_weather_field\nnumpoints × f64]
-    end
-    subgraph timing
-        W[warm-up\n1 iteration\ndiscarded]
-        T[timed iterations\nmedian taken]
-    end
-    subgraph report
-        R[format_table\nreference comparison\nASCII table]
-    end
+flowchart TD
+    G[Generate weather field] --> W[Warm-up iterations]
+    W --> T[Timed iterations]
+    T --> E[Encode]
+    E --> D[Decode]
+    D --> T
+    T --> F[Fidelity check]
+    F --> R[Print report]
 
-    G --> W --> T --> R
-    T --> |encode_pipeline| Enc[compressed bytes]
-    Enc --> |decode_pipeline| Dec[f64 values]
+    style G fill:#e8f4e8
+    style T fill:#e8e8f4
+    style F fill:#f4e8e8
 ```
 
-## Edge cases and limitations
+Each timed iteration runs a full encode → decode cycle. After all iterations
+complete, the last decoded output is compared against the original to produce
+the fidelity metrics.
 
-### Input validation
-
-Both benchmarks reject `num_points = 0` and `iterations = 0` with an `Err` return
-(no panic). These are caught before any data generation or pipeline calls.
-
-### Szip alignment padding
-
-The codec matrix rounds `num_points` up to the next multiple of 4 (by at most 3
-extra values) before running. This is required because libaec promotes 24-bit
-samples to 4-byte containers, so the packed byte count must be a multiple of 4.
-The padding values come from the same PRNG sequence, so the rounding has no effect
-on the overall benchmark character. The title line and `original_bytes` field both
-reflect the actual (padded) count.
+## Things to know
 
 ### Compression expansion
 
-Some compressors (especially LZ4 on raw f64 bytes) may produce output *larger*
-than the input (`Ratio > 100%`). This is expected and reported accurately — the
-`none+none` baseline itself is simply a memcpy and always shows 100.00%.
+Some compressors (especially LZ4 on raw 64-bit floats) may produce output *larger*
+than the input (Ratio > 100%). This is normal — high-entropy data can't always be
+compressed. The baseline row is a raw copy and always shows 100%.
 
-### Very small data sizes
+### Szip alignment
 
-With `--num-points 1` the codec matrix rounds to 4 values. All 24 combinations
-succeed at this size, but absolute timing values are dominated by per-call overhead
-rather than actual compression throughput. Use ≥ 10 000 points for meaningful
-relative comparisons.
+The codec matrix may round `num_points` up by 1–3 values for szip block alignment.
+This only matters for very small inputs.
 
-### PRNG determinism
+### Small data sizes
 
-The SplitMix64 PRNG is fully deterministic for a given seed, but the weather field
-generator uses `f64::sin()` / `f64::cos()` whose implementations may differ across
-platforms or libm versions. Timing comparisons are therefore only valid within the
-same build environment. Size-based metrics (`Ratio %`, `Size KiB`) are
-platform-independent.
+With `--num-points 1`, timing is dominated by per-call overhead rather than
+compression throughput. Use ≥ 10 000 points for meaningful comparisons.
 
-### GRIB grid factorization
+### GRIB grid shape
 
-For prime `num_points`, the GRIB benchmark creates a degenerate 1 × N grid.
-ecCodes handles this correctly, but it differs from the typical nearly-square grids
-used in production. For representative GRIB benchmarks, use composite sizes
-(e.g. 10 000 000 = 2500 × 4000).
+For prime `num_points`, the GRIB benchmark creates a 1 × N grid (not a realistic
+near-square grid). Use composite sizes for representative results
+(e.g. `--num-points 10000000`).
 
-## Error handling
+### Reproducibility
 
-All benchmark functions return `Result<_, BenchmarkError>` — no panics, no
-`unwrap()` in library code. Errors propagate to the binary entry point, which
-prints them to stderr and exits with code 1.
+The data generator is deterministic for a given `--seed`, so repeated runs on the
+same machine produce comparable timing. Compression ratios, sizes, and fidelity
+are reproducible across machines. Timing and throughput are not.
 
-### Error paths
+### Error handling
 
-| Source | When | Message |
-|--------|------|---------|
-| Input validation | `num_points = 0` | `"num_points must be > 0"` |
-| Input validation | `iterations = 0` | `"iterations must be > 0"` |
-| `compute_params` | All values identical (zero range) | `"sp(24) params: ..."` with inner error |
-| `encode_pipeline` | Codec failure (e.g. unsupported config) | Pipeline error description |
-| `decode_pipeline` | Corrupted or truncated encoded data | Pipeline error description |
-| ecCodes C API | `codes_set_long` returns non-zero | `"codes_set_long(key, val) returned rc"` |
-| ecCodes C API | Handle creation returns null | `"codes_grib_handle_new_from_samples(GRIB2) returned null; check ECCODES_SAMPLES_PATH..."` |
-| CString conversion | Key/value contains interior NUL byte | `"invalid key 'name': nul byte found..."` |
-
-### Graceful degradation
-
-In the codec matrix benchmark, if a single combination fails (e.g. a codec is
-unavailable at runtime), the error is logged to stderr and an `[ERROR]` row
-appears in the output table with zero times and zero size. The remaining
-combinations continue to run. The GRIB comparison benchmark uses the same pattern.
-
-## Reproducibility
-
-All benchmarks use a deterministic PRNG (SplitMix64) seeded by `--seed`. The same
-seed on the same machine produces identical data and therefore comparable timing
-across runs. For cross-machine comparisons, use the `Ratio (%)` and `Size (KiB)`
-columns (size-independent) rather than absolute millisecond values.
+If a single codec fails, the benchmark logs the error and continues with the
+remaining combinations. The summary line reports how many succeeded and failed.
+The CLI exits with code 1 if any combination failed.
 
 ## Running in CI
 
-For fast CI validation, pass `--num-points 10000 --iterations 1`:
+For fast CI validation, pass `--num-points 10000 --iterations 1 --warmup 1`:
 
 ```bash
 cargo run -p tensogram-benchmarks --bin codec-matrix -- \
-    --num-points 10000 --iterations 1
+    --num-points 10000 --iterations 1 --warmup 1
 ```
 
 The smoke test suite (`cargo test -p tensogram-benchmarks`) uses 500–1000 points

--- a/plans/DONE.md
+++ b/plans/DONE.md
@@ -56,7 +56,7 @@ Unit, integration, adversarial, and edge-case tests.
 - `simple_packing.rs` — GRIB-style lossy quantization, MSB-first bit packing, 0-64 bits, NaN rejection, `decode_range()` for arbitrary bit offsets. Optimized encode/decode: precomputed scale (no per-value division), specialized byte-aligned loops for 8/16/24/32 bits, fused NaN+min+max scan in `compute_params`.
 - `shuffle.rs` — Byte-level shuffle/unshuffle (HDF5-style)
 - `libaec.rs` — Safe Rust wrapper around libaec: `aec_compress()` with optional RSI block offset tracking (`aec_compress_no_offsets`), `aec_decompress()`, `aec_decompress_range()`. Auto-sets `AEC_DATA_3BYTE` for 17-24 bit samples (fixes corruption bug). 
-- `pipeline.rs` — `encode_pipeline_f64()` variant for callers with typed f64 data (avoids bytes→f64 conversion). Auto-sets `AEC_DATA_MSB` for szip when encoding is SimplePacking (fixes byte-order mismatch, improved compression ratio from 38% to 27%).
+- `pipeline.rs` — `encode_pipeline_f64()` variant for callers with typed f64 data (avoids bytes→f64 conversion). Auto-sets `AEC_DATA_MSB` for szip when encoding is SimplePacking (fixes byte-order mismatch so libaec's predictor sees most-significant bytes first; compression ratio now matches ecCodes at ~27% on 24-bit GRIB data — see `docs/src/guide/benchmark-results.md`).
 - `compression/` — `Compressor` trait + 6 implementations:
   - `szip.rs` — SzipCompressor (CCSDS 121.0-B-3, RSI block random access)
   - `zstd.rs` — ZstdCompressor (Zstandard, stream compressor)

--- a/plans/DONE.md
+++ b/plans/DONE.md
@@ -12,17 +12,24 @@
 
 ## tensogram-benchmarks
 
-9 tests (8 smoke + 1 GRIB, gated on `eccodes` feature). Separate workspace crate.
+23 smoke tests + 36 unit tests (+ GRIB tests gated on `eccodes`). Separate workspace crate.
 
-- `datagen.rs` — Deterministic SplitMix64-based synthetic weather field generator
-  (smooth sinusoidal temperature field, base ≈ 280 K, amplitude ≈ 30 K, ±0.1 K noise).
-- `report.rs` — ASCII table formatter with reference-relative comparison columns
-  (`vs Ref Enc`, `vs Ref Dec`, `Ratio %`, `Size KiB`). `median_ns` helper for timing.
-- `codec_matrix.rs` — 24 pipeline combos: baseline + raw f64 + simple_packing × {none,zstd,lz4,blosc2,szip} × {16,24,32 bits} + ZFP (rate 16/24/32) + SZ3 (abs=0.01).
-- `grib_comparison.rs` — ecCodes CCSDS (`grid_ccsds`) vs `grid_simple` vs tensogram `sp(24)+szip`. Feature-gated by `eccodes`. Uses raw C API via `extern "C"` declarations.
-- Two binaries: `codec-matrix` (default) and `grib-comparison` (requires `--features eccodes`).
+- `constants.rs` — Shared `AEC_DATA_PREPROCESS` constant (value 8, fixed from incorrect value 1).
+- `datagen.rs` — Deterministic SplitMix64-based synthetic weather field generator.
+- `report.rs` — `BenchmarkResult` with `TimingStats` (median/min/max), `Fidelity` enum
+  (Exact, Lossy{linf, l1, l2}, Unchecked), throughput (MB/s), compressed-size
+  variability tracking. `compute_fidelity()` compares decoded output to original.
+- `codec_matrix.rs` — 24 pipeline combos. `compute_params` inside the timed encode loop
+  for SP cases. Uses `encode_pipeline_f64` to avoid bytes→f64 round-trip. Configurable
+  warm-up (default 3). Returns `BenchmarkRun` with separate `results` and `failures`.
+- `grib_comparison.rs` — Symmetric end-to-end timing. Uses `encode_pipeline_f64`.
+  Returns `BenchmarkRun`.
+- `lib.rs` — `BenchmarkError` enum (Validation, Pipeline), `CaseFailure`, `BenchmarkRun`
+  with `all_passed()`. Binaries exit non-zero on failures.
+- Two binaries: `codec-matrix` (default 10 iterations, 3 warmup) and `grib-comparison`
+  (requires `--features eccodes`). Both accept `--warmup` flag.
 - `build.rs` — links `libeccodes` via pkg-config or Homebrew fallback when `eccodes` feature is active.
-- Documentation: `docs/src/guide/benchmarks.md`.
+- Documentation: `docs/src/guide/benchmarks.md`, `docs/src/guide/benchmark-results.md`.
 
 ## tensogram-core
 
@@ -46,9 +53,10 @@ Unit, integration, adversarial, and edge-case tests.
 
 47 tests.
 
-- `simple_packing.rs` — GRIB-style lossy quantization, MSB-first bit packing, 0-64 bits, NaN rejection, `decode_range()` for arbitrary bit offsets
+- `simple_packing.rs` — GRIB-style lossy quantization, MSB-first bit packing, 0-64 bits, NaN rejection, `decode_range()` for arbitrary bit offsets. Optimized encode/decode: precomputed scale (no per-value division), specialized byte-aligned loops for 8/16/24/32 bits, fused NaN+min+max scan in `compute_params`.
 - `shuffle.rs` — Byte-level shuffle/unshuffle (HDF5-style)
-- `libaec.rs` — Safe Rust wrapper around libaec: `aec_compress()` with RSI block offset tracking, `aec_decompress()`, `aec_decompress_range()`
+- `libaec.rs` — Safe Rust wrapper around libaec: `aec_compress()` with optional RSI block offset tracking (`aec_compress_no_offsets`), `aec_decompress()`, `aec_decompress_range()`. Auto-sets `AEC_DATA_3BYTE` for 17-24 bit samples (fixes corruption bug). 
+- `pipeline.rs` — `encode_pipeline_f64()` variant for callers with typed f64 data (avoids bytes→f64 conversion). Auto-sets `AEC_DATA_MSB` for szip when encoding is SimplePacking (fixes byte-order mismatch, improved compression ratio from 38% to 27%).
 - `compression/` — `Compressor` trait + 6 implementations:
   - `szip.rs` — SzipCompressor (CCSDS 121.0-B-3, RSI block random access)
   - `zstd.rs` — ZstdCompressor (Zstandard, stream compressor)

--- a/plans/IDEAS.md
+++ b/plans/IDEAS.md
@@ -14,6 +14,6 @@ Ideas for possible future implementation. Do not implement these yet.
     - [ ] SIMD payload alignment: optional padding for 16/32/64-byte aligned payloads. 
 
 - Performance
-    - [ ] benchmark suite?
-	- [ ] add performance tests
-	- [ ] compare with eccodes simple+szip
+    - [x] benchmark suite
+    - [x] compare with eccodes simple+szip
+    - [ ] 4-byte AEC containers for 24-bit szip: zero-padded 4-byte containers may improve compression ratio for 17-24 bit data. Requires padding/unpadding in the szip compressor and is a wire format change.


### PR DESCRIPTION
## Summary
Deep review of the benchmark crate uncovered two data-corruption bugs in the szip path and several measurement methodology issues. This PR fixes the bugs, restructures the benchmark harness, optimizes the encode/decode pipeline, and rewrites the documentation for end users.
## Bug fixes
- **szip 24-bit corruption:** `AEC_DATA_3BYTE` flag was never set for 17-24 bit samples, causing libaec to read 4 bytes per sample from 3-byte-packed data. Decoded values had ±60 max error instead of ±1.9×10⁻⁶. Fixed by auto-setting the flag in `effective_flags()`.
- **szip byte-order mismatch:** `AEC_DATA_MSB` was never set despite simple_packing producing MSB-first output. libaec's predictor saw reversed byte significance, hurting compression. Compression ratio improved from 38% to 27% (now matches ecCodes).
- **Benchmark `AEC_DATA_PREPROCESS` constant** was 1 (`AEC_DATA_SIGNED`) instead of 8. Benchmarks were running without the preprocessor step.
## Encode/decode optimization
Encode is 2.5× faster than before for SimplePacking cases:
- Fused NaN + min + max into a single pass in `compute_params` (was 3 passes)
- Removed redundant NaN check from `encode()`
- Precomputed `scale = 10^D × 2^(-E)` — eliminates per-value f64 division
- Specialized `encode_aligned<N>` / `decode_aligned<N>` loops for 8/16/24/32-bit widths — no `write_bits` dispatch, no bit-position tracking
- Added `encode_pipeline_f64()` — avoids the 80 MiB `bytes_to_f64` round-trip allocation
## Benchmark harness improvements
- Structured error handling: `BenchmarkError` enum, `BenchmarkRun` with separate `results`/`failures`, non-zero exit on failures (replaces `[ERROR]` fake rows)
- Fidelity validation: lossless paths checked for exact round-trip, lossy paths report Linf, L1, and L2 (RMSE) norms
- Honest timing: `compute_params` included in SP encode, GRIB comparison uses symmetric end-to-end scope
- Configurable `--warmup` (default 3), default iterations raised from 5 to 10
- Throughput (MB/s) reporting, compressed-size variability detection
## Documentation
- Benchmark results page rewritten with split tables (lossless / SimplePacking / lossy), human-readable method names, sizes in MiB, fidelity norms explained
- Methodology page cleaned of internal jargon — no Rust API names, no C function signatures, no implementation details
## GRIB comparison (vs ecCodes, 10M float64 at 24 bits)
| | Encode | Decode | Ratio |
|---|---|---|---|
| ecCodes CCSDS | 85 ms | 139 ms | 27.2% |
| Tensogram | 114 ms | 137 ms | 27.4% |


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/dev-section/tensogram/pull-requests/PR-20
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->