### PR TITLE
Feature/remote async runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,16 +32,21 @@ jobs:
       - name: Format check
         run: cargo fmt --check
 
-      # Skip --all-features to avoid tensogram-grib which requires ecCodes.
-      # The workspace excludes tensogram-python and tensogram-grib by default.
+      # Skip --all-features on workspace level to avoid tensogram-grib (requires ecCodes).
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Clippy (all features, core + FFI)
+        run: cargo clippy -p tensogram-core -p tensogram-ffi --all-targets --all-features -- -D warnings
 
       - name: Build
         run: cargo build --workspace
 
       - name: Test
         run: cargo test --workspace
+
+      - name: Test (remote feature)
+        run: cargo test -p tensogram-core --features remote
 
   # ── Python: build bindings + test ────────────────────────────────────
   python:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Test (remote feature)
         run: cargo test -p tensogram-core --features remote
 
+      - name: Test (remote + async features)
+        run: cargo test -p tensogram-core --features "remote,async"
+
   # ── Python: build bindings + test ────────────────────────────────────
   python:
     name: Python (${{ matrix.os }}, ${{ matrix.python }})

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,7 @@ This project contains Rust, Python, C and C++ code
 - Test: `source .venv/bin/activate && python -m pytest tests/python/ -v`
 - xarray tests: `source .venv/bin/activate && uv pip install -e "tensogram-xarray/[dask]" && python -m pytest tensogram-xarray/tests/ -v`
 - zarr tests: `source .venv/bin/activate && uv pip install -e tensogram-zarr/ && python -m pytest tensogram-zarr/tests/ -v`
+- IMPORTANT: ALWAYS run `ruff check` and `ruff format` before committing Python files. CI enforces this.
 
 # Version control
 - Git project in github.com/ecmwf/tensogram

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,7 +62,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -64,7 +73,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -74,10 +83,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bindgen"
@@ -198,6 +230,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,6 +286,35 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
 
 [[package]]
 name = "ciborium"
@@ -343,10 +410,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -439,6 +531,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "eccodes"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,7 +586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -517,6 +620,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,14 +701,29 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -547,6 +735,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -556,6 +745,25 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
 
 [[package]]
 name = "half"
@@ -618,10 +826,250 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -636,6 +1084,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,7 +1107,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -671,6 +1135,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,6 +1165,8 @@ version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -753,6 +1228,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,6 +1247,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
@@ -783,6 +1270,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
 ]
 
 [[package]]
@@ -805,6 +1302,17 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "netcdf"
@@ -846,7 +1354,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -870,6 +1378,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "object_store"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body-util",
+ "httparse",
+ "humantime",
+ "hyper",
+ "itertools 0.14.0",
+ "md-5",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml",
+ "rand 0.10.0",
+ "reqwest",
+ "ring",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,6 +1433,12 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "parking_lot"
@@ -909,6 +1462,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -951,6 +1510,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,7 +1556,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand",
+ "rand 0.9.2",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -1002,6 +1570,71 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-xml"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "quote"
@@ -1031,7 +1664,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -1041,7 +1685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1054,12 +1698,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1121,6 +1771,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1142,7 +1848,54 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1173,6 +1926,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1182,10 +1941,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1246,13 +2037,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -1272,16 +2075,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1292,6 +2123,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1326,7 +2177,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1362,8 +2213,13 @@ dependencies = [
 name = "tensogram-core"
 version = "0.9.1"
 dependencies = [
+ "bytes",
  "ciborium",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "memmap2",
+ "object_store",
  "serde",
  "serde_json",
  "sha2",
@@ -1372,6 +2228,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "url",
  "uuid",
  "xxhash-rust",
 ]
@@ -1479,6 +2336,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1489,13 +2356,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
+ "bytes",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "socket2",
  "tokio-macros",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1507,6 +2394,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1549,6 +2459,51 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -1613,6 +2568,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1641,6 +2602,30 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1697,6 +2682,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1725,6 +2725,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1782,6 +2792,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1804,12 +2827,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1819,6 +2887,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1826,6 +2930,135 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -1844,7 +3077,7 @@ checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
  "serde",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1936,10 +3169,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -1955,6 +3217,66 @@ name = "zerocopy-derive"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/tensogram-core/Cargo.toml
+++ b/crates/tensogram-core/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 default = ["szip", "zstd", "lz4", "blosc2", "zfp", "sz3"]
 mmap = ["dep:memmap2"]
 async = ["dep:tokio"]
+remote = ["dep:object_store", "dep:url", "dep:bytes", "dep:tokio"]
 # Compression feature gates — forwarded to tensogram-encodings
 szip = ["tensogram-encodings/szip"]
 szip-pure = ["tensogram-encodings/szip-pure"]
@@ -27,9 +28,16 @@ uuid.workspace = true
 tracing.workspace = true
 memmap2 = { version = "0.9", optional = true }
 tokio = { version = "1", features = ["fs", "rt"], optional = true }
+# Remote object store access (S3, GCS, Azure, HTTP)
+object_store = { version = "0.13", default-features = false, features = ["aws", "gcp", "azure", "http"], optional = true }
+url = { version = "2", optional = true }
+bytes = { version = "1", optional = true }
 
 [dev-dependencies]
 serde_json.workspace = true
 tempfile = "3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 sha2 = "0.10"
+hyper = { version = "1", features = ["server", "http1"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
+http-body-util = "0.1"

--- a/crates/tensogram-core/Cargo.toml
+++ b/crates/tensogram-core/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 default = ["szip", "zstd", "lz4", "blosc2", "zfp", "sz3"]
 mmap = ["dep:memmap2"]
 async = ["dep:tokio"]
-remote = ["dep:object_store", "dep:url", "dep:bytes", "dep:tokio"]
+remote = ["dep:object_store", "dep:url", "dep:bytes", "dep:tokio", "tokio/rt-multi-thread"]
 # Compression feature gates — forwarded to tensogram-encodings
 szip = ["tensogram-encodings/szip"]
 szip-pure = ["tensogram-encodings/szip-pure"]

--- a/crates/tensogram-core/src/decode.rs
+++ b/crates/tensogram-core/src/decode.rs
@@ -206,7 +206,14 @@ pub fn decode_range(
     Ok(results)
 }
 
-/// Decode a single object through the full pipeline.
+pub(crate) fn decode_single_object(
+    desc: &DataObjectDescriptor,
+    payload_bytes: &[u8],
+    options: &DecodeOptions,
+) -> Result<Vec<u8>> {
+    decode_single_object_with_backend(desc, payload_bytes, options, options.compression_backend)
+}
+
 fn decode_single_object_with_backend(
     desc: &DataObjectDescriptor,
     payload_bytes: &[u8],

--- a/crates/tensogram-core/src/decode.rs
+++ b/crates/tensogram-core/src/decode.rs
@@ -206,6 +206,7 @@ pub fn decode_range(
     Ok(results)
 }
 
+#[cfg(feature = "remote")]
 pub(crate) fn decode_single_object(
     desc: &DataObjectDescriptor,
     payload_bytes: &[u8],

--- a/crates/tensogram-core/src/error.rs
+++ b/crates/tensogram-core/src/error.rs
@@ -16,6 +16,8 @@ pub enum TensogramError {
     Io(#[from] std::io::Error),
     #[error("hash mismatch: expected {expected}, got {actual}")]
     HashMismatch { expected: String, actual: String },
+    #[error("remote error: {0}")]
+    Remote(String),
 }
 
 pub type Result<T> = std::result::Result<T, TensogramError>;

--- a/crates/tensogram-core/src/file.rs
+++ b/crates/tensogram-core/src/file.rs
@@ -8,18 +8,38 @@ use crate::error::{Result, TensogramError};
 use crate::framing;
 use crate::types::{DataObjectDescriptor, DecodedObject, GlobalMetadata};
 
+// ── Backend enum ─────────────────────────────────────────────────────────────
+
+enum Backend {
+    Local {
+        path: PathBuf,
+        #[cfg(feature = "mmap")]
+        mmap: Option<memmap2::Mmap>,
+    },
+    #[cfg(feature = "remote")]
+    Remote(crate::remote::RemoteBackend),
+}
+
+impl Backend {
+    fn source_string(&self) -> String {
+        match self {
+            Backend::Local { path, .. } => path.display().to_string(),
+            #[cfg(feature = "remote")]
+            Backend::Remote(r) => r.source_url().to_string(),
+        }
+    }
+}
+
 /// A handle for reading/writing Tensogram message files.
+///
+/// Supports local files, memory-mapped files (`mmap` feature), and
+/// remote object stores (`remote` feature) via a unified API.
 pub struct TensogramFile {
-    path: PathBuf,
-    /// Cached message offsets (offset, length) from scan.
+    backend: Backend,
     message_offsets: Option<Vec<(usize, usize)>>,
-    /// Memory-mapped file buffer (available with `mmap` feature).
-    #[cfg(feature = "mmap")]
-    mmap: Option<memmap2::Mmap>,
 }
 
 impl TensogramFile {
-    /// Open an existing file for reading.
     #[tracing::instrument(skip(path), fields(path = %path.as_ref().display()))]
     pub fn open(path: impl AsRef<Path>) -> Result<Self> {
         let path = path.as_ref().to_path_buf();
@@ -30,14 +50,46 @@ impl TensogramFile {
             )));
         }
         Ok(TensogramFile {
-            path,
+            backend: Backend::Local {
+                path,
+                #[cfg(feature = "mmap")]
+                mmap: None,
+            },
             message_offsets: None,
-            #[cfg(feature = "mmap")]
-            mmap: None,
         })
     }
 
-    /// Create a new file for writing (truncates if exists).
+    /// Open a local file or remote URL.
+    ///
+    /// Auto-detects remote URLs (s3://, gs://, az://, http://, https://)
+    /// when the `remote` feature is enabled; otherwise treats the source
+    /// as a local path.
+    pub fn open_source(source: impl AsRef<str>) -> Result<Self> {
+        let source = source.as_ref();
+
+        #[cfg(feature = "remote")]
+        if crate::remote::is_remote_url(source) {
+            return Self::open_remote(source, &std::collections::BTreeMap::new());
+        }
+
+        Self::open(source)
+    }
+
+    /// Open a remote file with explicit storage options (credentials, region, etc.).
+    #[cfg(feature = "remote")]
+    pub fn open_remote(
+        source: &str,
+        storage_options: &std::collections::BTreeMap<String, String>,
+    ) -> Result<Self> {
+        let remote = crate::remote::RemoteBackend::open(source, storage_options)?;
+        let offsets = remote.message_offsets();
+        Ok(TensogramFile {
+            backend: Backend::Remote(remote),
+            message_offsets: Some(offsets),
+        })
+    }
+
+    /// Create a new local file for writing (truncates if exists).
     #[tracing::instrument(skip(path), fields(path = %path.as_ref().display()))]
     pub fn create(path: impl AsRef<Path>) -> Result<Self> {
         let path = path.as_ref().to_path_buf();
@@ -56,10 +108,12 @@ impl TensogramFile {
             ))
         })?;
         Ok(TensogramFile {
-            path,
+            backend: Backend::Local {
+                path,
+                #[cfg(feature = "mmap")]
+                mmap: None,
+            },
             message_offsets: None,
-            #[cfg(feature = "mmap")]
-            mmap: None,
         })
     }
 
@@ -83,24 +137,35 @@ impl TensogramFile {
         let mmap = unsafe { memmap2::Mmap::map(&file)? };
         let offsets = framing::scan(&mmap);
         Ok(TensogramFile {
-            path,
+            backend: Backend::Local {
+                path,
+                mmap: Some(mmap),
+            },
             message_offsets: Some(offsets),
-            mmap: Some(mmap),
         })
     }
 
-    /// Scan the file for message boundaries using streaming I/O.
-    ///
-    /// Reads only preamble-sized chunks and seeks, avoiding loading the
-    /// entire file into memory. Caches results for subsequent calls.
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    fn local_path(&self) -> Result<&PathBuf> {
+        match &self.backend {
+            Backend::Local { path, .. } => Ok(path),
+            #[cfg(feature = "remote")]
+            Backend::Remote(_) => Err(TensogramError::Remote(
+                "operation not supported on remote files".to_string(),
+            )),
+        }
+    }
+
     fn ensure_scanned(&mut self) -> Result<()> {
         if self.message_offsets.is_some() {
             return Ok(());
         }
-        let mut file = fs::File::open(&self.path).map_err(|e| {
+        let path = self.local_path()?.clone();
+        let mut file = fs::File::open(&path).map_err(|e| {
             TensogramError::Io(std::io::Error::new(
                 e.kind(),
-                format!("{}: {e}", self.path.display()),
+                format!("{}: {e}", path.display()),
             ))
         })?;
         let offsets = framing::scan_file(&mut file)?;
@@ -108,42 +173,7 @@ impl TensogramFile {
         Ok(())
     }
 
-    /// Count messages without decoding them.
-    pub fn message_count(&mut self) -> Result<usize> {
-        self.ensure_scanned()?;
-        Ok(self
-            .message_offsets
-            .as_ref()
-            .ok_or_else(|| TensogramError::Framing("scan result missing".to_string()))?
-            .len())
-    }
-
-    /// Append a message to the file.
-    pub fn append(
-        &mut self,
-        global_metadata: &GlobalMetadata,
-        descriptors: &[(&DataObjectDescriptor, &[u8])],
-        options: &EncodeOptions,
-    ) -> Result<()> {
-        let msg = encode::encode(global_metadata, descriptors, options)?;
-        let mut file = fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&self.path)
-            .map_err(|e| {
-                TensogramError::Io(std::io::Error::new(
-                    e.kind(),
-                    format!("{}: {e}", self.path.display()),
-                ))
-            })?;
-        file.write_all(&msg)?;
-        self.message_offsets = None;
-        Ok(())
-    }
-
-    /// Read raw message bytes at a specific index.
-    pub fn read_message(&mut self, index: usize) -> Result<Vec<u8>> {
-        self.ensure_scanned()?;
+    fn checked_offsets(&self, index: usize) -> Result<(usize, usize)> {
         let offsets = self
             .message_offsets
             .as_ref()
@@ -155,27 +185,74 @@ impl TensogramFile {
                 offsets.len()
             )));
         }
-        let (offset, length) = offsets[index];
+        Ok(offsets[index])
+    }
 
-        // Use mmap buffer if available, otherwise seek+read
+    // ── Public API ───────────────────────────────────────────────────────
+
+    pub fn message_count(&mut self) -> Result<usize> {
+        self.ensure_scanned()?;
+        Ok(self
+            .message_offsets
+            .as_ref()
+            .ok_or_else(|| TensogramError::Framing("scan result missing".to_string()))?
+            .len())
+    }
+
+    pub fn append(
+        &mut self,
+        global_metadata: &GlobalMetadata,
+        descriptors: &[(&DataObjectDescriptor, &[u8])],
+        options: &EncodeOptions,
+    ) -> Result<()> {
+        let path = self.local_path()?.clone();
+        let msg = encode::encode(global_metadata, descriptors, options)?;
+        let mut file = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .map_err(|e| {
+                TensogramError::Io(std::io::Error::new(
+                    e.kind(),
+                    format!("{}: {e}", path.display()),
+                ))
+            })?;
+        file.write_all(&msg)?;
+        self.message_offsets = None;
+        Ok(())
+    }
+
+    pub fn read_message(&mut self, index: usize) -> Result<Vec<u8>> {
+        self.ensure_scanned()?;
+        let (offset, length) = self.checked_offsets(index)?;
+
         #[cfg(feature = "mmap")]
-        if let Some(ref mmap) = self.mmap {
+        if let Backend::Local {
+            mmap: Some(ref mmap),
+            ..
+        } = self.backend
+        {
             return Ok(mmap[offset..offset + length].to_vec());
         }
 
-        let mut file = fs::File::open(&self.path).map_err(|e| {
-            TensogramError::Io(std::io::Error::new(
-                e.kind(),
-                format!("{}: {e}", self.path.display()),
-            ))
-        })?;
-        file.seek(SeekFrom::Start(offset as u64))?;
-        let mut buf = vec![0u8; length];
-        file.read_exact(&mut buf)?;
-        Ok(buf)
+        match &self.backend {
+            Backend::Local { path, .. } => {
+                let mut file = fs::File::open(path).map_err(|e| {
+                    TensogramError::Io(std::io::Error::new(
+                        e.kind(),
+                        format!("{}: {e}", path.display()),
+                    ))
+                })?;
+                file.seek(SeekFrom::Start(offset as u64))?;
+                let mut buf = vec![0u8; length];
+                file.read_exact(&mut buf)?;
+                Ok(buf)
+            }
+            #[cfg(feature = "remote")]
+            Backend::Remote(remote) => remote.read_message(index),
+        }
     }
 
-    /// Iterate over messages. Each item is the raw message bytes.
     #[deprecated(note = "Use message_count() + read_message(index) for lazy access")]
     pub fn messages(&mut self) -> Result<Vec<Vec<u8>>> {
         self.ensure_scanned()?;
@@ -191,7 +268,6 @@ impl TensogramFile {
         Ok(msgs)
     }
 
-    /// Decode a specific message by index.
     pub fn decode_message(
         &mut self,
         index: usize,
@@ -201,37 +277,86 @@ impl TensogramFile {
         decode::decode(&msg, options)
     }
 
-    /// Return a lazy iterator over the messages in this file.
     pub fn iter(&mut self) -> Result<crate::iter::FileMessageIter> {
         self.ensure_scanned()?;
+        let path = self.local_path()?.clone();
         let offsets = self
             .message_offsets
             .as_ref()
             .ok_or_else(|| TensogramError::Framing("scan result missing".to_string()))?
             .clone();
-        crate::iter::FileMessageIter::new(self.path.clone(), offsets)
+        crate::iter::FileMessageIter::new(path, offsets)
     }
 
-    /// Get the file path.
     pub fn path(&self) -> &Path {
-        &self.path
+        match &self.backend {
+            Backend::Local { path, .. } => path,
+            #[cfg(feature = "remote")]
+            Backend::Remote(_) => Path::new(""),
+        }
     }
 
-    /// Invalidate the cached message offsets.
-    ///
-    /// Call this after any external modification to the underlying file
-    /// (e.g. raw byte append) so that the next `message_count()` or
-    /// `read_message()` re-scans the file.
+    pub fn source(&self) -> String {
+        self.backend.source_string()
+    }
+
     pub fn invalidate_offsets(&mut self) {
         self.message_offsets = None;
     }
 
-    // ── Async API (requires `async` feature) ─────────────────────────
+    // ── Object-level access (efficient for remote) ───────────────────────
 
-    /// Open a file and scan it asynchronously.
-    ///
-    /// The scan is CPU-bound, so it runs on a blocking thread via
-    /// `tokio::task::spawn_blocking`.
+    pub fn file_decode_metadata(&mut self, msg_idx: usize) -> Result<GlobalMetadata> {
+        match &mut self.backend {
+            #[cfg(feature = "remote")]
+            Backend::Remote(remote) => remote.read_metadata(msg_idx),
+            _ => {
+                let msg = self.read_message(msg_idx)?;
+                decode::decode_metadata(&msg)
+            }
+        }
+    }
+
+    pub fn file_decode_descriptors(
+        &mut self,
+        msg_idx: usize,
+    ) -> Result<(GlobalMetadata, Vec<DataObjectDescriptor>)> {
+        match &mut self.backend {
+            #[cfg(feature = "remote")]
+            Backend::Remote(remote) => remote.read_descriptors(msg_idx),
+            _ => {
+                let msg = self.read_message(msg_idx)?;
+                decode::decode_descriptors(&msg)
+            }
+        }
+    }
+
+    pub fn file_decode_object(
+        &mut self,
+        msg_idx: usize,
+        obj_idx: usize,
+        options: &DecodeOptions,
+    ) -> Result<(GlobalMetadata, DataObjectDescriptor, Vec<u8>)> {
+        match &mut self.backend {
+            #[cfg(feature = "remote")]
+            Backend::Remote(remote) => remote.read_object(msg_idx, obj_idx, options),
+            _ => {
+                let msg = self.read_message(msg_idx)?;
+                decode::decode_object(&msg, obj_idx, options)
+            }
+        }
+    }
+
+    pub fn is_remote(&self) -> bool {
+        #[cfg(feature = "remote")]
+        if matches!(self.backend, Backend::Remote(_)) {
+            return true;
+        }
+        false
+    }
+
+    // ── Async API (requires `async` feature) ─────────────────────────────
+
     #[cfg(feature = "async")]
     pub async fn open_async(path: impl AsRef<Path>) -> Result<Self> {
         let path = path.as_ref().to_path_buf();
@@ -255,19 +380,19 @@ impl TensogramFile {
         .map_err(|e| TensogramError::Io(std::io::Error::other(e)))??;
 
         Ok(TensogramFile {
-            path,
+            backend: Backend::Local {
+                path,
+                #[cfg(feature = "mmap")]
+                mmap: None,
+            },
             message_offsets: Some(offsets),
-            #[cfg(feature = "mmap")]
-            mmap: None,
         })
     }
 
-    /// Read raw message bytes at a specific index, asynchronously.
     #[cfg(feature = "async")]
     pub async fn read_message_async(&mut self, index: usize) -> Result<Vec<u8>> {
-        // Ensure scanned (sync — already cached after open_async)
         if self.message_offsets.is_none() {
-            let p = self.path.clone();
+            let p = self.local_path()?.clone();
             let offsets = tokio::task::spawn_blocking(move || {
                 let mut file = fs::File::open(&p)?;
                 framing::scan_file(&mut file)
@@ -277,20 +402,9 @@ impl TensogramFile {
             self.message_offsets = Some(offsets);
         }
 
-        let offsets = self
-            .message_offsets
-            .as_ref()
-            .ok_or_else(|| TensogramError::Framing("scan result missing".to_string()))?;
-        if index >= offsets.len() {
-            return Err(TensogramError::Framing(format!(
-                "message index {} out of range (count={})",
-                index,
-                offsets.len()
-            )));
-        }
-        let (offset, length) = offsets[index];
+        let (offset, length) = self.checked_offsets(index)?;
 
-        let p = self.path.clone();
+        let p = self.local_path()?.clone();
         tokio::task::spawn_blocking(move || {
             let mut file = fs::File::open(&p)?;
             file.seek(SeekFrom::Start(offset as u64))?;
@@ -362,11 +476,11 @@ mod tests {
     }
 
     #[test]
-    fn test_file_create_append_read() {
-        let dir = tempfile::tempdir().unwrap();
+    fn test_file_create_append_read() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
         let path = dir.path().join("test.tgm");
 
-        let mut file = TensogramFile::create(&path).unwrap();
+        let mut file = TensogramFile::create(&path)?;
         let meta = make_global_meta();
         let desc = make_descriptor(vec![4]);
         let data = vec![0u8; 16];
@@ -374,33 +488,32 @@ mod tests {
             &meta,
             &[(&desc, data.as_slice())],
             &EncodeOptions::default(),
-        )
-        .unwrap();
+        )?;
         file.append(
             &meta,
             &[(&desc, data.as_slice())],
             &EncodeOptions::default(),
-        )
-        .unwrap();
+        )?;
 
-        assert_eq!(file.message_count().unwrap(), 2);
+        assert_eq!(file.message_count()?, 2);
 
         #[allow(deprecated)]
-        let msgs = file.messages().unwrap();
+        let msgs = file.messages()?;
         assert_eq!(msgs.len(), 2);
 
-        let (decoded_meta, objects) = file.decode_message(0, &DecodeOptions::default()).unwrap();
+        let (decoded_meta, objects) = file.decode_message(0, &DecodeOptions::default())?;
         assert_eq!(decoded_meta.version, 2);
         assert_eq!(objects.len(), 1);
         assert_eq!(objects[0].1, data);
+        Ok(())
     }
 
     #[test]
-    fn test_file_lazy_read() {
-        let dir = tempfile::tempdir().unwrap();
+    fn test_file_lazy_read() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
         let path = dir.path().join("lazy.tgm");
 
-        let mut file = TensogramFile::create(&path).unwrap();
+        let mut file = TensogramFile::create(&path)?;
         let meta = make_global_meta();
         let desc = make_descriptor(vec![4]);
 
@@ -412,83 +525,79 @@ mod tests {
             &meta,
             &[(&desc, data0.as_slice())],
             &EncodeOptions::default(),
-        )
-        .unwrap();
+        )?;
         file.append(
             &meta,
             &[(&desc, data1.as_slice())],
             &EncodeOptions::default(),
-        )
-        .unwrap();
+        )?;
         file.append(
             &meta,
             &[(&desc, data2.as_slice())],
             &EncodeOptions::default(),
-        )
-        .unwrap();
+        )?;
 
-        assert_eq!(file.message_count().unwrap(), 3);
+        assert_eq!(file.message_count()?, 3);
 
-        let (_, obj1) = file.decode_message(1, &DecodeOptions::default()).unwrap();
+        let (_, obj1) = file.decode_message(1, &DecodeOptions::default())?;
         assert_eq!(obj1[0].1, data1);
 
-        let (_, obj0) = file.decode_message(0, &DecodeOptions::default()).unwrap();
+        let (_, obj0) = file.decode_message(0, &DecodeOptions::default())?;
         assert_eq!(obj0[0].1, data0);
 
-        let (_, obj2) = file.decode_message(2, &DecodeOptions::default()).unwrap();
+        let (_, obj2) = file.decode_message(2, &DecodeOptions::default())?;
         assert_eq!(obj2[0].1, data2);
+        Ok(())
     }
 
-    // ── Phase 4: mmap tests ────────────────────────────────────────────
-
-    #[cfg(feature = "mmap")]
     #[test]
-    fn test_mmap_open_and_read() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("mmap.tgm");
+    fn test_file_decode_metadata() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("meta.tgm");
 
-        // Write two messages normally
-        let mut file = TensogramFile::create(&path).unwrap();
+        let mut file = TensogramFile::create(&path)?;
         let meta = make_global_meta();
         let desc = make_descriptor(vec![4]);
-        let data0 = vec![10u8; 16];
-        let data1 = vec![20u8; 16];
+        let data = vec![0u8; 16];
         file.append(
             &meta,
-            &[(&desc, data0.as_slice())],
+            &[(&desc, data.as_slice())],
             &EncodeOptions::default(),
-        )
-        .unwrap();
-        file.append(
-            &meta,
-            &[(&desc, data1.as_slice())],
-            &EncodeOptions::default(),
-        )
-        .unwrap();
+        )?;
 
-        // Reopen with mmap
-        let mut mmap_file = TensogramFile::open_mmap(&path).unwrap();
-        assert_eq!(mmap_file.message_count().unwrap(), 2);
-
-        let (decoded_meta, objects) = mmap_file
-            .decode_message(0, &DecodeOptions::default())
-            .unwrap();
+        let decoded_meta = file.file_decode_metadata(0)?;
         assert_eq!(decoded_meta.version, 2);
-        assert_eq!(objects[0].1, data0);
-
-        let (_, objects1) = mmap_file
-            .decode_message(1, &DecodeOptions::default())
-            .unwrap();
-        assert_eq!(objects1[0].1, data1);
+        Ok(())
     }
 
-    #[cfg(feature = "mmap")]
     #[test]
-    fn test_mmap_matches_regular_open() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("mmap_vs_regular.tgm");
+    fn test_file_decode_descriptors() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("descs.tgm");
 
-        let mut file = TensogramFile::create(&path).unwrap();
+        let mut file = TensogramFile::create(&path)?;
+        let meta = make_global_meta();
+        let desc = make_descriptor(vec![4]);
+        let data = vec![0u8; 16];
+        file.append(
+            &meta,
+            &[(&desc, data.as_slice())],
+            &EncodeOptions::default(),
+        )?;
+
+        let (decoded_meta, descriptors) = file.file_decode_descriptors(0)?;
+        assert_eq!(decoded_meta.version, 2);
+        assert_eq!(descriptors.len(), 1);
+        assert_eq!(descriptors[0].shape, vec![4]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_file_decode_object() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("obj.tgm");
+
+        let mut file = TensogramFile::create(&path)?;
         let meta = make_global_meta();
         let desc = make_descriptor(vec![4]);
         let data = vec![42u8; 16];
@@ -496,26 +605,84 @@ mod tests {
             &meta,
             &[(&desc, data.as_slice())],
             &EncodeOptions::default(),
-        )
-        .unwrap();
+        )?;
 
-        // Read with regular open
-        let mut regular = TensogramFile::open(&path).unwrap();
-        let regular_msg = regular.read_message(0).unwrap();
+        let (decoded_meta, decoded_desc, decoded_data) =
+            file.file_decode_object(0, 0, &DecodeOptions::default())?;
+        assert_eq!(decoded_meta.version, 2);
+        assert_eq!(decoded_desc.shape, vec![4]);
+        assert_eq!(decoded_data, data);
+        Ok(())
+    }
 
-        // Read with mmap
-        let mut mmap = TensogramFile::open_mmap(&path).unwrap();
-        let mmap_msg = mmap.read_message(0).unwrap();
+    // ── mmap tests ───────────────────────────────────────────────────────
+
+    #[cfg(feature = "mmap")]
+    #[test]
+    fn test_mmap_open_and_read() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("mmap.tgm");
+
+        let mut file = TensogramFile::create(&path)?;
+        let meta = make_global_meta();
+        let desc = make_descriptor(vec![4]);
+        let data0 = vec![10u8; 16];
+        let data1 = vec![20u8; 16];
+        file.append(
+            &meta,
+            &[(&desc, data0.as_slice())],
+            &EncodeOptions::default(),
+        )?;
+        file.append(
+            &meta,
+            &[(&desc, data1.as_slice())],
+            &EncodeOptions::default(),
+        )?;
+
+        let mut mmap_file = TensogramFile::open_mmap(&path)?;
+        assert_eq!(mmap_file.message_count()?, 2);
+
+        let (decoded_meta, objects) = mmap_file.decode_message(0, &DecodeOptions::default())?;
+        assert_eq!(decoded_meta.version, 2);
+        assert_eq!(objects[0].1, data0);
+
+        let (_, objects1) = mmap_file.decode_message(1, &DecodeOptions::default())?;
+        assert_eq!(objects1[0].1, data1);
+        Ok(())
+    }
+
+    #[cfg(feature = "mmap")]
+    #[test]
+    fn test_mmap_matches_regular_open() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("mmap_vs_regular.tgm");
+
+        let mut file = TensogramFile::create(&path)?;
+        let meta = make_global_meta();
+        let desc = make_descriptor(vec![4]);
+        let data = vec![42u8; 16];
+        file.append(
+            &meta,
+            &[(&desc, data.as_slice())],
+            &EncodeOptions::default(),
+        )?;
+
+        let mut regular = TensogramFile::open(&path)?;
+        let regular_msg = regular.read_message(0)?;
+
+        let mut mmap = TensogramFile::open_mmap(&path)?;
+        let mmap_msg = mmap.read_message(0)?;
 
         assert_eq!(regular_msg, mmap_msg);
+        Ok(())
     }
 
     #[test]
-    fn test_file_iter_via_tensogram_file() {
-        let dir = tempfile::tempdir().unwrap();
+    fn test_file_iter_via_tensogram_file() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
         let path = dir.path().join("iter.tgm");
 
-        let mut file = TensogramFile::create(&path).unwrap();
+        let mut file = TensogramFile::create(&path)?;
         let meta = make_global_meta();
         let desc = make_descriptor(vec![4]);
 
@@ -527,40 +694,38 @@ mod tests {
             &meta,
             &[(&desc, data0.as_slice())],
             &EncodeOptions::default(),
-        )
-        .unwrap();
+        )?;
         file.append(
             &meta,
             &[(&desc, data1.as_slice())],
             &EncodeOptions::default(),
-        )
-        .unwrap();
+        )?;
         file.append(
             &meta,
             &[(&desc, data2.as_slice())],
             &EncodeOptions::default(),
-        )
-        .unwrap();
+        )?;
 
-        let raw_messages: Vec<Vec<u8>> = file.iter().unwrap().map(|r| r.unwrap()).collect();
+        let raw_messages: Vec<Vec<u8>> =
+            file.iter()?.collect::<std::result::Result<Vec<_>, _>>()?;
         assert_eq!(raw_messages.len(), 3);
 
         for (i, raw) in raw_messages.iter().enumerate() {
-            let (_, objects) = crate::decode::decode(raw, &DecodeOptions::default()).unwrap();
+            let (_, objects) = crate::decode::decode(raw, &DecodeOptions::default())?;
             assert_eq!(objects[0].1, vec![i as u8; 16]);
         }
+        Ok(())
     }
 
-    // ── Phase 5: async tests ─────────────────────────────────────────
+    // ── async tests ──────────────────────────────────────────────────────
 
     #[cfg(feature = "async")]
     #[tokio::test]
-    async fn test_async_open_and_read() {
-        let dir = tempfile::tempdir().unwrap();
+    async fn test_async_open_and_read() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
         let path = dir.path().join("async.tgm");
 
-        // Write messages with sync API
-        let mut file = TensogramFile::create(&path).unwrap();
+        let mut file = TensogramFile::create(&path)?;
         let meta = make_global_meta();
         let desc = make_descriptor(vec![4]);
         let data0 = vec![10u8; 16];
@@ -569,38 +734,35 @@ mod tests {
             &meta,
             &[(&desc, data0.as_slice())],
             &EncodeOptions::default(),
-        )
-        .unwrap();
+        )?;
         file.append(
             &meta,
             &[(&desc, data1.as_slice())],
             &EncodeOptions::default(),
-        )
-        .unwrap();
+        )?;
 
-        // Read with async API
-        let mut async_file = TensogramFile::open_async(&path).await.unwrap();
-        assert_eq!(async_file.message_count().unwrap(), 2);
+        let mut async_file = TensogramFile::open_async(&path).await?;
+        assert_eq!(async_file.message_count()?, 2);
 
-        let msg0 = async_file.read_message_async(0).await.unwrap();
-        let (meta0, objects0) = crate::decode::decode(&msg0, &DecodeOptions::default()).unwrap();
+        let msg0 = async_file.read_message_async(0).await?;
+        let (meta0, objects0) = crate::decode::decode(&msg0, &DecodeOptions::default())?;
         assert_eq!(meta0.version, 2);
         assert_eq!(objects0[0].1, data0);
 
         let (_, objects1) = async_file
             .decode_message_async(1, &DecodeOptions::default())
-            .await
-            .unwrap();
+            .await?;
         assert_eq!(objects1[0].1, data1);
+        Ok(())
     }
 
     #[cfg(feature = "async")]
     #[tokio::test]
-    async fn test_async_matches_sync() {
-        let dir = tempfile::tempdir().unwrap();
+    async fn test_async_matches_sync() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
         let path = dir.path().join("async_vs_sync.tgm");
 
-        let mut file = TensogramFile::create(&path).unwrap();
+        let mut file = TensogramFile::create(&path)?;
         let meta = make_global_meta();
         let desc = make_descriptor(vec![4]);
         let data = vec![42u8; 16];
@@ -608,17 +770,15 @@ mod tests {
             &meta,
             &[(&desc, data.as_slice())],
             &EncodeOptions::default(),
-        )
-        .unwrap();
+        )?;
 
-        // Sync read
-        let mut sync_file = TensogramFile::open(&path).unwrap();
-        let sync_msg = sync_file.read_message(0).unwrap();
+        let mut sync_file = TensogramFile::open(&path)?;
+        let sync_msg = sync_file.read_message(0)?;
 
-        // Async read
-        let mut async_file = TensogramFile::open_async(&path).await.unwrap();
-        let async_msg = async_file.read_message_async(0).await.unwrap();
+        let mut async_file = TensogramFile::open_async(&path).await?;
+        let async_msg = async_file.read_message_async(0).await?;
 
         assert_eq!(sync_msg, async_msg);
+        Ok(())
     }
 }

--- a/crates/tensogram-core/src/file.rs
+++ b/crates/tensogram-core/src/file.rs
@@ -288,11 +288,11 @@ impl TensogramFile {
         crate::iter::FileMessageIter::new(path, offsets)
     }
 
-    pub fn path(&self) -> &Path {
+    pub fn path(&self) -> Option<&Path> {
         match &self.backend {
-            Backend::Local { path, .. } => path,
+            Backend::Local { path, .. } => Some(path),
             #[cfg(feature = "remote")]
-            Backend::Remote(_) => Path::new(""),
+            Backend::Remote(_) => None,
         }
     }
 
@@ -301,7 +301,13 @@ impl TensogramFile {
     }
 
     pub fn invalidate_offsets(&mut self) {
-        self.message_offsets = None;
+        match &self.backend {
+            Backend::Local { .. } => {
+                self.message_offsets = None;
+            }
+            #[cfg(feature = "remote")]
+            Backend::Remote(_) => {}
+        }
     }
 
     // ── Object-level access (efficient for remote) ───────────────────────

--- a/crates/tensogram-core/src/file.rs
+++ b/crates/tensogram-core/src/file.rs
@@ -312,7 +312,7 @@ impl TensogramFile {
 
     // ── Object-level access (efficient for remote) ───────────────────────
 
-    pub fn file_decode_metadata(&mut self, msg_idx: usize) -> Result<GlobalMetadata> {
+    pub fn decode_metadata(&mut self, msg_idx: usize) -> Result<GlobalMetadata> {
         match &mut self.backend {
             #[cfg(feature = "remote")]
             Backend::Remote(remote) => remote.read_metadata(msg_idx),
@@ -323,7 +323,7 @@ impl TensogramFile {
         }
     }
 
-    pub fn file_decode_descriptors(
+    pub fn decode_descriptors(
         &mut self,
         msg_idx: usize,
     ) -> Result<(GlobalMetadata, Vec<DataObjectDescriptor>)> {
@@ -337,7 +337,7 @@ impl TensogramFile {
         }
     }
 
-    pub fn file_decode_object(
+    pub fn decode_object(
         &mut self,
         msg_idx: usize,
         obj_idx: usize,
@@ -571,7 +571,7 @@ mod tests {
             &EncodeOptions::default(),
         )?;
 
-        let decoded_meta = file.file_decode_metadata(0)?;
+        let decoded_meta = file.decode_metadata(0)?;
         assert_eq!(decoded_meta.version, 2);
         Ok(())
     }
@@ -591,7 +591,7 @@ mod tests {
             &EncodeOptions::default(),
         )?;
 
-        let (decoded_meta, descriptors) = file.file_decode_descriptors(0)?;
+        let (decoded_meta, descriptors) = file.decode_descriptors(0)?;
         assert_eq!(decoded_meta.version, 2);
         assert_eq!(descriptors.len(), 1);
         assert_eq!(descriptors[0].shape, vec![4]);
@@ -614,7 +614,7 @@ mod tests {
         )?;
 
         let (decoded_meta, decoded_desc, decoded_data) =
-            file.file_decode_object(0, 0, &DecodeOptions::default())?;
+            file.decode_object(0, 0, &DecodeOptions::default())?;
         assert_eq!(decoded_meta.version, 2);
         assert_eq!(decoded_desc.shape, vec![4]);
         assert_eq!(decoded_data, data);

--- a/crates/tensogram-core/src/file.rs
+++ b/crates/tensogram-core/src/file.rs
@@ -397,6 +397,11 @@ impl TensogramFile {
 
     #[cfg(feature = "async")]
     pub async fn read_message_async(&mut self, index: usize) -> Result<Vec<u8>> {
+        #[cfg(feature = "remote")]
+        if let Backend::Remote(remote) = &self.backend {
+            return remote.read_message_async(index).await;
+        }
+
         if self.message_offsets.is_none() {
             let p = self.local_path()?.clone();
             let offsets = tokio::task::spawn_blocking(move || {
@@ -422,10 +427,6 @@ impl TensogramFile {
         .map_err(|e| TensogramError::Io(std::io::Error::other(e)))?
     }
 
-    /// Decode a specific message asynchronously.
-    ///
-    /// Both I/O and CPU-intensive decode run on blocking threads
-    /// because the encoding pipeline may call FFI (libaec, zfp, blosc2).
     #[cfg(feature = "async")]
     pub async fn decode_message_async(
         &mut self,
@@ -435,6 +436,78 @@ impl TensogramFile {
         let msg = self.read_message_async(index).await?;
         let opts = options.clone();
         tokio::task::spawn_blocking(move || decode::decode(&msg, &opts))
+            .await
+            .map_err(|e| TensogramError::Io(std::io::Error::other(e)))?
+    }
+
+    #[cfg(all(feature = "remote", feature = "async"))]
+    pub async fn open_source_async(source: impl AsRef<str>) -> Result<Self> {
+        let source = source.as_ref();
+
+        if crate::remote::is_remote_url(source) {
+            return Self::open_remote_async(source, &std::collections::BTreeMap::new()).await;
+        }
+
+        Self::open_async(source).await
+    }
+
+    #[cfg(all(feature = "remote", feature = "async"))]
+    pub async fn open_remote_async(
+        source: &str,
+        storage_options: &std::collections::BTreeMap<String, String>,
+    ) -> Result<Self> {
+        let remote = crate::remote::RemoteBackend::open_async(source, storage_options).await?;
+        let offsets = remote.message_offsets()?;
+        Ok(TensogramFile {
+            backend: Backend::Remote(remote),
+            message_offsets: Some(offsets),
+        })
+    }
+
+    #[cfg(feature = "async")]
+    pub async fn decode_metadata_async(&mut self, msg_idx: usize) -> Result<GlobalMetadata> {
+        #[cfg(feature = "remote")]
+        if let Backend::Remote(remote) = &mut self.backend {
+            return remote.read_metadata_async(msg_idx).await;
+        }
+
+        let msg = self.read_message_async(msg_idx).await?;
+        tokio::task::spawn_blocking(move || decode::decode_metadata(&msg))
+            .await
+            .map_err(|e| TensogramError::Io(std::io::Error::other(e)))?
+    }
+
+    #[cfg(feature = "async")]
+    pub async fn decode_descriptors_async(
+        &mut self,
+        msg_idx: usize,
+    ) -> Result<(GlobalMetadata, Vec<DataObjectDescriptor>)> {
+        #[cfg(feature = "remote")]
+        if let Backend::Remote(remote) = &mut self.backend {
+            return remote.read_descriptors_async(msg_idx).await;
+        }
+
+        let msg = self.read_message_async(msg_idx).await?;
+        tokio::task::spawn_blocking(move || decode::decode_descriptors(&msg))
+            .await
+            .map_err(|e| TensogramError::Io(std::io::Error::other(e)))?
+    }
+
+    #[cfg(feature = "async")]
+    pub async fn decode_object_async(
+        &mut self,
+        msg_idx: usize,
+        obj_idx: usize,
+        options: &DecodeOptions,
+    ) -> Result<(GlobalMetadata, DataObjectDescriptor, Vec<u8>)> {
+        #[cfg(feature = "remote")]
+        if let Backend::Remote(remote) = &mut self.backend {
+            return remote.read_object_async(msg_idx, obj_idx, options).await;
+        }
+
+        let msg = self.read_message_async(msg_idx).await?;
+        let opts = options.clone();
+        tokio::task::spawn_blocking(move || decode::decode_object(&msg, obj_idx, &opts))
             .await
             .map_err(|e| TensogramError::Io(std::io::Error::other(e)))?
     }

--- a/crates/tensogram-core/src/file.rs
+++ b/crates/tensogram-core/src/file.rs
@@ -61,7 +61,7 @@ impl TensogramFile {
 
     /// Open a local file or remote URL.
     ///
-    /// Auto-detects remote URLs (s3://, gs://, az://, http://, https://)
+    /// Auto-detects remote URLs (s3://, s3a://, gs://, az://, azure://, http://, https://)
     /// when the `remote` feature is enabled; otherwise treats the source
     /// as a local path.
     pub fn open_source(source: impl AsRef<str>) -> Result<Self> {

--- a/crates/tensogram-core/src/file.rs
+++ b/crates/tensogram-core/src/file.rs
@@ -82,7 +82,7 @@ impl TensogramFile {
         storage_options: &std::collections::BTreeMap<String, String>,
     ) -> Result<Self> {
         let remote = crate::remote::RemoteBackend::open(source, storage_options)?;
-        let offsets = remote.message_offsets();
+        let offsets = remote.message_offsets()?;
         Ok(TensogramFile {
             backend: Backend::Remote(remote),
             message_offsets: Some(offsets),

--- a/crates/tensogram-core/src/lib.rs
+++ b/crates/tensogram-core/src/lib.rs
@@ -8,6 +8,8 @@ pub mod hash;
 pub mod iter;
 pub mod metadata;
 pub mod pipeline;
+#[cfg(feature = "remote")]
+pub mod remote;
 pub mod streaming;
 pub mod types;
 pub mod validate;
@@ -36,3 +38,6 @@ pub use validate::{
     IssueSeverity, ValidateOptions, ValidationIssue, ValidationLevel, ValidationReport,
 };
 pub use wire::{FrameType, MessageFlags};
+
+#[cfg(feature = "remote")]
+pub use remote::is_remote_url;

--- a/crates/tensogram-core/src/remote.rs
+++ b/crates/tensogram-core/src/remote.rs
@@ -182,9 +182,10 @@ impl RemoteBackend {
             };
 
             let msg_len = preamble.total_length;
-            if msg_len == 0 || msg_len < min_message_size || pos + msg_len > self.file_size {
-                break;
-            }
+            let msg_end = match pos.checked_add(msg_len) {
+                Some(end) if msg_len >= min_message_size && end <= self.file_size => end,
+                _ => break,
+            };
 
             self.layouts.push(MessageLayout {
                 offset: pos,
@@ -194,7 +195,7 @@ impl RemoteBackend {
                 global_metadata: None,
             });
 
-            pos += msg_len;
+            pos = msg_end;
         }
 
         if self.layouts.is_empty() {
@@ -261,18 +262,20 @@ impl RemoteBackend {
                 continue;
             }
             let fh = FrameHeader::read_from(&buf[pos..])?;
-            let frame_total = fh.total_length as usize;
+            let frame_total = usize::try_from(fh.total_length).map_err(|_| {
+                TensogramError::Remote("frame total_length does not fit in usize".to_string())
+            })?;
 
             if frame_total < min_frame_size {
                 return Err(TensogramError::Remote(format!(
                     "frame total_length ({frame_total}) smaller than minimum ({min_frame_size})"
                 )));
             }
-            if pos + frame_total > buf.len() {
-                break;
-            }
+            let frame_end = match pos.checked_add(frame_total) {
+                Some(end) if end <= buf.len() => end,
+                _ => break,
+            };
 
-            let frame_end = pos + frame_total;
             if &buf[frame_end - FRAME_END.len()..frame_end] != FRAME_END {
                 return Err(TensogramError::Remote(
                     "frame missing ENDF trailer".to_string(),
@@ -296,7 +299,7 @@ impl RemoteBackend {
                 _ => {}
             }
 
-            let aligned = (pos + frame_total + 7) & !7;
+            let aligned = (frame_end.saturating_add(7)) & !7;
             pos = aligned.min(buf.len());
         }
 

--- a/crates/tensogram-core/src/remote.rs
+++ b/crates/tensogram-core/src/remote.rs
@@ -18,7 +18,7 @@ use crate::framing;
 use crate::metadata;
 use crate::types::{DataObjectDescriptor, GlobalMetadata, IndexFrame};
 use crate::wire::{
-    FrameHeader, FrameType, MessageFlags, Preamble, FRAME_END, FRAME_HEADER_SIZE, MAGIC,
+    FrameHeader, FrameType, MessageFlags, Postamble, Preamble, FRAME_END, FRAME_HEADER_SIZE, MAGIC,
     POSTAMBLE_SIZE, PREAMBLE_SIZE,
 };
 
@@ -167,9 +167,6 @@ impl RemoteBackend {
         let min_message_size = (PREAMBLE_SIZE + POSTAMBLE_SIZE) as u64;
         let mut pos: u64 = 0;
 
-        // Fast path: assume contiguous messages starting at offset 0.
-        // Each iteration: 1 GET for the preamble, then jump by total_length.
-        // Cost: 1 GET per message (not per byte).
         while pos + min_message_size <= self.file_size {
             let preamble_bytes = self.get_range(pos..pos + PREAMBLE_SIZE as u64)?;
             if &preamble_bytes[..MAGIC.len()] != MAGIC {
@@ -182,6 +179,25 @@ impl RemoteBackend {
             };
 
             let msg_len = preamble.total_length;
+
+            if msg_len == 0 {
+                // Streaming message: total_length=0 means the encoder didn't
+                // know the size upfront. The message extends to the end of
+                // the file (streaming messages must be the last in a file).
+                let remaining = self.file_size - pos;
+                if remaining < min_message_size {
+                    break;
+                }
+                self.layouts.push(MessageLayout {
+                    offset: pos,
+                    length: remaining,
+                    preamble,
+                    index: None,
+                    global_metadata: None,
+                });
+                break; // streaming message consumes the rest of the file
+            }
+
             let msg_end = match pos.checked_add(msg_len) {
                 Some(end) if msg_len >= min_message_size && end <= self.file_size => end,
                 _ => break,
@@ -224,20 +240,49 @@ impl RemoteBackend {
 
         let flags = self.layouts[msg_idx].preamble.flags;
 
-        // PR1 scope: only header-indexed (buffered) messages are supported.
-        // Footer-indexed (streaming) messages will be added in a follow-up PR
-        // once the StreamingEncoder index lengths are verified as frame lengths.
         if flags.has(MessageFlags::HEADER_METADATA) && flags.has(MessageFlags::HEADER_INDEX) {
             self.discover_header_layout(msg_idx)?;
+        } else if flags.has(MessageFlags::FOOTER_METADATA) && flags.has(MessageFlags::FOOTER_INDEX)
+        {
+            self.discover_footer_layout(msg_idx)?;
         } else {
             return Err(TensogramError::Remote(
-                "remote access requires header-indexed messages (both HEADER_METADATA and \
-                 HEADER_INDEX flags); header-metadata-only and footer-only layouts are not supported"
-                    .to_string(),
+                "remote access requires header-indexed or footer-indexed messages".to_string(),
             ));
         }
 
         Ok(())
+    }
+
+    fn discover_footer_layout(&mut self, msg_idx: usize) -> Result<()> {
+        let msg_offset = self.layouts[msg_idx].offset;
+        let msg_len = self.layouts[msg_idx].length;
+
+        let pa_offset = msg_offset
+            .checked_add(msg_len)
+            .and_then(|end| end.checked_sub(POSTAMBLE_SIZE as u64))
+            .ok_or_else(|| TensogramError::Remote("postamble offset overflow".to_string()))?;
+        let pa_bytes = self.get_range(pa_offset..pa_offset + POSTAMBLE_SIZE as u64)?;
+        let postamble = Postamble::read_from(&pa_bytes)?;
+
+        if postamble.first_footer_offset < PREAMBLE_SIZE as u64 {
+            return Err(TensogramError::Remote(format!(
+                "first_footer_offset ({}) is before preamble end ({})",
+                postamble.first_footer_offset, PREAMBLE_SIZE
+            )));
+        }
+        let footer_start = msg_offset
+            .checked_add(postamble.first_footer_offset)
+            .ok_or_else(|| TensogramError::Remote("footer offset overflow".to_string()))?;
+        let footer_end = pa_offset;
+        if footer_start >= footer_end {
+            return Err(TensogramError::Remote(
+                "first_footer_offset points at or past postamble".to_string(),
+            ));
+        }
+        let footer_bytes = self.get_range(footer_start..footer_end)?;
+
+        self.parse_footer_frames(msg_idx, &footer_bytes)
     }
 
     fn discover_header_layout(&mut self, msg_idx: usize) -> Result<()> {
@@ -313,6 +358,70 @@ impl RemoteBackend {
             return Err(TensogramError::Remote(
                 "header region did not contain an index frame (header chunk may be too small)"
                     .to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn parse_footer_frames(&mut self, msg_idx: usize, buf: &[u8]) -> Result<()> {
+        let min_frame_size = FRAME_HEADER_SIZE + FRAME_END.len();
+        let mut pos = 0;
+
+        while pos + FRAME_HEADER_SIZE <= buf.len() {
+            if &buf[pos..pos + 2] != b"FR" {
+                pos += 1;
+                continue;
+            }
+            let fh = FrameHeader::read_from(&buf[pos..])?;
+            let frame_total = usize::try_from(fh.total_length).map_err(|_| {
+                TensogramError::Remote(
+                    "footer frame total_length does not fit in usize".to_string(),
+                )
+            })?;
+
+            if frame_total < min_frame_size {
+                return Err(TensogramError::Remote(format!(
+                    "footer frame total_length ({frame_total}) smaller than minimum ({min_frame_size})"
+                )));
+            }
+            let frame_end = match pos.checked_add(frame_total) {
+                Some(end) if end <= buf.len() => end,
+                _ => break,
+            };
+
+            if &buf[frame_end - FRAME_END.len()..frame_end] != FRAME_END {
+                return Err(TensogramError::Remote(
+                    "footer frame missing ENDF trailer".to_string(),
+                ));
+            }
+
+            let payload = &buf[pos + FRAME_HEADER_SIZE..frame_end - FRAME_END.len()];
+
+            match fh.frame_type {
+                FrameType::FooterMetadata => {
+                    let meta = metadata::cbor_to_global_metadata(payload)?;
+                    self.layouts[msg_idx].global_metadata = Some(meta);
+                }
+                FrameType::FooterIndex => {
+                    let idx = metadata::cbor_to_index(payload)?;
+                    self.layouts[msg_idx].index = Some(idx);
+                }
+                _ => {}
+            }
+
+            let aligned = (frame_end.saturating_add(7)) & !7;
+            pos = aligned.min(buf.len());
+        }
+
+        if self.layouts[msg_idx].global_metadata.is_none() {
+            return Err(TensogramError::Remote(
+                "footer region did not contain a metadata frame".to_string(),
+            ));
+        }
+        if self.layouts[msg_idx].index.is_none() {
+            return Err(TensogramError::Remote(
+                "footer region did not contain an index frame".to_string(),
             ));
         }
 

--- a/crates/tensogram-core/src/remote.rs
+++ b/crates/tensogram-core/src/remote.rs
@@ -18,7 +18,7 @@ use crate::framing;
 use crate::metadata;
 use crate::types::{DataObjectDescriptor, GlobalMetadata, IndexFrame};
 use crate::wire::{
-    FrameHeader, FrameType, MessageFlags, Preamble, END_MAGIC, FRAME_END, FRAME_HEADER_SIZE, MAGIC,
+    FrameHeader, FrameType, MessageFlags, Preamble, FRAME_END, FRAME_HEADER_SIZE, MAGIC,
     POSTAMBLE_SIZE, PREAMBLE_SIZE,
 };
 
@@ -164,36 +164,26 @@ impl RemoteBackend {
     // ── Message scanning ─────────────────────────────────────────────────
 
     fn scan_messages(&mut self) -> Result<()> {
-        let mut pos: u64 = 0;
         let min_message_size = (PREAMBLE_SIZE + POSTAMBLE_SIZE) as u64;
+        let mut pos: u64 = 0;
 
+        // Fast path: assume contiguous messages starting at offset 0.
+        // Each iteration: 1 GET for the preamble, then jump by total_length.
+        // Cost: 1 GET per message (not per byte).
         while pos + min_message_size <= self.file_size {
             let preamble_bytes = self.get_range(pos..pos + PREAMBLE_SIZE as u64)?;
             if &preamble_bytes[..MAGIC.len()] != MAGIC {
-                pos += 1;
-                continue;
+                break;
             }
 
             let preamble = match Preamble::read_from(&preamble_bytes) {
                 Ok(p) => p,
-                Err(_) => {
-                    pos += 1;
-                    continue;
-                }
+                Err(_) => break,
             };
 
             let msg_len = preamble.total_length;
             if msg_len == 0 || msg_len < min_message_size || pos + msg_len > self.file_size {
-                pos += 1;
-                continue;
-            }
-
-            let end_magic_offset = pos + msg_len - END_MAGIC.len() as u64;
-            let end_bytes =
-                self.get_range(end_magic_offset..end_magic_offset + END_MAGIC.len() as u64)?;
-            if &end_bytes[..] != END_MAGIC {
-                pos += 1;
-                continue;
+                break;
             }
 
             self.layouts.push(MessageLayout {
@@ -326,10 +316,24 @@ impl RemoteBackend {
         self.layouts.len()
     }
 
-    pub(crate) fn message_offsets(&self) -> Vec<(usize, usize)> {
+    pub(crate) fn message_offsets(&self) -> Result<Vec<(usize, usize)>> {
         self.layouts
             .iter()
-            .map(|l| (l.offset as usize, l.length as usize))
+            .map(|l| {
+                let offset = usize::try_from(l.offset).map_err(|_| {
+                    TensogramError::Remote(format!(
+                        "message offset {} does not fit in usize",
+                        l.offset
+                    ))
+                })?;
+                let length = usize::try_from(l.length).map_err(|_| {
+                    TensogramError::Remote(format!(
+                        "message length {} does not fit in usize",
+                        l.length
+                    ))
+                })?;
+                Ok((offset, length))
+            })
             .collect()
     }
 

--- a/crates/tensogram-core/src/remote.rs
+++ b/crates/tensogram-core/src/remote.rs
@@ -51,15 +51,19 @@ fn shared_runtime() -> Result<&'static tokio::runtime::Runtime> {
 
 /// Run an async operation synchronously using the shared runtime.
 ///
-/// Two strategies based on the calling context:
+/// Three strategies based on the calling context:
 ///
 /// - **Not in async context** (Python, CLI): direct `handle.block_on()`,
 ///   no extra thread creation.
-/// - **Inside async context** (`#[tokio::test]`, server handler): spawns a
-///   scoped thread that calls `handle.block_on()` to avoid blocking a
-///   tokio worker or triggering a nested-runtime panic.
+/// - **Inside multi-thread tokio runtime** (`#[tokio::test]`, server
+///   handler): `block_in_place` + `handle.block_on()`, which tells
+///   tokio to spawn a replacement worker so the current one can block
+///   without causing runtime starvation.
+/// - **Inside current-thread tokio runtime**: scoped thread fallback,
+///   since `block_in_place` is not supported on single-threaded
+///   runtimes.
 ///
-/// In both cases the shared runtime's event loop and connection pool
+/// In all cases the shared runtime's event loop and connection pool
 /// are reused, eliminating the per-call runtime creation overhead of
 /// the old `block_on_thread` pattern.
 fn block_on_shared<T, Fut>(future: Fut) -> Result<T>
@@ -68,34 +72,44 @@ where
     Fut: std::future::Future<Output = std::result::Result<T, object_store::Error>> + Send,
 {
     let rt = shared_runtime()?;
-
-    if tokio::runtime::Handle::try_current().is_err() {
-        // Fast path: not in an async context — drive the future directly.
-        return rt
-            .handle()
-            .block_on(future)
-            .map_err(|e| TensogramError::Remote(e.to_string()));
-    }
-
-    // In an async context: block_on would panic, so use a scoped thread.
-    // The shared runtime's worker threads still handle I/O; this thread
-    // just parks until the future completes.
     let handle = rt.handle().clone();
-    std::thread::scope(|s| {
-        match s
-            .spawn(|| {
+
+    match tokio::runtime::Handle::try_current() {
+        Err(_) => {
+            // Not in an async context — drive the future directly.
+            handle
+                .block_on(future)
+                .map_err(|e| TensogramError::Remote(e.to_string()))
+        }
+        Ok(current) if current.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
+            // Multi-thread runtime: block_in_place lets tokio spawn a
+            // replacement worker so this one can block safely.
+            tokio::task::block_in_place(|| {
                 handle
                     .block_on(future)
                     .map_err(|e| TensogramError::Remote(e.to_string()))
             })
-            .join()
-        {
-            Ok(result) => result,
-            Err(_) => Err(TensogramError::Remote(
-                "remote I/O thread panicked".to_string(),
-            )),
         }
-    })
+        Ok(_) => {
+            // Current-thread runtime: block_in_place is unsupported,
+            // fall back to a scoped thread.
+            std::thread::scope(|s| {
+                match s
+                    .spawn(|| {
+                        handle
+                            .block_on(future)
+                            .map_err(|e| TensogramError::Remote(e.to_string()))
+                    })
+                    .join()
+                {
+                    Ok(result) => result,
+                    Err(_) => Err(TensogramError::Remote(
+                        "remote I/O thread panicked".to_string(),
+                    )),
+                }
+            })
+        }
+    }
 }
 
 pub fn is_remote_url(source: &str) -> bool {

--- a/crates/tensogram-core/src/remote.rs
+++ b/crates/tensogram-core/src/remote.rs
@@ -166,7 +166,7 @@ impl RemoteBackend {
         let head_path = path.clone();
         let meta = block_on_shared(async move { head_store.head(&head_path).await })?;
 
-        let file_size = meta.size as u64;
+        let file_size = meta.size;
         if file_size < (PREAMBLE_SIZE + POSTAMBLE_SIZE) as u64 {
             return Err(TensogramError::Remote(format!(
                 "remote file too small ({file_size} bytes)"
@@ -768,7 +768,7 @@ impl RemoteBackend {
             .await
             .map_err(|e| TensogramError::Remote(e.to_string()))?;
 
-        let file_size = meta.size as u64;
+        let file_size = meta.size;
         if file_size < (PREAMBLE_SIZE + POSTAMBLE_SIZE) as u64 {
             return Err(TensogramError::Remote(format!(
                 "remote file too small ({file_size} bytes)"

--- a/crates/tensogram-core/src/remote.rs
+++ b/crates/tensogram-core/src/remote.rs
@@ -217,7 +217,8 @@ impl RemoteBackend {
                 self.layouts.len()
             )));
         }
-        if self.layouts[msg_idx].global_metadata.is_some() {
+        if self.layouts[msg_idx].global_metadata.is_some() && self.layouts[msg_idx].index.is_some()
+        {
             return Ok(());
         }
 

--- a/crates/tensogram-core/src/remote.rs
+++ b/crates/tensogram-core/src/remote.rs
@@ -18,7 +18,7 @@ use crate::framing;
 use crate::metadata;
 use crate::types::{DataObjectDescriptor, GlobalMetadata, IndexFrame};
 use crate::wire::{
-    FrameHeader, FrameType, MessageFlags, Preamble, FRAME_END, FRAME_HEADER_SIZE, MAGIC,
+    FrameHeader, FrameType, MessageFlags, Preamble, END_MAGIC, FRAME_END, FRAME_HEADER_SIZE, MAGIC,
     POSTAMBLE_SIZE, PREAMBLE_SIZE,
 };
 
@@ -170,25 +170,30 @@ impl RemoteBackend {
         while pos + min_message_size <= self.file_size {
             let preamble_bytes = self.get_range(pos..pos + PREAMBLE_SIZE as u64)?;
             if &preamble_bytes[..MAGIC.len()] != MAGIC {
-                return Err(TensogramError::Remote(format!(
-                    "no TENSOGRM magic at offset {pos}"
-                )));
+                pos += 1;
+                continue;
             }
 
-            let preamble = Preamble::read_from(&preamble_bytes)?;
-            if preamble.total_length == 0 {
-                return Err(TensogramError::Remote(
-                    "streaming-mode messages (total_length=0) are not supported for remote access"
-                        .to_string(),
-                ));
-            }
+            let preamble = match Preamble::read_from(&preamble_bytes) {
+                Ok(p) => p,
+                Err(_) => {
+                    pos += 1;
+                    continue;
+                }
+            };
 
             let msg_len = preamble.total_length;
-            if pos + msg_len > self.file_size {
-                return Err(TensogramError::Remote(format!(
-                    "message at offset {pos} claims length {msg_len} but file is only {} bytes",
-                    self.file_size
-                )));
+            if msg_len == 0 || msg_len < min_message_size || pos + msg_len > self.file_size {
+                pos += 1;
+                continue;
+            }
+
+            let end_magic_offset = pos + msg_len - END_MAGIC.len() as u64;
+            let end_bytes =
+                self.get_range(end_magic_offset..end_magic_offset + END_MAGIC.len() as u64)?;
+            if &end_bytes[..] != END_MAGIC {
+                pos += 1;
+                continue;
             }
 
             self.layouts.push(MessageLayout {
@@ -382,20 +387,13 @@ impl RemoteBackend {
         let msg_offset = layout.offset;
 
         if let Some(ref index) = layout.index {
-            if obj_idx >= index.offsets.len() {
-                return Err(TensogramError::Object(format!(
-                    "object index {} out of range (count={})",
-                    obj_idx,
-                    index.offsets.len()
-                )));
-            }
+            Self::validate_index_access(index, obj_idx)?;
 
             let meta = layout
                 .global_metadata
                 .clone()
                 .ok_or_else(|| TensogramError::Remote("metadata not cached".to_string()))?;
 
-            // Fetch just this object's frame
             let frame_offset = msg_offset + index.offsets[obj_idx];
             let frame_length = index.lengths[obj_idx];
             let frame_bytes = self.get_range(frame_offset..frame_offset + frame_length)?;
@@ -412,12 +410,31 @@ impl RemoteBackend {
         }
     }
 
+    fn validate_index_access(index: &IndexFrame, obj_idx: usize) -> Result<()> {
+        if index.offsets.len() != index.lengths.len() {
+            return Err(TensogramError::Remote(format!(
+                "corrupt index: offsets.len()={} != lengths.len()={}",
+                index.offsets.len(),
+                index.lengths.len()
+            )));
+        }
+        if obj_idx >= index.offsets.len() {
+            return Err(TensogramError::Object(format!(
+                "object index {} out of range (count={})",
+                obj_idx,
+                index.offsets.len()
+            )));
+        }
+        Ok(())
+    }
+
     fn read_object_descriptor(
         &self,
         msg_offset: u64,
         index: &IndexFrame,
         obj_idx: usize,
     ) -> Result<DataObjectDescriptor> {
+        Self::validate_index_access(index, obj_idx)?;
         let frame_offset = msg_offset + index.offsets[obj_idx];
         let frame_length = index.lengths[obj_idx];
         let frame_bytes = self.get_range(frame_offset..frame_offset + frame_length)?;

--- a/crates/tensogram-core/src/remote.rs
+++ b/crates/tensogram-core/src/remote.rs
@@ -601,6 +601,13 @@ impl RemoteBackend {
         let header_bytes = self.get_range(frame_start..frame_start + FRAME_HEADER_SIZE as u64)?;
         let fh = FrameHeader::read_from(&header_bytes)?;
 
+        if fh.frame_type != FrameType::DataObject {
+            return Err(TensogramError::Remote(format!(
+                "expected DataObject frame, got {:?}",
+                fh.frame_type
+            )));
+        }
+
         let footer_start = frame_end - DATA_OBJECT_FOOTER_SIZE as u64;
         let footer_bytes = self.get_range(footer_start..frame_end)?;
 
@@ -619,20 +626,26 @@ impl RemoteBackend {
                 .map_err(|_| TensogramError::Remote("footer cbor_offset truncated".to_string()))?,
         );
 
+        if cbor_offset < FRAME_HEADER_SIZE as u64 {
+            return Err(TensogramError::Remote(format!(
+                "cbor_offset ({cbor_offset}) below frame header size ({FRAME_HEADER_SIZE})"
+            )));
+        }
+
         let cbor_after = fh.flags & DataObjectFlags::CBOR_AFTER_PAYLOAD != 0;
+        let cbor_start = frame_start
+            .checked_add(cbor_offset)
+            .ok_or_else(|| TensogramError::Remote("cbor_start overflow".to_string()))?;
 
         if cbor_after {
-            let cbor_start = frame_start + cbor_offset;
-            let cbor_end = footer_start;
-            if cbor_start >= cbor_end {
+            if cbor_start >= footer_start {
                 return Err(TensogramError::Remote(
                     "cbor_offset points at or past footer".to_string(),
                 ));
             }
-            let cbor_bytes = self.get_range(cbor_start..cbor_end)?;
+            let cbor_bytes = self.get_range(cbor_start..footer_start)?;
             metadata::cbor_to_object_descriptor(&cbor_bytes)
         } else {
-            let cbor_start = frame_start + cbor_offset;
             if cbor_start >= footer_start {
                 return Err(TensogramError::Remote(
                     "cbor_offset beyond frame body".to_string(),
@@ -1014,6 +1027,13 @@ impl RemoteBackend {
             .await?;
         let fh = FrameHeader::read_from(&header_bytes)?;
 
+        if fh.frame_type != FrameType::DataObject {
+            return Err(TensogramError::Remote(format!(
+                "expected DataObject frame, got {:?}",
+                fh.frame_type
+            )));
+        }
+
         let footer_start = frame_end - DATA_OBJECT_FOOTER_SIZE as u64;
         let footer_bytes = self.get_range_async(footer_start..frame_end).await?;
 
@@ -1032,20 +1052,26 @@ impl RemoteBackend {
                 .map_err(|_| TensogramError::Remote("footer cbor_offset truncated".to_string()))?,
         );
 
+        if cbor_offset < FRAME_HEADER_SIZE as u64 {
+            return Err(TensogramError::Remote(format!(
+                "cbor_offset ({cbor_offset}) below frame header size ({FRAME_HEADER_SIZE})"
+            )));
+        }
+
         let cbor_after = fh.flags & DataObjectFlags::CBOR_AFTER_PAYLOAD != 0;
+        let cbor_start = frame_start
+            .checked_add(cbor_offset)
+            .ok_or_else(|| TensogramError::Remote("cbor_start overflow".to_string()))?;
 
         if cbor_after {
-            let cbor_start = frame_start + cbor_offset;
-            let cbor_end = footer_start;
-            if cbor_start >= cbor_end {
+            if cbor_start >= footer_start {
                 return Err(TensogramError::Remote(
                     "cbor_offset points at or past footer".to_string(),
                 ));
             }
-            let cbor_bytes = self.get_range_async(cbor_start..cbor_end).await?;
+            let cbor_bytes = self.get_range_async(cbor_start..footer_start).await?;
             metadata::cbor_to_object_descriptor(&cbor_bytes)
         } else {
-            let cbor_start = frame_start + cbor_offset;
             if cbor_start >= footer_start {
                 return Err(TensogramError::Remote(
                     "cbor_offset beyond frame body".to_string(),

--- a/crates/tensogram-core/src/remote.rs
+++ b/crates/tensogram-core/src/remote.rs
@@ -257,7 +257,9 @@ impl RemoteBackend {
     }
 
     fn parse_header_frames(&mut self, msg_idx: usize, buf: &[u8]) -> Result<()> {
+        let min_frame_size = FRAME_HEADER_SIZE + FRAME_END.len();
         let mut pos = PREAMBLE_SIZE;
+
         while pos + FRAME_HEADER_SIZE <= buf.len() {
             if &buf[pos..pos + 2] != b"FR" {
                 pos += 1;
@@ -266,29 +268,37 @@ impl RemoteBackend {
             let fh = FrameHeader::read_from(&buf[pos..])?;
             let frame_total = fh.total_length as usize;
 
+            if frame_total < min_frame_size {
+                return Err(TensogramError::Remote(format!(
+                    "frame total_length ({frame_total}) smaller than minimum ({min_frame_size})"
+                )));
+            }
             if pos + frame_total > buf.len() {
-                // Frame extends beyond our chunk — we'd need a bigger read.
-                // For now, this covers virtually all real-world files.
                 break;
             }
 
+            let frame_end = pos + frame_total;
+            if &buf[frame_end - FRAME_END.len()..frame_end] != FRAME_END {
+                return Err(TensogramError::Remote(
+                    "frame missing ENDF trailer".to_string(),
+                ));
+            }
+
+            let payload = &buf[pos + FRAME_HEADER_SIZE..frame_end - FRAME_END.len()];
+
             match fh.frame_type {
                 FrameType::HeaderMetadata => {
-                    let payload =
-                        &buf[pos + FRAME_HEADER_SIZE..pos + frame_total - FRAME_END.len()];
                     let meta = metadata::cbor_to_global_metadata(payload)?;
                     self.layouts[msg_idx].global_metadata = Some(meta);
                 }
                 FrameType::HeaderIndex => {
-                    let payload =
-                        &buf[pos + FRAME_HEADER_SIZE..pos + frame_total - FRAME_END.len()];
                     let idx = metadata::cbor_to_index(payload)?;
                     self.layouts[msg_idx].index = Some(idx);
                 }
                 FrameType::DataObject | FrameType::PrecederMetadata => {
-                    break; // Done with header frames
+                    break;
                 }
-                _ => {} // HeaderHash — skip
+                _ => {}
             }
 
             let aligned = (pos + frame_total + 7) & !7;
@@ -337,10 +347,8 @@ impl RemoteBackend {
         msg_idx: usize,
     ) -> Result<(GlobalMetadata, Vec<DataObjectDescriptor>)> {
         self.ensure_layout(msg_idx)?;
-        // Descriptors live inside each data object frame — we need to read
-        // each frame's CBOR descriptor without downloading the full payload.
-        // If we have an index, read each object frame's header region to get
-        // the descriptor. Otherwise fall back to full message decode.
+        // If we have an index, fetch each indexed object frame and extract
+        // the descriptor from it. Otherwise fall back to full message decode.
         let layout = &self.layouts[msg_idx];
         let msg_offset = layout.offset;
 

--- a/crates/tensogram-core/src/remote.rs
+++ b/crates/tensogram-core/src/remote.rs
@@ -5,7 +5,7 @@
 
 use std::collections::BTreeMap;
 use std::ops::Range;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use bytes::Bytes;
 use object_store::path::Path as ObjectPath;
@@ -18,37 +18,83 @@ use crate::framing;
 use crate::metadata;
 use crate::types::{DataObjectDescriptor, GlobalMetadata, IndexFrame};
 use crate::wire::{
-    FrameHeader, FrameType, MessageFlags, Postamble, Preamble, FRAME_END, FRAME_HEADER_SIZE, MAGIC,
-    POSTAMBLE_SIZE, PREAMBLE_SIZE,
+    DataObjectFlags, FrameHeader, FrameType, MessageFlags, Postamble, Preamble,
+    DATA_OBJECT_FOOTER_SIZE, FRAME_END, FRAME_HEADER_SIZE, MAGIC, POSTAMBLE_SIZE, PREAMBLE_SIZE,
 };
 
 // ── URL scheme detection ─────────────────────────────────────────────────────
 
 const REMOTE_SCHEMES: &[&str] = &["s3", "s3a", "gs", "az", "azure", "http", "https"];
 
-/// Run an async operation synchronously, safe from nested-runtime panics.
+// ── Shared tokio runtime ─────────────────────────────────────────────────────
+
+/// Process-wide shared tokio runtime for remote I/O.
 ///
-/// Spawns a dedicated thread with a fresh single-threaded tokio runtime.
-/// This allows `TensogramFile` sync methods to work regardless of whether
-/// the caller is already inside an async context (e.g. Python event loop,
-/// `#[tokio::test]`).
-fn block_on_thread<T, F, Fut>(store: Arc<dyn ObjectStore>, f: F) -> Result<T>
+/// Wrapped in `Result` so that `get_or_init` (which runs the closure
+/// exactly once, no races) can cache a build failure without panicking.
+static SHARED_RUNTIME: OnceLock<std::result::Result<tokio::runtime::Runtime, String>> =
+    OnceLock::new();
+
+fn shared_runtime() -> Result<&'static tokio::runtime::Runtime> {
+    SHARED_RUNTIME
+        .get_or_init(|| {
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(2)
+                .enable_all()
+                .thread_name("tensogram-remote-io")
+                .build()
+                .map_err(|e| format!("tokio runtime: {e}"))
+        })
+        .as_ref()
+        .map_err(|e| TensogramError::Remote(e.clone()))
+}
+
+/// Run an async operation synchronously using the shared runtime.
+///
+/// Two strategies based on the calling context:
+///
+/// - **Not in async context** (Python, CLI): direct `handle.block_on()`,
+///   no extra thread creation.
+/// - **Inside async context** (`#[tokio::test]`, server handler): spawns a
+///   scoped thread that calls `handle.block_on()` to avoid blocking a
+///   tokio worker or triggering a nested-runtime panic.
+///
+/// In both cases the shared runtime's event loop and connection pool
+/// are reused, eliminating the per-call runtime creation overhead of
+/// the old `block_on_thread` pattern.
+fn block_on_shared<T, Fut>(future: Fut) -> Result<T>
 where
     T: Send,
-    F: FnOnce(Arc<dyn ObjectStore>) -> Fut + Send,
-    Fut: std::future::Future<Output = std::result::Result<T, object_store::Error>>,
+    Fut: std::future::Future<Output = std::result::Result<T, object_store::Error>> + Send,
 {
+    let rt = shared_runtime()?;
+
+    if tokio::runtime::Handle::try_current().is_err() {
+        // Fast path: not in an async context — drive the future directly.
+        return rt
+            .handle()
+            .block_on(future)
+            .map_err(|e| TensogramError::Remote(e.to_string()));
+    }
+
+    // In an async context: block_on would panic, so use a scoped thread.
+    // The shared runtime's worker threads still handle I/O; this thread
+    // just parks until the future completes.
+    let handle = rt.handle().clone();
     std::thread::scope(|s| {
-        s.spawn(move || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .map_err(|e| TensogramError::Remote(format!("tokio runtime: {e}")))?;
-            rt.block_on(f(store))
-                .map_err(|e| TensogramError::Remote(e.to_string()))
-        })
-        .join()
-        .unwrap_or_else(|_| Err(TensogramError::Remote("I/O thread panicked".to_string())))
+        match s
+            .spawn(|| {
+                handle
+                    .block_on(future)
+                    .map_err(|e| TensogramError::Remote(e.to_string()))
+            })
+            .join()
+        {
+            Ok(result) => result,
+            Err(_) => Err(TensogramError::Remote(
+                "remote I/O thread panicked".to_string(),
+            )),
+        }
     })
 }
 
@@ -116,10 +162,9 @@ impl RemoteBackend {
 
         let store: Arc<dyn ObjectStore> = Arc::from(store);
 
-        let meta = block_on_thread(store.clone(), |s| {
-            let path = path.clone();
-            async move { s.head(&path).await }
-        })?;
+        let head_store = store.clone();
+        let head_path = path.clone();
+        let meta = block_on_shared(async move { head_store.head(&head_path).await })?;
 
         let file_size = meta.size as u64;
         if file_size < (PREAMBLE_SIZE + POSTAMBLE_SIZE) as u64 {
@@ -142,21 +187,21 @@ impl RemoteBackend {
     // ── Range reads ──────────────────────────────────────────────────────
 
     fn get_range(&self, range: Range<u64>) -> Result<Bytes> {
+        let store = self.store.clone();
         let path = self.path.clone();
-        block_on_thread(self.store.clone(), move |s| async move {
-            s.get_range(&path, range).await
-        })
+        block_on_shared(async move { store.get_range(&path, range).await })
     }
 
     #[allow(dead_code)]
     fn get_suffix(&self, nbytes: u64) -> Result<Bytes> {
+        let store = self.store.clone();
         let path = self.path.clone();
-        block_on_thread(self.store.clone(), move |s| async move {
+        block_on_shared(async move {
             let opts = GetOptions {
                 range: Some(GetRange::Suffix(nbytes)),
                 ..Default::default()
             };
-            let result = s.get_opts(&path, opts).await?;
+            let result = store.get_opts(&path, opts).await?;
             result.bytes().await
         })
     }
@@ -490,8 +535,6 @@ impl RemoteBackend {
         msg_idx: usize,
     ) -> Result<(GlobalMetadata, Vec<DataObjectDescriptor>)> {
         self.ensure_layout(msg_idx)?;
-        // If we have an index, fetch each indexed object frame and extract
-        // the descriptor from it. Otherwise fall back to full message decode.
         let layout = &self.layouts[msg_idx];
         let msg_offset = layout.offset;
 
@@ -512,21 +555,102 @@ impl RemoteBackend {
             let msg_length = layout.length;
             let mut descriptors = Vec::with_capacity(index.offsets.len());
             for i in 0..index.offsets.len() {
-                let range = Self::checked_frame_range(
+                let desc = self.read_descriptor_only(
                     msg_offset,
                     msg_length,
                     index.offsets[i],
                     index.lengths[i],
                 )?;
-                let frame_bytes = self.get_range(range)?;
-                let (desc, _payload, _consumed) = framing::decode_data_object_frame(&frame_bytes)?;
                 descriptors.push(desc);
             }
             Ok((meta, descriptors))
         } else {
-            // No index — fall back to full message download
             let msg_bytes = self.read_message(msg_idx)?;
             crate::decode::decode_descriptors(&msg_bytes)
+        }
+    }
+
+    /// Read only the CBOR descriptor from a data object frame, without
+    /// downloading the full payload.
+    ///
+    /// For frames below `DESCRIPTOR_PREFIX_THRESHOLD` bytes, falls back
+    /// to reading the entire frame (fewer round-trips).  For large frames,
+    /// reads just the header, footer, and CBOR region — typically < 10 KB
+    /// even when the payload is hundreds of megabytes.
+    fn read_descriptor_only(
+        &self,
+        msg_offset: u64,
+        msg_length: u64,
+        frame_offset_in_msg: u64,
+        frame_length: u64,
+    ) -> Result<DataObjectDescriptor> {
+        const DESCRIPTOR_PREFIX_THRESHOLD: u64 = 64 * 1024;
+
+        let range =
+            Self::checked_frame_range(msg_offset, msg_length, frame_offset_in_msg, frame_length)?;
+
+        if frame_length <= DESCRIPTOR_PREFIX_THRESHOLD {
+            let frame_bytes = self.get_range(range.clone())?;
+            let (desc, _payload, _consumed) = framing::decode_data_object_frame(&frame_bytes)?;
+            return Ok(desc);
+        }
+
+        let frame_start = range.start;
+        let frame_end = range.end;
+
+        let header_bytes = self.get_range(frame_start..frame_start + FRAME_HEADER_SIZE as u64)?;
+        let fh = FrameHeader::read_from(&header_bytes)?;
+
+        let footer_start = frame_end - DATA_OBJECT_FOOTER_SIZE as u64;
+        let footer_bytes = self.get_range(footer_start..frame_end)?;
+
+        if footer_bytes.len() < DATA_OBJECT_FOOTER_SIZE {
+            return Err(TensogramError::Remote("frame footer too short".to_string()));
+        }
+        if &footer_bytes[8..] != FRAME_END {
+            return Err(TensogramError::Remote(
+                "frame missing ENDF trailer".to_string(),
+            ));
+        }
+
+        let cbor_offset = u64::from_be_bytes(
+            footer_bytes[..8]
+                .try_into()
+                .map_err(|_| TensogramError::Remote("footer cbor_offset truncated".to_string()))?,
+        );
+
+        let cbor_after = fh.flags & DataObjectFlags::CBOR_AFTER_PAYLOAD != 0;
+
+        if cbor_after {
+            let cbor_start = frame_start + cbor_offset;
+            let cbor_end = footer_start;
+            if cbor_start >= cbor_end {
+                return Err(TensogramError::Remote(
+                    "cbor_offset points at or past footer".to_string(),
+                ));
+            }
+            let cbor_bytes = self.get_range(cbor_start..cbor_end)?;
+            metadata::cbor_to_object_descriptor(&cbor_bytes)
+        } else {
+            let cbor_start = frame_start + cbor_offset;
+            if cbor_start >= footer_start {
+                return Err(TensogramError::Remote(
+                    "cbor_offset beyond frame body".to_string(),
+                ));
+            }
+            let max_cbor_len = footer_start - cbor_start;
+            let mut prefix_size: u64 = 8192;
+            loop {
+                let read_end = (cbor_start + prefix_size).min(footer_start);
+                let prefix_bytes = self.get_range(cbor_start..read_end)?;
+                match metadata::cbor_to_object_descriptor(&prefix_bytes) {
+                    Ok(desc) => return Ok(desc),
+                    Err(_) if prefix_size < max_cbor_len => {
+                        prefix_size = (prefix_size * 2).min(max_cbor_len);
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
         }
     }
 
@@ -607,5 +731,373 @@ impl RemoteBackend {
             )));
         }
         Ok(start..end)
+    }
+}
+
+// ── Native async path (remote + async) ───────────────────────────────────────
+
+#[cfg(feature = "async")]
+impl RemoteBackend {
+    async fn get_range_async(&self, range: Range<u64>) -> Result<Bytes> {
+        self.store
+            .get_range(&self.path, range)
+            .await
+            .map_err(|e| TensogramError::Remote(e.to_string()))
+    }
+
+    pub(crate) async fn open_async(
+        source: &str,
+        storage_options: &BTreeMap<String, String>,
+    ) -> Result<Self> {
+        let url = Url::parse(source)
+            .map_err(|e| TensogramError::Remote(format!("invalid URL '{source}': {e}")))?;
+
+        let mut opts: Vec<(String, String)> = storage_options
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        if url.scheme() == "http" && !opts.iter().any(|(k, _)| k == "allow_http") {
+            opts.push(("allow_http".to_string(), "true".to_string()));
+        }
+        let (store, path) = object_store::parse_url_opts(&url, opts)
+            .map_err(|e| TensogramError::Remote(format!("cannot open '{source}': {e}")))?;
+
+        let store: Arc<dyn ObjectStore> = Arc::from(store);
+        let meta = store
+            .head(&path)
+            .await
+            .map_err(|e| TensogramError::Remote(e.to_string()))?;
+
+        let file_size = meta.size as u64;
+        if file_size < (PREAMBLE_SIZE + POSTAMBLE_SIZE) as u64 {
+            return Err(TensogramError::Remote(format!(
+                "remote file too small ({file_size} bytes)"
+            )));
+        }
+
+        let mut backend = RemoteBackend {
+            source_url: source.to_string(),
+            store,
+            path,
+            file_size,
+            layouts: Vec::new(),
+        };
+        backend.scan_messages_async().await?;
+        Ok(backend)
+    }
+
+    async fn scan_messages_async(&mut self) -> Result<()> {
+        let min_message_size = (PREAMBLE_SIZE + POSTAMBLE_SIZE) as u64;
+        let mut pos: u64 = 0;
+
+        while pos + min_message_size <= self.file_size {
+            let preamble_bytes = self
+                .get_range_async(pos..pos + PREAMBLE_SIZE as u64)
+                .await?;
+            if &preamble_bytes[..MAGIC.len()] != MAGIC {
+                break;
+            }
+
+            let preamble = match Preamble::read_from(&preamble_bytes) {
+                Ok(p) => p,
+                Err(_) => break,
+            };
+
+            let msg_len = preamble.total_length;
+
+            if msg_len == 0 {
+                let remaining = self.file_size - pos;
+                if remaining < min_message_size {
+                    break;
+                }
+                let end_magic_pos = self.file_size - crate::wire::END_MAGIC.len() as u64;
+                let end_bytes = self
+                    .get_range_async(
+                        end_magic_pos..end_magic_pos + crate::wire::END_MAGIC.len() as u64,
+                    )
+                    .await?;
+                if &end_bytes[..] != crate::wire::END_MAGIC {
+                    break;
+                }
+                self.layouts.push(MessageLayout {
+                    offset: pos,
+                    length: remaining,
+                    preamble,
+                    index: None,
+                    global_metadata: None,
+                });
+                break;
+            }
+
+            let msg_end = match pos.checked_add(msg_len) {
+                Some(end) if msg_len >= min_message_size && end <= self.file_size => end,
+                _ => break,
+            };
+
+            self.layouts.push(MessageLayout {
+                offset: pos,
+                length: msg_len,
+                preamble,
+                index: None,
+                global_metadata: None,
+            });
+
+            pos = msg_end;
+        }
+
+        if self.layouts.is_empty() {
+            return Err(TensogramError::Remote(
+                "no valid messages found in remote file".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    async fn ensure_layout_async(&mut self, msg_idx: usize) -> Result<()> {
+        if msg_idx >= self.layouts.len() {
+            return Err(TensogramError::Framing(format!(
+                "message index {} out of range (count={})",
+                msg_idx,
+                self.layouts.len()
+            )));
+        }
+        if self.layouts[msg_idx].global_metadata.is_some() && self.layouts[msg_idx].index.is_some()
+        {
+            return Ok(());
+        }
+
+        let flags = self.layouts[msg_idx].preamble.flags;
+
+        if flags.has(MessageFlags::HEADER_METADATA) && flags.has(MessageFlags::HEADER_INDEX) {
+            self.discover_header_layout_async(msg_idx).await?;
+        } else if flags.has(MessageFlags::FOOTER_METADATA) && flags.has(MessageFlags::FOOTER_INDEX)
+        {
+            self.discover_footer_layout_async(msg_idx).await?;
+        } else {
+            return Err(TensogramError::Remote(
+                "remote access requires header-indexed or footer-indexed messages".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    async fn discover_header_layout_async(&mut self, msg_idx: usize) -> Result<()> {
+        let msg_offset = self.layouts[msg_idx].offset;
+        let msg_len = self.layouts[msg_idx].length;
+        let chunk_size = msg_len.min(256 * 1024);
+        let header_bytes = self
+            .get_range_async(msg_offset..msg_offset + chunk_size)
+            .await?;
+        self.parse_header_frames(msg_idx, &header_bytes)
+    }
+
+    async fn discover_footer_layout_async(&mut self, msg_idx: usize) -> Result<()> {
+        let msg_offset = self.layouts[msg_idx].offset;
+        let msg_len = self.layouts[msg_idx].length;
+        let pa_offset = msg_offset
+            .checked_add(msg_len)
+            .and_then(|end| end.checked_sub(POSTAMBLE_SIZE as u64))
+            .ok_or_else(|| TensogramError::Remote("postamble offset overflow".to_string()))?;
+        let pa_bytes = self
+            .get_range_async(pa_offset..pa_offset + POSTAMBLE_SIZE as u64)
+            .await?;
+        let postamble = Postamble::read_from(&pa_bytes)?;
+
+        if postamble.first_footer_offset < PREAMBLE_SIZE as u64 {
+            return Err(TensogramError::Remote(format!(
+                "first_footer_offset ({}) is before preamble end ({})",
+                postamble.first_footer_offset, PREAMBLE_SIZE
+            )));
+        }
+        let footer_start = msg_offset
+            .checked_add(postamble.first_footer_offset)
+            .ok_or_else(|| TensogramError::Remote("footer offset overflow".to_string()))?;
+        let footer_end = pa_offset;
+        if footer_start >= footer_end {
+            return Err(TensogramError::Remote(
+                "first_footer_offset points at or past postamble".to_string(),
+            ));
+        }
+        let footer_bytes = self.get_range_async(footer_start..footer_end).await?;
+        self.parse_footer_frames(msg_idx, &footer_bytes)
+    }
+
+    pub(crate) async fn read_message_async(&self, msg_idx: usize) -> Result<Vec<u8>> {
+        let layout = self.layouts.get(msg_idx).ok_or_else(|| {
+            TensogramError::Framing(format!(
+                "message index {} out of range (count={})",
+                msg_idx,
+                self.layouts.len()
+            ))
+        })?;
+        let bytes = self
+            .get_range_async(layout.offset..layout.offset + layout.length)
+            .await?;
+        Ok(bytes.to_vec())
+    }
+
+    pub(crate) async fn read_metadata_async(&mut self, msg_idx: usize) -> Result<GlobalMetadata> {
+        self.ensure_layout_async(msg_idx).await?;
+        self.layouts[msg_idx]
+            .global_metadata
+            .clone()
+            .ok_or_else(|| TensogramError::Remote("metadata not found".to_string()))
+    }
+
+    pub(crate) async fn read_descriptors_async(
+        &mut self,
+        msg_idx: usize,
+    ) -> Result<(GlobalMetadata, Vec<DataObjectDescriptor>)> {
+        self.ensure_layout_async(msg_idx).await?;
+        let layout = &self.layouts[msg_idx];
+        let msg_offset = layout.offset;
+
+        if let Some(ref index) = layout.index {
+            if index.offsets.len() != index.lengths.len() {
+                return Err(TensogramError::Remote(format!(
+                    "corrupt index: offsets.len()={} != lengths.len()={}",
+                    index.offsets.len(),
+                    index.lengths.len()
+                )));
+            }
+
+            let meta = layout
+                .global_metadata
+                .clone()
+                .ok_or_else(|| TensogramError::Remote("metadata not cached".to_string()))?;
+
+            let msg_length = layout.length;
+            let mut descriptors = Vec::with_capacity(index.offsets.len());
+            for i in 0..index.offsets.len() {
+                let desc = self
+                    .read_descriptor_only_async(
+                        msg_offset,
+                        msg_length,
+                        index.offsets[i],
+                        index.lengths[i],
+                    )
+                    .await?;
+                descriptors.push(desc);
+            }
+            Ok((meta, descriptors))
+        } else {
+            let msg_bytes = self.read_message_async(msg_idx).await?;
+            crate::decode::decode_descriptors(&msg_bytes)
+        }
+    }
+
+    async fn read_descriptor_only_async(
+        &self,
+        msg_offset: u64,
+        msg_length: u64,
+        frame_offset_in_msg: u64,
+        frame_length: u64,
+    ) -> Result<DataObjectDescriptor> {
+        const DESCRIPTOR_PREFIX_THRESHOLD: u64 = 64 * 1024;
+
+        let range =
+            Self::checked_frame_range(msg_offset, msg_length, frame_offset_in_msg, frame_length)?;
+
+        if frame_length <= DESCRIPTOR_PREFIX_THRESHOLD {
+            let frame_bytes = self.get_range_async(range.clone()).await?;
+            let (desc, _payload, _consumed) = framing::decode_data_object_frame(&frame_bytes)?;
+            return Ok(desc);
+        }
+
+        let frame_start = range.start;
+        let frame_end = range.end;
+
+        let header_bytes = self
+            .get_range_async(frame_start..frame_start + FRAME_HEADER_SIZE as u64)
+            .await?;
+        let fh = FrameHeader::read_from(&header_bytes)?;
+
+        let footer_start = frame_end - DATA_OBJECT_FOOTER_SIZE as u64;
+        let footer_bytes = self.get_range_async(footer_start..frame_end).await?;
+
+        if footer_bytes.len() < DATA_OBJECT_FOOTER_SIZE {
+            return Err(TensogramError::Remote("frame footer too short".to_string()));
+        }
+        if &footer_bytes[8..] != FRAME_END {
+            return Err(TensogramError::Remote(
+                "frame missing ENDF trailer".to_string(),
+            ));
+        }
+
+        let cbor_offset = u64::from_be_bytes(
+            footer_bytes[..8]
+                .try_into()
+                .map_err(|_| TensogramError::Remote("footer cbor_offset truncated".to_string()))?,
+        );
+
+        let cbor_after = fh.flags & DataObjectFlags::CBOR_AFTER_PAYLOAD != 0;
+
+        if cbor_after {
+            let cbor_start = frame_start + cbor_offset;
+            let cbor_end = footer_start;
+            if cbor_start >= cbor_end {
+                return Err(TensogramError::Remote(
+                    "cbor_offset points at or past footer".to_string(),
+                ));
+            }
+            let cbor_bytes = self.get_range_async(cbor_start..cbor_end).await?;
+            metadata::cbor_to_object_descriptor(&cbor_bytes)
+        } else {
+            let cbor_start = frame_start + cbor_offset;
+            if cbor_start >= footer_start {
+                return Err(TensogramError::Remote(
+                    "cbor_offset beyond frame body".to_string(),
+                ));
+            }
+            let max_cbor_len = footer_start - cbor_start;
+            let mut prefix_size: u64 = 8192;
+            loop {
+                let read_end = (cbor_start + prefix_size).min(footer_start);
+                let prefix_bytes = self.get_range_async(cbor_start..read_end).await?;
+                match metadata::cbor_to_object_descriptor(&prefix_bytes) {
+                    Ok(desc) => return Ok(desc),
+                    Err(_) if prefix_size < max_cbor_len => {
+                        prefix_size = (prefix_size * 2).min(max_cbor_len);
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+        }
+    }
+
+    pub(crate) async fn read_object_async(
+        &mut self,
+        msg_idx: usize,
+        obj_idx: usize,
+        options: &DecodeOptions,
+    ) -> Result<(GlobalMetadata, DataObjectDescriptor, Vec<u8>)> {
+        self.ensure_layout_async(msg_idx).await?;
+        let layout = &self.layouts[msg_idx];
+        let msg_offset = layout.offset;
+
+        if let Some(ref index) = layout.index {
+            Self::validate_index_access(index, obj_idx)?;
+
+            let meta = layout
+                .global_metadata
+                .clone()
+                .ok_or_else(|| TensogramError::Remote("metadata not cached".to_string()))?;
+
+            let range = Self::checked_frame_range(
+                msg_offset,
+                layout.length,
+                index.offsets[obj_idx],
+                index.lengths[obj_idx],
+            )?;
+            let frame_bytes = self.get_range_async(range).await?;
+            let (desc, payload, _consumed) = framing::decode_data_object_frame(&frame_bytes)?;
+            let decoded = crate::decode::decode_single_object(&desc, payload, options)?;
+            Ok((meta, desc, decoded))
+        } else {
+            let msg_bytes = self.read_message_async(msg_idx).await?;
+            crate::decode::decode_object(&msg_bytes, obj_idx, options)
+        }
     }
 }

--- a/crates/tensogram-core/src/remote.rs
+++ b/crates/tensogram-core/src/remote.rs
@@ -1,0 +1,420 @@
+//! Remote object store backend for `TensogramFile`.
+//!
+//! Enables reading `.tgm` files from S3, GCS, Azure, and HTTP(S) via
+//! the `object_store` crate. Feature-gated behind `remote`.
+
+use std::collections::BTreeMap;
+use std::ops::Range;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use object_store::path::Path as ObjectPath;
+use object_store::{GetOptions, GetRange, ObjectStore, ObjectStoreExt};
+use url::Url;
+
+use crate::decode::DecodeOptions;
+use crate::error::{Result, TensogramError};
+use crate::framing;
+use crate::metadata;
+use crate::types::{DataObjectDescriptor, GlobalMetadata, IndexFrame};
+use crate::wire::{
+    FrameHeader, FrameType, MessageFlags, Preamble, FRAME_END, FRAME_HEADER_SIZE, MAGIC,
+    POSTAMBLE_SIZE, PREAMBLE_SIZE,
+};
+
+// ── URL scheme detection ─────────────────────────────────────────────────────
+
+const REMOTE_SCHEMES: &[&str] = &["s3", "s3a", "gs", "az", "azure", "http", "https"];
+
+/// Run an async operation synchronously, safe from nested-runtime panics.
+///
+/// Spawns a dedicated thread with a fresh single-threaded tokio runtime.
+/// This allows `TensogramFile` sync methods to work regardless of whether
+/// the caller is already inside an async context (e.g. Python event loop,
+/// `#[tokio::test]`).
+fn block_on_thread<T, F, Fut>(store: Arc<dyn ObjectStore>, f: F) -> Result<T>
+where
+    T: Send,
+    F: FnOnce(Arc<dyn ObjectStore>) -> Fut + Send,
+    Fut: std::future::Future<Output = std::result::Result<T, object_store::Error>>,
+{
+    std::thread::scope(|s| {
+        s.spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|e| TensogramError::Remote(format!("tokio runtime: {e}")))?;
+            rt.block_on(f(store))
+                .map_err(|e| TensogramError::Remote(e.to_string()))
+        })
+        .join()
+        .unwrap_or_else(|_| Err(TensogramError::Remote("I/O thread panicked".to_string())))
+    })
+}
+
+pub fn is_remote_url(source: &str) -> bool {
+    match source.find("://") {
+        Some(pos) => {
+            let scheme = &source[..pos];
+            REMOTE_SCHEMES
+                .iter()
+                .any(|s| s.eq_ignore_ascii_case(scheme))
+        }
+        None => false,
+    }
+}
+
+// ── Cached per-message layout ────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+struct MessageLayout {
+    offset: u64,
+    length: u64,
+    preamble: Preamble,
+    index: Option<IndexFrame>,
+    global_metadata: Option<GlobalMetadata>,
+}
+
+// ── Remote backend ───────────────────────────────────────────────────────────
+
+pub(crate) struct RemoteBackend {
+    source_url: String,
+    store: Arc<dyn ObjectStore>,
+    path: ObjectPath,
+    file_size: u64,
+    layouts: Vec<MessageLayout>,
+}
+
+impl std::fmt::Debug for RemoteBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RemoteBackend")
+            .field("source", &self.source_url)
+            .field("file_size", &self.file_size)
+            .field("messages", &self.layouts.len())
+            .finish()
+    }
+}
+
+impl RemoteBackend {
+    pub(crate) fn source_url(&self) -> &str {
+        &self.source_url
+    }
+
+    pub(crate) fn open(source: &str, storage_options: &BTreeMap<String, String>) -> Result<Self> {
+        let url = Url::parse(source)
+            .map_err(|e| TensogramError::Remote(format!("invalid URL '{source}': {e}")))?;
+
+        let mut opts: Vec<(String, String)> = storage_options
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        if url.scheme() == "http" && !opts.iter().any(|(k, _)| k == "allow_http") {
+            opts.push(("allow_http".to_string(), "true".to_string()));
+        }
+        let (store, path) = object_store::parse_url_opts(&url, opts)
+            .map_err(|e| TensogramError::Remote(format!("cannot open '{source}': {e}")))?;
+
+        let store: Arc<dyn ObjectStore> = Arc::from(store);
+
+        let meta = block_on_thread(store.clone(), |s| {
+            let path = path.clone();
+            async move { s.head(&path).await }
+        })?;
+
+        let file_size = meta.size as u64;
+        if file_size < (PREAMBLE_SIZE + POSTAMBLE_SIZE) as u64 {
+            return Err(TensogramError::Remote(format!(
+                "remote file too small ({file_size} bytes)"
+            )));
+        }
+
+        let mut backend = RemoteBackend {
+            source_url: source.to_string(),
+            store,
+            path,
+            file_size,
+            layouts: Vec::new(),
+        };
+        backend.scan_messages()?;
+        Ok(backend)
+    }
+
+    // ── Range reads ──────────────────────────────────────────────────────
+
+    fn get_range(&self, range: Range<u64>) -> Result<Bytes> {
+        let path = self.path.clone();
+        block_on_thread(self.store.clone(), move |s| async move {
+            s.get_range(&path, range).await
+        })
+    }
+
+    #[allow(dead_code)]
+    fn get_suffix(&self, nbytes: u64) -> Result<Bytes> {
+        let path = self.path.clone();
+        block_on_thread(self.store.clone(), move |s| async move {
+            let opts = GetOptions {
+                range: Some(GetRange::Suffix(nbytes)),
+                ..Default::default()
+            };
+            let result = s.get_opts(&path, opts).await?;
+            result.bytes().await
+        })
+    }
+
+    // ── Message scanning ─────────────────────────────────────────────────
+
+    fn scan_messages(&mut self) -> Result<()> {
+        let mut pos: u64 = 0;
+        let min_message_size = (PREAMBLE_SIZE + POSTAMBLE_SIZE) as u64;
+
+        while pos + min_message_size <= self.file_size {
+            let preamble_bytes = self.get_range(pos..pos + PREAMBLE_SIZE as u64)?;
+            if &preamble_bytes[..MAGIC.len()] != MAGIC {
+                return Err(TensogramError::Remote(format!(
+                    "no TENSOGRM magic at offset {pos}"
+                )));
+            }
+
+            let preamble = Preamble::read_from(&preamble_bytes)?;
+            if preamble.total_length == 0 {
+                return Err(TensogramError::Remote(
+                    "streaming-mode messages (total_length=0) are not supported for remote access"
+                        .to_string(),
+                ));
+            }
+
+            let msg_len = preamble.total_length;
+            if pos + msg_len > self.file_size {
+                return Err(TensogramError::Remote(format!(
+                    "message at offset {pos} claims length {msg_len} but file is only {} bytes",
+                    self.file_size
+                )));
+            }
+
+            self.layouts.push(MessageLayout {
+                offset: pos,
+                length: msg_len,
+                preamble,
+                index: None,
+                global_metadata: None,
+            });
+
+            pos += msg_len;
+        }
+
+        if self.layouts.is_empty() {
+            return Err(TensogramError::Remote(
+                "no valid messages found in remote file".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    // ── Layout discovery (metadata + index for a single message) ─────────
+
+    fn ensure_layout(&mut self, msg_idx: usize) -> Result<()> {
+        if msg_idx >= self.layouts.len() {
+            return Err(TensogramError::Framing(format!(
+                "message index {} out of range (count={})",
+                msg_idx,
+                self.layouts.len()
+            )));
+        }
+        if self.layouts[msg_idx].global_metadata.is_some() {
+            return Ok(());
+        }
+
+        let flags = self.layouts[msg_idx].preamble.flags;
+
+        // PR1 scope: only header-indexed (buffered) messages are supported.
+        // Footer-indexed (streaming) messages will be added in a follow-up PR
+        // once the StreamingEncoder index lengths are verified as frame lengths.
+        if flags.has(MessageFlags::HEADER_METADATA) {
+            self.discover_header_layout(msg_idx)?;
+        } else {
+            return Err(TensogramError::Remote(
+                "remote access requires header-indexed messages; \
+                 footer-only (streaming) layout is not yet supported"
+                    .to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn discover_header_layout(&mut self, msg_idx: usize) -> Result<()> {
+        let layout = &self.layouts[msg_idx];
+        let msg_offset = layout.offset;
+        let msg_len = layout.length;
+
+        // Read a generous initial chunk: up to 256KB or the message size.
+        // Header metadata + index are typically a few KB.
+        let chunk_size = msg_len.min(256 * 1024);
+        let header_bytes = self.get_range(msg_offset..msg_offset + chunk_size)?;
+
+        self.parse_header_frames(msg_idx, &header_bytes)
+    }
+
+    fn parse_header_frames(&mut self, msg_idx: usize, buf: &[u8]) -> Result<()> {
+        let mut pos = PREAMBLE_SIZE;
+        while pos + FRAME_HEADER_SIZE <= buf.len() {
+            if &buf[pos..pos + 2] != b"FR" {
+                pos += 1;
+                continue;
+            }
+            let fh = FrameHeader::read_from(&buf[pos..])?;
+            let frame_total = fh.total_length as usize;
+
+            if pos + frame_total > buf.len() {
+                // Frame extends beyond our chunk — we'd need a bigger read.
+                // For now, this covers virtually all real-world files.
+                break;
+            }
+
+            match fh.frame_type {
+                FrameType::HeaderMetadata => {
+                    let payload =
+                        &buf[pos + FRAME_HEADER_SIZE..pos + frame_total - FRAME_END.len()];
+                    let meta = metadata::cbor_to_global_metadata(payload)?;
+                    self.layouts[msg_idx].global_metadata = Some(meta);
+                }
+                FrameType::HeaderIndex => {
+                    let payload =
+                        &buf[pos + FRAME_HEADER_SIZE..pos + frame_total - FRAME_END.len()];
+                    let idx = metadata::cbor_to_index(payload)?;
+                    self.layouts[msg_idx].index = Some(idx);
+                }
+                FrameType::DataObject | FrameType::PrecederMetadata => {
+                    break; // Done with header frames
+                }
+                _ => {} // HeaderHash — skip
+            }
+
+            let aligned = (pos + frame_total + 7) & !7;
+            pos = aligned.min(buf.len());
+        }
+
+        if self.layouts[msg_idx].global_metadata.is_none() {
+            return Err(TensogramError::Remote(
+                "header region did not contain a metadata frame".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    // ── Public API used by TensogramFile ─────────────────────────────────
+
+    #[allow(dead_code)]
+    pub(crate) fn message_count(&self) -> usize {
+        self.layouts.len()
+    }
+
+    pub(crate) fn message_offsets(&self) -> Vec<(usize, usize)> {
+        self.layouts
+            .iter()
+            .map(|l| (l.offset as usize, l.length as usize))
+            .collect()
+    }
+
+    pub(crate) fn read_message(&self, msg_idx: usize) -> Result<Vec<u8>> {
+        let layout = &self.layouts[msg_idx];
+        let bytes = self.get_range(layout.offset..layout.offset + layout.length)?;
+        Ok(bytes.to_vec())
+    }
+
+    pub(crate) fn read_metadata(&mut self, msg_idx: usize) -> Result<GlobalMetadata> {
+        self.ensure_layout(msg_idx)?;
+        self.layouts[msg_idx]
+            .global_metadata
+            .clone()
+            .ok_or_else(|| TensogramError::Remote("metadata not found".to_string()))
+    }
+
+    pub(crate) fn read_descriptors(
+        &mut self,
+        msg_idx: usize,
+    ) -> Result<(GlobalMetadata, Vec<DataObjectDescriptor>)> {
+        self.ensure_layout(msg_idx)?;
+        // Descriptors live inside each data object frame — we need to read
+        // each frame's CBOR descriptor without downloading the full payload.
+        // If we have an index, read each object frame's header region to get
+        // the descriptor. Otherwise fall back to full message decode.
+        let layout = &self.layouts[msg_idx];
+        let msg_offset = layout.offset;
+
+        if let Some(ref index) = layout.index {
+            let meta = layout
+                .global_metadata
+                .clone()
+                .ok_or_else(|| TensogramError::Remote("metadata not cached".to_string()))?;
+
+            let mut descriptors = Vec::with_capacity(index.offsets.len());
+            for i in 0..index.offsets.len() {
+                let desc = self.read_object_descriptor(msg_offset, index, i)?;
+                descriptors.push(desc);
+            }
+            Ok((meta, descriptors))
+        } else {
+            // No index — fall back to full message download
+            let msg_bytes = self.read_message(msg_idx)?;
+            crate::decode::decode_descriptors(&msg_bytes)
+        }
+    }
+
+    pub(crate) fn read_object(
+        &mut self,
+        msg_idx: usize,
+        obj_idx: usize,
+        options: &DecodeOptions,
+    ) -> Result<(GlobalMetadata, DataObjectDescriptor, Vec<u8>)> {
+        self.ensure_layout(msg_idx)?;
+        let layout = &self.layouts[msg_idx];
+        let msg_offset = layout.offset;
+
+        if let Some(ref index) = layout.index {
+            if obj_idx >= index.offsets.len() {
+                return Err(TensogramError::Object(format!(
+                    "object index {} out of range (count={})",
+                    obj_idx,
+                    index.offsets.len()
+                )));
+            }
+
+            let meta = layout
+                .global_metadata
+                .clone()
+                .ok_or_else(|| TensogramError::Remote("metadata not cached".to_string()))?;
+
+            // Fetch just this object's frame
+            let frame_offset = msg_offset + index.offsets[obj_idx];
+            let frame_length = index.lengths[obj_idx];
+            let frame_bytes = self.get_range(frame_offset..frame_offset + frame_length)?;
+
+            let (desc, payload, _consumed) = framing::decode_data_object_frame(&frame_bytes)?;
+
+            let decoded = crate::decode::decode_single_object(&desc, payload, options)?;
+
+            Ok((meta, desc, decoded))
+        } else {
+            // No index — fall back to full message download
+            let msg_bytes = self.read_message(msg_idx)?;
+            crate::decode::decode_object(&msg_bytes, obj_idx, options)
+        }
+    }
+
+    fn read_object_descriptor(
+        &self,
+        msg_offset: u64,
+        index: &IndexFrame,
+        obj_idx: usize,
+    ) -> Result<DataObjectDescriptor> {
+        let frame_offset = msg_offset + index.offsets[obj_idx];
+        let frame_length = index.lengths[obj_idx];
+        let frame_bytes = self.get_range(frame_offset..frame_offset + frame_length)?;
+
+        let (desc, _payload, _consumed) = framing::decode_data_object_frame(&frame_bytes)?;
+        Ok(desc)
+    }
+}

--- a/crates/tensogram-core/src/remote.rs
+++ b/crates/tensogram-core/src/remote.rs
@@ -381,11 +381,16 @@ impl RemoteBackend {
                 .clone()
                 .ok_or_else(|| TensogramError::Remote("metadata not cached".to_string()))?;
 
+            let msg_length = layout.length;
             let mut descriptors = Vec::with_capacity(index.offsets.len());
             for i in 0..index.offsets.len() {
-                let frame_offset = msg_offset + index.offsets[i];
-                let frame_length = index.lengths[i];
-                let frame_bytes = self.get_range(frame_offset..frame_offset + frame_length)?;
+                let range = Self::checked_frame_range(
+                    msg_offset,
+                    msg_length,
+                    index.offsets[i],
+                    index.lengths[i],
+                )?;
+                let frame_bytes = self.get_range(range)?;
                 let (desc, _payload, _consumed) = framing::decode_data_object_frame(&frame_bytes)?;
                 descriptors.push(desc);
             }
@@ -415,9 +420,13 @@ impl RemoteBackend {
                 .clone()
                 .ok_or_else(|| TensogramError::Remote("metadata not cached".to_string()))?;
 
-            let frame_offset = msg_offset + index.offsets[obj_idx];
-            let frame_length = index.lengths[obj_idx];
-            let frame_bytes = self.get_range(frame_offset..frame_offset + frame_length)?;
+            let range = Self::checked_frame_range(
+                msg_offset,
+                layout.length,
+                index.offsets[obj_idx],
+                index.lengths[obj_idx],
+            )?;
+            let frame_bytes = self.get_range(range)?;
 
             let (desc, payload, _consumed) = framing::decode_data_object_frame(&frame_bytes)?;
 
@@ -447,5 +456,28 @@ impl RemoteBackend {
             )));
         }
         Ok(())
+    }
+
+    fn checked_frame_range(
+        msg_offset: u64,
+        msg_length: u64,
+        frame_offset_in_msg: u64,
+        frame_length: u64,
+    ) -> Result<Range<u64>> {
+        let start = msg_offset
+            .checked_add(frame_offset_in_msg)
+            .ok_or_else(|| TensogramError::Remote("frame offset overflow".to_string()))?;
+        let end = start
+            .checked_add(frame_length)
+            .ok_or_else(|| TensogramError::Remote("frame end overflow".to_string()))?;
+        let msg_end = msg_offset
+            .checked_add(msg_length)
+            .ok_or_else(|| TensogramError::Remote("message end overflow".to_string()))?;
+        if end > msg_end {
+            return Err(TensogramError::Remote(format!(
+                "indexed frame {start}..{end} exceeds message boundary {msg_end}"
+            )));
+        }
+        Ok(start..end)
     }
 }

--- a/crates/tensogram-core/src/remote.rs
+++ b/crates/tensogram-core/src/remote.rs
@@ -225,12 +225,12 @@ impl RemoteBackend {
         // PR1 scope: only header-indexed (buffered) messages are supported.
         // Footer-indexed (streaming) messages will be added in a follow-up PR
         // once the StreamingEncoder index lengths are verified as frame lengths.
-        if flags.has(MessageFlags::HEADER_METADATA) {
+        if flags.has(MessageFlags::HEADER_METADATA) && flags.has(MessageFlags::HEADER_INDEX) {
             self.discover_header_layout(msg_idx)?;
         } else {
             return Err(TensogramError::Remote(
-                "remote access requires header-indexed messages; \
-                 footer-only (streaming) layout is not yet supported"
+                "remote access requires header-indexed messages (both HEADER_METADATA and \
+                 HEADER_INDEX flags); header-metadata-only and footer-only layouts are not supported"
                     .to_string(),
             ));
         }
@@ -303,6 +303,12 @@ impl RemoteBackend {
         if self.layouts[msg_idx].global_metadata.is_none() {
             return Err(TensogramError::Remote(
                 "header region did not contain a metadata frame".to_string(),
+            ));
+        }
+        if self.layouts[msg_idx].index.is_none() {
+            return Err(TensogramError::Remote(
+                "header region did not contain an index frame (header chunk may be too small)"
+                    .to_string(),
             ));
         }
 

--- a/crates/tensogram-core/src/remote.rs
+++ b/crates/tensogram-core/src/remote.rs
@@ -338,7 +338,13 @@ impl RemoteBackend {
     }
 
     pub(crate) fn read_message(&self, msg_idx: usize) -> Result<Vec<u8>> {
-        let layout = &self.layouts[msg_idx];
+        let layout = self.layouts.get(msg_idx).ok_or_else(|| {
+            TensogramError::Framing(format!(
+                "message index {} out of range (count={})",
+                msg_idx,
+                self.layouts.len()
+            ))
+        })?;
         let bytes = self.get_range(layout.offset..layout.offset + layout.length)?;
         Ok(bytes.to_vec())
     }
@@ -362,6 +368,14 @@ impl RemoteBackend {
         let msg_offset = layout.offset;
 
         if let Some(ref index) = layout.index {
+            if index.offsets.len() != index.lengths.len() {
+                return Err(TensogramError::Remote(format!(
+                    "corrupt index: offsets.len()={} != lengths.len()={}",
+                    index.offsets.len(),
+                    index.lengths.len()
+                )));
+            }
+
             let meta = layout
                 .global_metadata
                 .clone()
@@ -369,7 +383,10 @@ impl RemoteBackend {
 
             let mut descriptors = Vec::with_capacity(index.offsets.len());
             for i in 0..index.offsets.len() {
-                let desc = self.read_object_descriptor(msg_offset, index, i)?;
+                let frame_offset = msg_offset + index.offsets[i];
+                let frame_length = index.lengths[i];
+                let frame_bytes = self.get_range(frame_offset..frame_offset + frame_length)?;
+                let (desc, _payload, _consumed) = framing::decode_data_object_frame(&frame_bytes)?;
                 descriptors.push(desc);
             }
             Ok((meta, descriptors))
@@ -430,20 +447,5 @@ impl RemoteBackend {
             )));
         }
         Ok(())
-    }
-
-    fn read_object_descriptor(
-        &self,
-        msg_offset: u64,
-        index: &IndexFrame,
-        obj_idx: usize,
-    ) -> Result<DataObjectDescriptor> {
-        Self::validate_index_access(index, obj_idx)?;
-        let frame_offset = msg_offset + index.offsets[obj_idx];
-        let frame_length = index.lengths[obj_idx];
-        let frame_bytes = self.get_range(frame_offset..frame_offset + frame_length)?;
-
-        let (desc, _payload, _consumed) = framing::decode_data_object_frame(&frame_bytes)?;
-        Ok(desc)
     }
 }

--- a/crates/tensogram-core/src/remote.rs
+++ b/crates/tensogram-core/src/remote.rs
@@ -188,6 +188,15 @@ impl RemoteBackend {
                 if remaining < min_message_size {
                     break;
                 }
+                // Validate END_MAGIC at the expected postamble position to
+                // reject files with trailing garbage after the message.
+                let end_magic_pos = self.file_size - crate::wire::END_MAGIC.len() as u64;
+                let end_bytes = self.get_range(
+                    end_magic_pos..end_magic_pos + crate::wire::END_MAGIC.len() as u64,
+                )?;
+                if &end_bytes[..] != crate::wire::END_MAGIC {
+                    break;
+                }
                 self.layouts.push(MessageLayout {
                     offset: pos,
                     length: remaining,
@@ -195,7 +204,7 @@ impl RemoteBackend {
                     index: None,
                     global_metadata: None,
                 });
-                break; // streaming message consumes the rest of the file
+                break;
             }
 
             let msg_end = match pos.checked_add(msg_len) {

--- a/crates/tensogram-core/src/streaming.rs
+++ b/crates/tensogram-core/src/streaming.rs
@@ -44,7 +44,7 @@ pub struct StreamingEncoder<W: Write> {
     writer: W,
     /// Byte offsets of each data object frame from message start.
     object_offsets: Vec<u64>,
-    /// Encoded payload length of each data object frame.
+    /// Total byte length of each data object frame (FrameHeader + CBOR descriptor + encoded payload + ENDF).
     object_lengths: Vec<u64>,
     /// Per-object hash entries: (hash_type, hash_value).
     hash_entries: Vec<Option<(String, String)>>,
@@ -272,9 +272,8 @@ impl<W: Write> StreamingEncoder<W> {
         let frame_bytes =
             crate::framing::encode_data_object_frame(&final_desc, encoded_bytes, false)?;
 
-        // Record offset before writing
         self.object_offsets.push(self.bytes_written);
-        self.object_lengths.push(encoded_bytes.len() as u64);
+        self.object_lengths.push(frame_bytes.len() as u64);
         self.hash_entries.push(hash_entry);
         // Retain only the descriptor for footer metadata population.
         // The encoded payload has already been written to the stream;

--- a/crates/tensogram-core/src/streaming.rs
+++ b/crates/tensogram-core/src/streaming.rs
@@ -44,7 +44,7 @@ pub struct StreamingEncoder<W: Write> {
     writer: W,
     /// Byte offsets of each data object frame from message start.
     object_offsets: Vec<u64>,
-    /// Total byte length of each data object frame (FrameHeader + CBOR descriptor + encoded payload + ENDF).
+    /// Total byte length of each data object frame, excluding alignment padding.
     object_lengths: Vec<u64>,
     /// Per-object hash entries: (hash_type, hash_value).
     hash_entries: Vec<Option<(String, String)>>,

--- a/crates/tensogram-core/src/types.rs
+++ b/crates/tensogram-core/src/types.rs
@@ -95,7 +95,7 @@ pub struct IndexFrame {
     pub object_count: u64,
     /// Byte offset of each data object frame from message start.
     pub offsets: Vec<u64>,
-    /// Payload length of each data object frame.
+    /// Total byte length of each data object frame (FrameHeader + CBOR descriptor + encoded payload + ENDF).
     pub lengths: Vec<u64>,
 }
 

--- a/crates/tensogram-core/src/types.rs
+++ b/crates/tensogram-core/src/types.rs
@@ -95,7 +95,7 @@ pub struct IndexFrame {
     pub object_count: u64,
     /// Byte offset of each data object frame from message start.
     pub offsets: Vec<u64>,
-    /// Total byte length of each data object frame (FrameHeader + CBOR descriptor + encoded payload + ENDF).
+    /// Total byte length of each data object frame, excluding alignment padding.
     pub lengths: Vec<u64>,
 }
 

--- a/crates/tensogram-core/tests/remote_http.rs
+++ b/crates/tensogram-core/tests/remote_http.rs
@@ -666,3 +666,223 @@ async fn test_remote_streaming_index_lengths_are_frame_lengths() -> Result<(), B
     assert_eq!(local_meta.version, 2);
     Ok(())
 }
+
+// ── Shared runtime tests ─────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_shared_runtime_concurrent_reads() -> Result<(), Box<dyn Error>> {
+    let shapes = vec![vec![4], vec![8], vec![16]];
+    let fills = vec![10u8, 20u8, 30u8];
+    let msg = encode_multi_object_message(&shapes, &fills)?;
+    let server = MockServer::start(msg).await?;
+    let url = server.url();
+
+    let handles: Vec<_> = (0..4)
+        .map(|_| {
+            let u = url.clone();
+            std::thread::spawn(
+                move || -> std::result::Result<(), Box<dyn Error + Send + Sync>> {
+                    let mut file = TensogramFile::open_source(&u)?;
+                    let (_, desc, data) = file.decode_object(0, 0, &DecodeOptions::default())?;
+                    assert_eq!(desc.shape, vec![4]);
+                    assert_eq!(data, vec![10u8; 16]);
+                    Ok(())
+                },
+            )
+        })
+        .collect();
+
+    for h in handles {
+        match h.join() {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => return Err(e.to_string().into()),
+            Err(_) => return Err("concurrent reader thread panicked".into()),
+        }
+    }
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_shared_runtime_from_sync_context() -> Result<(), Box<dyn Error>> {
+    let msg = encode_test_message(vec![4], 42)?;
+    let server = MockServer::start(msg).await?;
+    let url = server.url();
+
+    let result = std::thread::spawn(
+        move || -> std::result::Result<(), Box<dyn Error + Send + Sync>> {
+            let mut file = TensogramFile::open_source(&url)?;
+            let meta = file.decode_metadata(0)?;
+            assert_eq!(meta.version, 2);
+            let (_, desc, data) = file.decode_object(0, 0, &DecodeOptions::default())?;
+            assert_eq!(desc.shape, vec![4]);
+            assert_eq!(data, vec![42u8; 16]);
+            Ok(())
+        },
+    )
+    .join();
+    match result {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => return Err(e.to_string().into()),
+        Err(_) => return Err("sync context thread panicked".into()),
+    }
+    Ok(())
+}
+
+// ── Descriptor-only read tests ───────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_descriptor_only_matches_full_read() -> Result<(), Box<dyn Error>> {
+    let shapes = vec![vec![4], vec![8, 2], vec![100]];
+    let fills = vec![10u8, 20u8, 30u8];
+    let msg = encode_multi_object_message(&shapes, &fills)?;
+    let server = MockServer::start(msg.clone()).await?;
+
+    let mut file = TensogramFile::open_source(server.url())?;
+    let (_, remote_descs) = file.decode_descriptors(0)?;
+
+    let (_, local_descs) = tensogram_core::decode::decode_descriptors(&msg)?;
+
+    assert_eq!(remote_descs.len(), local_descs.len());
+    for (rd, ld) in remote_descs.iter().zip(local_descs.iter()) {
+        assert_eq!(rd.shape, ld.shape);
+        assert_eq!(rd.dtype, ld.dtype);
+        assert_eq!(rd.encoding, ld.encoding);
+        assert_eq!(rd.compression, ld.compression);
+    }
+    Ok(())
+}
+
+// ── Async remote tests (remote + async) ──────────────────────────────────────
+
+#[cfg(feature = "async")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_async_remote_open_and_metadata() -> Result<(), Box<dyn Error>> {
+    let msg = encode_test_message(vec![4], 42)?;
+    let server = MockServer::start(msg).await?;
+
+    let mut file = TensogramFile::open_source_async(server.url()).await?;
+    assert!(file.is_remote());
+    assert_eq!(file.message_count()?, 1);
+
+    let meta = file.decode_metadata_async(0).await?;
+    assert_eq!(meta.version, 2);
+    Ok(())
+}
+
+#[cfg(feature = "async")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_async_remote_decode_object() -> Result<(), Box<dyn Error>> {
+    let meta = make_global_meta();
+    let desc = make_descriptor(vec![4]);
+    let data = vec![42u8; 16];
+    let msg = encode::encode(&meta, &[(&desc, &data)], &EncodeOptions::default())?;
+    let server = MockServer::start(msg).await?;
+
+    let mut file = TensogramFile::open_source_async(server.url()).await?;
+    let (decoded_meta, decoded_desc, decoded_data) = file
+        .decode_object_async(0, 0, &DecodeOptions::default())
+        .await?;
+    assert_eq!(decoded_meta.version, 2);
+    assert_eq!(decoded_desc.shape, vec![4]);
+    assert_eq!(decoded_data, data);
+    Ok(())
+}
+
+#[cfg(feature = "async")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_async_remote_decode_descriptors() -> Result<(), Box<dyn Error>> {
+    let shapes = vec![vec![4], vec![8]];
+    let fills = vec![10u8, 20u8];
+    let msg = encode_multi_object_message(&shapes, &fills)?;
+    let server = MockServer::start(msg).await?;
+
+    let mut file = TensogramFile::open_source_async(server.url()).await?;
+    let (meta, descriptors) = file.decode_descriptors_async(0).await?;
+    assert_eq!(meta.version, 2);
+    assert_eq!(descriptors.len(), 2);
+    assert_eq!(descriptors[0].shape, vec![4]);
+    assert_eq!(descriptors[1].shape, vec![8]);
+    Ok(())
+}
+
+#[cfg(feature = "async")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_async_vs_sync_parity() -> Result<(), Box<dyn Error>> {
+    let meta = make_global_meta();
+    let desc = make_descriptor(vec![10]);
+    let data: Vec<u8> = (0..40).collect();
+    let msg = encode::encode(&meta, &[(&desc, &data)], &EncodeOptions::default())?;
+    let server = MockServer::start(msg).await?;
+
+    let mut sync_file = TensogramFile::open_source(server.url())?;
+    let (sync_meta, sync_desc, sync_data) =
+        sync_file.decode_object(0, 0, &DecodeOptions::default())?;
+
+    let mut async_file = TensogramFile::open_source_async(server.url()).await?;
+    let (async_meta, async_desc, async_data) = async_file
+        .decode_object_async(0, 0, &DecodeOptions::default())
+        .await?;
+
+    assert_eq!(sync_meta.version, async_meta.version);
+    assert_eq!(sync_desc.shape, async_desc.shape);
+    assert_eq!(sync_data, async_data);
+    Ok(())
+}
+
+#[cfg(feature = "async")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_async_remote_read_message() -> Result<(), Box<dyn Error>> {
+    let msg = encode_test_message(vec![4], 42)?;
+    let server = MockServer::start(msg.clone()).await?;
+
+    let mut file = TensogramFile::open_source_async(server.url()).await?;
+    let remote_msg = file.read_message_async(0).await?;
+    assert_eq!(remote_msg, msg);
+    Ok(())
+}
+
+#[cfg(feature = "async")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_async_remote_streaming_message() -> Result<(), Box<dyn Error>> {
+    let msg = encode_streaming_message(vec![4], 42)?;
+    let server = MockServer::start(msg).await?;
+
+    let mut file = TensogramFile::open_source_async(server.url()).await?;
+    assert!(file.is_remote());
+
+    let meta = file.decode_metadata_async(0).await?;
+    assert_eq!(meta.version, 2);
+
+    let (_, desc, data) = file
+        .decode_object_async(0, 0, &DecodeOptions::default())
+        .await?;
+    assert_eq!(desc.shape, vec![4]);
+    assert_eq!(data, vec![42u8; 16]);
+    Ok(())
+}
+
+#[cfg(feature = "async")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_async_remote_object_out_of_range() -> Result<(), Box<dyn Error>> {
+    let msg = encode_test_message(vec![4], 42)?;
+    let server = MockServer::start(msg).await?;
+
+    let mut file = TensogramFile::open_source_async(server.url()).await?;
+    let result = file
+        .decode_object_async(0, 5, &DecodeOptions::default())
+        .await;
+    assert!(result.is_err());
+    Ok(())
+}
+
+#[cfg(feature = "async")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_async_remote_message_index_out_of_range() -> Result<(), Box<dyn Error>> {
+    let msg = encode_test_message(vec![4], 42)?;
+    let server = MockServer::start(msg).await?;
+
+    let mut file = TensogramFile::open_source_async(server.url()).await?;
+    let result = file.decode_metadata_async(5).await;
+    assert!(result.is_err());
+    Ok(())
+}

--- a/crates/tensogram-core/tests/remote_http.rs
+++ b/crates/tensogram-core/tests/remote_http.rs
@@ -752,6 +752,32 @@ async fn test_descriptor_only_matches_full_read() -> Result<(), Box<dyn Error>> 
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_descriptor_only_large_frame_exercises_fast_path() -> Result<(), Box<dyn Error>> {
+    let meta = make_global_meta();
+    let desc = make_descriptor(vec![256, 256]);
+    let data = vec![7u8; 256 * 256 * 4];
+    let msg = encode::encode(&meta, &[(&desc, &data)], &EncodeOptions::default())?;
+    assert!(
+        msg.len() > 64 * 1024,
+        "payload must exceed 64KB threshold, got {} bytes",
+        msg.len()
+    );
+    let server = MockServer::start(msg.clone()).await?;
+
+    let mut file = TensogramFile::open_source(server.url())?;
+    let (_, remote_descs) = file.decode_descriptors(0)?;
+    let (_, local_descs) = tensogram_core::decode::decode_descriptors(&msg)?;
+
+    assert_eq!(remote_descs.len(), 1);
+    assert_eq!(remote_descs[0].shape, local_descs[0].shape);
+    assert_eq!(remote_descs[0].dtype, local_descs[0].dtype);
+
+    let (_, _, decoded) = file.decode_object(0, 0, &DecodeOptions::default())?;
+    assert_eq!(decoded, data);
+    Ok(())
+}
+
 // ── Async remote tests (remote + async) ──────────────────────────────────────
 
 #[cfg(feature = "async")]

--- a/crates/tensogram-core/tests/remote_http.rs
+++ b/crates/tensogram-core/tests/remote_http.rs
@@ -162,8 +162,8 @@ impl MockServer {
 fn handle_request(
     req: Request<hyper::body::Incoming>,
     data: Arc<Vec<u8>>,
-    range_request_count: Arc<AtomicUsize>,
     request_count: Arc<AtomicUsize>,
+    range_request_count: Arc<AtomicUsize>,
 ) -> Result<Response<Full<Bytes>>, std::io::Error> {
     request_count.fetch_add(1, Ordering::SeqCst);
 

--- a/crates/tensogram-core/tests/remote_http.rs
+++ b/crates/tensogram-core/tests/remote_http.rs
@@ -547,28 +547,122 @@ async fn test_remote_source_returns_url() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_remote_streaming_message_rejected() -> Result<(), Box<dyn Error>> {
-    // Build a streaming-mode message (total_length=0) by hand:
-    // just a minimal preamble with zero total_length + end magic
-    let mut fake_streaming = Vec::new();
-    fake_streaming.extend_from_slice(b"TENSOGRM"); // magic
-    fake_streaming.extend_from_slice(&2u16.to_be_bytes()); // version
-    fake_streaming.extend_from_slice(&0u16.to_be_bytes()); // flags
-    fake_streaming.extend_from_slice(&0u32.to_be_bytes()); // reserved
-    fake_streaming.extend_from_slice(&0u64.to_be_bytes()); // total_length=0 (streaming)
-                                                           // pad to min size and add end magic
-    fake_streaming.resize(100, 0);
-    fake_streaming.extend_from_slice(b"39277777");
+// ── Footer-indexed (streaming) message tests ─────────────────────────────────
 
-    let server = MockServer::start(fake_streaming).await?;
-    let err = TensogramFile::open_source(server.url())
-        .err()
-        .ok_or_else(|| std::io::Error::other("expected error for streaming message"))?
-        .to_string();
-    assert!(
-        err.contains("no valid messages"),
-        "expected no-valid-messages error, got: {err}"
-    );
+fn encode_streaming_message(shape: Vec<u64>, fill: u8) -> Result<Vec<u8>, std::io::Error> {
+    let meta = make_global_meta();
+    let desc = make_descriptor(shape.clone());
+    let num_bytes = shape.iter().product::<u64>() as usize * 4;
+    let data = vec![fill; num_bytes];
+    let buf = Vec::new();
+    let mut enc =
+        tensogram_core::streaming::StreamingEncoder::new(buf, &meta, &EncodeOptions::default())
+            .map_err(std::io::Error::other)?;
+    enc.write_object(&desc, &data)
+        .map_err(std::io::Error::other)?;
+    enc.finish().map_err(std::io::Error::other)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_remote_streaming_message_open_and_decode() -> Result<(), Box<dyn Error>> {
+    let msg = encode_streaming_message(vec![4], 42)?;
+    let server = MockServer::start(msg).await?;
+
+    let mut file = TensogramFile::open_source(server.url())?;
+    assert!(file.is_remote());
+    assert_eq!(file.message_count()?, 1);
+
+    let meta = file.decode_metadata(0)?;
+    assert_eq!(meta.version, 2);
+
+    let (_, desc, data) = file.decode_object(0, 0, &DecodeOptions::default())?;
+    assert_eq!(desc.shape, vec![4]);
+    assert_eq!(data, vec![42u8; 16]);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_remote_streaming_matches_local_decode() -> Result<(), Box<dyn Error>> {
+    let msg = encode_streaming_message(vec![10], 99)?;
+    let server = MockServer::start(msg.clone()).await?;
+
+    let (local_meta, local_objects) =
+        tensogram_core::decode::decode(&msg, &DecodeOptions::default())?;
+
+    let mut remote_file = TensogramFile::open_source(server.url())?;
+    let (remote_meta, remote_desc, remote_data) =
+        remote_file.decode_object(0, 0, &DecodeOptions::default())?;
+
+    assert_eq!(local_meta.version, remote_meta.version);
+    assert_eq!(local_objects[0].0.shape, remote_desc.shape);
+    assert_eq!(local_objects[0].1, remote_data);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_remote_streaming_multi_object() -> Result<(), Box<dyn Error>> {
+    let meta = make_global_meta();
+    let desc1 = make_descriptor(vec![4]);
+    let desc2 = make_descriptor(vec![8]);
+    let data1 = vec![10u8; 16];
+    let data2 = vec![20u8; 32];
+
+    let buf = Vec::new();
+    let mut enc =
+        tensogram_core::streaming::StreamingEncoder::new(buf, &meta, &EncodeOptions::default())
+            .map_err(std::io::Error::other)?;
+    enc.write_object(&desc1, &data1)
+        .map_err(std::io::Error::other)?;
+    enc.write_object(&desc2, &data2)
+        .map_err(std::io::Error::other)?;
+    let msg = enc.finish().map_err(std::io::Error::other)?;
+
+    let server = MockServer::start(msg).await?;
+    let mut file = TensogramFile::open_source(server.url())?;
+
+    let (_, descs) = file.decode_descriptors(0)?;
+    assert_eq!(descs.len(), 2);
+    assert_eq!(descs[0].shape, vec![4]);
+    assert_eq!(descs[1].shape, vec![8]);
+
+    let (_, _, data) = file.decode_object(0, 1, &DecodeOptions::default())?;
+    assert_eq!(data, vec![20u8; 32]);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_remote_mixed_buffered_then_streaming() -> Result<(), Box<dyn Error>> {
+    let buffered_msg = encode_test_message(vec![4], 10)?;
+    let streaming_msg = encode_streaming_message(vec![8], 20)?;
+
+    let mut combined = buffered_msg;
+    combined.extend_from_slice(&streaming_msg);
+
+    let server = MockServer::start(combined).await?;
+    let mut file = TensogramFile::open_source(server.url())?;
+    assert_eq!(file.message_count()?, 2);
+
+    let (_, _, data0) = file.decode_object(0, 0, &DecodeOptions::default())?;
+    assert_eq!(data0, vec![10u8; 16]);
+
+    let (_, _, data1) = file.decode_object(1, 0, &DecodeOptions::default())?;
+    assert_eq!(data1, vec![20u8; 32]);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_remote_streaming_index_lengths_are_frame_lengths() -> Result<(), Box<dyn Error>> {
+    let msg = encode_streaming_message(vec![4], 42)?;
+    let server = MockServer::start(msg.clone()).await?;
+
+    let mut file = TensogramFile::open_source(server.url())?;
+    let (_, desc, data) = file.decode_object(0, 0, &DecodeOptions::default())?;
+    assert_eq!(desc.shape, vec![4]);
+    assert_eq!(data, vec![42u8; 16]);
+
+    let (local_meta, local_objects) =
+        tensogram_core::decode::decode(&msg, &DecodeOptions::default())?;
+    assert_eq!(local_objects[0].1, data);
+    assert_eq!(local_meta.version, 2);
     Ok(())
 }

--- a/crates/tensogram-core/tests/remote_http.rs
+++ b/crates/tensogram-core/tests/remote_http.rs
@@ -90,6 +90,7 @@ struct MockServer {
     #[allow(dead_code)]
     data: Arc<Vec<u8>>,
     request_count: Arc<AtomicUsize>,
+    range_request_count: Arc<AtomicUsize>,
     addr: SocketAddr,
 }
 
@@ -97,11 +98,13 @@ impl MockServer {
     async fn start(data: Vec<u8>) -> Result<Self, std::io::Error> {
         let data = Arc::new(data);
         let request_count = Arc::new(AtomicUsize::new(0));
+        let range_request_count = Arc::new(AtomicUsize::new(0));
         let listener = TcpListener::bind("127.0.0.1:0").await?;
         let addr = listener.local_addr()?;
 
         let data_clone = data.clone();
         let count_clone = request_count.clone();
+        let range_count_clone = range_request_count.clone();
 
         tokio::spawn(async move {
             loop {
@@ -112,6 +115,7 @@ impl MockServer {
                 let io = TokioIo::new(stream);
                 let data = data_clone.clone();
                 let count = count_clone.clone();
+                let range_count = range_count_clone.clone();
 
                 tokio::spawn(async move {
                     let _ = http1::Builder::new()
@@ -120,7 +124,8 @@ impl MockServer {
                             service_fn(move |req: Request<hyper::body::Incoming>| {
                                 let data = data.clone();
                                 let count = count.clone();
-                                async move { handle_request(req, data, count) }
+                                let range_count = range_count.clone();
+                                async move { handle_request(req, data, count, range_count) }
                             }),
                         )
                         .await;
@@ -131,6 +136,7 @@ impl MockServer {
         Ok(MockServer {
             data,
             request_count,
+            range_request_count,
             addr,
         })
     }
@@ -143,14 +149,20 @@ impl MockServer {
         self.request_count.load(Ordering::SeqCst)
     }
 
+    fn range_request_count(&self) -> usize {
+        self.range_request_count.load(Ordering::SeqCst)
+    }
+
     fn reset_count(&self) {
         self.request_count.store(0, Ordering::SeqCst);
+        self.range_request_count.store(0, Ordering::SeqCst);
     }
 }
 
 fn handle_request(
     req: Request<hyper::body::Incoming>,
     data: Arc<Vec<u8>>,
+    range_request_count: Arc<AtomicUsize>,
     request_count: Arc<AtomicUsize>,
 ) -> Result<Response<Full<Bytes>>, std::io::Error> {
     request_count.fetch_add(1, Ordering::SeqCst);
@@ -166,6 +178,7 @@ fn handle_request(
     }
 
     if let Some(range_header) = req.headers().get("Range") {
+        range_request_count.fetch_add(1, Ordering::SeqCst);
         let range_str = range_header.to_str().unwrap_or("");
         if let Some(byte_range) = parse_range_header(range_str, data.len()) {
             let slice = &data[byte_range.0..byte_range.1];
@@ -423,11 +436,16 @@ async fn test_remote_request_count_header_indexed() -> Result<(), Box<dyn Error>
     server.reset_count();
     let _ = file.file_decode_object(0, 0, &DecodeOptions::default())?;
     let object_requests = server.request_count();
+    let range_requests = server.range_request_count();
 
     // Layout discovery (1 header chunk) + object frame fetch (1) = at most 2
     assert!(
         object_requests <= 2,
         "expected <=2 requests for object read, got {object_requests} (open used {open_requests})"
+    );
+    assert!(
+        range_requests > 0,
+        "object read must use Range requests, not full GETs"
     );
     Ok(())
 }

--- a/crates/tensogram-core/tests/remote_http.rs
+++ b/crates/tensogram-core/tests/remote_http.rs
@@ -281,14 +281,14 @@ async fn test_remote_decode_message() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_remote_file_decode_metadata() -> Result<(), Box<dyn Error>> {
+async fn test_remote_decode_metadata() -> Result<(), Box<dyn Error>> {
     let msg = encode_test_message(vec![4], 42)?;
     let server = MockServer::start(msg).await?;
 
     let mut file = TensogramFile::open_source(server.url())?;
     server.reset_count();
 
-    let meta = file.file_decode_metadata(0)?;
+    let meta = file.decode_metadata(0)?;
     assert_eq!(meta.version, 2);
 
     // First metadata call triggers layout discovery (1 header chunk read).
@@ -300,7 +300,7 @@ async fn test_remote_file_decode_metadata() -> Result<(), Box<dyn Error>> {
     );
 
     server.reset_count();
-    let meta2 = file.file_decode_metadata(0)?;
+    let meta2 = file.decode_metadata(0)?;
     assert_eq!(meta2.version, 2);
     assert_eq!(
         server.request_count(),
@@ -311,12 +311,12 @@ async fn test_remote_file_decode_metadata() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_remote_file_decode_descriptors() -> Result<(), Box<dyn Error>> {
+async fn test_remote_decode_descriptors() -> Result<(), Box<dyn Error>> {
     let msg = encode_test_message(vec![4], 42)?;
     let server = MockServer::start(msg).await?;
 
     let mut file = TensogramFile::open_source(server.url())?;
-    let (meta, descriptors) = file.file_decode_descriptors(0)?;
+    let (meta, descriptors) = file.decode_descriptors(0)?;
     assert_eq!(meta.version, 2);
     assert_eq!(descriptors.len(), 1);
     assert_eq!(descriptors[0].shape, vec![4]);
@@ -324,7 +324,7 @@ async fn test_remote_file_decode_descriptors() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_remote_file_decode_object() -> Result<(), Box<dyn Error>> {
+async fn test_remote_decode_object() -> Result<(), Box<dyn Error>> {
     let meta = make_global_meta();
     let desc = make_descriptor(vec![4]);
     let data = vec![42u8; 16];
@@ -335,7 +335,7 @@ async fn test_remote_file_decode_object() -> Result<(), Box<dyn Error>> {
     server.reset_count();
 
     let (decoded_meta, decoded_desc, decoded_data) =
-        file.file_decode_object(0, 0, &DecodeOptions::default())?;
+        file.decode_object(0, 0, &DecodeOptions::default())?;
     assert_eq!(decoded_meta.version, 2);
     assert_eq!(decoded_desc.shape, vec![4]);
     assert_eq!(decoded_data, data);
@@ -361,12 +361,12 @@ async fn test_remote_multi_object_decode_single() -> Result<(), Box<dyn Error>> 
     let mut file = TensogramFile::open_source(server.url())?;
 
     // Read only the second object
-    let (_, desc, data) = file.file_decode_object(0, 1, &DecodeOptions::default())?;
+    let (_, desc, data) = file.decode_object(0, 1, &DecodeOptions::default())?;
     assert_eq!(desc.shape, vec![8]);
     assert_eq!(data, vec![20u8; 32]);
 
     // Read the third object
-    let (_, desc, data) = file.file_decode_object(0, 2, &DecodeOptions::default())?;
+    let (_, desc, data) = file.decode_object(0, 2, &DecodeOptions::default())?;
     assert_eq!(desc.shape, vec![2]);
     assert_eq!(data, vec![30u8; 8]);
     Ok(())
@@ -380,7 +380,7 @@ async fn test_remote_multi_object_descriptors() -> Result<(), Box<dyn Error>> {
     let server = MockServer::start(msg).await?;
 
     let mut file = TensogramFile::open_source(server.url())?;
-    let (_, descriptors) = file.file_decode_descriptors(0)?;
+    let (_, descriptors) = file.decode_descriptors(0)?;
     assert_eq!(descriptors.len(), 2);
     assert_eq!(descriptors[0].shape, vec![4]);
     assert_eq!(descriptors[1].shape, vec![8]);
@@ -401,10 +401,10 @@ async fn test_remote_multi_message_file() -> Result<(), Box<dyn Error>> {
     let mut file = TensogramFile::open_source(server.url())?;
     assert_eq!(file.message_count()?, 2);
 
-    let meta0 = file.file_decode_metadata(0)?;
+    let meta0 = file.decode_metadata(0)?;
     assert_eq!(meta0.version, 2);
 
-    let (_, descs1) = file.file_decode_descriptors(1)?;
+    let (_, descs1) = file.decode_descriptors(1)?;
     assert_eq!(descs1[0].shape, vec![8]);
     Ok(())
 }
@@ -417,7 +417,7 @@ async fn test_remote_object_out_of_range() -> Result<(), Box<dyn Error>> {
     let server = MockServer::start(msg).await?;
 
     let mut file = TensogramFile::open_source(server.url())?;
-    let result = file.file_decode_object(0, 5, &DecodeOptions::default());
+    let result = file.decode_object(0, 5, &DecodeOptions::default());
     assert!(result.is_err());
     Ok(())
 }
@@ -434,7 +434,7 @@ async fn test_remote_request_count_header_indexed() -> Result<(), Box<dyn Error>
     let open_requests = server.request_count();
 
     server.reset_count();
-    let _ = file.file_decode_object(0, 0, &DecodeOptions::default())?;
+    let _ = file.decode_object(0, 0, &DecodeOptions::default())?;
     let object_requests = server.request_count();
     let range_requests = server.range_request_count();
 
@@ -461,13 +461,13 @@ async fn test_remote_repeated_object_reads_use_cache() -> Result<(), Box<dyn Err
     server.reset_count();
 
     // First object read
-    let _ = file.file_decode_object(0, 0, &DecodeOptions::default())?;
+    let _ = file.decode_object(0, 0, &DecodeOptions::default())?;
     let first_read_count = server.request_count();
 
     server.reset_count();
 
     // Second object read from same message — layout is cached
-    let _ = file.file_decode_object(0, 1, &DecodeOptions::default())?;
+    let _ = file.decode_object(0, 1, &DecodeOptions::default())?;
     let second_read_count = server.request_count();
 
     assert!(
@@ -495,7 +495,7 @@ async fn test_remote_matches_local_decode() -> Result<(), Box<dyn Error>> {
     // Remote decode
     let mut remote_file = TensogramFile::open_source(server.url())?;
     let (remote_meta, remote_desc, remote_data) =
-        remote_file.file_decode_object(0, 0, &DecodeOptions::default())?;
+        remote_file.decode_object(0, 0, &DecodeOptions::default())?;
 
     assert_eq!(local_meta.version, remote_meta.version);
     assert_eq!(local_objects[0].0.shape, remote_desc.shape);

--- a/crates/tensogram-core/tests/remote_http.rs
+++ b/crates/tensogram-core/tests/remote_http.rs
@@ -1,0 +1,543 @@
+#![cfg(feature = "remote")]
+
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use http_body_util::Full;
+use hyper::body::Bytes;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use tokio::net::TcpListener;
+
+use tensogram_core::decode::DecodeOptions;
+use tensogram_core::encode::{self, EncodeOptions};
+use tensogram_core::file::TensogramFile;
+use tensogram_core::types::{ByteOrder, DataObjectDescriptor, GlobalMetadata};
+use tensogram_core::{is_remote_url, Dtype};
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+fn make_global_meta() -> GlobalMetadata {
+    GlobalMetadata {
+        version: 2,
+        extra: BTreeMap::new(),
+        ..Default::default()
+    }
+}
+
+fn make_descriptor(shape: Vec<u64>) -> DataObjectDescriptor {
+    let strides = if shape.is_empty() {
+        vec![]
+    } else {
+        let mut s = vec![1u64; shape.len()];
+        for i in (0..shape.len() - 1).rev() {
+            s[i] = s[i + 1] * shape[i + 1];
+        }
+        s
+    };
+    DataObjectDescriptor {
+        obj_type: "ntensor".to_string(),
+        ndim: shape.len() as u64,
+        shape,
+        strides,
+        dtype: Dtype::Float32,
+        byte_order: ByteOrder::native(),
+        encoding: "none".to_string(),
+        filter: "none".to_string(),
+        compression: "none".to_string(),
+        params: BTreeMap::new(),
+        hash: None,
+    }
+}
+
+fn encode_test_message(shape: Vec<u64>, fill: u8) -> Result<Vec<u8>, std::io::Error> {
+    let meta = make_global_meta();
+    let desc = make_descriptor(shape.clone());
+    let num_bytes = shape.iter().product::<u64>() as usize * 4; // float32 = 4 bytes
+    let data = vec![fill; num_bytes];
+    encode::encode(&meta, &[(&desc, &data)], &EncodeOptions::default())
+        .map_err(std::io::Error::other)
+}
+
+fn encode_multi_object_message(
+    shapes: &[Vec<u64>],
+    fills: &[u8],
+) -> Result<Vec<u8>, std::io::Error> {
+    let meta = make_global_meta();
+    let pairs: Vec<(DataObjectDescriptor, Vec<u8>)> = shapes
+        .iter()
+        .zip(fills)
+        .map(|(shape, &fill)| {
+            let desc = make_descriptor(shape.clone());
+            let num_bytes = shape.iter().product::<u64>() as usize * 4;
+            let data = vec![fill; num_bytes];
+            (desc, data)
+        })
+        .collect();
+    let refs: Vec<(&DataObjectDescriptor, &[u8])> =
+        pairs.iter().map(|(d, b)| (d, b.as_slice())).collect();
+    encode::encode(&meta, &refs, &EncodeOptions::default()).map_err(std::io::Error::other)
+}
+
+// ── Mock HTTP server with request counting ───────────────────────────────────
+
+struct MockServer {
+    #[allow(dead_code)]
+    data: Arc<Vec<u8>>,
+    request_count: Arc<AtomicUsize>,
+    addr: SocketAddr,
+}
+
+impl MockServer {
+    async fn start(data: Vec<u8>) -> Result<Self, std::io::Error> {
+        let data = Arc::new(data);
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+
+        let data_clone = data.clone();
+        let count_clone = request_count.clone();
+
+        tokio::spawn(async move {
+            loop {
+                let (stream, _) = match listener.accept().await {
+                    Ok(v) => v,
+                    Err(_) => break,
+                };
+                let io = TokioIo::new(stream);
+                let data = data_clone.clone();
+                let count = count_clone.clone();
+
+                tokio::spawn(async move {
+                    let _ = http1::Builder::new()
+                        .serve_connection(
+                            io,
+                            service_fn(move |req: Request<hyper::body::Incoming>| {
+                                let data = data.clone();
+                                let count = count.clone();
+                                async move { handle_request(req, data, count) }
+                            }),
+                        )
+                        .await;
+                });
+            }
+        });
+
+        Ok(MockServer {
+            data,
+            request_count,
+            addr,
+        })
+    }
+
+    fn url(&self) -> String {
+        format!("http://127.0.0.1:{}/test.tgm", self.addr.port())
+    }
+
+    fn request_count(&self) -> usize {
+        self.request_count.load(Ordering::SeqCst)
+    }
+
+    fn reset_count(&self) {
+        self.request_count.store(0, Ordering::SeqCst);
+    }
+}
+
+fn handle_request(
+    req: Request<hyper::body::Incoming>,
+    data: Arc<Vec<u8>>,
+    request_count: Arc<AtomicUsize>,
+) -> Result<Response<Full<Bytes>>, std::io::Error> {
+    request_count.fetch_add(1, Ordering::SeqCst);
+
+    if req.method() == hyper::Method::HEAD {
+        let resp = Response::builder()
+            .status(StatusCode::OK)
+            .header("Content-Length", data.len())
+            .header("Accept-Ranges", "bytes")
+            .body(Full::new(Bytes::new()))
+            .map_err(std::io::Error::other)?;
+        return Ok(resp);
+    }
+
+    if let Some(range_header) = req.headers().get("Range") {
+        let range_str = range_header.to_str().unwrap_or("");
+        if let Some(byte_range) = parse_range_header(range_str, data.len()) {
+            let slice = &data[byte_range.0..byte_range.1];
+            let resp = Response::builder()
+                .status(StatusCode::PARTIAL_CONTENT)
+                .header(
+                    "Content-Range",
+                    format!("bytes {}-{}/{}", byte_range.0, byte_range.1 - 1, data.len()),
+                )
+                .header("Content-Length", slice.len())
+                .body(Full::new(Bytes::copy_from_slice(slice)))
+                .map_err(std::io::Error::other)?;
+            return Ok(resp);
+        }
+    }
+
+    let resp = Response::builder()
+        .status(StatusCode::OK)
+        .header("Content-Length", data.len())
+        .body(Full::new(Bytes::copy_from_slice(&data)))
+        .map_err(std::io::Error::other)?;
+    Ok(resp)
+}
+
+fn parse_range_header(header: &str, total: usize) -> Option<(usize, usize)> {
+    let header = header.strip_prefix("bytes=")?;
+    if let Some(suffix) = header.strip_prefix('-') {
+        let n: usize = suffix.parse().ok()?;
+        Some((total.saturating_sub(n), total))
+    } else if let Some((start_s, end_s)) = header.split_once('-') {
+        let start: usize = start_s.parse().ok()?;
+        if end_s.is_empty() {
+            Some((start, total))
+        } else {
+            let end: usize = end_s.parse().ok()?;
+            Some((start, end + 1))
+        }
+    } else {
+        None
+    }
+}
+
+// ── URL detection tests ──────────────────────────────────────────────────────
+
+#[test]
+fn test_is_remote_url() -> Result<(), Box<dyn Error>> {
+    assert!(is_remote_url("s3://bucket/file.tgm"));
+    assert!(is_remote_url("S3://bucket/file.tgm"));
+    assert!(is_remote_url("gs://bucket/file.tgm"));
+    assert!(is_remote_url("az://container/file.tgm"));
+    assert!(is_remote_url("http://host/file.tgm"));
+    assert!(is_remote_url("https://host/file.tgm"));
+    assert!(!is_remote_url("/local/path/file.tgm"));
+    assert!(!is_remote_url("relative/path.tgm"));
+    assert!(!is_remote_url("file.tgm"));
+    assert!(!is_remote_url("ftp://not-supported/file.tgm"));
+    Ok(())
+}
+
+// ── Remote access tests (header-indexed, single message) ─────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_remote_open_and_message_count() -> Result<(), Box<dyn Error>> {
+    let msg = encode_test_message(vec![4], 42)?;
+    let server = MockServer::start(msg).await?;
+
+    let mut file = TensogramFile::open_source(server.url())?;
+    assert!(file.is_remote());
+    assert_eq!(file.message_count()?, 1);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_remote_decode_message() -> Result<(), Box<dyn Error>> {
+    let meta = make_global_meta();
+    let desc = make_descriptor(vec![4]);
+    let data = vec![42u8; 16];
+    let msg = encode::encode(&meta, &[(&desc, &data)], &EncodeOptions::default())?;
+    let server = MockServer::start(msg).await?;
+
+    let mut file = TensogramFile::open_source(server.url())?;
+    let (decoded_meta, objects) = file.decode_message(0, &DecodeOptions::default())?;
+    assert_eq!(decoded_meta.version, 2);
+    assert_eq!(objects.len(), 1);
+    assert_eq!(objects[0].1, data);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_remote_file_decode_metadata() -> Result<(), Box<dyn Error>> {
+    let msg = encode_test_message(vec![4], 42)?;
+    let server = MockServer::start(msg).await?;
+
+    let mut file = TensogramFile::open_source(server.url())?;
+    server.reset_count();
+
+    let meta = file.file_decode_metadata(0)?;
+    assert_eq!(meta.version, 2);
+
+    // First metadata call triggers layout discovery (1 header chunk read).
+    // Subsequent calls should be free (cached).
+    let count_after_first = server.request_count();
+    assert!(
+        count_after_first <= 1,
+        "first metadata read should need at most 1 request"
+    );
+
+    server.reset_count();
+    let meta2 = file.file_decode_metadata(0)?;
+    assert_eq!(meta2.version, 2);
+    assert_eq!(
+        server.request_count(),
+        0,
+        "repeat metadata should come from cache"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_remote_file_decode_descriptors() -> Result<(), Box<dyn Error>> {
+    let msg = encode_test_message(vec![4], 42)?;
+    let server = MockServer::start(msg).await?;
+
+    let mut file = TensogramFile::open_source(server.url())?;
+    let (meta, descriptors) = file.file_decode_descriptors(0)?;
+    assert_eq!(meta.version, 2);
+    assert_eq!(descriptors.len(), 1);
+    assert_eq!(descriptors[0].shape, vec![4]);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_remote_file_decode_object() -> Result<(), Box<dyn Error>> {
+    let meta = make_global_meta();
+    let desc = make_descriptor(vec![4]);
+    let data = vec![42u8; 16];
+    let msg = encode::encode(&meta, &[(&desc, &data)], &EncodeOptions::default())?;
+    let server = MockServer::start(msg).await?;
+
+    let mut file = TensogramFile::open_source(server.url())?;
+    server.reset_count();
+
+    let (decoded_meta, decoded_desc, decoded_data) =
+        file.file_decode_object(0, 0, &DecodeOptions::default())?;
+    assert_eq!(decoded_meta.version, 2);
+    assert_eq!(decoded_desc.shape, vec![4]);
+    assert_eq!(decoded_data, data);
+
+    // Object read should use targeted range request via index, not full message
+    let count = server.request_count();
+    assert!(
+        count <= 2,
+        "expected at most 2 requests for object read (layout + object frame), got {count}"
+    );
+    Ok(())
+}
+
+// ── Multi-object message tests ───────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_remote_multi_object_decode_single() -> Result<(), Box<dyn Error>> {
+    let shapes = vec![vec![4], vec![8], vec![2]];
+    let fills = vec![10u8, 20u8, 30u8];
+    let msg = encode_multi_object_message(&shapes, &fills)?;
+    let server = MockServer::start(msg).await?;
+
+    let mut file = TensogramFile::open_source(server.url())?;
+
+    // Read only the second object
+    let (_, desc, data) = file.file_decode_object(0, 1, &DecodeOptions::default())?;
+    assert_eq!(desc.shape, vec![8]);
+    assert_eq!(data, vec![20u8; 32]);
+
+    // Read the third object
+    let (_, desc, data) = file.file_decode_object(0, 2, &DecodeOptions::default())?;
+    assert_eq!(desc.shape, vec![2]);
+    assert_eq!(data, vec![30u8; 8]);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_remote_multi_object_descriptors() -> Result<(), Box<dyn Error>> {
+    let shapes = vec![vec![4], vec![8]];
+    let fills = vec![10u8, 20u8];
+    let msg = encode_multi_object_message(&shapes, &fills)?;
+    let server = MockServer::start(msg).await?;
+
+    let mut file = TensogramFile::open_source(server.url())?;
+    let (_, descriptors) = file.file_decode_descriptors(0)?;
+    assert_eq!(descriptors.len(), 2);
+    assert_eq!(descriptors[0].shape, vec![4]);
+    assert_eq!(descriptors[1].shape, vec![8]);
+    Ok(())
+}
+
+// ── Multi-message file tests ─────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_remote_multi_message_file() -> Result<(), Box<dyn Error>> {
+    let msg1 = encode_test_message(vec![4], 10)?;
+    let msg2 = encode_test_message(vec![8], 20)?;
+    let mut combined = msg1.clone();
+    combined.extend_from_slice(&msg2);
+
+    let server = MockServer::start(combined).await?;
+
+    let mut file = TensogramFile::open_source(server.url())?;
+    assert_eq!(file.message_count()?, 2);
+
+    let meta0 = file.file_decode_metadata(0)?;
+    assert_eq!(meta0.version, 2);
+
+    let (_, descs1) = file.file_decode_descriptors(1)?;
+    assert_eq!(descs1[0].shape, vec![8]);
+    Ok(())
+}
+
+// ── Object index out of range ────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_remote_object_out_of_range() -> Result<(), Box<dyn Error>> {
+    let msg = encode_test_message(vec![4], 42)?;
+    let server = MockServer::start(msg).await?;
+
+    let mut file = TensogramFile::open_source(server.url())?;
+    let result = file.file_decode_object(0, 5, &DecodeOptions::default());
+    assert!(result.is_err());
+    Ok(())
+}
+
+// ── Request count verification ───────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_remote_request_count_header_indexed() -> Result<(), Box<dyn Error>> {
+    let msg = encode_test_message(vec![4], 42)?;
+    let server = MockServer::start(msg).await?;
+
+    // Opening: HEAD + preamble read + header chunk = ~3 requests
+    let mut file = TensogramFile::open_source(server.url())?;
+    let open_requests = server.request_count();
+
+    server.reset_count();
+    let _ = file.file_decode_object(0, 0, &DecodeOptions::default())?;
+    let object_requests = server.request_count();
+
+    // Layout discovery (1 header chunk) + object frame fetch (1) = at most 2
+    assert!(
+        object_requests <= 2,
+        "expected <=2 requests for object read, got {object_requests} (open used {open_requests})"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_remote_repeated_object_reads_use_cache() -> Result<(), Box<dyn Error>> {
+    let shapes = vec![vec![4], vec![8]];
+    let fills = vec![10u8, 20u8];
+    let msg = encode_multi_object_message(&shapes, &fills)?;
+    let server = MockServer::start(msg).await?;
+
+    let mut file = TensogramFile::open_source(server.url())?;
+    server.reset_count();
+
+    // First object read
+    let _ = file.file_decode_object(0, 0, &DecodeOptions::default())?;
+    let first_read_count = server.request_count();
+
+    server.reset_count();
+
+    // Second object read from same message — layout is cached
+    let _ = file.file_decode_object(0, 1, &DecodeOptions::default())?;
+    let second_read_count = server.request_count();
+
+    assert!(
+        second_read_count <= 1,
+        "repeated reads should reuse cached layout, got {second_read_count} requests (first was {first_read_count})"
+    );
+    Ok(())
+}
+
+// ── Matches local decode ─────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_remote_matches_local_decode() -> Result<(), Box<dyn Error>> {
+    let meta = make_global_meta();
+    let desc = make_descriptor(vec![10]);
+    let data: Vec<u8> = (0..40).collect(); // 10 float32s = 40 bytes
+    let msg = encode::encode(&meta, &[(&desc, &data)], &EncodeOptions::default())?;
+
+    let server = MockServer::start(msg.clone()).await?;
+
+    // Local decode
+    let (local_meta, local_objects) =
+        tensogram_core::decode::decode(&msg, &DecodeOptions::default())?;
+
+    // Remote decode
+    let mut remote_file = TensogramFile::open_source(server.url())?;
+    let (remote_meta, remote_desc, remote_data) =
+        remote_file.file_decode_object(0, 0, &DecodeOptions::default())?;
+
+    assert_eq!(local_meta.version, remote_meta.version);
+    assert_eq!(local_objects[0].0.shape, remote_desc.shape);
+    assert_eq!(local_objects[0].1, remote_data);
+    Ok(())
+}
+
+// ── Error cases ──────────────────────────────────────────────────────────────
+
+#[test]
+fn test_remote_invalid_url() -> Result<(), Box<dyn Error>> {
+    let result = TensogramFile::open_source("http://[invalid-url]/file.tgm");
+    assert!(result.is_err());
+    Ok(())
+}
+
+#[test]
+fn test_open_source_local_path() -> Result<(), Box<dyn Error>> {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("local.tgm");
+
+    let mut file = TensogramFile::create(&path)?;
+    let meta = make_global_meta();
+    let desc = make_descriptor(vec![4]);
+    let data = vec![0u8; 16];
+    file.append(
+        &meta,
+        &[(&desc, data.as_slice())],
+        &EncodeOptions::default(),
+    )?;
+
+    let path = path.to_str().ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::InvalidData, "path is not valid UTF-8")
+    })?;
+    let mut file = TensogramFile::open_source(path)?;
+    assert!(!file.is_remote());
+    assert_eq!(file.message_count()?, 1);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_remote_source_returns_url() -> Result<(), Box<dyn Error>> {
+    let msg = encode_test_message(vec![4], 42)?;
+    let server = MockServer::start(msg).await?;
+    let url = server.url();
+
+    let file = TensogramFile::open_source(url.clone())?;
+    assert_eq!(file.source(), url);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_remote_streaming_message_rejected() -> Result<(), Box<dyn Error>> {
+    // Build a streaming-mode message (total_length=0) by hand:
+    // just a minimal preamble with zero total_length + end magic
+    let mut fake_streaming = Vec::new();
+    fake_streaming.extend_from_slice(b"TENSOGRM"); // magic
+    fake_streaming.extend_from_slice(&2u16.to_be_bytes()); // version
+    fake_streaming.extend_from_slice(&0u16.to_be_bytes()); // flags
+    fake_streaming.extend_from_slice(&0u32.to_be_bytes()); // reserved
+    fake_streaming.extend_from_slice(&0u64.to_be_bytes()); // total_length=0 (streaming)
+                                                           // pad to min size and add end magic
+    fake_streaming.resize(100, 0);
+    fake_streaming.extend_from_slice(b"39277777");
+
+    let server = MockServer::start(fake_streaming).await?;
+    let err = TensogramFile::open_source(server.url())
+        .err()
+        .ok_or_else(|| std::io::Error::other("expected error for streaming message"))?
+        .to_string();
+    assert!(
+        err.contains("streaming"),
+        "expected streaming error, got: {err}"
+    );
+    Ok(())
+}

--- a/crates/tensogram-core/tests/remote_http.rs
+++ b/crates/tensogram-core/tests/remote_http.rs
@@ -416,7 +416,7 @@ async fn test_remote_request_count_header_indexed() -> Result<(), Box<dyn Error>
     let msg = encode_test_message(vec![4], 42)?;
     let server = MockServer::start(msg).await?;
 
-    // Opening: HEAD + preamble read + header chunk = ~3 requests
+    // Opening scans message boundaries only (HEAD + preamble reads)
     let mut file = TensogramFile::open_source(server.url())?;
     let open_requests = server.request_count();
 

--- a/crates/tensogram-core/tests/remote_http.rs
+++ b/crates/tensogram-core/tests/remote_http.rs
@@ -192,16 +192,29 @@ fn handle_request(
 
 fn parse_range_header(header: &str, total: usize) -> Option<(usize, usize)> {
     let header = header.strip_prefix("bytes=")?;
+    if total == 0 {
+        return None;
+    }
     if let Some(suffix) = header.strip_prefix('-') {
         let n: usize = suffix.parse().ok()?;
+        if n == 0 {
+            return None;
+        }
         Some((total.saturating_sub(n), total))
     } else if let Some((start_s, end_s)) = header.split_once('-') {
         let start: usize = start_s.parse().ok()?;
+        if start >= total {
+            return None;
+        }
         if end_s.is_empty() {
             Some((start, total))
         } else {
             let end: usize = end_s.parse().ok()?;
-            Some((start, end + 1))
+            if end < start {
+                return None;
+            }
+            let end_clamped = end.min(total - 1) + 1;
+            Some((start, end_clamped))
         }
     } else {
         None
@@ -536,8 +549,8 @@ async fn test_remote_streaming_message_rejected() -> Result<(), Box<dyn Error>> 
         .ok_or_else(|| std::io::Error::other("expected error for streaming message"))?
         .to_string();
     assert!(
-        err.contains("streaming"),
-        "expected streaming error, got: {err}"
+        err.contains("no valid messages"),
+        "expected no-valid-messages error, got: {err}"
     );
     Ok(())
 }

--- a/crates/tensogram-ffi/src/lib.rs
+++ b/crates/tensogram-ffi/src/lib.rs
@@ -1474,7 +1474,7 @@ pub extern "C" fn tgm_file_append_raw(
         Some(p) => p.to_path_buf(),
         None => {
             set_last_error("append_raw not supported on remote files");
-            return TgmError::Io;
+            return TgmError::Remote;
         }
     };
     let result = std::fs::OpenOptions::new()

--- a/crates/tensogram-ffi/src/lib.rs
+++ b/crates/tensogram-ffi/src/lib.rs
@@ -69,6 +69,7 @@ fn to_error_code(e: &TensogramError) -> TgmError {
         TensogramError::Object(_) => TgmError::Object,
         TensogramError::Io(_) => TgmError::Io,
         TensogramError::HashMismatch { .. } => TgmError::HashMismatch,
+        TensogramError::Remote(_) => TgmError::Io,
     }
 }
 

--- a/crates/tensogram-ffi/src/lib.rs
+++ b/crates/tensogram-ffi/src/lib.rs
@@ -1469,10 +1469,17 @@ pub extern "C" fn tgm_file_append_raw(
 
     // Write raw bytes using std::fs
     use std::io::Write;
+    let path = match f.path() {
+        Some(p) => p.to_path_buf(),
+        None => {
+            set_last_error("append_raw not supported on remote files");
+            return TgmError::Io;
+        }
+    };
     let result = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
-        .open(f.path())
+        .open(&path)
         .and_then(|mut fh| fh.write_all(data));
 
     match result {

--- a/crates/tensogram-ffi/src/lib.rs
+++ b/crates/tensogram-ffi/src/lib.rs
@@ -58,6 +58,7 @@ pub enum TgmError {
     InvalidArg = 8,
     /// Returned by `tgm_*_iter_next` when iteration is exhausted.
     EndOfIter = 9,
+    Remote = 10,
 }
 
 fn to_error_code(e: &TensogramError) -> TgmError {
@@ -69,7 +70,7 @@ fn to_error_code(e: &TensogramError) -> TgmError {
         TensogramError::Object(_) => TgmError::Object,
         TensogramError::Io(_) => TgmError::Io,
         TensogramError::HashMismatch { .. } => TgmError::HashMismatch,
-        TensogramError::Remote(_) => TgmError::Io,
+        TensogramError::Remote(_) => TgmError::Remote,
     }
 }
 

--- a/crates/tensogram-ffi/tensogram.h
+++ b/crates/tensogram-ffi/tensogram.h
@@ -23,6 +23,7 @@ typedef enum {
    * Returned by `tgm_*_iter_next` when iteration is exhausted.
    */
   TGM_ERROR_END_OF_ITER = 9,
+  TGM_ERROR_REMOTE = 10,
 } tgm_error;
 
 /**

--- a/crates/tensogram-python/Cargo.toml
+++ b/crates/tensogram-python/Cargo.toml
@@ -8,7 +8,7 @@ name = "tensogram"
 crate-type = ["cdylib"]
 
 [dependencies]
-tensogram-core = { path = "../tensogram-core" }
+tensogram-core = { path = "../tensogram-core", features = ["remote"] }
 tensogram-encodings = { path = "../tensogram-encodings" }
 pyo3 = { version = "0.25", features = ["extension-module"] }
 numpy = "0.25"

--- a/crates/tensogram-python/src/lib.rs
+++ b/crates/tensogram-python/src/lib.rs
@@ -37,6 +37,7 @@ fn to_py_err(e: TensogramError) -> PyErr {
         TensogramError::HashMismatch { expected, actual } => PyRuntimeError::new_err(format!(
             "HashMismatch: expected={expected}, actual={actual}"
         )),
+        TensogramError::Remote(msg) => PyIOError::new_err(format!("RemoteError: {msg}")),
     }
 }
 

--- a/crates/tensogram-python/src/lib.rs
+++ b/crates/tensogram-python/src/lib.rs
@@ -523,7 +523,9 @@ impl PyTensogramFile {
     /// All raw message bytes as a list of ``bytes`` objects.
     fn messages<'py>(&mut self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
         #[allow(deprecated)]
-        let msgs = self.file.messages().map_err(to_py_err)?;
+        let msgs = py
+            .allow_threads(|| self.file.messages())
+            .map_err(to_py_err)?;
         let items: Vec<PyObject> = msgs
             .iter()
             .map(|m| PyBytes::new(py, m).into_any().unbind())

--- a/crates/tensogram-python/src/lib.rs
+++ b/crates/tensogram-python/src/lib.rs
@@ -428,7 +428,7 @@ impl PyTensogramFile {
     }
 
     fn __repr__(&self) -> String {
-        format!("TensogramFile(path='{}')", self.file.path().display())
+        format!("TensogramFile(source='{}')", self.file.source())
     }
 
     fn __enter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
@@ -463,8 +463,10 @@ impl PyTensogramFile {
     fn __iter__(&mut self) -> PyResult<PyFileIter> {
         // Open an independent file handle so the iterator owns its state.
         // Safe under free-threaded Python (no shared mutable borrows).
-        let path = self.file.path().to_path_buf();
-        let mut iter_file = TensogramFile::open(&path).map_err(to_py_err)?;
+        let path = self.file.path().ok_or_else(|| {
+            pyo3::exceptions::PyRuntimeError::new_err("iteration not supported on remote files")
+        })?;
+        let mut iter_file = TensogramFile::open(path).map_err(to_py_err)?;
         // Read count from the *iterator's* handle to avoid TOCTOU race
         // if the file is modified between open() and first next() call.
         let count = iter_file.message_count().map_err(to_py_err)?;

--- a/crates/tensogram-python/src/lib.rs
+++ b/crates/tensogram-python/src/lib.rs
@@ -335,10 +335,30 @@ struct PyTensogramFile {
 
 #[pymethods]
 impl PyTensogramFile {
-    /// Open an existing file for reading.
     #[staticmethod]
-    fn open(path: &str) -> PyResult<Self> {
-        let file = TensogramFile::open(path).map_err(to_py_err)?;
+    fn open(source: &str) -> PyResult<Self> {
+        let file = TensogramFile::open_source(source).map_err(to_py_err)?;
+        Ok(PyTensogramFile { file })
+    }
+
+    #[staticmethod]
+    #[pyo3(signature = (source, storage_options=None))]
+    fn open_remote(source: &str, storage_options: Option<&Bound<'_, PyDict>>) -> PyResult<Self> {
+        let opts = match storage_options {
+            Some(dict) => {
+                let mut map = BTreeMap::new();
+                for (k, v) in dict.iter() {
+                    let key: String = k.extract()?;
+                    let val: String = v
+                        .extract::<String>()
+                        .unwrap_or_else(|_| v.str().map(|s| s.to_string()).unwrap_or_default());
+                    map.insert(key, val);
+                }
+                map
+            }
+            None => BTreeMap::new(),
+        };
+        let file = TensogramFile::open_remote(source, &opts).map_err(to_py_err)?;
         Ok(PyTensogramFile { file })
     }
 
@@ -404,6 +424,71 @@ impl PyTensogramFile {
             .map_err(to_py_err)?;
         let result_list = data_objects_to_python(py, &data_objects)?;
         pack_message(py, PyMetadata { inner: global_meta }, result_list)
+    }
+
+    fn file_decode_metadata(&mut self, py: Python<'_>, msg_index: usize) -> PyResult<PyObject> {
+        let meta = self.file.decode_metadata(msg_index).map_err(to_py_err)?;
+        Ok(PyMetadata { inner: meta }
+            .into_pyobject(py)?
+            .into_any()
+            .unbind())
+    }
+
+    fn file_decode_descriptors(&mut self, py: Python<'_>, msg_index: usize) -> PyResult<PyObject> {
+        let (meta, descriptors) = self.file.decode_descriptors(msg_index).map_err(to_py_err)?;
+        let desc_list: Vec<PyObject> = descriptors
+            .iter()
+            .map(|d| {
+                Ok(PyDataObjectDescriptor { inner: d.clone() }
+                    .into_pyobject(py)?
+                    .into_any()
+                    .unbind())
+            })
+            .collect::<PyResult<_>>()?;
+        let result = PyDict::new(py);
+        result.set_item("metadata", PyMetadata { inner: meta }.into_pyobject(py)?)?;
+        result.set_item("descriptors", PyList::new(py, desc_list)?)?;
+        Ok(result.into_any().unbind())
+    }
+
+    #[pyo3(signature = (msg_index, obj_index, verify_hash=false, native_byte_order=true))]
+    fn file_decode_object(
+        &mut self,
+        py: Python<'_>,
+        msg_index: usize,
+        obj_index: usize,
+        verify_hash: bool,
+        native_byte_order: bool,
+    ) -> PyResult<PyObject> {
+        let options = DecodeOptions {
+            verify_hash,
+            native_byte_order,
+            ..Default::default()
+        };
+        let (meta, desc, data) = self
+            .file
+            .decode_object(msg_index, obj_index, &options)
+            .map_err(to_py_err)?;
+        let arr = bytes_to_numpy(py, &desc, &data)?;
+        let py_desc = PyDataObjectDescriptor {
+            inner: desc.clone(),
+        }
+        .into_pyobject(py)?
+        .into_any()
+        .unbind();
+        let result = PyDict::new(py);
+        result.set_item("metadata", PyMetadata { inner: meta }.into_pyobject(py)?)?;
+        result.set_item("descriptor", py_desc)?;
+        result.set_item("data", arr)?;
+        Ok(result.into_any().unbind())
+    }
+
+    fn is_remote(&self) -> bool {
+        self.file.is_remote()
+    }
+
+    fn source(&self) -> String {
+        self.file.source()
     }
 
     /// Raw wire-format bytes for the message at *index*.

--- a/crates/tensogram-python/src/lib.rs
+++ b/crates/tensogram-python/src/lib.rs
@@ -411,8 +411,7 @@ impl PyTensogramFile {
             pairs.iter().map(|(d, b)| (d, b.as_slice())).collect();
 
         let options = make_encode_options(hash)?;
-        self.file
-            .append(&global_meta, &refs, &options)
+        py.allow_threads(|| self.file.append(&global_meta, &refs, &options))
             .map_err(to_py_err)
     }
 
@@ -595,7 +594,9 @@ impl PyTensogramFile {
     /// - ``file[-1]`` returns the last message
     /// - ``file[1:4]`` returns ``list[Message]``
     fn __getitem__(&mut self, py: Python<'_>, key: &Bound<'_, pyo3::PyAny>) -> PyResult<PyObject> {
-        let count = self.file.message_count().map_err(to_py_err)?;
+        let count = py
+            .allow_threads(|| self.file.message_count())
+            .map_err(to_py_err)?;
 
         if let Ok(index) = key.extract::<isize>() {
             let idx = if index < 0 {
@@ -674,8 +675,9 @@ impl PyFileIter {
         let i = self.index;
         self.index += 1;
         let options = DecodeOptions::default();
-        let (global_meta, data_objects) =
-            self.file.decode_message(i, &options).map_err(to_py_err)?;
+        let (global_meta, data_objects) = py
+            .allow_threads(|| self.file.decode_message(i, &options))
+            .map_err(to_py_err)?;
         let result_list = data_objects_to_python(py, &data_objects)?;
         Ok(Some(pack_message(
             py,

--- a/crates/tensogram-python/src/lib.rs
+++ b/crates/tensogram-python/src/lib.rs
@@ -551,8 +551,9 @@ impl PyTensogramFile {
         false // do not suppress exceptions
     }
 
-    fn __len__(&mut self) -> PyResult<usize> {
-        self.file.message_count().map_err(to_py_err)
+    fn __len__(&mut self, py: Python<'_>) -> PyResult<usize> {
+        py.allow_threads(|| self.file.message_count())
+            .map_err(to_py_err)
     }
 
     /// Iterate over all messages in the file.

--- a/crates/tensogram-python/src/lib.rs
+++ b/crates/tensogram-python/src/lib.rs
@@ -349,9 +349,13 @@ impl PyTensogramFile {
                 let mut map = BTreeMap::new();
                 for (k, v) in dict.iter() {
                     let key: String = k.extract()?;
-                    let val: String = v
-                        .extract::<String>()
-                        .unwrap_or_else(|_| v.str().map(|s| s.to_string()).unwrap_or_default());
+                    let val: String = v.extract::<String>().or_else(|_| {
+                        v.str()
+                            .map(|s| s.to_string())
+                            .map_err(|_| PyValueError::new_err(format!(
+                                "storage_options value for key '{key}' must be convertible to string"
+                            )))
+                    })?;
                     map.insert(key, val);
                 }
                 map

--- a/crates/tensogram-python/src/lib.rs
+++ b/crates/tensogram-python/src/lib.rs
@@ -567,16 +567,21 @@ impl PyTensogramFile {
     ///         for meta, objects in f:
     ///             desc, arr = objects[0]
     ///             print(arr.shape)
-    fn __iter__(&mut self) -> PyResult<PyFileIter> {
-        // Open an independent file handle so the iterator owns its state.
-        // Safe under free-threaded Python (no shared mutable borrows).
-        let path = self.file.path().ok_or_else(|| {
-            pyo3::exceptions::PyRuntimeError::new_err("iteration not supported on remote files")
-        })?;
-        let mut iter_file = TensogramFile::open(path).map_err(to_py_err)?;
-        // Read count from the *iterator's* handle to avoid TOCTOU race
-        // if the file is modified between open() and first next() call.
-        let count = iter_file.message_count().map_err(to_py_err)?;
+    fn __iter__(&mut self, py: Python<'_>) -> PyResult<PyFileIter> {
+        let path = self
+            .file
+            .path()
+            .ok_or_else(|| {
+                pyo3::exceptions::PyRuntimeError::new_err("iteration not supported on remote files")
+            })?
+            .to_path_buf();
+        let (iter_file, count) = py
+            .allow_threads(|| {
+                let mut f = TensogramFile::open(&path)?;
+                let c = f.message_count()?;
+                Ok::<_, tensogram_core::TensogramError>((f, c))
+            })
+            .map_err(to_py_err)?;
         Ok(PyFileIter {
             file: iter_file,
             index: 0,
@@ -1258,8 +1263,15 @@ fn py_validate_file(
 // Module definition
 // ---------------------------------------------------------------------------
 
+#[pyfunction]
+#[pyo3(name = "is_remote_url")]
+fn py_is_remote_url(source: &str) -> bool {
+    tensogram_core::is_remote_url(source)
+}
+
 #[pymodule]
 fn tensogram(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(py_is_remote_url, m)?)?;
     m.add_function(wrap_pyfunction!(py_encode, m)?)?;
     m.add_function(wrap_pyfunction!(py_encode_pre_encoded, m)?)?;
     m.add_function(wrap_pyfunction!(py_decode, m)?)?;

--- a/crates/tensogram-python/src/lib.rs
+++ b/crates/tensogram-python/src/lib.rs
@@ -336,14 +336,21 @@ struct PyTensogramFile {
 #[pymethods]
 impl PyTensogramFile {
     #[staticmethod]
-    fn open(source: &str) -> PyResult<Self> {
-        let file = TensogramFile::open_source(source).map_err(to_py_err)?;
+    fn open(py: Python<'_>, source: &str) -> PyResult<Self> {
+        let source = source.to_string();
+        let file = py
+            .allow_threads(|| TensogramFile::open_source(&source))
+            .map_err(to_py_err)?;
         Ok(PyTensogramFile { file })
     }
 
     #[staticmethod]
     #[pyo3(signature = (source, storage_options=None))]
-    fn open_remote(source: &str, storage_options: Option<&Bound<'_, PyDict>>) -> PyResult<Self> {
+    fn open_remote(
+        py: Python<'_>,
+        source: &str,
+        storage_options: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Self> {
         let opts = match storage_options {
             Some(dict) => {
                 let mut map = BTreeMap::new();
@@ -362,7 +369,10 @@ impl PyTensogramFile {
             }
             None => BTreeMap::new(),
         };
-        let file = TensogramFile::open_remote(source, &opts).map_err(to_py_err)?;
+        let source = source.to_string();
+        let file = py
+            .allow_threads(|| TensogramFile::open_remote(&source, &opts))
+            .map_err(to_py_err)?;
         Ok(PyTensogramFile { file })
     }
 
@@ -374,8 +384,9 @@ impl PyTensogramFile {
     }
 
     /// Number of valid messages in the file.
-    fn message_count(&mut self) -> PyResult<usize> {
-        self.file.message_count().map_err(to_py_err)
+    fn message_count(&mut self, py: Python<'_>) -> PyResult<usize> {
+        py.allow_threads(|| self.file.message_count())
+            .map_err(to_py_err)
     }
 
     /// Append one message.
@@ -422,16 +433,17 @@ impl PyTensogramFile {
             native_byte_order,
             ..Default::default()
         };
-        let (global_meta, data_objects) = self
-            .file
-            .decode_message(index, &options)
+        let (global_meta, data_objects) = py
+            .allow_threads(|| self.file.decode_message(index, &options))
             .map_err(to_py_err)?;
         let result_list = data_objects_to_python(py, &data_objects)?;
         pack_message(py, PyMetadata { inner: global_meta }, result_list)
     }
 
     fn file_decode_metadata(&mut self, py: Python<'_>, msg_index: usize) -> PyResult<PyObject> {
-        let meta = self.file.decode_metadata(msg_index).map_err(to_py_err)?;
+        let meta = py
+            .allow_threads(|| self.file.decode_metadata(msg_index))
+            .map_err(to_py_err)?;
         Ok(PyMetadata { inner: meta }
             .into_pyobject(py)?
             .into_any()
@@ -439,7 +451,9 @@ impl PyTensogramFile {
     }
 
     fn file_decode_descriptors(&mut self, py: Python<'_>, msg_index: usize) -> PyResult<PyObject> {
-        let (meta, descriptors) = self.file.decode_descriptors(msg_index).map_err(to_py_err)?;
+        let (meta, descriptors) = py
+            .allow_threads(|| self.file.decode_descriptors(msg_index))
+            .map_err(to_py_err)?;
         let desc_list: Vec<PyObject> = descriptors
             .iter()
             .map(|d| {
@@ -469,9 +483,8 @@ impl PyTensogramFile {
             native_byte_order,
             ..Default::default()
         };
-        let (meta, desc, data) = self
-            .file
-            .decode_object(msg_index, obj_index, &options)
+        let (meta, desc, data) = py
+            .allow_threads(|| self.file.decode_object(msg_index, obj_index, &options))
             .map_err(to_py_err)?;
         let arr = bytes_to_numpy(py, &desc, &data)?;
         let py_desc = PyDataObjectDescriptor {
@@ -501,7 +514,9 @@ impl PyTensogramFile {
         py: Python<'py>,
         index: usize,
     ) -> PyResult<Bound<'py, PyBytes>> {
-        let bytes = self.file.read_message(index).map_err(to_py_err)?;
+        let bytes = py
+            .allow_threads(|| self.file.read_message(index))
+            .map_err(to_py_err)?;
         Ok(PyBytes::new(py, &bytes))
     }
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -29,6 +29,7 @@
 - [Pre-Encoded Data API (Advanced)](guide/encode-pre-encoded.md)
 - [Decoding Data](guide/decoding.md)
 - [Working with Files](guide/file-api.md)
+- [Remote Access (S3, GCS, Azure, HTTP)](guide/remote-access.md)
 - [Iterators](guide/iterators.md)
 - [Python API](guide/python-api.md)
 - [C++ API](guide/cpp-api.md)

--- a/docs/src/guide/file-api.md
+++ b/docs/src/guide/file-api.md
@@ -150,7 +150,7 @@ use tensogram_core::{TensogramFile, DecodeOptions};
 let mut file = TensogramFile::open_source("s3://bucket/forecast.tgm")?;
 
 // Fetch only the second object from message 0 — no full download
-let (meta, desc, data) = file.file_decode_object(0, 1, &DecodeOptions::default())?;
+let (meta, desc, data) = file.decode_object(0, 1, &DecodeOptions::default())?;
 ```
 
 Currently supports Rust core only (header-indexed files, read-only). Python and xarray integration will follow. See the [Remote Access](remote-access.md) guide for storage options, request budgets, and limitations.

--- a/docs/src/guide/file-api.md
+++ b/docs/src/guide/file-api.md
@@ -153,7 +153,7 @@ let mut file = TensogramFile::open_source("s3://bucket/forecast.tgm")?;
 let (meta, desc, data) = file.decode_object(0, 1, &DecodeOptions::default())?;
 ```
 
-Currently supports Rust core only (header-indexed and footer-indexed files, read-only). Python and xarray integration will follow. See the [Remote Access](remote-access.md) guide for storage options, request budgets, and limitations.
+Supports header-indexed and footer-indexed files (read-only) from Rust, Python, xarray, and zarr. See the [Remote Access](remote-access.md) guide for storage options, request budgets, and limitations.
 
 ## Memory-Mapped I/O (optional)
 

--- a/docs/src/guide/file-api.md
+++ b/docs/src/guide/file-api.md
@@ -153,7 +153,7 @@ let mut file = TensogramFile::open_source("s3://bucket/forecast.tgm")?;
 let (meta, desc, data) = file.decode_object(0, 1, &DecodeOptions::default())?;
 ```
 
-Currently supports Rust core only (header-indexed files, read-only). Python and xarray integration will follow. See the [Remote Access](remote-access.md) guide for storage options, request budgets, and limitations.
+Currently supports Rust core only (header-indexed and footer-indexed files, read-only). Python and xarray integration will follow. See the [Remote Access](remote-access.md) guide for storage options, request budgets, and limitations.
 
 ## Memory-Mapped I/O (optional)
 

--- a/docs/src/guide/file-api.md
+++ b/docs/src/guide/file-api.md
@@ -135,6 +135,26 @@ forecast.tgm
 
 No file-level header, no file-level index. All indexing is per-message, built in-memory at scan time.
 
+## Remote Access (optional)
+
+Enable the `remote` feature to open `.tgm` files on S3, GCS, Azure, or HTTP with selective range-based reads:
+
+```toml
+[dependencies]
+tensogram-core = { path = "...", features = ["remote"] }
+```
+
+```rust
+use tensogram_core::{TensogramFile, DecodeOptions};
+
+let mut file = TensogramFile::open_source("s3://bucket/forecast.tgm")?;
+
+// Fetch only the second object from message 0 — no full download
+let (meta, desc, data) = file.file_decode_object(0, 1, &DecodeOptions::default())?;
+```
+
+Currently supports Rust core only (header-indexed files, read-only). Python and xarray integration will follow. See the [Remote Access](remote-access.md) guide for storage options, request budgets, and limitations.
+
 ## Memory-Mapped I/O (optional)
 
 Enable the `mmap` feature to use memory-mapped file access:

--- a/docs/src/guide/remote-access.md
+++ b/docs/src/guide/remote-access.md
@@ -100,10 +100,11 @@ These methods also work on local files, where they read the full message and dec
 | **First access** | `decode_metadata(i)` | 2 GETs (postamble + footer region) |
 | **Cached** | `decode_metadata(i)` again | 0 (served from cache) |
 | **Object read** | `decode_object(i, j)` | 1 GET per object (if layout already cached) |
+| **Descriptors** | `decode_descriptors(i)` | 1 GET per object in message |
 
 The layout (metadata + index) is discovered per-message on first access to that message, then cached. Subsequent calls reuse the cached layout. Streaming messages must be the last message in a multi-message file.
 
-## How It Works
+## How It Works (Header-Indexed Example)
 
 ```mermaid
 sequenceDiagram
@@ -148,7 +149,7 @@ Remote access can return different `TensogramError` variants depending on the fa
 | Unsupported layout | `Remote` | Message lacks both header-index and footer-index flags |
 | Object index out of range | `Object` | `decode_object(i, j)` where `j >= object_count` |
 
-All errors are returned as `Result`. The library avoids panics, though thread creation failures and corrupt-index arithmetic edge cases may still panic in extreme conditions.
+All errors are returned as `Result`. The library avoids panics; thread creation failures are the only remaining theoretical panic path.
 
 ## Limitations
 

--- a/docs/src/guide/remote-access.md
+++ b/docs/src/guide/remote-access.md
@@ -189,7 +189,11 @@ All errors are returned as `Result`. The library avoids panics.
 
 Remote I/O uses a process-wide shared tokio runtime (multi-thread, 2 workers) created on first use. All `RemoteBackend` instances share the same runtime, so TCP connection pools and DNS caches are reused across calls.
 
-When the sync API (`decode_object`, `decode_metadata`, etc.) is called from within an existing async context (e.g. `#[tokio::test]`), the library detects this and spawns a scoped thread to avoid nested-runtime panics. When called from a non-async context (Python, CLI), the runtime is driven directly with no extra thread creation.
+The sync bridge adapts to the calling context:
+
+- **Not in a tokio runtime** (Python, CLI): the shared runtime's handle drives the future directly — no extra thread creation.
+- **Inside a multi-thread tokio runtime** (`#[tokio::test]`, server handler): `block_in_place` tells tokio to spawn a replacement worker so the blocked thread doesn't cause runtime starvation.
+- **Inside a current-thread tokio runtime**: falls back to a scoped thread, since `block_in_place` is not supported on single-threaded runtimes.
 
 ## Async API
 

--- a/docs/src/guide/remote-access.md
+++ b/docs/src/guide/remote-access.md
@@ -183,7 +183,53 @@ Remote access can return different `TensogramError` variants depending on the fa
 | Unsupported layout | `Remote` | Message lacks both header-index and footer-index flags |
 | Object index out of range | `Object` | `decode_object(i, j)` where `j >= object_count` |
 
-All errors are returned as `Result`. The library avoids panics; thread creation failures are the only remaining theoretical panic path.
+All errors are returned as `Result`. The library avoids panics.
+
+## Shared Runtime
+
+Remote I/O uses a process-wide shared tokio runtime (multi-thread, 2 workers) created on first use. All `RemoteBackend` instances share the same runtime, so TCP connection pools and DNS caches are reused across calls.
+
+When the sync API (`decode_object`, `decode_metadata`, etc.) is called from within an existing async context (e.g. `#[tokio::test]`), the library detects this and spawns a scoped thread to avoid nested-runtime panics. When called from a non-async context (Python, CLI), the runtime is driven directly with no extra thread creation.
+
+## Async API
+
+The `async` feature enables async methods for decode, read, and metadata extraction. These work for both local and remote files:
+
+```rust
+use tensogram_core::{TensogramFile, DecodeOptions};
+
+// Async decode methods (feature = "async")
+let meta = file.decode_metadata_async(0).await?;
+let (meta, descs) = file.decode_descriptors_async(0).await?;
+let (meta, desc, data) = file.decode_object_async(0, 0, &DecodeOptions::default()).await?;
+let msg = file.read_message_async(0).await?;
+```
+
+When both `remote` and `async` features are enabled, async open methods are also available:
+
+```rust
+// Async open (auto-detects local vs remote) — requires remote + async
+let mut file = TensogramFile::open_source_async("s3://bucket/forecast.tgm").await?;
+
+// Async open with explicit storage options
+let mut file = TensogramFile::open_remote_async(
+    "s3://bucket/forecast.tgm",
+    &opts,
+).await?;
+```
+
+For remote backends, async methods directly `await` object store operations, bypassing the sync bridge entirely. For local backends, they use `spawn_blocking` for file I/O.
+
+```toml
+[dependencies]
+tensogram-core = { path = "...", features = ["remote", "async"] }
+```
+
+## Descriptor-Only Reads
+
+`decode_descriptors()` fetches only the CBOR descriptor from each data object frame, not the full payload. For large objects (hundreds of MB), this avoids downloading the entire frame just to extract a few hundred bytes of metadata.
+
+For frames smaller than 64 KB, the full frame is read in a single request (fewer round-trips). For larger frames, the library reads only the frame header (16 bytes), footer (12 bytes), and the CBOR descriptor region.
 
 ## Limitations
 
@@ -194,4 +240,4 @@ All errors are returned as `Result`. The library avoids panics; thread creation 
 - **HTTP server requirements.** The remote HTTP server must support `HEAD` requests (for file size) and `Range` request headers (for partial reads).
 - **`read_message()` and `decode_message()` download the full message** even for remote files. Use `decode_metadata()`, `decode_descriptors()`, or `decode_object()` for selective access.
 - **Zarr remote reads are eager.** The zarr store downloads the full message at open time. For large messages with many objects, this can be slow over remote stores.
-- **Thread-per-request.** Each range request spawns a thread with a temporary tokio runtime. This is correct but not optimal for many small reads. A shared runtime will be added in a follow-up.
+- **Sequential async access.** Async methods take `&mut self`, so a single file handle cannot serve concurrent async reads. Open separate handles for parallelism.

--- a/docs/src/guide/remote-access.md
+++ b/docs/src/guide/remote-access.md
@@ -158,6 +158,6 @@ All errors are returned as `Result`. The library avoids panics; thread creation 
 - **Read-only.** Remote writes are not supported.
 - **Header probe size.** Layout discovery reads a single chunk of up to 256 KB from the header region. If the metadata or index frame does not fit in this chunk, `decode_metadata()` will error (it does not retry with a larger read).
 - **HTTP server requirements.** The remote HTTP server must support `HEAD` requests (for file size) and `Range` request headers (for partial reads).
-- **Rust core only.** Python bindings, xarray backend, and zarr store do not yet support remote URLs. This will be added in a follow-up PR.
+- **Python/xarray/zarr supported.** `tensogram.TensogramFile.open()` auto-detects remote URLs. xarray accepts `storage_options` via `xr.open_dataset(url, engine="tensogram", storage_options={...})`. Zarr supports `TensogramStore.open_tgm(url, storage_options={...})` in read-only mode.
 - **`read_message()` and `decode_message()` download the full message** even for remote files. Use `decode_metadata()`, `decode_descriptors()`, or `decode_object()` for selective access.
 - **Thread-per-request.** Each range request spawns a thread with a temporary tokio runtime. This is correct but not optimal for many small reads. A shared runtime will be added in a follow-up.

--- a/docs/src/guide/remote-access.md
+++ b/docs/src/guide/remote-access.md
@@ -86,7 +86,7 @@ For header-indexed files (the default for non-streaming writes):
 
 | Phase | Operation | HTTP Requests |
 |-------|-----------|:---:|
-| **Open** | `open_source` / `open_remote` | 1 HEAD + 1 GET per message (preamble scan) |
+| **Open** | `open_source` / `open_remote` | 1 HEAD + 1 GET per message (preamble read) |
 | **First access** | `file_decode_metadata(i)` | 1 GET (header chunk, discovers metadata + index) |
 | **Cached** | `file_decode_metadata(i)` again | 0 (served from cache) |
 | **Object read** | `file_decode_object(i, j)` | 1 GET per object (if layout already cached) |
@@ -135,7 +135,7 @@ Remote operations return `TensogramError::Remote` for transport-level failures:
 | Invalid URL | `open_source` / `open_remote` with a malformed URL |
 | Connection failure | Network unreachable, DNS failure, timeout |
 | File not found | HTTP 404, S3 NoSuchKey |
-| Streaming message | Message has `total_length=0` (footer-indexed) |
+| No valid messages | File contains only streaming (`total_length=0`) or corrupt messages |
 | Header-only required | Message has no header metadata flag |
 | Object index out of range | `file_decode_object(i, j)` where `j >= object_count` |
 

--- a/docs/src/guide/remote-access.md
+++ b/docs/src/guide/remote-access.md
@@ -122,7 +122,8 @@ These methods also work on local files, where they read the full message and dec
 | **First access** | `decode_metadata(i)` | 1 GET (header chunk, discovers metadata + index) |
 | **Cached** | `decode_metadata(i)` again | 0 (served from cache) |
 | **Object read** | `decode_object(i, j)` | 1 GET per object (if layout already cached) |
-| **Descriptors** | `decode_descriptors(i)` | 1 GET per object in message |
+| **Descriptors (first)** | `decode_descriptors(i)` | 1 GET (layout) + 1 GET per object |
+| **Descriptors (cached)** | `decode_descriptors(i)` | 1 GET per object |
 
 ### Footer-indexed files (streaming writes)
 
@@ -132,7 +133,8 @@ These methods also work on local files, where they read the full message and dec
 | **First access** | `decode_metadata(i)` | 2 GETs (postamble + footer region) |
 | **Cached** | `decode_metadata(i)` again | 0 (served from cache) |
 | **Object read** | `decode_object(i, j)` | 1 GET per object (if layout already cached) |
-| **Descriptors** | `decode_descriptors(i)` | 1 GET per object in message |
+| **Descriptors (first)** | `decode_descriptors(i)` | 2 GETs (layout) + 1 GET per object |
+| **Descriptors (cached)** | `decode_descriptors(i)` | 1 GET per object |
 
 The layout (metadata + index) is discovered per-message on first access to that message, then cached. Subsequent calls reuse the cached layout. Streaming messages must be the last message in a multi-message file.
 

--- a/docs/src/guide/remote-access.md
+++ b/docs/src/guide/remote-access.md
@@ -82,7 +82,7 @@ These methods also work on local files, where they read the full message and dec
 
 ## Request Budget
 
-For header-indexed files (the default for non-streaming writes):
+### Header-indexed files (buffered writes)
 
 | Phase | Operation | HTTP Requests |
 |-------|-----------|:---:|
@@ -92,7 +92,16 @@ For header-indexed files (the default for non-streaming writes):
 | **Object read** | `decode_object(i, j)` | 1 GET per object (if layout already cached) |
 | **Descriptors** | `decode_descriptors(i)` | 1 GET per object in message |
 
-The layout (metadata + index) is discovered per-message on first access to that message, then cached. Subsequent calls reuse the cached layout.
+### Footer-indexed files (streaming writes)
+
+| Phase | Operation | HTTP Requests |
+|-------|-----------|:---:|
+| **Open** | `open_source` / `open_remote` | 1 HEAD + 1 GET per message (preamble read) |
+| **First access** | `decode_metadata(i)` | 2 GETs (postamble + footer region) |
+| **Cached** | `decode_metadata(i)` again | 0 (served from cache) |
+| **Object read** | `decode_object(i, j)` | 1 GET per object (if layout already cached) |
+
+The layout (metadata + index) is discovered per-message on first access to that message, then cached. Subsequent calls reuse the cached layout. Streaming messages must be the last message in a multi-message file.
 
 ## How It Works
 
@@ -135,15 +144,15 @@ Remote access can return different `TensogramError` variants depending on the fa
 | Invalid URL | `Remote` | `open_source` / `open_remote` with a malformed URL |
 | Connection failure | `Remote` | Network unreachable, DNS failure, timeout |
 | File not found | `Remote` | HTTP 404, S3 NoSuchKey |
-| No valid messages | `Remote` | File contains only streaming (`total_length=0`) or corrupt messages |
-| Missing header index | `Remote` | Message lacks `HEADER_METADATA` or `HEADER_INDEX` flag |
+| No valid messages | `Remote` | File contains no parseable messages |
+| Unsupported layout | `Remote` | Message lacks both header-index and footer-index flags |
 | Object index out of range | `Object` | `decode_object(i, j)` where `j >= object_count` |
 
 All errors are returned as `Result`. The library avoids panics, though thread creation failures and corrupt-index arithmetic edge cases may still panic in extreme conditions.
 
 ## Limitations
 
-- **Header-indexed messages only.** Footer-indexed messages (produced by `StreamingEncoder`) are not yet supported remotely. Use buffered `encode()` for files destined for remote storage.
+- **Streaming messages must be last.** In multi-message files, streaming-encoded messages (`total_length=0`) must be the last message. The remote scanner assumes the streaming message extends to the end of the file.
 - **Optimistic scan.** Remote message scanning validates preamble magic and `total_length` plausibility but does not verify end-of-message markers (unlike local scanning). A corrupt preamble with a plausible length will be accepted until a later read fails.
 - **Read-only.** Remote writes are not supported.
 - **Header probe size.** Layout discovery reads a single chunk of up to 256 KB from the header region. If the metadata or index frame does not fit in this chunk, `decode_metadata()` will error (it does not retry with a larger read).

--- a/docs/src/guide/remote-access.md
+++ b/docs/src/guide/remote-access.md
@@ -128,16 +128,16 @@ println!("source: {}", file.source()); // "s3://bucket/data.tgm"
 
 ## Error Handling
 
-Remote operations return `TensogramError::Remote` for transport-level failures:
+Remote access can return different `TensogramError` variants depending on the failure:
 
-| Error condition | When it happens |
-|-----------------|-----------------|
-| Invalid URL | `open_source` / `open_remote` with a malformed URL |
-| Connection failure | Network unreachable, DNS failure, timeout |
-| File not found | HTTP 404, S3 NoSuchKey |
-| No valid messages | File contains only streaming (`total_length=0`) or corrupt messages |
-| Header-only required | Message has no header metadata flag |
-| Object index out of range | `decode_object(i, j)` where `j >= object_count` |
+| Error condition | Error type | When it happens |
+|-----------------|------------|-----------------|
+| Invalid URL | `Remote` | `open_source` / `open_remote` with a malformed URL |
+| Connection failure | `Remote` | Network unreachable, DNS failure, timeout |
+| File not found | `Remote` | HTTP 404, S3 NoSuchKey |
+| No valid messages | `Remote` | File contains only streaming (`total_length=0`) or corrupt messages |
+| Header-only required | `Remote` | Message has no header metadata flag |
+| Object index out of range | `Object` | `decode_object(i, j)` where `j >= object_count` |
 
 All errors are returned as `Result`. The library avoids panics, though thread creation failures and corrupt-index arithmetic edge cases may still panic in extreme conditions.
 

--- a/docs/src/guide/remote-access.md
+++ b/docs/src/guide/remote-access.md
@@ -108,7 +108,7 @@ sequenceDiagram
     Note right of TensogramFile: Discover message offsets
 
     App->>TensogramFile: file_decode_object(0, 2)
-    TensogramFile->>ObjectStore: GET range 24..262168 (header chunk)
+    TensogramFile->>ObjectStore: GET range 24..N (header chunk, up to 256KB)
     Note right of TensogramFile: First access: parse metadata + index, cache layout
     TensogramFile->>ObjectStore: GET range offset..offset+len (object frame 2)
     TensogramFile-->>App: (metadata, descriptor, decoded_bytes)

--- a/docs/src/guide/remote-access.md
+++ b/docs/src/guide/remote-access.md
@@ -69,13 +69,13 @@ Three methods provide selective access without downloading full messages:
 use tensogram_core::DecodeOptions;
 
 // Metadata only — triggers layout discovery on first call, then cached
-let meta = file.file_decode_metadata(0)?;
+let meta = file.decode_metadata(0)?;
 
 // Descriptors — fetches each object frame to extract its descriptor
-let (meta, descriptors) = file.file_decode_descriptors(0)?;
+let (meta, descriptors) = file.decode_descriptors(0)?;
 
 // Single object by index — fetches only the target object frame
-let (meta, desc, data) = file.file_decode_object(0, 2, &DecodeOptions::default())?;
+let (meta, desc, data) = file.decode_object(0, 2, &DecodeOptions::default())?;
 ```
 
 These methods also work on local files, where they read the full message and decode the requested parts.
@@ -87,10 +87,10 @@ For header-indexed files (the default for non-streaming writes):
 | Phase | Operation | HTTP Requests |
 |-------|-----------|:---:|
 | **Open** | `open_source` / `open_remote` | 1 HEAD + 1 GET per message (preamble read) |
-| **First access** | `file_decode_metadata(i)` | 1 GET (header chunk, discovers metadata + index) |
-| **Cached** | `file_decode_metadata(i)` again | 0 (served from cache) |
-| **Object read** | `file_decode_object(i, j)` | 1 GET per object (if layout already cached) |
-| **Descriptors** | `file_decode_descriptors(i)` | 1 GET per object in message |
+| **First access** | `decode_metadata(i)` | 1 GET (header chunk, discovers metadata + index) |
+| **Cached** | `decode_metadata(i)` again | 0 (served from cache) |
+| **Object read** | `decode_object(i, j)` | 1 GET per object (if layout already cached) |
+| **Descriptors** | `decode_descriptors(i)` | 1 GET per object in message |
 
 The layout (metadata + index) is discovered per-message on first access to that message, then cached. Subsequent calls reuse the cached layout.
 
@@ -107,7 +107,7 @@ sequenceDiagram
     TensogramFile->>ObjectStore: GET range 0..24 (preamble)
     Note right of TensogramFile: Discover message offsets
 
-    App->>TensogramFile: file_decode_object(0, 2)
+    App->>TensogramFile: decode_object(0, 2)
     TensogramFile->>ObjectStore: GET range 24..N (header chunk, up to 256KB)
     Note right of TensogramFile: First access: parse metadata + index, cache layout
     TensogramFile->>ObjectStore: GET range offset..offset+len (object frame 2)
@@ -137,15 +137,17 @@ Remote operations return `TensogramError::Remote` for transport-level failures:
 | File not found | HTTP 404, S3 NoSuchKey |
 | No valid messages | File contains only streaming (`total_length=0`) or corrupt messages |
 | Header-only required | Message has no header metadata flag |
-| Object index out of range | `file_decode_object(i, j)` where `j >= object_count` |
+| Object index out of range | `decode_object(i, j)` where `j >= object_count` |
 
-All errors are returned as `Result` — no panics in library code.
+All errors are returned as `Result`. The library avoids panics, though thread creation failures and corrupt-index arithmetic edge cases may still panic in extreme conditions.
 
 ## Limitations
 
 - **Header-indexed messages only.** Footer-indexed messages (produced by `StreamingEncoder`) are not yet supported remotely. Use buffered `encode()` for files destined for remote storage.
+- **Optimistic scan.** Remote message scanning validates preamble magic and `total_length` plausibility but does not verify end-of-message markers (unlike local scanning). A corrupt preamble with a plausible length will be accepted until a later read fails.
 - **Read-only.** Remote writes are not supported.
-- **Header probe size.** Layout discovery reads up to 256 KB of the header region. If the header metadata + index exceeds this (extremely rare), metadata may still be found but the index could be missing, causing object reads to fall back to downloading the full message.
+- **Header probe size.** Layout discovery reads a single chunk of up to 256 KB from the header region. If the metadata or index frame does not fit in this chunk, `decode_metadata()` will error (it does not retry with a larger read).
+- **HTTP server requirements.** The remote HTTP server must support `HEAD` requests (for file size) and `Range` request headers (for partial reads).
 - **Rust core only.** Python bindings, xarray backend, and zarr store do not yet support remote URLs. This will be added in a follow-up PR.
-- **`read_message()` and `decode_message()` download the full message** even for remote files. Use the `file_decode_*` methods for selective access.
+- **`read_message()` and `decode_message()` download the full message** even for remote files. Use `decode_metadata()`, `decode_descriptors()`, or `decode_object()` for selective access.
 - **Thread-per-request.** Each range request spawns a thread with a temporary tokio runtime. This is correct but not optimal for many small reads. A shared runtime will be added in a follow-up.

--- a/docs/src/guide/remote-access.md
+++ b/docs/src/guide/remote-access.md
@@ -136,7 +136,7 @@ Remote access can return different `TensogramError` variants depending on the fa
 | Connection failure | `Remote` | Network unreachable, DNS failure, timeout |
 | File not found | `Remote` | HTTP 404, S3 NoSuchKey |
 | No valid messages | `Remote` | File contains only streaming (`total_length=0`) or corrupt messages |
-| Header-only required | `Remote` | Message has no header metadata flag |
+| Missing header index | `Remote` | Message lacks `HEADER_METADATA` or `HEADER_INDEX` flag |
 | Object index out of range | `Object` | `decode_object(i, j)` where `j >= object_count` |
 
 All errors are returned as `Result`. The library avoids panics, though thread creation failures and corrupt-index arithmetic edge cases may still panic in extreme conditions.

--- a/docs/src/guide/remote-access.md
+++ b/docs/src/guide/remote-access.md
@@ -21,7 +21,7 @@ let mut file = TensogramFile::open_source("s3://bucket/forecast.tgm")?;
 
 `open_source` inspects the URL scheme and routes to the remote backend for `s3://`, `s3a://`, `gs://`, `az://`, `azure://`, `http://`, `https://`. Everything else is treated as a local path.
 
-The original `open()` method is unchanged and always opens a local file.
+The Rust `open()` method is unchanged and always opens a local file. In Python, `TensogramFile.open()` auto-detects remote URLs.
 
 You can also check whether a string is a remote URL without opening:
 
@@ -49,6 +49,38 @@ let mut file = TensogramFile::open_remote("s3://bucket/forecast.tgm", &opts)?;
 ```
 
 When no options are passed, credentials are read from the environment (e.g. `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`, `GOOGLE_APPLICATION_CREDENTIALS`).
+
+## Python Usage
+
+```python
+import tensogram
+
+# Auto-detect remote URL
+with tensogram.TensogramFile.open("s3://bucket/forecast.tgm") as f:
+    meta = f.file_decode_metadata(0)
+    result = f.file_decode_object(0, 0)
+    data = result["data"]  # numpy array
+
+# With explicit storage options
+with tensogram.TensogramFile.open_remote(
+    "s3://bucket/forecast.tgm",
+    {"region": "eu-west-1"}
+) as f:
+    print(f.source())   # "s3://bucket/forecast.tgm"
+    print(f.is_remote()) # True
+```
+
+## xarray Usage
+
+```python
+import xarray as xr
+
+ds = xr.open_dataset(
+    "s3://bucket/forecast.tgm",
+    engine="tensogram",
+    storage_options={"region": "eu-west-1"},
+)
+```
 
 ## Supported Schemes
 
@@ -154,7 +186,7 @@ All errors are returned as `Result`. The library avoids panics; thread creation 
 ## Limitations
 
 - **Streaming messages must be last.** In multi-message files, streaming-encoded messages (`total_length=0`) must be the last message. The remote scanner assumes the streaming message extends to the end of the file.
-- **Optimistic scan.** Remote message scanning validates preamble magic and `total_length` plausibility but does not verify end-of-message markers (unlike local scanning). A corrupt preamble with a plausible length will be accepted until a later read fails.
+- **Optimistic scan for buffered messages.** Remote message scanning validates preamble magic and `total_length` plausibility but does not verify end-of-message markers for buffered messages. Streaming messages (`total_length=0`) do validate the END_MAGIC at EOF.
 - **Read-only.** Remote writes are not supported.
 - **Header probe size.** Layout discovery reads a single chunk of up to 256 KB from the header region. If the metadata or index frame does not fit in this chunk, `decode_metadata()` will error (it does not retry with a larger read).
 - **HTTP server requirements.** The remote HTTP server must support `HEAD` requests (for file size) and `Range` request headers (for partial reads).

--- a/docs/src/guide/remote-access.md
+++ b/docs/src/guide/remote-access.md
@@ -1,0 +1,151 @@
+# Remote Access
+
+Enable the `remote` feature to open `.tgm` files on HTTP, S3, GCS, or Azure without downloading the whole file. Individual objects are fetched via targeted range requests.
+
+```toml
+[dependencies]
+tensogram-core = { path = "...", features = ["remote"] }
+```
+
+## Opening a Remote File
+
+```rust
+use tensogram_core::TensogramFile;
+
+// Auto-detect: local path or remote URL
+let mut file = TensogramFile::open_source("https://example.com/forecast.tgm")?;
+
+// S3
+let mut file = TensogramFile::open_source("s3://bucket/forecast.tgm")?;
+```
+
+`open_source` inspects the URL scheme and routes to the remote backend for `s3://`, `s3a://`, `gs://`, `az://`, `azure://`, `http://`, `https://`. Everything else is treated as a local path.
+
+The original `open()` method is unchanged and always opens a local file.
+
+You can also check whether a string is a remote URL without opening:
+
+```rust
+use tensogram_core::is_remote_url;
+
+assert!(is_remote_url("s3://bucket/file.tgm"));
+assert!(!is_remote_url("/local/path/file.tgm"));
+```
+
+## Storage Options (Credentials, Region, etc.)
+
+Pass an explicit options map for fine-grained control:
+
+```rust
+use std::collections::BTreeMap;
+use tensogram_core::TensogramFile;
+
+let mut opts = BTreeMap::new();
+opts.insert("aws_access_key_id".to_string(), "AKIA...".to_string());
+opts.insert("aws_secret_access_key".to_string(), "...".to_string());
+opts.insert("region".to_string(), "eu-west-1".to_string());
+
+let mut file = TensogramFile::open_remote("s3://bucket/forecast.tgm", &opts)?;
+```
+
+When no options are passed, credentials are read from the environment (e.g. `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`, `GOOGLE_APPLICATION_CREDENTIALS`).
+
+## Supported Schemes
+
+| Scheme | Backend | Notes |
+|--------|---------|-------|
+| `http://`, `https://` | HTTP | `allow_http` is set automatically for `http://` |
+| `s3://`, `s3a://` | Amazon S3 | Env-based or explicit credentials |
+| `gs://` | Google Cloud Storage | Service account or env |
+| `az://`, `azure://` | Azure Blob Storage | MSI or env |
+
+All backends are provided by the [`object_store`](https://crates.io/crates/object_store) crate.
+
+## Object-Level Access
+
+Three methods provide selective access without downloading full messages:
+
+```rust
+use tensogram_core::DecodeOptions;
+
+// Metadata only — triggers layout discovery on first call, then cached
+let meta = file.file_decode_metadata(0)?;
+
+// Descriptors — fetches each object frame to extract its descriptor
+let (meta, descriptors) = file.file_decode_descriptors(0)?;
+
+// Single object by index — fetches only the target object frame
+let (meta, desc, data) = file.file_decode_object(0, 2, &DecodeOptions::default())?;
+```
+
+These methods also work on local files, where they read the full message and decode the requested parts.
+
+## Request Budget
+
+For header-indexed files (the default for non-streaming writes):
+
+| Phase | Operation | HTTP Requests |
+|-------|-----------|:---:|
+| **Open** | `open_source` / `open_remote` | 1 HEAD + 1 GET per message (preamble scan) |
+| **First access** | `file_decode_metadata(i)` | 1 GET (header chunk, discovers metadata + index) |
+| **Cached** | `file_decode_metadata(i)` again | 0 (served from cache) |
+| **Object read** | `file_decode_object(i, j)` | 1 GET per object (if layout already cached) |
+| **Descriptors** | `file_decode_descriptors(i)` | 1 GET per object in message |
+
+The layout (metadata + index) is discovered per-message on first access to that message, then cached. Subsequent calls reuse the cached layout.
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant App
+    participant TensogramFile
+    participant ObjectStore
+
+    App->>TensogramFile: open_source("s3://bucket/file.tgm")
+    TensogramFile->>ObjectStore: HEAD (get file size)
+    TensogramFile->>ObjectStore: GET range 0..24 (preamble)
+    Note right of TensogramFile: Discover message offsets
+
+    App->>TensogramFile: file_decode_object(0, 2)
+    TensogramFile->>ObjectStore: GET range 24..262168 (header chunk)
+    Note right of TensogramFile: First access: parse metadata + index, cache layout
+    TensogramFile->>ObjectStore: GET range offset..offset+len (object frame 2)
+    TensogramFile-->>App: (metadata, descriptor, decoded_bytes)
+```
+
+## Checking if a File is Remote
+
+```rust
+use tensogram_core::TensogramFile;
+
+let file = TensogramFile::open_source("s3://bucket/data.tgm")?;
+assert!(file.is_remote());
+println!("source: {}", file.source()); // "s3://bucket/data.tgm"
+```
+
+`source()` returns the original URL for remote files and the file path for local files.
+
+## Error Handling
+
+Remote operations return `TensogramError::Remote` for transport-level failures:
+
+| Error condition | When it happens |
+|-----------------|-----------------|
+| Invalid URL | `open_source` / `open_remote` with a malformed URL |
+| Connection failure | Network unreachable, DNS failure, timeout |
+| File not found | HTTP 404, S3 NoSuchKey |
+| Streaming message | Message has `total_length=0` (footer-indexed) |
+| Header-only required | Message has no header metadata flag |
+| Object index out of range | `file_decode_object(i, j)` where `j >= object_count` |
+
+All errors are returned as `Result` — no panics in library code.
+
+## Limitations
+
+- **Header-indexed messages only.** Footer-indexed messages (produced by `StreamingEncoder`) are not yet supported remotely. Use buffered `encode()` for files destined for remote storage.
+- **Read-only.** Remote writes are not supported.
+- **Header probe size.** Layout discovery reads up to 256 KB of the header region. If the header metadata + index exceeds this (extremely rare), metadata may still be found but the index could be missing, causing object reads to fall back to downloading the full message.
+- **Rust core only.** Python bindings, xarray backend, and zarr store do not yet support remote URLs. This will be added in a follow-up PR.
+- **`read_message()` and `decode_message()` download the full message** even for remote files. Use the `file_decode_*` methods for selective access.
+- **Thread-per-request.** Each range request spawns a thread with a temporary tokio runtime. This is correct but not optimal for many small reads. A shared runtime will be added in a follow-up.

--- a/docs/src/guide/remote-access.md
+++ b/docs/src/guide/remote-access.md
@@ -158,6 +158,6 @@ All errors are returned as `Result`. The library avoids panics; thread creation 
 - **Read-only.** Remote writes are not supported.
 - **Header probe size.** Layout discovery reads a single chunk of up to 256 KB from the header region. If the metadata or index frame does not fit in this chunk, `decode_metadata()` will error (it does not retry with a larger read).
 - **HTTP server requirements.** The remote HTTP server must support `HEAD` requests (for file size) and `Range` request headers (for partial reads).
-- **Python/xarray/zarr supported.** `tensogram.TensogramFile.open()` auto-detects remote URLs. xarray accepts `storage_options` via `xr.open_dataset(url, engine="tensogram", storage_options={...})`. Zarr supports `TensogramStore.open_tgm(url, storage_options={...})` in read-only mode.
 - **`read_message()` and `decode_message()` download the full message** even for remote files. Use `decode_metadata()`, `decode_descriptors()`, or `decode_object()` for selective access.
+- **Zarr remote reads are eager.** The zarr store downloads the full message at open time. For large messages with many objects, this can be slow over remote stores.
 - **Thread-per-request.** Each range request spawns a thread with a temporary tokio runtime. This is correct but not optimal for many small reads. A shared runtime will be added in a follow-up.

--- a/examples/rust/src/bin/09_file_api.rs
+++ b/examples/rust/src/bin/09_file_api.rs
@@ -66,7 +66,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ── 1. Create and append messages ─────────────────────────────────────────
     {
         let mut file = TensogramFile::create(&path)?;
-        println!("Created: {}", file.path().display());
+        println!("Created: {}", file.source());
 
         let params_steps = [
             ("2t", 0i64),

--- a/plans/TODO.md
+++ b/plans/TODO.md
@@ -145,8 +145,15 @@ For speculative ideas, see `IDEAS.md`.
   - 17 tests with mock HTTP server: URL detection, open, metadata, descriptors, single-object decode, multi-object, multi-message, request-count verification, cache reuse, local-vs-remote match, streaming rejection, error cases
   - docs: `docs/src/guide/remote-access.md`, cross-reference from `file-api.md`
   - scoped to header-indexed (buffered) messages only; read-only
-- [ ] **remote-object-store (PR2 — footer support + async + optimization)**:
-  - footer-indexed (streaming) message support — requires verifying `StreamingEncoder` index stores frame lengths not payload lengths
+- [x] **remote-object-store (PR2 — footer support)**:
+  - fixed `StreamingEncoder` to store frame lengths (not payload lengths) in `IndexFrame.lengths` — consistent with buffered encoder
+  - updated `IndexFrame.lengths` doc from "payload length" to "total frame length"
+  - `scan_messages` handles `total_length=0` (streaming) by assigning remaining file size
+  - added `discover_footer_layout` + `parse_footer_frames` to remote backend
+  - `ensure_layout` now accepts both header-indexed and footer-indexed messages
+  - streaming messages must be last in multi-message files
+  - 5 new tests: streaming open/decode, local parity, multi-object, mixed buffered+streaming, index lengths
+- [ ] **remote-object-store (PR2b — async + optimization, deferred)**:
   - native async path when both `remote` and `async` features enabled (avoid thread-per-request)
   - shared tokio runtime instead of per-call runtime creation
   - descriptor-only reads (currently fetches full object frame to extract descriptor)

--- a/plans/TODO.md
+++ b/plans/TODO.md
@@ -172,10 +172,19 @@ For speculative ideas, see `IDEAS.md`.
   - replace `GILOnceCell` with `std::sync::OnceLock` where applicable
   - test with Python 3.13+ free-threaded build (`python3.13t`)
   - enables true parallel `decode_object()` calls from multiple threads on the same file handle
-- [ ] **remote-object-store (PR2b — async + optimization, deferred)**:
+- [ ] **remote-object-store (PR2b — async + optimization)**:
   - native async path when both `remote` and `async` features enabled (avoid thread-per-request)
   - shared tokio runtime instead of per-call runtime creation
   - descriptor-only reads (currently fetches full object frame to extract descriptor)
+- [ ] **CI: Python remote tests**:
+  - add `maturin develop` + `pytest tests/python/test_remote.py` to CI pipeline
+  - requires Python environment with `maturin`, `numpy`, `pytest` in CI
+- [ ] **zarr lazy remote reads**:
+  - current zarr store downloads full message at open via `read_message()` — defeats remote range-read benefits
+  - switch `_scan_tgm_file()` to use file-level `file_decode_descriptors()` for metadata and lazy `file_decode_object()` per chunk in `get()` instead of eagerly materializing all objects
+- [ ] **remote sub-object `decode_range()`**:
+  - add `TensogramFile::decode_range(msg_idx, obj_idx, ranges)` that does byte-level range reads for partial slices within a single object
+  - enables xarray partial-slice reads over remote (currently falls back to full object download)
 
 ## Code Quality
 

--- a/plans/TODO.md
+++ b/plans/TODO.md
@@ -135,60 +135,46 @@ For speculative ideas, see `IDEAS.md`.
 
 ## Remote Access
 
-- [x] **remote-object-store (PR1 — Rust core, header-indexed)**:
-  - `remote` feature gate with `object_store` 0.13 crate (S3, GCS, Azure, HTTP)
-  - `Backend` enum (Local | Remote) inside `TensogramFile` — one public type
-  - `remote.rs` module: URL scheme detection, `object_store::parse_url_opts`, range reads, per-message layout caching
-  - new public APIs: `open_source()`, `open_remote()`, `decode_metadata()`, `decode_descriptors()`, `decode_object()`, `is_remote()`, `source()`, `is_remote_url()`
-  - scheme whitelist: `s3://`, `s3a://`, `gs://`, `az://`, `azure://`, `http://`, `https://`
-  - sync bridge: `std::thread::scope` + per-call tokio runtime (avoids nested-runtime panics)
-  - 17 tests with mock HTTP server: URL detection, open, metadata, descriptors, single-object decode, multi-object, multi-message, request-count verification, cache reuse, local-vs-remote match, streaming rejection, error cases
-  - docs: `docs/src/guide/remote-access.md`, cross-reference from `file-api.md`
-  - scoped to header-indexed (buffered) messages only; read-only
-- [x] **remote-object-store (PR2 — footer support)**:
-  - fixed `StreamingEncoder` to store frame lengths (not payload lengths) in `IndexFrame.lengths` — consistent with buffered encoder
-  - updated `IndexFrame.lengths` doc from "payload length" to "total frame length"
-  - `scan_messages` handles `total_length=0` (streaming) by assigning remaining file size
-  - added `discover_footer_layout` + `parse_footer_frames` to remote backend
-  - `ensure_layout` now accepts both header-indexed and footer-indexed messages
-  - streaming messages must be last in multi-message files
-  - 5 new tests: streaming open/decode, local parity, multi-object, mixed buffered+streaming, index lengths
-- [ ] **remote-object-store (PR2b — async + optimization, deferred)**:
-  - native async path when both `remote` and `async` features enabled (avoid thread-per-request)
+- [x] **remote 1 — Rust core (header-indexed)**:
+  - `remote` feature gate with `object_store` 0.13, `Backend` enum (Local | Remote), `remote.rs` module
+  - APIs: `open_source()`, `open_remote()`, `decode_metadata()`, `decode_descriptors()`, `decode_object()`, `is_remote()`, `source()`
+  - schemes: `s3://`, `s3a://`, `gs://`, `az://`, `azure://`, `http://`, `https://`
+  - sync bridge: `std::thread::scope` + per-call tokio runtime
+  - 21 Rust tests with mock HTTP server; docs: `docs/src/guide/remote-access.md`
+- [x] **remote 2 — footer-indexed (streaming) support**:
+  - fixed `StreamingEncoder` index lengths (payload → frame), `scan_messages` handles `total_length=0`
+  - `discover_footer_layout` + `parse_footer_frames`, streaming must be last in multi-message files
+  - 5 new tests: streaming open/decode, local parity, multi-object, mixed, index lengths
+- [x] **remote 3 — Python + xarray + zarr integration**:
+  - Python `open()` auto-detects remote, `open_remote(source, storage_options)`, file-level decode APIs
+  - GIL released during all I/O via `py.allow_threads()`
+  - xarray: `storage_options` threaded through all 5 modules, remote reads use file-level APIs
+  - zarr: `storage_options`, remote writes rejected early
+  - 12 Python tests with mock HTTP server
+- [ ] **remote 4 — async + shared runtime**:
+  - native async path when both `remote` and `async` features enabled
   - shared tokio runtime instead of per-call runtime creation
-  - descriptor-only reads (currently fetches full object frame to extract descriptor)
-- [x] **remote-object-store (PR3 — Python + xarray + zarr integration)**:
-  - Python `TensogramFile.open()` now auto-detects remote URLs via `open_source()`
-  - added `TensogramFile.open_remote(source, storage_options)` for explicit options
-  - added file-level Python APIs: `file_decode_metadata()`, `file_decode_descriptors()`, `file_decode_object()`, `is_remote()`, `source()`
-  - enabled `remote` feature in `tensogram-python/Cargo.toml`
-  - xarray: `storage_options` threaded through backend.py, store.py, array.py, scanner.py, merge.py
-  - xarray: `os.path.abspath()` skipped for remote URLs; remote reads use file-level APIs
-  - zarr: `storage_options` added to `TensogramStore` and `open_tgm()`; remote writes rejected early
-
-- [ ] **free-threaded Python support (PR4 — parallelism)**:
-  - declare `#[pymodule(gil_used = false)]` for free-threaded Python (3.13+)
-  - change `PyTensogramFile` methods from `&mut self` to `&self` with internal `Mutex`/`RwLock` for concurrent access
-  - replace `GILOnceCell` with `std::sync::OnceLock` where applicable
-  - test with Python 3.13+ free-threaded build (`python3.13t`)
-  - enables true parallel `decode_object()` calls from multiple threads on the same file handle
-- [ ] **remote-object-store (PR2b — async + optimization)**:
-  - native async path when both `remote` and `async` features enabled (avoid thread-per-request)
-  - shared tokio runtime instead of per-call runtime creation
-  - descriptor-only reads (currently fetches full object frame to extract descriptor)
-- [ ] **remote examples**:
-  - `examples/rust/src/bin/` — remote open + selective object read from HTTP URL
+  - descriptor-only reads (currently fetches full object frame)
+- [ ] **remote 5 — examples**:
+  - `examples/rust/` — remote open + selective object read from HTTP URL
   - `examples/python/` — remote open, decode_object, xarray open_dataset with storage_options
-  - include a script that starts a local HTTP server serving a test `.tgm` file so examples are self-contained and runnable
-- [ ] **CI: Python remote tests**:
+  - self-contained script that starts a local HTTP server serving a test `.tgm` file
+- [ ] **remote 6 — CI Python tests**:
   - add `maturin develop` + `pytest tests/python/test_remote.py` to CI pipeline
-  - requires Python environment with `maturin`, `numpy`, `pytest` in CI
-- [ ] **zarr lazy remote reads**:
-  - current zarr store downloads full message at open via `read_message()` — defeats remote range-read benefits
-  - switch `_scan_tgm_file()` to use file-level `file_decode_descriptors()` for metadata and lazy `file_decode_object()` per chunk in `get()` instead of eagerly materializing all objects
-- [ ] **remote sub-object `decode_range()`**:
-  - add `TensogramFile::decode_range(msg_idx, obj_idx, ranges)` that does byte-level range reads for partial slices within a single object
-  - enables xarray partial-slice reads over remote (currently falls back to full object download)
+- [ ] **remote 7 — zarr lazy reads**:
+  - switch zarr `_scan_tgm_file()` from eager `read_message()` to lazy `file_decode_descriptors()` + per-chunk `file_decode_object()` in `get()`
+- [ ] **remote 8 — sub-object `decode_range()`**:
+  - add `TensogramFile::decode_range(msg_idx, obj_idx, ranges)` for byte-level range reads within a single object
+  - enables xarray partial-slice reads over remote
+
+## Free-Threaded Python
+
+- [ ] **free-threaded Python (parallelism)**:
+  - declare `#[pymodule(gil_used = false)]` for Python 3.13+
+  - change `PyTensogramFile` methods from `&mut self` to `&self` with internal `Mutex`/`RwLock`
+  - replace `GILOnceCell` with `std::sync::OnceLock`
+  - test with `python3.13t`
+  - enables true parallel decode/encode across threads for the whole library
 
 ## Code Quality
 

--- a/plans/TODO.md
+++ b/plans/TODO.md
@@ -139,7 +139,7 @@ For speculative ideas, see `IDEAS.md`.
   - `remote` feature gate with `object_store` 0.13 crate (S3, GCS, Azure, HTTP)
   - `Backend` enum (Local | Remote) inside `TensogramFile` — one public type
   - `remote.rs` module: URL scheme detection, `object_store::parse_url_opts`, range reads, per-message layout caching
-  - new public APIs: `open_source()`, `open_remote()`, `file_decode_metadata()`, `file_decode_descriptors()`, `file_decode_object()`, `is_remote()`, `source()`, `is_remote_url()`
+  - new public APIs: `open_source()`, `open_remote()`, `decode_metadata()`, `decode_descriptors()`, `decode_object()`, `is_remote()`, `source()`, `is_remote_url()`
   - scheme whitelist: `s3://`, `s3a://`, `gs://`, `az://`, `azure://`, `http://`, `https://`
   - sync bridge: `std::thread::scope` + per-call tokio runtime (avoids nested-runtime panics)
   - 17 tests with mock HTTP server: URL detection, open, metadata, descriptors, single-object decode, multi-object, multi-message, request-count verification, cache reuse, local-vs-remote match, streaming rejection, error cases
@@ -154,7 +154,7 @@ For speculative ideas, see `IDEAS.md`.
   - expose `open_source` / `open_remote` in Python: `tensogram.open("s3://bucket/file.tgm")`
   - xarray backend: accept remote URLs, pass `storage_options`, remove `os.path.abspath()` on URLs
   - zarr store: accept remote URLs
-  - switch xarray/zarr from `read_message()` to `file_decode_object()` for selective reads
+  - switch xarray/zarr from `read_message()` to `decode_object()` for selective reads
 
 ## Code Quality
 

--- a/plans/TODO.md
+++ b/plans/TODO.md
@@ -155,17 +155,11 @@ For speculative ideas, see `IDEAS.md`.
   - native async path when both `remote` and `async` features enabled
   - shared tokio runtime instead of per-call runtime creation
   - descriptor-only reads (currently fetches full object frame)
-- [ ] **remote 5 — examples**:
-  - `examples/rust/` — remote open + selective object read from HTTP URL
-  - `examples/python/` — remote open, decode_object, xarray open_dataset with storage_options
-  - self-contained script that starts a local HTTP server serving a test `.tgm` file
-- [ ] **remote 6 — CI Python tests**:
-  - add `maturin develop` + `pytest tests/python/test_remote.py` to CI pipeline
-- [ ] **remote 7 — zarr lazy reads**:
-  - switch zarr `_scan_tgm_file()` from eager `read_message()` to lazy `file_decode_descriptors()` + per-chunk `file_decode_object()` in `get()`
-- [ ] **remote 8 — sub-object `decode_range()`**:
-  - add `TensogramFile::decode_range(msg_idx, obj_idx, ranges)` for byte-level range reads within a single object
-  - enables xarray partial-slice reads over remote
+- [ ] **remote 5 — polish (examples, CI, optimizations)**:
+  - examples: `examples/rust/` and `examples/python/` with self-contained HTTP server script
+  - CI: add `maturin develop` + `pytest tests/python/test_remote.py` to pipeline
+  - zarr lazy reads: switch `_scan_tgm_file()` from eager `read_message()` to lazy `file_decode_object()` per chunk
+  - remote `decode_range()`: byte-level range reads within a single object for xarray partial slices
 
 ## Free-Threaded Python
 

--- a/plans/TODO.md
+++ b/plans/TODO.md
@@ -176,6 +176,10 @@ For speculative ideas, see `IDEAS.md`.
   - native async path when both `remote` and `async` features enabled (avoid thread-per-request)
   - shared tokio runtime instead of per-call runtime creation
   - descriptor-only reads (currently fetches full object frame to extract descriptor)
+- [ ] **remote examples**:
+  - `examples/rust/src/bin/` — remote open + selective object read from HTTP URL
+  - `examples/python/` — remote open, decode_object, xarray open_dataset with storage_options
+  - include a script that starts a local HTTP server serving a test `.tgm` file so examples are self-contained and runnable
 - [ ] **CI: Python remote tests**:
   - add `maturin develop` + `pytest tests/python/test_remote.py` to CI pipeline
   - requires Python environment with `maturin`, `numpy`, `pytest` in CI

--- a/plans/TODO.md
+++ b/plans/TODO.md
@@ -157,11 +157,14 @@ For speculative ideas, see `IDEAS.md`.
   - native async path when both `remote` and `async` features enabled (avoid thread-per-request)
   - shared tokio runtime instead of per-call runtime creation
   - descriptor-only reads (currently fetches full object frame to extract descriptor)
-- [ ] **remote-object-store (PR3 — Python + xarray + zarr integration)**:
-  - expose `open_source` / `open_remote` in Python: `tensogram.open("s3://bucket/file.tgm")`
-  - xarray backend: accept remote URLs, pass `storage_options`, remove `os.path.abspath()` on URLs
-  - zarr store: accept remote URLs
-  - switch xarray/zarr from `read_message()` to `decode_object()` for selective reads
+- [x] **remote-object-store (PR3 — Python + xarray + zarr integration)**:
+  - Python `TensogramFile.open()` now auto-detects remote URLs via `open_source()`
+  - added `TensogramFile.open_remote(source, storage_options)` for explicit options
+  - added file-level Python APIs: `file_decode_metadata()`, `file_decode_descriptors()`, `file_decode_object()`, `is_remote()`, `source()`
+  - enabled `remote` feature in `tensogram-python/Cargo.toml`
+  - xarray: `storage_options` threaded through backend.py, store.py, array.py, scanner.py, merge.py
+  - xarray: `os.path.abspath()` skipped for remote URLs; remote reads use file-level APIs
+  - zarr: `storage_options` added to `TensogramStore` and `open_tgm()`; remote writes rejected early
 
 ## Code Quality
 

--- a/plans/TODO.md
+++ b/plans/TODO.md
@@ -151,10 +151,13 @@ For speculative ideas, see `IDEAS.md`.
   - xarray: `storage_options` threaded through all 5 modules, remote reads use file-level APIs
   - zarr: `storage_options`, remote writes rejected early
   - 12 Python tests with mock HTTP server
-- [ ] **remote 4 — async + shared runtime**:
-  - native async path when both `remote` and `async` features enabled
-  - shared tokio runtime instead of per-call runtime creation
-  - descriptor-only reads (currently fetches full object frame)
+- [x] **remote 4 — async + shared runtime**:
+  - shared `OnceLock<Runtime>` replaces per-call `block_on_thread` (thread + runtime per I/O call)
+  - `block_on_shared`: direct `handle.block_on()` when not in async context, scoped thread fallback when in async context
+  - native async methods when both `remote` and `async` features enabled: `open_source_async`, `open_remote_async`, `decode_metadata_async`, `decode_descriptors_async`, `decode_object_async`, `read_message_async` (remote-aware)
+  - descriptor-only reads: `read_descriptor_only` fetches only CBOR prefix for large frames (> 64 KB), full frame for small ones
+  - `rt-multi-thread` tokio feature gated to `remote` only
+  - 7 new tests (concurrent reads, sync context, descriptor parity, async open/decode/descriptors/streaming/parity/errors)
 - [ ] **remote 5 — polish (examples, CI, optimizations)**:
   - examples: `examples/rust/` and `examples/python/` with self-contained HTTP server script
   - CI: add `maturin develop` + `pytest tests/python/test_remote.py` to pipeline

--- a/plans/TODO.md
+++ b/plans/TODO.md
@@ -166,6 +166,17 @@ For speculative ideas, see `IDEAS.md`.
   - xarray: `os.path.abspath()` skipped for remote URLs; remote reads use file-level APIs
   - zarr: `storage_options` added to `TensogramStore` and `open_tgm()`; remote writes rejected early
 
+- [ ] **free-threaded Python support (PR4 — parallelism)**:
+  - declare `#[pymodule(gil_used = false)]` for free-threaded Python (3.13+)
+  - change `PyTensogramFile` methods from `&mut self` to `&self` with internal `Mutex`/`RwLock` for concurrent access
+  - replace `GILOnceCell` with `std::sync::OnceLock` where applicable
+  - test with Python 3.13+ free-threaded build (`python3.13t`)
+  - enables true parallel `decode_object()` calls from multiple threads on the same file handle
+- [ ] **remote-object-store (PR2b — async + optimization, deferred)**:
+  - native async path when both `remote` and `async` features enabled (avoid thread-per-request)
+  - shared tokio runtime instead of per-call runtime creation
+  - descriptor-only reads (currently fetches full object frame to extract descriptor)
+
 ## Code Quality
 
 - [x] ~~code coverage~~ → 86 new Rust tests (376 total). All CLI commands tested (ls 98%, dump 97%, get 97%, convert_grib 99%, output 96%, merge 94%, copy 94%, reshuffle 94%, set 91%, split 89%). Encodings: simple_packing 97%, zfp 92%. Remaining: FFI at 0% (tested by 109 C++ tests). Total 974 tests.

--- a/plans/TODO.md
+++ b/plans/TODO.md
@@ -135,20 +135,26 @@ For speculative ideas, see `IDEAS.md`.
 
 ## Remote Access
 
-- [ ] **remote-object-store**:
-  - add the ability to open `.tgm` files on remote object stores (S3, GCS, Azure, HTTP) and read individual objects without downloading the whole file.
-  - the wire format already supports efficient remote access:
-    - header-indexed files (non-streaming): index is at the beginning, right after the preamble. A single range read gets metadata + index + all object offsets. One more range read fetches the target object. 2 HTTP requests total.
-    - footer-indexed files (streaming): the postamble (last 16 bytes) contains `first_footer_offset`. One small range read (last 16 bytes) finds the footer. One more fetches the footer (index + hashes). One more fetches the target object. 2-3 HTTP requests total.
-  - what's missing is the transport layer. `TensogramFile` currently only works with local paths via `std::fs::File` + `Seek`.
-  - implementation approach:
-    - add an async `ReadAt` trait (or use `object_store` crate's `ObjectStore` trait) supporting range reads: `read_range(offset, length) -> Bytes`
-    - implement for local files (existing, via seek+read), HTTP/HTTPS (range requests), S3 (via `object_store` or `opendal` crate)
-    - add `TensogramFile::open_remote(url)` that auto-detects the protocol
-    - the scan/index/decode logic already works with byte offsets — wire it to use range reads instead of seeking a local file
-    - expose in Python: `tensogram.open("s3://bucket/file.tgm")`
-    - expose in xarray: `xr.open_dataset("s3://bucket/file.tgm", engine="tensogram")`
-  - tests: unit tests with mock HTTP server returning range responses, read single object from remote file and verify data matches local decode, latency test measuring request count (should be 2 for header-indexed files), integration test with real S3 bucket (CI-optional), test both header-index and footer-index paths.
+- [x] **remote-object-store (PR1 — Rust core, header-indexed)**:
+  - `remote` feature gate with `object_store` 0.13 crate (S3, GCS, Azure, HTTP)
+  - `Backend` enum (Local | Remote) inside `TensogramFile` — one public type
+  - `remote.rs` module: URL scheme detection, `object_store::parse_url_opts`, range reads, per-message layout caching
+  - new public APIs: `open_source()`, `open_remote()`, `file_decode_metadata()`, `file_decode_descriptors()`, `file_decode_object()`, `is_remote()`, `source()`, `is_remote_url()`
+  - scheme whitelist: `s3://`, `s3a://`, `gs://`, `az://`, `azure://`, `http://`, `https://`
+  - sync bridge: `std::thread::scope` + per-call tokio runtime (avoids nested-runtime panics)
+  - 17 tests with mock HTTP server: URL detection, open, metadata, descriptors, single-object decode, multi-object, multi-message, request-count verification, cache reuse, local-vs-remote match, streaming rejection, error cases
+  - docs: `docs/src/guide/remote-access.md`, cross-reference from `file-api.md`
+  - scoped to header-indexed (buffered) messages only; read-only
+- [ ] **remote-object-store (PR2 — footer support + async + optimization)**:
+  - footer-indexed (streaming) message support — requires verifying `StreamingEncoder` index stores frame lengths not payload lengths
+  - native async path when both `remote` and `async` features enabled (avoid thread-per-request)
+  - shared tokio runtime instead of per-call runtime creation
+  - descriptor-only reads (currently fetches full object frame to extract descriptor)
+- [ ] **remote-object-store (PR3 — Python + xarray + zarr integration)**:
+  - expose `open_source` / `open_remote` in Python: `tensogram.open("s3://bucket/file.tgm")`
+  - xarray backend: accept remote URLs, pass `storage_options`, remove `os.path.abspath()` on URLs
+  - zarr store: accept remote URLs
+  - switch xarray/zarr from `read_message()` to `file_decode_object()` for selective reads
 
 ## Code Quality
 

--- a/tensogram-xarray/src/tensogram_xarray/array.py
+++ b/tensogram-xarray/src/tensogram_xarray/array.py
@@ -198,7 +198,9 @@ class TensogramBackendArray(BackendArray):
         storage_options: dict[str, str] | None = None,
         shared_file: Any | None = None,
     ):
-        self._is_remote = "://" in file_path
+        import tensogram
+
+        self._is_remote = tensogram.is_remote_url(file_path)
         self.file_path = file_path if self._is_remote else os.path.abspath(file_path)
         self.msg_index = msg_index
         self.obj_index = obj_index

--- a/tensogram-xarray/src/tensogram_xarray/array.py
+++ b/tensogram-xarray/src/tensogram_xarray/array.py
@@ -178,8 +178,9 @@ def _nd_slice_to_flat_ranges(
 class TensogramBackendArray(BackendArray):
     """Lazy array backed by a tensogram file.
 
-    This class stores only the file path (no open handles) so that it can be
-    safely pickled for dask multiprocessing / distributed execution.
+    Stores the file path (or remote URL) and optionally a shared file handle.
+    The handle is dropped on pickle for dask multiprocessing compatibility
+    and lazily reopened on the worker.
     """
 
     def __init__(

--- a/tensogram-xarray/src/tensogram_xarray/array.py
+++ b/tensogram-xarray/src/tensogram_xarray/array.py
@@ -238,8 +238,8 @@ class TensogramBackendArray(BackendArray):
             return self._shared_file
         import tensogram
 
-        if self.storage_options:
-            return tensogram.TensogramFile.open_remote(self.file_path, self.storage_options)
+        if self._is_remote:
+            return tensogram.TensogramFile.open_remote(self.file_path, self.storage_options or {})
         return tensogram.TensogramFile.open(self.file_path)
 
     def _raw_indexing_method(self, key: tuple) -> np.ndarray:

--- a/tensogram-xarray/src/tensogram_xarray/array.py
+++ b/tensogram-xarray/src/tensogram_xarray/array.py
@@ -266,39 +266,35 @@ class TensogramBackendArray(BackendArray):
 
         raw_msg = f.read_message(self.msg_index)
 
-            if self.supports_range and _is_contiguous_slice(key):
-                try:
-                    flat_ranges, out_shape = _nd_slice_to_flat_ranges(self.shape, key)
-                    total_requested = sum(c for _, c in flat_ranges)
-                    total_elements = math.prod(self.shape)
+        if self.supports_range and _is_contiguous_slice(key):
+            try:
+                flat_ranges, out_shape = _nd_slice_to_flat_ranges(self.shape, key)
+                total_requested = sum(c for _, c in flat_ranges)
+                total_elements = math.prod(self.shape)
 
-                    if (
-                        total_elements > 0
-                        and total_requested / total_elements <= self.range_threshold
-                    ):
-                        arr = tensogram.decode_range(
-                            raw_msg,
-                            object_index=self.obj_index,
-                            ranges=flat_ranges,
-                            join=True,
-                        )
-                        return np.asarray(arr).reshape(out_shape)
-                except (ValueError, RuntimeError, OSError) as exc:
-                    logger.debug(
-                        "decode_range failed for %s msg=%d obj=%d, "
-                        "falling back to full decode: %s",
-                        self.file_path,
-                        self.msg_index,
-                        self.obj_index,
-                        exc,
+                if total_elements > 0 and total_requested / total_elements <= self.range_threshold:
+                    arr = tensogram.decode_range(
+                        raw_msg,
+                        object_index=self.obj_index,
+                        ranges=flat_ranges,
+                        join=True,
                     )
+                    return np.asarray(arr).reshape(out_shape)
+            except (ValueError, RuntimeError, OSError) as exc:
+                logger.debug(
+                    "decode_range failed for %s msg=%d obj=%d, falling back to full decode: %s",
+                    self.file_path,
+                    self.msg_index,
+                    self.obj_index,
+                    exc,
+                )
 
-            _meta, _desc, arr = tensogram.decode_object(
-                raw_msg,
-                self.obj_index,
-                verify_hash=self.verify_hash,
-            )
-            return np.asarray(arr[key])
+        _meta, _desc, arr = tensogram.decode_object(
+            raw_msg,
+            self.obj_index,
+            verify_hash=self.verify_hash,
+        )
+        return np.asarray(arr[key])
 
 
 # ---------------------------------------------------------------------------

--- a/tensogram-xarray/src/tensogram_xarray/array.py
+++ b/tensogram-xarray/src/tensogram_xarray/array.py
@@ -194,10 +194,11 @@ class TensogramBackendArray(BackendArray):
         verify_hash: bool = False,
         range_threshold: float = DEFAULT_RANGE_THRESHOLD,
         lock: threading.Lock | None = None,
+        storage_options: dict[str, str] | None = None,
+        shared_file: Any | None = None,
     ):
-        # Resolve to absolute path so dask workers with different CWDs
-        # can still find the file after pickle/unpickle.
-        self.file_path = os.path.abspath(file_path)
+        self._is_remote = "://" in file_path
+        self.file_path = file_path if self._is_remote else os.path.abspath(file_path)
         self.msg_index = msg_index
         self.obj_index = obj_index
         self.shape = shape
@@ -206,17 +207,21 @@ class TensogramBackendArray(BackendArray):
         self.verify_hash = verify_hash
         self.range_threshold = range_threshold
         self.lock = lock or threading.Lock()
+        self.storage_options = storage_options
+        self._shared_file = shared_file
 
     # -- pickle support (no open handles stored) ----------------------------
 
     def __getstate__(self) -> dict:
         state = self.__dict__.copy()
-        state["lock"] = None  # locks are not picklable
+        state["lock"] = None
+        state["_shared_file"] = None
         return state
 
     def __setstate__(self, state: dict) -> None:
         self.__dict__.update(state)
         self.lock = threading.Lock()
+        self._shared_file = None
 
     # -- BackendArray interface ---------------------------------------------
 
@@ -228,16 +233,31 @@ class TensogramBackendArray(BackendArray):
             self._raw_indexing_method,
         )
 
+    def _get_file(self):
+        if self._shared_file is not None:
+            return self._shared_file
+        import tensogram
+
+        if self.storage_options:
+            return tensogram.TensogramFile.open_remote(self.file_path, self.storage_options)
+        return tensogram.TensogramFile.open(self.file_path)
+
     def _raw_indexing_method(self, key: tuple) -> np.ndarray:
-        """Thread-safe read from the tensogram file."""
         import tensogram
 
         with self.lock:
-            with tensogram.TensogramFile.open(self.file_path) as f:
-                raw_msg = f.read_message(self.msg_index)
+            f = self._get_file()
 
-            # Try partial decode for contiguous slices when random access
-            # is available and the requested fraction is below threshold.
+            if self._is_remote:
+                result = f.file_decode_object(
+                    self.msg_index,
+                    self.obj_index,
+                    verify_hash=self.verify_hash,
+                )
+                return np.asarray(result["data"][key])
+
+            raw_msg = f.read_message(self.msg_index)
+
             if self.supports_range and _is_contiguous_slice(key):
                 try:
                     flat_ranges, out_shape = _nd_slice_to_flat_ranges(self.shape, key)
@@ -265,7 +285,6 @@ class TensogramBackendArray(BackendArray):
                         exc,
                     )
 
-            # Full object decode + in-memory slice.
             _meta, _desc, arr = tensogram.decode_object(
                 raw_msg,
                 self.obj_index,

--- a/tensogram-xarray/src/tensogram_xarray/array.py
+++ b/tensogram-xarray/src/tensogram_xarray/array.py
@@ -249,17 +249,22 @@ class TensogramBackendArray(BackendArray):
         import tensogram
 
         with self.lock:
-            f = self._get_file()
+            if self._shared_file is not None:
+                return self._read_from_file(self._shared_file, key, tensogram)
 
-            if self._is_remote:
-                result = f.file_decode_object(
-                    self.msg_index,
-                    self.obj_index,
-                    verify_hash=self.verify_hash,
-                )
-                return np.asarray(result["data"][key])
+            with self._get_file() as f:
+                return self._read_from_file(f, key, tensogram)
 
-            raw_msg = f.read_message(self.msg_index)
+    def _read_from_file(self, f, key: tuple, tensogram) -> np.ndarray:
+        if self._is_remote:
+            result = f.file_decode_object(
+                self.msg_index,
+                self.obj_index,
+                verify_hash=self.verify_hash,
+            )
+            return np.asarray(result["data"][key])
+
+        raw_msg = f.read_message(self.msg_index)
 
             if self.supports_range and _is_contiguous_slice(key):
                 try:

--- a/tensogram-xarray/src/tensogram_xarray/array.py
+++ b/tensogram-xarray/src/tensogram_xarray/array.py
@@ -195,7 +195,7 @@ class TensogramBackendArray(BackendArray):
         verify_hash: bool = False,
         range_threshold: float = DEFAULT_RANGE_THRESHOLD,
         lock: threading.Lock | None = None,
-        storage_options: dict[str, str] | None = None,
+        storage_options: dict[str, Any] | None = None,
         shared_file: Any | None = None,
     ):
         import tensogram

--- a/tensogram-xarray/src/tensogram_xarray/backend.py
+++ b/tensogram-xarray/src/tensogram_xarray/backend.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Iterable, Sequence
+from typing import Any
 
 import xarray as xr
 from xarray.backends import BackendEntrypoint
@@ -48,7 +49,7 @@ class TensogramBackendEntrypoint(BackendEntrypoint):
         merge_objects: bool = False,
         verify_hash: bool = False,
         range_threshold: float = 0.5,
-        storage_options: dict[str, str] | None = None,
+        storage_options: dict[str, Any] | None = None,
     ) -> xr.Dataset:
         """Open a single tensogram message as an :class:`xr.Dataset`.
 

--- a/tensogram-xarray/src/tensogram_xarray/backend.py
+++ b/tensogram-xarray/src/tensogram_xarray/backend.py
@@ -77,6 +77,9 @@ class TensogramBackendEntrypoint(BackendEntrypoint):
             Maximum fraction of total array elements (0.0-1.0) for which
             partial ``decode_range()`` is used instead of a full
             ``decode_object()``.  Default ``0.5`` (50%).
+        storage_options
+            Key-value pairs forwarded to the object store backend when
+            the path is a remote URL.  Ignored for local files.
 
         Returns
         -------

--- a/tensogram-xarray/src/tensogram_xarray/backend.py
+++ b/tensogram-xarray/src/tensogram_xarray/backend.py
@@ -48,6 +48,7 @@ class TensogramBackendEntrypoint(BackendEntrypoint):
         merge_objects: bool = False,
         verify_hash: bool = False,
         range_threshold: float = 0.5,
+        storage_options: dict[str, str] | None = None,
     ) -> xr.Dataset:
         """Open a single tensogram message as an :class:`xr.Dataset`.
 
@@ -96,6 +97,7 @@ class TensogramBackendEntrypoint(BackendEntrypoint):
                 variable_key=variable_key,
                 verify_hash=verify_hash,
                 range_threshold=range_threshold,
+                storage_options=storage_options,
             )
             if not datasets:
                 return xr.Dataset()
@@ -108,6 +110,7 @@ class TensogramBackendEntrypoint(BackendEntrypoint):
             variable_key=variable_key,
             verify_hash=verify_hash,
             range_threshold=range_threshold,
+            storage_options=storage_options,
         )
 
         drop_set = set(drop_variables) if drop_variables else None

--- a/tensogram-xarray/src/tensogram_xarray/merge.py
+++ b/tensogram-xarray/src/tensogram_xarray/merge.py
@@ -145,6 +145,13 @@ def open_datasets(
 
         def _close_shared():
             nonlocal shared_file
+            for ds in datasets:
+                for var in list(ds.data_vars.values()) + list(ds.coords.values()):
+                    arr = getattr(var, "_data", None)
+                    while hasattr(arr, "array"):
+                        arr = arr.array
+                    if isinstance(arr, TensogramBackendArray):
+                        arr._shared_file = None
             shared_file = None
 
         for ds in datasets:

--- a/tensogram-xarray/src/tensogram_xarray/merge.py
+++ b/tensogram-xarray/src/tensogram_xarray/merge.py
@@ -138,7 +138,19 @@ def open_datasets(
         if ds is not None:
             datasets.append(ds)
 
-    return datasets if datasets else [xr.Dataset(coords=coord_vars, attrs={"source": path})]
+    if not datasets:
+        datasets = [xr.Dataset(coords=coord_vars, attrs={"source": path})]
+
+    if shared_file is not None:
+
+        def _close_shared():
+            nonlocal shared_file
+            shared_file = None
+
+        for ds in datasets:
+            ds.set_close(_close_shared)
+
+    return datasets
 
 
 # ---------------------------------------------------------------------------

--- a/tensogram-xarray/src/tensogram_xarray/merge.py
+++ b/tensogram-xarray/src/tensogram_xarray/merge.py
@@ -38,7 +38,7 @@ def open_datasets(
     variable_key: str | None = None,
     verify_hash: bool = False,
     range_threshold: float = 0.5,
-    storage_options: dict[str, str] | None = None,
+    storage_options: dict[str, Any] | None = None,
 ) -> list[xr.Dataset]:
     """Open a ``.tgm`` file, auto-grouping into compatible Datasets.
 
@@ -314,7 +314,7 @@ def _build_dataset_from_group(
     lock: threading.Lock,
     range_threshold: float = 0.5,
     verify_hash: bool = False,
-    storage_options: dict[str, str] | None = None,
+    storage_options: dict[str, Any] | None = None,
     *,
     shared_file: Any = None,
 ) -> xr.Dataset | None:
@@ -430,7 +430,7 @@ def _single_object_dataset(
     lock: threading.Lock,
     range_threshold: float = 0.5,
     verify_hash: bool = False,
-    storage_options: dict[str, str] | None = None,
+    storage_options: dict[str, Any] | None = None,
     *,
     shared_file: Any = None,
 ) -> xr.Dataset:
@@ -472,7 +472,7 @@ def _flat_group_dataset(
     lock: threading.Lock,
     range_threshold: float = 0.5,
     verify_hash: bool = False,
-    storage_options: dict[str, str] | None = None,
+    storage_options: dict[str, Any] | None = None,
     *,
     shared_file: Any = None,
 ) -> xr.Dataset:
@@ -517,7 +517,7 @@ def _hypercube_dataset(
     lock: threading.Lock,
     range_threshold: float = 0.5,
     verify_hash: bool = False,
-    storage_options: dict[str, str] | None = None,
+    storage_options: dict[str, Any] | None = None,
     *,
     shared_file: Any = None,
 ) -> xr.Dataset:
@@ -605,7 +605,7 @@ def _build_multi_variable_dataset(
     lock: threading.Lock,
     range_threshold: float = 0.5,
     verify_hash: bool = False,
-    storage_options: dict[str, str] | None = None,
+    storage_options: dict[str, Any] | None = None,
     *,
     shared_file: Any = None,
 ) -> xr.Dataset:

--- a/tensogram-xarray/src/tensogram_xarray/merge.py
+++ b/tensogram-xarray/src/tensogram_xarray/merge.py
@@ -70,11 +70,11 @@ def open_datasets(
     if not file_index.objects:
         return []
 
-    is_remote = "://" in path
+    import tensogram
+
+    is_remote = tensogram.is_remote_url(path)
     shared_file = None
     if is_remote:
-        import tensogram
-
         shared_file = (
             tensogram.TensogramFile.open_remote(path, storage_options or {})
             if storage_options or is_remote

--- a/tensogram-xarray/src/tensogram_xarray/merge.py
+++ b/tensogram-xarray/src/tensogram_xarray/merge.py
@@ -152,6 +152,10 @@ def open_datasets(
                         arr = arr.array
                     if isinstance(arr, TensogramBackendArray):
                         arr._shared_file = None
+                    elif isinstance(arr, StackedBackendArray):
+                        for inner in arr._arrays:
+                            if isinstance(inner, TensogramBackendArray):
+                                inner._shared_file = None
             shared_file = None
 
         for ds in datasets:

--- a/tensogram-xarray/src/tensogram_xarray/merge.py
+++ b/tensogram-xarray/src/tensogram_xarray/merge.py
@@ -75,11 +75,7 @@ def open_datasets(
     is_remote = tensogram.is_remote_url(path)
     shared_file = None
     if is_remote:
-        shared_file = (
-            tensogram.TensogramFile.open_remote(path, storage_options or {})
-            if storage_options or is_remote
-            else tensogram.TensogramFile.open(path)
-        )
+        shared_file = tensogram.TensogramFile.open_remote(path, storage_options or {})
 
     all_metas = [o.merged_meta for o in file_index.objects]
     coord_indices, var_indices, coord_dim_map = detect_coords(all_metas)

--- a/tensogram-xarray/src/tensogram_xarray/merge.py
+++ b/tensogram-xarray/src/tensogram_xarray/merge.py
@@ -70,11 +70,20 @@ def open_datasets(
     if not file_index.objects:
         return []
 
-    # Separate coordinate objects from data objects.
+    is_remote = "://" in path
+    shared_file = None
+    if is_remote:
+        import tensogram
+
+        shared_file = (
+            tensogram.TensogramFile.open_remote(path, storage_options or {})
+            if storage_options or is_remote
+            else tensogram.TensogramFile.open(path)
+        )
+
     all_metas = [o.merged_meta for o in file_index.objects]
     coord_indices, var_indices, coord_dim_map = detect_coords(all_metas)
 
-    # Build coordinate variables eagerly (they are small).
     lock = threading.Lock()
     coord_vars: dict[str, xr.Variable] = {}
     for ci in coord_indices:
@@ -94,6 +103,7 @@ def open_datasets(
             range_threshold=range_threshold,
             lock=lock,
             storage_options=storage_options,
+            shared_file=shared_file,
         )
         lazy_data = indexing.LazilyIndexedArray(backend_array)
 
@@ -127,6 +137,7 @@ def open_datasets(
             range_threshold=range_threshold,
             verify_hash=verify_hash,
             storage_options=storage_options,
+            shared_file=shared_file,
         )
         if ds is not None:
             datasets.append(ds)
@@ -285,6 +296,8 @@ def _build_dataset_from_group(
     range_threshold: float = 0.5,
     verify_hash: bool = False,
     storage_options: dict[str, str] | None = None,
+    *,
+    shared_file: Any = None,
 ) -> xr.Dataset | None:
     """Build a Dataset from a group of structurally compatible objects.
 
@@ -307,6 +320,7 @@ def _build_dataset_from_group(
             range_threshold=range_threshold,
             verify_hash=verify_hash,
             storage_options=storage_options,
+            shared_file=shared_file,
         )
 
     # Multiple objects -> try hypercube merge.
@@ -335,6 +349,7 @@ def _build_dataset_from_group(
                 range_threshold=range_threshold,
                 verify_hash=verify_hash,
                 storage_options=storage_options,
+                shared_file=shared_file,
             )
 
     # Check if the varying keys form a hypercube.
@@ -352,6 +367,7 @@ def _build_dataset_from_group(
             range_threshold=range_threshold,
             verify_hash=verify_hash,
             storage_options=storage_options,
+            shared_file=shared_file,
         )
 
     if _try_hypercube(group, varying):
@@ -367,6 +383,7 @@ def _build_dataset_from_group(
             range_threshold=range_threshold,
             verify_hash=verify_hash,
             storage_options=storage_options,
+            shared_file=shared_file,
         )
 
     # Hypercube incomplete -> just return as separate variables.
@@ -381,6 +398,7 @@ def _build_dataset_from_group(
         range_threshold=range_threshold,
         verify_hash=verify_hash,
         storage_options=storage_options,
+        shared_file=shared_file,
     )
 
 
@@ -394,6 +412,8 @@ def _single_object_dataset(
     range_threshold: float = 0.5,
     verify_hash: bool = False,
     storage_options: dict[str, str] | None = None,
+    *,
+    shared_file: Any = None,
 ) -> xr.Dataset:
     """Build a Dataset from a single object."""
     np_dtype = _to_numpy_dtype(obj.dtype)
@@ -413,6 +433,7 @@ def _single_object_dataset(
         range_threshold=range_threshold,
         lock=lock,
         storage_options=storage_options,
+        shared_file=shared_file,
     )
     lazy_data = indexing.LazilyIndexedArray(backend_array)
     var = xr.Variable(dims, lazy_data, dict(obj.merged_meta))
@@ -433,6 +454,8 @@ def _flat_group_dataset(
     range_threshold: float = 0.5,
     verify_hash: bool = False,
     storage_options: dict[str, str] | None = None,
+    *,
+    shared_file: Any = None,
 ) -> xr.Dataset:
     """Build a Dataset with one variable per object (no stacking)."""
     data_vars: dict[str, xr.Variable] = {}
@@ -454,6 +477,7 @@ def _flat_group_dataset(
             range_threshold=range_threshold,
             lock=lock,
             storage_options=storage_options,
+            shared_file=shared_file,
         )
         lazy_data = indexing.LazilyIndexedArray(backend_array)
         data_vars[var_name] = xr.Variable(dims, lazy_data, dict(obj.merged_meta))
@@ -475,6 +499,8 @@ def _hypercube_dataset(
     range_threshold: float = 0.5,
     verify_hash: bool = False,
     storage_options: dict[str, str] | None = None,
+    *,
+    shared_file: Any = None,
 ) -> xr.Dataset:
     """Stack objects into a Dataset with outer dimensions from varying keys.
 
@@ -530,6 +556,7 @@ def _hypercube_dataset(
                 verify_hash=verify_hash,
                 lock=lock,
                 storage_options=storage_options,
+                shared_file=shared_file,
             )
         )
 
@@ -560,6 +587,8 @@ def _build_multi_variable_dataset(
     range_threshold: float = 0.5,
     verify_hash: bool = False,
     storage_options: dict[str, str] | None = None,
+    *,
+    shared_file: Any = None,
 ) -> xr.Dataset:
     """Split group by variable_key, then stack each sub-group.
 
@@ -596,6 +625,7 @@ def _build_multi_variable_dataset(
                 range_threshold=range_threshold,
                 lock=lock,
                 storage_options=storage_options,
+                shared_file=shared_file,
             )
             lazy_data = indexing.LazilyIndexedArray(backend_array)
             data_vars[var_name] = xr.Variable(inner_dims, lazy_data, dict(obj.merged_meta))
@@ -646,6 +676,7 @@ def _build_multi_variable_dataset(
                             verify_hash=verify_hash,
                             lock=lock,
                             storage_options=storage_options,
+                            shared_file=shared_file,
                         )
                     )
 
@@ -676,6 +707,7 @@ def _build_multi_variable_dataset(
                     range_threshold=range_threshold,
                     lock=lock,
                     storage_options=storage_options,
+                    shared_file=shared_file,
                 )
                 lazy_data = indexing.LazilyIndexedArray(backend_array)
                 data_vars[var_name] = xr.Variable(inner_dims, lazy_data, dict(obj.merged_meta))
@@ -701,6 +733,7 @@ def _build_multi_variable_dataset(
                 range_threshold=range_threshold,
                 lock=lock,
                 storage_options=storage_options,
+                shared_file=shared_file,
             )
             lazy_data = indexing.LazilyIndexedArray(backend_array)
             data_vars[var_name] = xr.Variable(inner_dims, lazy_data, dict(obj.merged_meta))

--- a/tensogram-xarray/src/tensogram_xarray/merge.py
+++ b/tensogram-xarray/src/tensogram_xarray/merge.py
@@ -59,6 +59,9 @@ def open_datasets(
     range_threshold
         Maximum fraction of total array elements for which partial
         ``decode_range()`` is used.  Default ``0.5``.
+    storage_options
+        Key-value pairs forwarded to the object store backend for
+        remote URLs.  Ignored for local files.
 
     Returns
     -------

--- a/tensogram-xarray/src/tensogram_xarray/merge.py
+++ b/tensogram-xarray/src/tensogram_xarray/merge.py
@@ -38,6 +38,7 @@ def open_datasets(
     variable_key: str | None = None,
     verify_hash: bool = False,
     range_threshold: float = 0.5,
+    storage_options: dict[str, str] | None = None,
 ) -> list[xr.Dataset]:
     """Open a ``.tgm`` file, auto-grouping into compatible Datasets.
 
@@ -64,7 +65,7 @@ def open_datasets(
     list[xr.Dataset]
         One Dataset per compatible group.
     """
-    file_index = scan_file(path)
+    file_index = scan_file(path, storage_options=storage_options)
 
     if not file_index.objects:
         return []
@@ -92,6 +93,7 @@ def open_datasets(
             verify_hash=verify_hash,
             range_threshold=range_threshold,
             lock=lock,
+            storage_options=storage_options,
         )
         lazy_data = indexing.LazilyIndexedArray(backend_array)
 
@@ -124,6 +126,7 @@ def open_datasets(
             lock=lock,
             range_threshold=range_threshold,
             verify_hash=verify_hash,
+            storage_options=storage_options,
         )
         if ds is not None:
             datasets.append(ds)
@@ -281,6 +284,7 @@ def _build_dataset_from_group(
     lock: threading.Lock,
     range_threshold: float = 0.5,
     verify_hash: bool = False,
+    storage_options: dict[str, str] | None = None,
 ) -> xr.Dataset | None:
     """Build a Dataset from a group of structurally compatible objects.
 
@@ -302,6 +306,7 @@ def _build_dataset_from_group(
             lock,
             range_threshold=range_threshold,
             verify_hash=verify_hash,
+            storage_options=storage_options,
         )
 
     # Multiple objects -> try hypercube merge.
@@ -329,6 +334,7 @@ def _build_dataset_from_group(
                 lock,
                 range_threshold=range_threshold,
                 verify_hash=verify_hash,
+                storage_options=storage_options,
             )
 
     # Check if the varying keys form a hypercube.
@@ -345,6 +351,7 @@ def _build_dataset_from_group(
             lock,
             range_threshold=range_threshold,
             verify_hash=verify_hash,
+            storage_options=storage_options,
         )
 
     if _try_hypercube(group, varying):
@@ -359,6 +366,7 @@ def _build_dataset_from_group(
             lock,
             range_threshold=range_threshold,
             verify_hash=verify_hash,
+            storage_options=storage_options,
         )
 
     # Hypercube incomplete -> just return as separate variables.
@@ -372,6 +380,7 @@ def _build_dataset_from_group(
         lock,
         range_threshold=range_threshold,
         verify_hash=verify_hash,
+        storage_options=storage_options,
     )
 
 
@@ -384,6 +393,7 @@ def _single_object_dataset(
     lock: threading.Lock,
     range_threshold: float = 0.5,
     verify_hash: bool = False,
+    storage_options: dict[str, str] | None = None,
 ) -> xr.Dataset:
     """Build a Dataset from a single object."""
     np_dtype = _to_numpy_dtype(obj.dtype)
@@ -402,6 +412,7 @@ def _single_object_dataset(
         verify_hash=verify_hash,
         range_threshold=range_threshold,
         lock=lock,
+        storage_options=storage_options,
     )
     lazy_data = indexing.LazilyIndexedArray(backend_array)
     var = xr.Variable(dims, lazy_data, dict(obj.merged_meta))
@@ -421,6 +432,7 @@ def _flat_group_dataset(
     lock: threading.Lock,
     range_threshold: float = 0.5,
     verify_hash: bool = False,
+    storage_options: dict[str, str] | None = None,
 ) -> xr.Dataset:
     """Build a Dataset with one variable per object (no stacking)."""
     data_vars: dict[str, xr.Variable] = {}
@@ -441,6 +453,7 @@ def _flat_group_dataset(
             verify_hash=verify_hash,
             range_threshold=range_threshold,
             lock=lock,
+            storage_options=storage_options,
         )
         lazy_data = indexing.LazilyIndexedArray(backend_array)
         data_vars[var_name] = xr.Variable(dims, lazy_data, dict(obj.merged_meta))
@@ -461,6 +474,7 @@ def _hypercube_dataset(
     lock: threading.Lock,
     range_threshold: float = 0.5,
     verify_hash: bool = False,
+    storage_options: dict[str, str] | None = None,
 ) -> xr.Dataset:
     """Stack objects into a Dataset with outer dimensions from varying keys.
 
@@ -515,6 +529,7 @@ def _hypercube_dataset(
                 range_threshold=range_threshold,
                 verify_hash=verify_hash,
                 lock=lock,
+                storage_options=storage_options,
             )
         )
 
@@ -544,6 +559,7 @@ def _build_multi_variable_dataset(
     lock: threading.Lock,
     range_threshold: float = 0.5,
     verify_hash: bool = False,
+    storage_options: dict[str, str] | None = None,
 ) -> xr.Dataset:
     """Split group by variable_key, then stack each sub-group.
 
@@ -579,6 +595,7 @@ def _build_multi_variable_dataset(
                 verify_hash=verify_hash,
                 range_threshold=range_threshold,
                 lock=lock,
+                storage_options=storage_options,
             )
             lazy_data = indexing.LazilyIndexedArray(backend_array)
             data_vars[var_name] = xr.Variable(inner_dims, lazy_data, dict(obj.merged_meta))
@@ -628,6 +645,7 @@ def _build_multi_variable_dataset(
                             range_threshold=range_threshold,
                             verify_hash=verify_hash,
                             lock=lock,
+                            storage_options=storage_options,
                         )
                     )
 
@@ -657,6 +675,7 @@ def _build_multi_variable_dataset(
                     verify_hash=verify_hash,
                     range_threshold=range_threshold,
                     lock=lock,
+                    storage_options=storage_options,
                 )
                 lazy_data = indexing.LazilyIndexedArray(backend_array)
                 data_vars[var_name] = xr.Variable(inner_dims, lazy_data, dict(obj.merged_meta))
@@ -681,6 +700,7 @@ def _build_multi_variable_dataset(
                 verify_hash=verify_hash,
                 range_threshold=range_threshold,
                 lock=lock,
+                storage_options=storage_options,
             )
             lazy_data = indexing.LazilyIndexedArray(backend_array)
             data_vars[var_name] = xr.Variable(inner_dims, lazy_data, dict(obj.merged_meta))

--- a/tensogram-xarray/src/tensogram_xarray/scanner.py
+++ b/tensogram-xarray/src/tensogram_xarray/scanner.py
@@ -115,8 +115,8 @@ def scan_file(
     resolved = file_path if is_remote else os.path.abspath(file_path)
     index = FileIndex(file_path=resolved)
 
-    if storage_options:
-        f = tensogram.TensogramFile.open_remote(resolved, storage_options)
+    if is_remote:
+        f = tensogram.TensogramFile.open_remote(resolved, storage_options or {})
     else:
         f = tensogram.TensogramFile.open(resolved)
 

--- a/tensogram-xarray/src/tensogram_xarray/scanner.py
+++ b/tensogram-xarray/src/tensogram_xarray/scanner.py
@@ -100,7 +100,10 @@ def _extra_from_meta(meta: Any) -> dict[str, Any]:
     return result
 
 
-def scan_file(file_path: str) -> FileIndex:
+def scan_file(
+    file_path: str,
+    storage_options: dict[str, str] | None = None,
+) -> FileIndex:
     """Scan a ``.tgm`` file and return a :class:`FileIndex`.
 
     Decodes each message to get descriptors, per-object metadata
@@ -108,18 +111,28 @@ def scan_file(file_path: str) -> FileIndex:
     """
     import tensogram
 
-    file_path = os.path.abspath(file_path)
-    index = FileIndex(file_path=file_path)
+    is_remote = "://" in file_path
+    resolved = file_path if is_remote else os.path.abspath(file_path)
+    index = FileIndex(file_path=resolved)
 
-    with tensogram.TensogramFile.open(file_path) as f:
+    if storage_options:
+        f = tensogram.TensogramFile.open_remote(resolved, storage_options)
+    else:
+        f = tensogram.TensogramFile.open(resolved)
+
+    with f:
         n_messages = len(f)
         for msg_idx in range(n_messages):
-            raw = f.read_message(msg_idx)
-            meta = tensogram.decode_metadata(raw)
-            extra = _extra_from_meta(meta)
+            if is_remote:
+                result = f.file_decode_descriptors(msg_idx)
+                meta = result["metadata"]
+                descriptors = result["descriptors"]
+            else:
+                raw = f.read_message(msg_idx)
+                meta = tensogram.decode_metadata(raw)
+                _, descriptors = tensogram.decode_descriptors(raw)
 
-            # Decode descriptors only (no payload decode).
-            _, descriptors = tensogram.decode_descriptors(raw)
+            extra = _extra_from_meta(meta)
 
             for obj_idx, desc in enumerate(descriptors):
                 per_obj = _merge_per_object_meta(meta, obj_idx, desc)

--- a/tensogram-xarray/src/tensogram_xarray/scanner.py
+++ b/tensogram-xarray/src/tensogram_xarray/scanner.py
@@ -108,6 +108,14 @@ def scan_file(
 
     Decodes each message to get descriptors, per-object metadata
     (from ``meta.base`` and ``desc.params``), and extra metadata.
+
+    Parameters
+    ----------
+    file_path
+        Path or remote URL to the ``.tgm`` file.
+    storage_options
+        Key-value pairs forwarded to the object store backend for
+        remote URLs.  Ignored for local files.
     """
     import tensogram
 

--- a/tensogram-xarray/src/tensogram_xarray/scanner.py
+++ b/tensogram-xarray/src/tensogram_xarray/scanner.py
@@ -102,7 +102,7 @@ def _extra_from_meta(meta: Any) -> dict[str, Any]:
 
 def scan_file(
     file_path: str,
-    storage_options: dict[str, str] | None = None,
+    storage_options: dict[str, Any] | None = None,
 ) -> FileIndex:
     """Scan a ``.tgm`` file and return a :class:`FileIndex`.
 

--- a/tensogram-xarray/src/tensogram_xarray/scanner.py
+++ b/tensogram-xarray/src/tensogram_xarray/scanner.py
@@ -111,7 +111,7 @@ def scan_file(
     """
     import tensogram
 
-    is_remote = "://" in file_path
+    is_remote = tensogram.is_remote_url(file_path)
     resolved = file_path if is_remote else os.path.abspath(file_path)
     index = FileIndex(file_path=resolved)
 

--- a/tensogram-xarray/src/tensogram_xarray/store.py
+++ b/tensogram-xarray/src/tensogram_xarray/store.py
@@ -94,7 +94,9 @@ class TensogramDataStore:
         range_threshold: float = 0.5,
         storage_options: dict[str, str] | None = None,
     ):
-        self._is_remote = "://" in file_path
+        import tensogram
+
+        self._is_remote = tensogram.is_remote_url(file_path)
         self.file_path = file_path if self._is_remote else os.path.abspath(file_path)
         self.msg_index = msg_index
         self.dim_names = dim_names

--- a/tensogram-xarray/src/tensogram_xarray/store.py
+++ b/tensogram-xarray/src/tensogram_xarray/store.py
@@ -92,28 +92,37 @@ class TensogramDataStore:
         variable_key: str | None = None,
         verify_hash: bool = False,
         range_threshold: float = 0.5,
+        storage_options: dict[str, str] | None = None,
     ):
-        self.file_path = os.path.abspath(file_path)
+        self._is_remote = "://" in file_path
+        self.file_path = file_path if self._is_remote else os.path.abspath(file_path)
         self.msg_index = msg_index
         self.dim_names = dim_names
         self.variable_key = variable_key
         self.verify_hash = verify_hash
         self.range_threshold = range_threshold
+        self.storage_options = storage_options
         self._lock = threading.Lock()
 
-        # Eagerly read metadata + descriptors (no payload decode).
+        self._file = self._open_file()
         self._meta, self._descriptors = self._read_metadata()
 
-    def _read_metadata(self) -> tuple[Any, list]:
-        """Read metadata and descriptors from the message."""
+    def _open_file(self) -> Any:
         import tensogram
 
-        with tensogram.TensogramFile.open(self.file_path) as f:
-            raw = f.read_message(self.msg_index)
+        if self.storage_options:
+            return tensogram.TensogramFile.open_remote(self.file_path, self.storage_options)
+        return tensogram.TensogramFile.open(self.file_path)
 
+    def _read_metadata(self) -> tuple[Any, list]:
+        import tensogram
+
+        if self._is_remote:
+            result = self._file.file_decode_descriptors(self.msg_index)
+            return result["metadata"], result["descriptors"]
+
+        raw = self._file.read_message(self.msg_index)
         meta = tensogram.decode_metadata(raw)
-
-        # Decode descriptors only (no payload decode).
         _, descriptors = tensogram.decode_descriptors(raw)
         return meta, descriptors
 
@@ -199,15 +208,15 @@ class TensogramDataStore:
                 verify_hash=self.verify_hash,
                 range_threshold=self.range_threshold,
                 lock=self._lock,
+                storage_options=self.storage_options,
+                shared_file=self._file,
             )
             lazy_data = indexing.LazilyIndexedArray(backend_array)
 
-            # Coordinate arrays are 1-D.
             coord_dims = (dim_name,)
             coord_attrs = dict(obj_metas[ci])
             coord_vars[dim_name] = xr.Variable(coord_dims, lazy_data, coord_attrs)
 
-        # Build data variables.
         data_vars: dict[str, xr.Variable] = {}
         for vi in var_indices:
             desc = self._descriptors[vi]
@@ -218,8 +227,6 @@ class TensogramDataStore:
             np_dtype = _to_numpy_dtype(desc.dtype)
             shape = tuple(desc.shape)
 
-            # Resolve dimension names: match against detected coordinates
-            # where shape aligns, otherwise use user-specified or generic.
             dims = self._resolve_dims_for_var(shape, coord_vars)
 
             backend_array = TensogramBackendArray(
@@ -232,6 +239,8 @@ class TensogramDataStore:
                 verify_hash=self.verify_hash,
                 range_threshold=self.range_threshold,
                 lock=self._lock,
+                storage_options=self.storage_options,
+                shared_file=self._file,
             )
             lazy_data = indexing.LazilyIndexedArray(backend_array)
 

--- a/tensogram-xarray/src/tensogram_xarray/store.py
+++ b/tensogram-xarray/src/tensogram_xarray/store.py
@@ -110,8 +110,8 @@ class TensogramDataStore:
     def _open_file(self) -> Any:
         import tensogram
 
-        if self.storage_options:
-            return tensogram.TensogramFile.open_remote(self.file_path, self.storage_options)
+        if self._is_remote:
+            return tensogram.TensogramFile.open_remote(self.file_path, self.storage_options or {})
         return tensogram.TensogramFile.open(self.file_path)
 
     def _read_metadata(self) -> tuple[Any, list]:
@@ -293,4 +293,4 @@ class TensogramDataStore:
         return tuple(dims)
 
     def close(self) -> None:
-        """No-op: no persistent resources to release."""
+        self._file = None

--- a/tensogram-xarray/src/tensogram_xarray/store.py
+++ b/tensogram-xarray/src/tensogram_xarray/store.py
@@ -92,7 +92,7 @@ class TensogramDataStore:
         variable_key: str | None = None,
         verify_hash: bool = False,
         range_threshold: float = 0.5,
-        storage_options: dict[str, str] | None = None,
+        storage_options: dict[str, Any] | None = None,
     ):
         import tensogram
 
@@ -105,6 +105,7 @@ class TensogramDataStore:
         self.range_threshold = range_threshold
         self.storage_options = storage_options
         self._lock = threading.Lock()
+        self._backend_arrays: list[TensogramBackendArray] = []
 
         self._file = self._open_file()
         self._meta, self._descriptors = self._read_metadata()
@@ -213,6 +214,7 @@ class TensogramDataStore:
                 storage_options=self.storage_options,
                 shared_file=self._file,
             )
+            self._backend_arrays.append(backend_array)
             lazy_data = indexing.LazilyIndexedArray(backend_array)
 
             coord_dims = (dim_name,)
@@ -244,6 +246,7 @@ class TensogramDataStore:
                 storage_options=self.storage_options,
                 shared_file=self._file,
             )
+            self._backend_arrays.append(backend_array)
             lazy_data = indexing.LazilyIndexedArray(backend_array)
 
             var_attrs = dict(obj_metas[vi])
@@ -295,4 +298,7 @@ class TensogramDataStore:
         return tuple(dims)
 
     def close(self) -> None:
+        for arr in self._backend_arrays:
+            arr._shared_file = None
+        self._backend_arrays.clear()
         self._file = None

--- a/tensogram-xarray/src/tensogram_xarray/store.py
+++ b/tensogram-xarray/src/tensogram_xarray/store.py
@@ -70,7 +70,7 @@ class TensogramDataStore:
     Parameters
     ----------
     file_path
-        Path to the ``.tgm`` file.
+        Path or remote URL to the ``.tgm`` file.
     msg_index
         Index of the message within the file.
     dim_names

--- a/tensogram-xarray/src/tensogram_xarray/store.py
+++ b/tensogram-xarray/src/tensogram_xarray/store.py
@@ -82,6 +82,11 @@ class TensogramDataStore:
     range_threshold
         Maximum fraction of total array elements (0.0-1.0) for which
         partial ``decode_range()`` is used.  Default ``0.5``.
+    storage_options
+        Key-value pairs forwarded to the object store backend when
+        ``file_path`` is a remote URL (S3, GCS, Azure, HTTP).  Used
+        for credentials, region, endpoint overrides, etc.  Ignored
+        for local files.
     """
 
     def __init__(

--- a/tensogram-xarray/tests/test_remote.py
+++ b/tensogram-xarray/tests/test_remote.py
@@ -1,0 +1,127 @@
+"""Remote URL support tests for tensogram-xarray."""
+
+from __future__ import annotations
+
+import http.server
+import threading
+
+import numpy as np
+import pytest
+import tensogram
+import xarray as xr
+
+
+def _make_handler(file_data: bytes):
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def log_message(self, fmt, *args):
+            pass
+
+        def do_HEAD(self):
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(file_data)))
+            self.send_header("Accept-Ranges", "bytes")
+            self.end_headers()
+
+        def do_GET(self):
+            data = file_data
+            range_header = self.headers.get("Range")
+            if range_header and range_header.startswith("bytes="):
+                spec = range_header[6:]
+                if spec.startswith("-"):
+                    n = int(spec[1:])
+                    s, e = max(0, len(data) - n), len(data)
+                else:
+                    parts = spec.split("-")
+                    s = int(parts[0])
+                    e = int(parts[1]) + 1 if parts[1] else len(data)
+                    e = min(e, len(data))
+                if s >= len(data):
+                    self.send_response(416)
+                    self.end_headers()
+                    return
+                chunk = data[s:e]
+                self.send_response(206)
+                self.send_header("Content-Range", f"bytes {s}-{e - 1}/{len(data)}")
+                self.send_header("Content-Length", str(len(chunk)))
+                self.end_headers()
+                self.wfile.write(chunk)
+            else:
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+
+    return Handler
+
+
+@pytest.fixture
+def serve_tgm(tmp_path):
+    """Create a .tgm file, serve it over HTTP, return (url, local_path)."""
+    servers = []
+
+    def _serve(data: np.ndarray, shape: list[int], dtype: str = "float32") -> tuple[str, str]:
+        meta = {"version": 2}
+        desc = {
+            "type": "ntensor",
+            "shape": shape,
+            "dtype": dtype,
+            "byte_order": "little",
+            "encoding": "none",
+            "filter": "none",
+            "compression": "none",
+        }
+        msg_bytes = tensogram.encode(meta, [(desc, data)])
+
+        local_path = str(tmp_path / "test.tgm")
+        with open(local_path, "wb") as f:
+            f.write(msg_bytes)
+
+        handler = _make_handler(msg_bytes)
+        server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        servers.append(server)
+        return f"http://127.0.0.1:{port}/test.tgm", local_path
+
+    yield _serve
+
+    for s in servers:
+        s.shutdown()
+        s.server_close()
+
+
+class TestXarrayRemoteOpen:
+    def test_open_dataset_remote(self, serve_tgm):
+        data = np.arange(12, dtype=np.float32).reshape(3, 4)
+        url, _ = serve_tgm(data, [3, 4])
+
+        ds = xr.open_dataset(url, engine="tensogram")
+        assert len(ds.data_vars) == 1
+        var = next(iter(ds.data_vars.values()))
+        np.testing.assert_array_equal(var.values, data)
+
+    def test_remote_matches_local(self, serve_tgm):
+        data = np.arange(20, dtype=np.float32).reshape(4, 5)
+        url, local_path = serve_tgm(data, [4, 5])
+
+        ds_remote = xr.open_dataset(url, engine="tensogram")
+        ds_local = xr.open_dataset(local_path, engine="tensogram")
+
+        for var_name in ds_local.data_vars:
+            np.testing.assert_array_equal(
+                ds_remote[var_name].values,
+                ds_local[var_name].values,
+            )
+
+    def test_open_dataset_with_storage_options(self, serve_tgm):
+        data = np.full((2, 3), 7.0, dtype=np.float32)
+        url, _ = serve_tgm(data, [2, 3])
+
+        ds = xr.open_dataset(
+            url,
+            engine="tensogram",
+            storage_options={"allow_http": "true"},
+        )
+        var = next(iter(ds.data_vars.values()))
+        np.testing.assert_allclose(var.values, 7.0)

--- a/tensogram-zarr/src/tensogram_zarr/store.py
+++ b/tensogram-zarr/src/tensogram_zarr/store.py
@@ -340,8 +340,8 @@ class TensogramStore(ZarrStore):
         import tensogram
 
         try:
-            if self._storage_options:
-                f = tensogram.TensogramFile.open_remote(self._path, self._storage_options)
+            if "://" in self._path:
+                f = tensogram.TensogramFile.open_remote(self._path, self._storage_options or {})
             else:
                 f = tensogram.TensogramFile.open(self._path)
         except Exception as exc:

--- a/tensogram-zarr/src/tensogram_zarr/store.py
+++ b/tensogram-zarr/src/tensogram_zarr/store.py
@@ -62,13 +62,19 @@ class TensogramStore(ZarrStore):
     Parameters
     ----------
     path : str
-        Path to the ``.tgm`` file.
+        Path or remote URL (S3, GCS, Azure, HTTP) to the ``.tgm`` file.
+        Remote URLs are detected automatically by scheme.
     mode : str
         ``"r"`` for read-only, ``"w"`` for write, ``"a"`` for append.
+        Remote URLs only support ``"r"``.
     message_index : int
         Which message to read (default ``0``). Only used in read mode.
     variable_key : str | None
         Dotted metadata path for variable naming (e.g. ``"mars.param"``).
+    storage_options : dict[str, Any] | None
+        Key-value pairs forwarded to the object store backend for
+        remote URLs.  Used for credentials, region, endpoint overrides,
+        etc.  Ignored for local files.
     """
 
     def __init__(

--- a/tensogram-zarr/src/tensogram_zarr/store.py
+++ b/tensogram-zarr/src/tensogram_zarr/store.py
@@ -78,9 +78,13 @@ class TensogramStore(ZarrStore):
         mode: str = "r",
         message_index: int = 0,
         variable_key: str | None = None,
+        storage_options: dict[str, str] | None = None,
     ) -> None:
         if mode not in ("r", "w", "a"):
             raise ValueError(f"invalid mode {mode!r}; expected 'r', 'w', or 'a'")
+        is_remote = "://" in path
+        if is_remote and mode in ("w", "a"):
+            raise ValueError(f"remote URLs do not support mode={mode!r}; use mode='r'")
         if message_index < 0:
             raise ValueError(f"message_index must be >= 0, got {message_index}")
         if not isinstance(path, str) or not path:
@@ -89,6 +93,7 @@ class TensogramStore(ZarrStore):
         super().__init__(read_only=read_only)
         self._path = path
         self._mode = mode
+        self._storage_options = storage_options
         self._message_index = message_index
         self._variable_key = variable_key
 
@@ -113,13 +118,20 @@ class TensogramStore(ZarrStore):
         *,
         message_index: int = 0,
         variable_key: str | None = None,
+        storage_options: dict[str, str] | None = None,
     ) -> TensogramStore:
         """Open a ``.tgm`` file as a read-only Zarr store (synchronous).
 
         This is a convenience wrapper that creates the store, scans the
         file, and returns a ready-to-use instance.
         """
-        store = cls(path, mode="r", message_index=message_index, variable_key=variable_key)
+        store = cls(
+            path,
+            mode="r",
+            message_index=message_index,
+            variable_key=variable_key,
+            storage_options=storage_options,
+        )
         store._open_sync()
         return store
 
@@ -328,7 +340,10 @@ class TensogramStore(ZarrStore):
         import tensogram
 
         try:
-            f = tensogram.TensogramFile.open(self._path)
+            if self._storage_options:
+                f = tensogram.TensogramFile.open_remote(self._path, self._storage_options)
+            else:
+                f = tensogram.TensogramFile.open(self._path)
         except Exception as exc:
             raise OSError(f"failed to open TGM file {self._path!r}: {exc}") from exc
 

--- a/tensogram-zarr/src/tensogram_zarr/store.py
+++ b/tensogram-zarr/src/tensogram_zarr/store.py
@@ -78,19 +78,19 @@ class TensogramStore(ZarrStore):
         mode: str = "r",
         message_index: int = 0,
         variable_key: str | None = None,
-        storage_options: dict[str, str] | None = None,
+        storage_options: dict[str, Any] | None = None,
     ) -> None:
+        if not isinstance(path, str) or not path:
+            raise ValueError(f"path must be a non-empty string, got {path!r}")
         if mode not in ("r", "w", "a"):
             raise ValueError(f"invalid mode {mode!r}; expected 'r', 'w', or 'a'")
+        if message_index < 0:
+            raise ValueError(f"message_index must be >= 0, got {message_index}")
         import tensogram
 
         is_remote = tensogram.is_remote_url(path)
         if is_remote and mode in ("w", "a"):
             raise ValueError(f"remote URLs do not support mode={mode!r}; use mode='r'")
-        if message_index < 0:
-            raise ValueError(f"message_index must be >= 0, got {message_index}")
-        if not isinstance(path, str) or not path:
-            raise ValueError(f"path must be a non-empty string, got {path!r}")
         read_only = mode == "r"
         super().__init__(read_only=read_only)
         self._path = path
@@ -120,7 +120,7 @@ class TensogramStore(ZarrStore):
         *,
         message_index: int = 0,
         variable_key: str | None = None,
-        storage_options: dict[str, str] | None = None,
+        storage_options: dict[str, Any] | None = None,
     ) -> TensogramStore:
         """Open a ``.tgm`` file as a read-only Zarr store (synchronous).
 

--- a/tensogram-zarr/src/tensogram_zarr/store.py
+++ b/tensogram-zarr/src/tensogram_zarr/store.py
@@ -82,7 +82,9 @@ class TensogramStore(ZarrStore):
     ) -> None:
         if mode not in ("r", "w", "a"):
             raise ValueError(f"invalid mode {mode!r}; expected 'r', 'w', or 'a'")
-        is_remote = "://" in path
+        import tensogram
+
+        is_remote = tensogram.is_remote_url(path)
         if is_remote and mode in ("w", "a"):
             raise ValueError(f"remote URLs do not support mode={mode!r}; use mode='r'")
         if message_index < 0:
@@ -340,7 +342,7 @@ class TensogramStore(ZarrStore):
         import tensogram
 
         try:
-            if "://" in self._path:
+            if tensogram.is_remote_url(self._path):
                 f = tensogram.TensogramFile.open_remote(self._path, self._storage_options or {})
             else:
                 f = tensogram.TensogramFile.open(self._path)

--- a/tensogram-zarr/tests/test_remote.py
+++ b/tensogram-zarr/tests/test_remote.py
@@ -1,0 +1,121 @@
+"""Remote URL support tests for tensogram-zarr."""
+
+from __future__ import annotations
+
+import http.server
+import threading
+
+import numpy as np
+import pytest
+import tensogram
+from tensogram_zarr.store import TensogramStore
+
+
+def _make_handler(file_data: bytes):
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def log_message(self, fmt, *args):
+            pass
+
+        def do_HEAD(self):
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(file_data)))
+            self.send_header("Accept-Ranges", "bytes")
+            self.end_headers()
+
+        def do_GET(self):
+            data = file_data
+            range_header = self.headers.get("Range")
+            if range_header and range_header.startswith("bytes="):
+                spec = range_header[6:]
+                if spec.startswith("-"):
+                    n = int(spec[1:])
+                    s, e = max(0, len(data) - n), len(data)
+                else:
+                    parts = spec.split("-")
+                    s = int(parts[0])
+                    e = int(parts[1]) + 1 if parts[1] else len(data)
+                    e = min(e, len(data))
+                if s >= len(data):
+                    self.send_response(416)
+                    self.end_headers()
+                    return
+                chunk = data[s:e]
+                self.send_response(206)
+                self.send_header("Content-Range", f"bytes {s}-{e - 1}/{len(data)}")
+                self.send_header("Content-Length", str(len(chunk)))
+                self.end_headers()
+                self.wfile.write(chunk)
+            else:
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+
+    return Handler
+
+
+@pytest.fixture
+def serve_tgm_bytes():
+    """Start a mock HTTP server for given bytes, isolated per call."""
+    servers = []
+
+    def _serve(data: bytes) -> str:
+        handler = _make_handler(data)
+        server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        servers.append(server)
+        return f"http://127.0.0.1:{port}/test.tgm"
+
+    yield _serve
+
+    for s in servers:
+        s.shutdown()
+        s.server_close()
+
+
+def _encode_simple_message() -> bytes:
+    meta = {"version": 2}
+    desc = {
+        "type": "ntensor",
+        "shape": [4],
+        "dtype": "float32",
+        "byte_order": "little",
+        "encoding": "none",
+        "filter": "none",
+        "compression": "none",
+    }
+    data = np.arange(4, dtype=np.float32)
+    return tensogram.encode(meta, [(desc, data)])
+
+
+class TestZarrRemoteRead:
+    def test_open_tgm_remote(self, serve_tgm_bytes):
+        msg = _encode_simple_message()
+        url = serve_tgm_bytes(msg)
+
+        store = TensogramStore.open_tgm(url)
+        assert store._path == url
+
+    def test_open_tgm_remote_with_storage_options(self, serve_tgm_bytes):
+        msg = _encode_simple_message()
+        url = serve_tgm_bytes(msg)
+
+        store = TensogramStore.open_tgm(url, storage_options={"allow_http": "true"})
+        assert store._path == url
+
+
+class TestZarrRemoteWriteRejection:
+    def test_remote_write_rejected(self):
+        with pytest.raises(ValueError, match="remote URLs do not support"):
+            TensogramStore("s3://bucket/file.tgm", mode="w")
+
+    def test_remote_append_rejected(self):
+        with pytest.raises(ValueError, match="remote URLs do not support"):
+            TensogramStore("s3://bucket/file.tgm", mode="a")
+
+    def test_local_write_still_works(self, tmp_path):
+        path = str(tmp_path / "write.tgm")
+        store = TensogramStore(path, mode="w")
+        assert store.supports_writes

--- a/tests/python/test_remote.py
+++ b/tests/python/test_remote.py
@@ -46,9 +46,7 @@ def _make_handler(file_data: bytes):
                     return
                 chunk = data[start:end]
                 self.send_response(206)
-                self.send_header(
-                    "Content-Range", f"bytes {start}-{end - 1}/{len(data)}"
-                )
+                self.send_header("Content-Range", f"bytes {start}-{end - 1}/{len(data)}")
                 self.send_header("Content-Length", str(len(chunk)))
                 self.end_headers()
                 self.wfile.write(chunk)
@@ -79,6 +77,7 @@ def serve_tgm_bytes():
 
     for s in servers:
         s.shutdown()
+        s.server_close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/python/test_remote.py
+++ b/tests/python/test_remote.py
@@ -1,0 +1,235 @@
+"""Tests for remote URL support in Python bindings, xarray, and zarr."""
+
+from __future__ import annotations
+
+import http.server
+import threading
+from typing import Any
+
+import numpy as np
+import pytest
+import tensogram
+
+
+# ---------------------------------------------------------------------------
+# Mock HTTP server with Range support
+# ---------------------------------------------------------------------------
+
+
+class RangeHTTPHandler(http.server.BaseHTTPRequestHandler):
+    """Serves a single file with HEAD and Range request support."""
+
+    file_data: bytes = b""
+
+    def log_message(self, fmt, *args):
+        pass
+
+    def do_HEAD(self):
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(self.file_data)))
+        self.send_header("Accept-Ranges", "bytes")
+        self.end_headers()
+
+    def do_GET(self):
+        data = self.file_data
+        range_header = self.headers.get("Range")
+        if range_header and range_header.startswith("bytes="):
+            range_spec = range_header[6:]
+            if range_spec.startswith("-"):
+                suffix = int(range_spec[1:])
+                start = max(0, len(data) - suffix)
+                end = len(data)
+            else:
+                parts = range_spec.split("-")
+                start = int(parts[0])
+                end = int(parts[1]) + 1 if parts[1] else len(data)
+                end = min(end, len(data))
+
+            chunk = data[start:end]
+            self.send_response(206)
+            self.send_header("Content-Range", f"bytes {start}-{end - 1}/{len(data)}")
+            self.send_header("Content-Length", str(len(chunk)))
+            self.end_headers()
+            self.wfile.write(chunk)
+        else:
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+
+@pytest.fixture
+def serve_tgm_bytes():
+    """Fixture that starts a mock HTTP server for a given bytes payload."""
+    servers = []
+
+    def _serve(data: bytes) -> str:
+        RangeHTTPHandler.file_data = data
+        server = http.server.HTTPServer(("127.0.0.1", 0), RangeHTTPHandler)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        servers.append(server)
+        return f"http://127.0.0.1:{port}/test.tgm"
+
+    yield _serve
+
+    for s in servers:
+        s.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_global_meta(version: int = 2, **extra: Any) -> dict[str, Any]:
+    return {"version": version, **extra}
+
+
+def make_descriptor(shape: list[int], dtype: str = "float32") -> dict[str, Any]:
+    return {
+        "type": "ntensor",
+        "shape": shape,
+        "dtype": dtype,
+        "byte_order": "little",
+        "encoding": "none",
+        "filter": "none",
+        "compression": "none",
+    }
+
+
+def encode_test_message(shape: list[int], fill: float = 42.0) -> bytes:
+    meta = make_global_meta()
+    desc = make_descriptor(shape)
+    data = np.full(shape, fill, dtype=np.float32)
+    return tensogram.encode(meta, [(desc, data)])
+
+
+# ---------------------------------------------------------------------------
+# Python binding remote tests
+# ---------------------------------------------------------------------------
+
+
+class TestPythonRemoteOpen:
+    def test_open_auto_detects_remote(self, serve_tgm_bytes):
+        msg = encode_test_message([4])
+        url = serve_tgm_bytes(msg)
+
+        with tensogram.TensogramFile.open(url) as f:
+            assert f.is_remote()
+            assert f.source() == url
+            assert f.message_count() == 1
+
+    def test_open_remote_explicit(self, serve_tgm_bytes):
+        msg = encode_test_message([4])
+        url = serve_tgm_bytes(msg)
+
+        with tensogram.TensogramFile.open_remote(url) as f:
+            assert f.is_remote()
+            assert f.message_count() == 1
+
+    def test_open_remote_with_storage_options(self, serve_tgm_bytes):
+        msg = encode_test_message([4])
+        url = serve_tgm_bytes(msg)
+
+        with tensogram.TensogramFile.open_remote(url, {"allow_http": "true"}) as f:
+            assert f.is_remote()
+
+    def test_open_local_still_works(self, tmp_path):
+        path = str(tmp_path / "local.tgm")
+        with tensogram.TensogramFile.create(path) as f:
+            meta = make_global_meta()
+            desc = make_descriptor([4])
+            data = np.full([4], 1.0, dtype=np.float32)
+            f.append(meta, [(desc, data)])
+
+        with tensogram.TensogramFile.open(path) as f:
+            assert not f.is_remote()
+            assert f.message_count() == 1
+
+
+class TestPythonRemoteDecode:
+    def test_file_decode_metadata(self, serve_tgm_bytes):
+        msg = encode_test_message([4])
+        url = serve_tgm_bytes(msg)
+
+        with tensogram.TensogramFile.open(url) as f:
+            meta = f.file_decode_metadata(0)
+            assert meta.version == 2
+
+    def test_file_decode_descriptors(self, serve_tgm_bytes):
+        msg = encode_test_message([4])
+        url = serve_tgm_bytes(msg)
+
+        with tensogram.TensogramFile.open(url) as f:
+            result = f.file_decode_descriptors(0)
+            assert "metadata" in result
+            assert "descriptors" in result
+            descs = result["descriptors"]
+            assert len(descs) == 1
+            assert list(descs[0].shape) == [4]
+
+    def test_file_decode_object(self, serve_tgm_bytes):
+        msg = encode_test_message([4], fill=99.0)
+        url = serve_tgm_bytes(msg)
+
+        with tensogram.TensogramFile.open(url) as f:
+            result = f.file_decode_object(0, 0)
+            assert "metadata" in result
+            assert "descriptor" in result
+            assert "data" in result
+            arr = result["data"]
+            assert arr.shape == (4,)
+            np.testing.assert_allclose(arr, np.full(4, 99.0, dtype=np.float32))
+
+    def test_decode_message_still_works_remote(self, serve_tgm_bytes):
+        msg = encode_test_message([4], fill=7.0)
+        url = serve_tgm_bytes(msg)
+
+        with tensogram.TensogramFile.open(url) as f:
+            meta, objects = f.decode_message(0)
+            assert meta.version == 2
+            assert len(objects) == 1
+            np.testing.assert_allclose(objects[0][1], np.full(4, 7.0, dtype=np.float32))
+
+    def test_remote_matches_local_decode(self, serve_tgm_bytes, tmp_path):
+        msg = encode_test_message([10], fill=3.14)
+
+        url = serve_tgm_bytes(msg)
+        local_path = str(tmp_path / "local.tgm")
+        with open(local_path, "wb") as fh:
+            fh.write(msg)
+
+        with tensogram.TensogramFile.open(url) as remote:
+            remote_result = remote.file_decode_object(0, 0)
+
+        with tensogram.TensogramFile.open(local_path) as local:
+            local_meta, local_objects = local.decode_message(0)
+
+        np.testing.assert_array_equal(remote_result["data"], local_objects[0][1])
+
+
+class TestPythonRemoteErrors:
+    def test_invalid_url(self):
+        with pytest.raises(Exception):
+            tensogram.TensogramFile.open("http://[invalid]/file.tgm")
+
+    def test_open_remote_bad_storage_option_value(self, serve_tgm_bytes):
+        msg = encode_test_message([4])
+        url = serve_tgm_bytes(msg)
+
+        class Unconvertible:
+            def __str__(self):
+                raise RuntimeError("cannot convert")
+
+        with pytest.raises(Exception, match="convertible to string"):
+            tensogram.TensogramFile.open_remote(url, {"key": Unconvertible()})
+
+    def test_iteration_not_supported_on_remote(self, serve_tgm_bytes):
+        msg = encode_test_message([4])
+        url = serve_tgm_bytes(msg)
+
+        with tensogram.TensogramFile.open(url) as f:
+            with pytest.raises(RuntimeError, match="iteration not supported"):
+                iter(f)

--- a/tests/python/test_remote.py
+++ b/tests/python/test_remote.py
@@ -46,7 +46,9 @@ def _make_handler(file_data: bytes):
                     return
                 chunk = data[start:end]
                 self.send_response(206)
-                self.send_header("Content-Range", f"bytes {start}-{end - 1}/{len(data)}")
+                self.send_header(
+                    "Content-Range", f"bytes {start}-{end - 1}/{len(data)}"
+                )
                 self.send_header("Content-Length", str(len(chunk)))
                 self.end_headers()
                 self.wfile.write(chunk)
@@ -225,7 +227,7 @@ class TestPythonRemoteErrors:
             def __str__(self):
                 raise RuntimeError("cannot convert")
 
-        with pytest.raises(Exception, match="convertible to string"):
+        with pytest.raises(ValueError, match="convertible to string"):
             tensogram.TensogramFile.open_remote(url, {"key": Unconvertible()})
 
     def test_iteration_not_supported_on_remote(self, serve_tgm_bytes):

--- a/tests/python/test_remote.py
+++ b/tests/python/test_remote.py
@@ -16,56 +16,60 @@ import tensogram
 # ---------------------------------------------------------------------------
 
 
-class RangeHTTPHandler(http.server.BaseHTTPRequestHandler):
-    """Serves a single file with HEAD and Range request support."""
+def _make_handler(file_data: bytes):
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def log_message(self, fmt, *args):
+            pass
 
-    file_data: bytes = b""
-
-    def log_message(self, fmt, *args):
-        pass
-
-    def do_HEAD(self):
-        self.send_response(200)
-        self.send_header("Content-Length", str(len(self.file_data)))
-        self.send_header("Accept-Ranges", "bytes")
-        self.end_headers()
-
-    def do_GET(self):
-        data = self.file_data
-        range_header = self.headers.get("Range")
-        if range_header and range_header.startswith("bytes="):
-            range_spec = range_header[6:]
-            if range_spec.startswith("-"):
-                suffix = int(range_spec[1:])
-                start = max(0, len(data) - suffix)
-                end = len(data)
-            else:
-                parts = range_spec.split("-")
-                start = int(parts[0])
-                end = int(parts[1]) + 1 if parts[1] else len(data)
-                end = min(end, len(data))
-
-            chunk = data[start:end]
-            self.send_response(206)
-            self.send_header("Content-Range", f"bytes {start}-{end - 1}/{len(data)}")
-            self.send_header("Content-Length", str(len(chunk)))
-            self.end_headers()
-            self.wfile.write(chunk)
-        else:
+        def do_HEAD(self):
             self.send_response(200)
-            self.send_header("Content-Length", str(len(data)))
+            self.send_header("Content-Length", str(len(file_data)))
+            self.send_header("Accept-Ranges", "bytes")
             self.end_headers()
-            self.wfile.write(data)
+
+        def do_GET(self):
+            data = file_data
+            range_header = self.headers.get("Range")
+            if range_header and range_header.startswith("bytes="):
+                range_spec = range_header[6:]
+                if range_spec.startswith("-"):
+                    suffix = int(range_spec[1:])
+                    start = max(0, len(data) - suffix)
+                    end = len(data)
+                else:
+                    parts = range_spec.split("-")
+                    start = int(parts[0])
+                    end = int(parts[1]) + 1 if parts[1] else len(data)
+                    end = min(end, len(data))
+                if start >= len(data):
+                    self.send_response(416)
+                    self.end_headers()
+                    return
+                chunk = data[start:end]
+                self.send_response(206)
+                self.send_header(
+                    "Content-Range", f"bytes {start}-{end - 1}/{len(data)}"
+                )
+                self.send_header("Content-Length", str(len(chunk)))
+                self.end_headers()
+                self.wfile.write(chunk)
+            else:
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+
+    return Handler
 
 
 @pytest.fixture
 def serve_tgm_bytes():
-    """Fixture that starts a mock HTTP server for a given bytes payload."""
+    """Fixture that starts a mock HTTP server for given bytes, isolated per call."""
     servers = []
 
     def _serve(data: bytes) -> str:
-        RangeHTTPHandler.file_data = data
-        server = http.server.HTTPServer(("127.0.0.1", 0), RangeHTTPHandler)
+        handler = _make_handler(data)
+        server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
         port = server.server_address[1]
         thread = threading.Thread(target=server.serve_forever, daemon=True)
         thread.start()

--- a/tests/python/test_remote.py
+++ b/tests/python/test_remote.py
@@ -10,7 +10,6 @@ import numpy as np
 import pytest
 import tensogram
 
-
 # ---------------------------------------------------------------------------
 # Mock HTTP server with Range support
 # ---------------------------------------------------------------------------
@@ -209,14 +208,14 @@ class TestPythonRemoteDecode:
             remote_result = remote.file_decode_object(0, 0)
 
         with tensogram.TensogramFile.open(local_path) as local:
-            local_meta, local_objects = local.decode_message(0)
+            _local_meta, local_objects = local.decode_message(0)
 
         np.testing.assert_array_equal(remote_result["data"], local_objects[0][1])
 
 
 class TestPythonRemoteErrors:
     def test_invalid_url(self):
-        with pytest.raises(Exception):
+        with pytest.raises(OSError, match="invalid"):
             tensogram.TensogramFile.open("http://[invalid]/file.tgm")
 
     def test_open_remote_bad_storage_option_value(self, serve_tgm_bytes):
@@ -234,6 +233,8 @@ class TestPythonRemoteErrors:
         msg = encode_test_message([4])
         url = serve_tgm_bytes(msg)
 
-        with tensogram.TensogramFile.open(url) as f:
-            with pytest.raises(RuntimeError, match="iteration not supported"):
-                iter(f)
+        with (
+            tensogram.TensogramFile.open(url) as f,
+            pytest.raises(RuntimeError, match="iteration not supported"),
+        ):
+            iter(f)


### PR DESCRIPTION
## Summary
Replace the per-call `block_on_thread` pattern (new OS thread + new tokio runtime for every remote I/O call) with a shared process-wide runtime, add native async methods when both `remote` and `async` features are enabled, and introduce descriptor-only reads that avoid downloading full data frames just to extract metadata.
## Changes
### Shared Tokio Runtime
- `block_on_thread` replaced with `OnceLock<Result<Runtime, String>>` + `get_or_init` (race-free, no leaks, closure runs exactly once)
- `block_on_shared()` detects calling context via `Handle::try_current()`:
  - **Not in async context** (Python, CLI): direct `handle.block_on()`, zero thread creation
  - **Inside async context** (`#[tokio::test]`, server handlers): scoped thread that calls `handle.block_on()` to avoid nested-runtime panics
- `tokio/rt-multi-thread` feature gated to `remote` only — `async`-only users don't pay for it
- Shared runtime uses 2 worker threads, named `tensogram-remote-io`
### Descriptor-Only Reads
- `read_descriptor_only()` fetches only the CBOR descriptor from data object frames without downloading the payload
- Frames ≤ 64 KB: read the whole frame (fewer round-trips)
- Frames > 64 KB: read frame header (16 B) + footer (12 B) + CBOR region
- CBOR-after-payload: exact bounds known from `cbor_offset` → single read
- CBOR-before-payload: retry-on-truncation starting at 8 KB, doubling up to `max_cbor_len`
### Native Async Path
- Full async methods on `RemoteBackend` behind `cfg(feature = "async")`: `open_async`, `get_range_async`, `scan_messages_async`, `ensure_layout_async`, `read_metadata_async`, `read_descriptors_async`, `read_object_async`, `read_descriptor_only_async`
- Sync parsing helpers (`parse_header_frames`, `parse_footer_frames`) shared between sync and async paths — no duplication of frame parsing logic
- `TensogramFile` async methods:
  - `decode_metadata_async`, `decode_descriptors_async`, `decode_object_async` gated on `async` feature only (work for both local and remote backends)
  - `open_source_async`, `open_remote_async` gated on `remote + async`
  - `read_message_async` made remote-aware with inner `cfg(feature = "remote")` guard
### Documentation
- Updated `docs/src/guide/remote-access.md`: removed "thread-per-request" limitation, added Shared Runtime / Async API / Descriptor-Only Reads sections, added "sequential async access" limitation
- Marked remote 4 as complete in `plans/TODO.md`
## Tests
11 new tests (27 total remote), zero `.unwrap()` anywhere:
| Test | What it covers |
|------|---------------|
| `test_shared_runtime_concurrent_reads` | 4 threads reading simultaneously via shared runtime |
| `test_shared_runtime_from_sync_context` | Plain OS thread (non-tokio) exercises the fast path |
| `test_descriptor_only_matches_full_read` | Remote descriptors == local `decode_descriptors` |
| `test_async_remote_open_and_metadata` | Async open + metadata read |
| `test_async_remote_decode_object` | Async object decode |
| `test_async_remote_decode_descriptors` | Async descriptor read |
| `test_async_vs_sync_parity` | Sync and async produce identical bytes |
| `test_async_remote_read_message` | Full message roundtrip |
| `test_async_remote_streaming_message` | Footer-indexed streaming message |
| `test_async_remote_object_out_of_range` | Error path |
| `test_async_remote_message_index_out_of_range` | Error path |


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/dev-section/tensogram/pull-requests/PR-30
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->