### PR TITLE
feat: async Python bindings with batched remote I/O

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,10 +109,11 @@ jobs:
           uv python install 3.13
           uv venv .venv --python 3.13
           source .venv/bin/activate
-          uv pip install maturin pytest numpy ruff
+          uv pip install maturin pytest pytest-asyncio numpy ruff
           cd crates/tensogram-python && maturin develop && cd ../..
           ruff check --config crates/tensogram-python/pyproject.toml tests/python/
           python -m pytest tests/python/ -v
+          cargo check --manifest-path crates/tensogram-python/Cargo.toml --no-default-features
 
       - name: Cleanup
         if: always()
@@ -152,7 +153,7 @@ jobs:
           uv python install cpython-3.13+freethreaded
           uv venv .venv --python python3.13t
           source .venv/bin/activate
-          uv pip install maturin pytest "numpy>=2.1"
+          uv pip install maturin pytest pytest-asyncio "numpy>=2.1"
           python -c "import sys; assert not sys._is_gil_enabled(), 'GIL should be disabled'"
           cd crates/tensogram-python && maturin develop --release && cd ../..
           python -m pytest tests/python/ -v

--- a/crates/tensogram-core/src/file.rs
+++ b/crates/tensogram-core/src/file.rs
@@ -1137,7 +1137,7 @@ mod tests {
         }
 
         // Open with mmap and try to append
-        let mmap_file = TensogramFile::open_mmap(&path)?;
+        let mut mmap_file = TensogramFile::open_mmap(&path)?;
         let meta = make_global_meta();
         let desc = make_descriptor(vec![4]);
         let data = vec![0u8; 16];

--- a/crates/tensogram-core/src/file.rs
+++ b/crates/tensogram-core/src/file.rs
@@ -370,6 +370,39 @@ impl TensogramFile {
         }
     }
 
+    #[cfg(feature = "remote")]
+    pub fn decode_range_batch(
+        &self,
+        msg_indices: &[usize],
+        obj_idx: usize,
+        ranges: &[(u64, u64)],
+        options: &DecodeOptions,
+    ) -> Result<Vec<(DataObjectDescriptor, Vec<Vec<u8>>)>> {
+        match &self.backend {
+            Backend::Remote(remote) => {
+                remote.read_range_batch(msg_indices, obj_idx, ranges, options)
+            }
+            _ => Err(TensogramError::Io(std::io::Error::other(
+                "batch range decode requires a remote backend",
+            ))),
+        }
+    }
+
+    #[cfg(feature = "remote")]
+    pub fn decode_object_batch(
+        &self,
+        msg_indices: &[usize],
+        obj_idx: usize,
+        options: &DecodeOptions,
+    ) -> Result<Vec<(GlobalMetadata, DataObjectDescriptor, Vec<u8>)>> {
+        match &self.backend {
+            Backend::Remote(remote) => remote.read_object_batch(msg_indices, obj_idx, options),
+            _ => Err(TensogramError::Io(std::io::Error::other(
+                "batch object decode requires a remote backend",
+            ))),
+        }
+    }
+
     pub fn decode_range(
         &self,
         msg_idx: usize,
@@ -430,7 +463,32 @@ impl TensogramFile {
     }
 
     #[cfg(feature = "async")]
-    pub async fn read_message_async(&mut self, index: usize) -> Result<Vec<u8>> {
+    pub async fn message_count_async(&self) -> Result<usize> {
+        #[cfg(feature = "remote")]
+        if let Backend::Remote(remote) = &self.backend {
+            return remote.message_count_async().await;
+        }
+
+        if self.message_offsets.get().is_none() {
+            let p = self.local_path()?.clone();
+            let offsets = tokio::task::spawn_blocking(move || {
+                let mut file = fs::File::open(&p)?;
+                framing::scan_file(&mut file)
+            })
+            .await
+            .map_err(|e| TensogramError::Io(std::io::Error::other(e)))??;
+            let _ = self.message_offsets.set(offsets);
+        }
+
+        Ok(self
+            .message_offsets
+            .get()
+            .ok_or_else(|| TensogramError::Framing("scan result missing".to_string()))?
+            .len())
+    }
+
+    #[cfg(feature = "async")]
+    pub async fn read_message_async(&self, index: usize) -> Result<Vec<u8>> {
         #[cfg(feature = "remote")]
         if let Backend::Remote(remote) = &self.backend {
             return remote.read_message_async(index).await;
@@ -463,7 +521,7 @@ impl TensogramFile {
 
     #[cfg(feature = "async")]
     pub async fn decode_message_async(
-        &mut self,
+        &self,
         index: usize,
         options: &DecodeOptions,
     ) -> Result<(GlobalMetadata, Vec<DecodedObject>)> {
@@ -498,9 +556,9 @@ impl TensogramFile {
     }
 
     #[cfg(feature = "async")]
-    pub async fn decode_metadata_async(&mut self, msg_idx: usize) -> Result<GlobalMetadata> {
+    pub async fn decode_metadata_async(&self, msg_idx: usize) -> Result<GlobalMetadata> {
         #[cfg(feature = "remote")]
-        if let Backend::Remote(remote) = &mut self.backend {
+        if let Backend::Remote(remote) = &self.backend {
             return remote.read_metadata_async(msg_idx).await;
         }
 
@@ -512,11 +570,11 @@ impl TensogramFile {
 
     #[cfg(feature = "async")]
     pub async fn decode_descriptors_async(
-        &mut self,
+        &self,
         msg_idx: usize,
     ) -> Result<(GlobalMetadata, Vec<DataObjectDescriptor>)> {
         #[cfg(feature = "remote")]
-        if let Backend::Remote(remote) = &mut self.backend {
+        if let Backend::Remote(remote) = &self.backend {
             return remote.read_descriptors_async(msg_idx).await;
         }
 
@@ -528,13 +586,13 @@ impl TensogramFile {
 
     #[cfg(feature = "async")]
     pub async fn decode_object_async(
-        &mut self,
+        &self,
         msg_idx: usize,
         obj_idx: usize,
         options: &DecodeOptions,
     ) -> Result<(GlobalMetadata, DataObjectDescriptor, Vec<u8>)> {
         #[cfg(feature = "remote")]
-        if let Backend::Remote(remote) = &mut self.backend {
+        if let Backend::Remote(remote) = &self.backend {
             return remote.read_object_async(msg_idx, obj_idx, options).await;
         }
 
@@ -543,6 +601,72 @@ impl TensogramFile {
         tokio::task::spawn_blocking(move || decode::decode_object(&msg, obj_idx, &opts))
             .await
             .map_err(|e| TensogramError::Io(std::io::Error::other(e)))?
+    }
+
+    #[cfg(feature = "async")]
+    pub async fn decode_range_async(
+        &self,
+        msg_idx: usize,
+        obj_idx: usize,
+        ranges: &[(u64, u64)],
+        options: &DecodeOptions,
+    ) -> Result<(DataObjectDescriptor, Vec<Vec<u8>>)> {
+        #[cfg(feature = "remote")]
+        if let Backend::Remote(remote) = &self.backend {
+            return remote
+                .read_range_async(msg_idx, obj_idx, ranges, options)
+                .await;
+        }
+
+        let msg = self.read_message_async(msg_idx).await?;
+        let ranges = ranges.to_vec();
+        let opts = options.clone();
+        tokio::task::spawn_blocking(move || decode::decode_range(&msg, obj_idx, &ranges, &opts))
+            .await
+            .map_err(|e| TensogramError::Io(std::io::Error::other(e)))?
+    }
+
+    #[cfg(all(feature = "remote", feature = "async"))]
+    pub async fn prefetch_layouts_async(&self, msg_indices: &[usize]) -> Result<()> {
+        if let Backend::Remote(remote) = &self.backend {
+            return remote.ensure_all_layouts_batch_async(msg_indices).await;
+        }
+        Ok(())
+    }
+
+    #[cfg(all(feature = "remote", feature = "async"))]
+    pub async fn decode_object_batch_async(
+        &self,
+        msg_indices: &[usize],
+        obj_idx: usize,
+        options: &DecodeOptions,
+    ) -> Result<Vec<(GlobalMetadata, DataObjectDescriptor, Vec<u8>)>> {
+        if let Backend::Remote(remote) = &self.backend {
+            return remote
+                .read_object_batch_async(msg_indices, obj_idx, options)
+                .await;
+        }
+        Err(TensogramError::Io(std::io::Error::other(
+            "batch object decode requires a remote backend",
+        )))
+    }
+
+    #[cfg(all(feature = "remote", feature = "async"))]
+    pub async fn decode_range_batch_async(
+        &self,
+        msg_indices: &[usize],
+        obj_idx: usize,
+        ranges: &[(u64, u64)],
+        options: &DecodeOptions,
+    ) -> Result<Vec<(DataObjectDescriptor, Vec<Vec<u8>>)>> {
+        if let Backend::Remote(remote) = &self.backend {
+            return remote
+                .read_range_batch_async(msg_indices, obj_idx, ranges, options)
+                .await;
+        }
+        Err(TensogramError::Io(std::io::Error::other(
+            "batch range decode requires a remote backend",
+        )))
     }
 }
 
@@ -853,7 +977,7 @@ mod tests {
             &EncodeOptions::default(),
         )?;
 
-        let mut async_file = TensogramFile::open_async(&path).await?;
+        let async_file = TensogramFile::open_async(&path).await?;
         assert_eq!(async_file.message_count()?, 2);
 
         let msg0 = async_file.read_message_async(0).await?;
@@ -887,7 +1011,7 @@ mod tests {
         let sync_file = TensogramFile::open(&path)?;
         let sync_msg = sync_file.read_message(0)?;
 
-        let mut async_file = TensogramFile::open_async(&path).await?;
+        let async_file = TensogramFile::open_async(&path).await?;
         let async_msg = async_file.read_message_async(0).await?;
 
         assert_eq!(sync_msg, async_msg);
@@ -1013,7 +1137,7 @@ mod tests {
         }
 
         // Open with mmap and try to append
-        let mut mmap_file = TensogramFile::open_mmap(&path)?;
+        let mmap_file = TensogramFile::open_mmap(&path)?;
         let meta = make_global_meta();
         let desc = make_descriptor(vec![4]);
         let data = vec![0u8; 16];
@@ -1072,7 +1196,7 @@ mod tests {
             &EncodeOptions::default(),
         )?;
 
-        let mut async_file = TensogramFile::open_async(&path).await?;
+        let async_file = TensogramFile::open_async(&path).await?;
         let result = async_file.read_message_async(5).await;
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
@@ -1100,7 +1224,7 @@ mod tests {
             &EncodeOptions::default(),
         )?;
 
-        let mut async_file = TensogramFile::open_async(&path).await?;
+        let async_file = TensogramFile::open_async(&path).await?;
         let result = async_file.decode_metadata_async(10).await;
         assert!(result.is_err());
         Ok(())
@@ -1123,7 +1247,7 @@ mod tests {
             &EncodeOptions::default(),
         )?;
 
-        let mut async_file = TensogramFile::open_async(&path).await?;
+        let async_file = TensogramFile::open_async(&path).await?;
         let (decoded_meta, descriptors) = async_file.decode_descriptors_async(0).await?;
         assert_eq!(decoded_meta.version, 2);
         assert_eq!(descriptors.len(), 1);
@@ -1147,7 +1271,7 @@ mod tests {
             &EncodeOptions::default(),
         )?;
 
-        let mut async_file = TensogramFile::open_async(&path).await?;
+        let async_file = TensogramFile::open_async(&path).await?;
         let (decoded_meta, decoded_desc, decoded_data) = async_file
             .decode_object_async(0, 0, &DecodeOptions::default())
             .await?;

--- a/crates/tensogram-core/src/remote.rs
+++ b/crates/tensogram-core/src/remote.rs
@@ -1791,6 +1791,9 @@ impl RemoteBackend {
     }
 
     pub(crate) async fn ensure_all_layouts_batch_async(&self, msg_indices: &[usize]) -> Result<()> {
+        if msg_indices.is_empty() {
+            return Ok(());
+        }
         let max_idx = msg_indices.iter().copied().max().unwrap_or(0);
         loop {
             let (need_scan, scan_complete) = {

--- a/crates/tensogram-core/src/remote.rs
+++ b/crates/tensogram-core/src/remote.rs
@@ -933,6 +933,60 @@ impl RemoteBackend {
         }
     }
 
+    pub(crate) fn read_range_batch(
+        &self,
+        msg_indices: &[usize],
+        obj_idx: usize,
+        ranges: &[(u64, u64)],
+        options: &DecodeOptions,
+    ) -> Result<Vec<(DataObjectDescriptor, Vec<Vec<u8>>)>> {
+        for &msg_idx in msg_indices {
+            let mut state = self
+                .state
+                .lock()
+                .map_err(|_| TensogramError::Remote("remote state lock poisoned".to_string()))?;
+            self.ensure_layout_eager_locked(&mut state, msg_idx)?;
+        }
+
+        let mut byte_ranges = Vec::with_capacity(msg_indices.len());
+        {
+            let state = self
+                .state
+                .lock()
+                .map_err(|_| TensogramError::Remote("remote state lock poisoned".to_string()))?;
+            for &msg_idx in msg_indices {
+                let layout = &state.layouts[msg_idx];
+                if let Some(ref index) = layout.index {
+                    Self::validate_index_access(index, obj_idx)?;
+                    byte_ranges.push(Self::checked_frame_range(
+                        layout.offset,
+                        layout.length,
+                        index.offsets[obj_idx],
+                        index.lengths[obj_idx],
+                    )?);
+                } else {
+                    return Err(TensogramError::Remote(format!(
+                        "message {} has no index frame; batch requires indexed messages",
+                        msg_idx
+                    )));
+                }
+            }
+        }
+
+        let store = self.store.clone();
+        let path = self.path.clone();
+        let all_bytes =
+            block_on_shared(async move { store.get_ranges(&path, &byte_ranges).await })?;
+
+        let mut results = Vec::with_capacity(msg_indices.len());
+        for frame_bytes in &all_bytes {
+            let (desc, payload, _consumed) = framing::decode_data_object_frame(frame_bytes)?;
+            let parts = crate::decode::decode_range_from_payload(&desc, payload, ranges, options)?;
+            results.push((desc, parts));
+        }
+        Ok(results)
+    }
+
     pub(crate) fn read_range(
         &self,
         msg_idx: usize,
@@ -1527,6 +1581,21 @@ impl RemoteBackend {
         Self::parse_footer_frames(&mut state, msg_idx, &footer_bytes)
     }
 
+    pub(crate) async fn message_count_async(&self) -> Result<usize> {
+        loop {
+            let done = {
+                let state = self.lock_state()?;
+                state.scan_complete
+            };
+            if done {
+                break;
+            }
+            self.scan_and_discover_next_async().await?;
+        }
+        let state = self.lock_state()?;
+        Ok(state.layouts.len())
+    }
+
     pub(crate) async fn read_message_async(&self, msg_idx: usize) -> Result<Vec<u8>> {
         self.ensure_message_async(msg_idx).await?;
         let (offset, length) = {
@@ -1718,6 +1787,338 @@ impl RemoteBackend {
         } else {
             let msg_bytes = self.read_message_async(msg_idx).await?;
             crate::decode::decode_object(&msg_bytes, obj_idx, options)
+        }
+    }
+
+    pub(crate) async fn ensure_all_layouts_batch_async(&self, msg_indices: &[usize]) -> Result<()> {
+        let max_idx = msg_indices.iter().copied().max().unwrap_or(0);
+        loop {
+            let (need_scan, scan_complete) = {
+                let state = self.lock_state()?;
+                (state.layouts.len() <= max_idx, state.scan_complete)
+            };
+            if !need_scan || scan_complete {
+                break;
+            }
+            self.scan_and_discover_next_async().await?;
+        }
+
+        {
+            let state = self.lock_state()?;
+            for &idx in msg_indices {
+                if idx >= state.layouts.len() {
+                    return Err(TensogramError::Framing(format!(
+                        "message index {} out of range (count={})",
+                        idx,
+                        state.layouts.len()
+                    )));
+                }
+            }
+        }
+
+        // Phase 2: find which messages still need layout discovery.
+        let needs_layout: Vec<usize> = {
+            let state = self.lock_state()?;
+            msg_indices
+                .iter()
+                .copied()
+                .filter(|&idx| {
+                    state
+                        .layouts
+                        .get(idx)
+                        .is_none_or(|l| l.global_metadata.is_none() || l.index.is_none())
+                })
+                .collect()
+        };
+
+        if needs_layout.is_empty() {
+            return Ok(());
+        }
+
+        // Phase 3: compute header/footer byte ranges for all cold messages.
+        let mut fetch_ranges: Vec<Range<u64>> = Vec::new();
+        let mut fetch_map: Vec<(usize, bool)> = Vec::new(); // (msg_idx, is_header)
+        {
+            let state = self.lock_state()?;
+            for &msg_idx in &needs_layout {
+                let layout = &state.layouts[msg_idx];
+                let flags = layout.preamble.flags;
+                if flags.has(MessageFlags::HEADER_METADATA) && flags.has(MessageFlags::HEADER_INDEX)
+                {
+                    let chunk_size = layout.length.min(256 * 1024);
+                    fetch_ranges.push(layout.offset..layout.offset + chunk_size);
+                    fetch_map.push((msg_idx, true));
+                } else if flags.has(MessageFlags::FOOTER_METADATA)
+                    && flags.has(MessageFlags::FOOTER_INDEX)
+                {
+                    let pa_offset = layout
+                        .offset
+                        .checked_add(layout.length)
+                        .and_then(|end| end.checked_sub(POSTAMBLE_SIZE as u64))
+                        .ok_or_else(|| {
+                            TensogramError::Remote("postamble offset overflow".to_string())
+                        })?;
+                    fetch_ranges.push(pa_offset..pa_offset + POSTAMBLE_SIZE as u64);
+                    fetch_map.push((msg_idx, false));
+                } else {
+                    return Err(TensogramError::Remote(
+                        "remote batch requires header-indexed or footer-indexed messages"
+                            .to_string(),
+                    ));
+                }
+            }
+        }
+
+        // Phase 4: batched HTTP fetch for all layout headers.
+        let all_bytes = self
+            .store
+            .get_ranges(&self.path, &fetch_ranges)
+            .await
+            .map_err(|e| TensogramError::Remote(e.to_string()))?;
+
+        // Phase 5: parse header layouts.
+        let mut footer_fetches: Vec<(usize, Range<u64>)> = Vec::new();
+        {
+            let mut state = self.lock_state()?;
+            for (bytes, &(msg_idx, is_header)) in all_bytes.iter().zip(fetch_map.iter()) {
+                if state.layouts[msg_idx].global_metadata.is_some()
+                    && state.layouts[msg_idx].index.is_some()
+                {
+                    continue;
+                }
+                if is_header {
+                    Self::parse_header_frames(&mut state, msg_idx, bytes)?;
+                } else {
+                    let postamble = Postamble::read_from(bytes)?;
+                    let layout = &state.layouts[msg_idx];
+                    let footer_start = layout
+                        .offset
+                        .checked_add(postamble.first_footer_offset)
+                        .ok_or_else(|| {
+                            TensogramError::Remote("footer offset overflow".to_string())
+                        })?;
+                    let pa_offset = layout
+                        .offset
+                        .checked_add(layout.length)
+                        .and_then(|end| end.checked_sub(POSTAMBLE_SIZE as u64))
+                        .ok_or_else(|| {
+                            TensogramError::Remote("postamble offset overflow".to_string())
+                        })?;
+                    footer_fetches.push((msg_idx, footer_start..pa_offset));
+                }
+            }
+        }
+
+        // Phase 6: batched footer fetch if any footer-indexed messages.
+        if !footer_fetches.is_empty() {
+            let footer_ranges: Vec<Range<u64>> =
+                footer_fetches.iter().map(|(_, r)| r.clone()).collect();
+            let footer_bytes = self
+                .store
+                .get_ranges(&self.path, &footer_ranges)
+                .await
+                .map_err(|e| TensogramError::Remote(e.to_string()))?;
+            let mut state = self.lock_state()?;
+            for (bytes, &(msg_idx, _)) in footer_bytes.iter().zip(footer_fetches.iter()) {
+                if state.layouts[msg_idx].global_metadata.is_some()
+                    && state.layouts[msg_idx].index.is_some()
+                {
+                    continue;
+                }
+                Self::parse_footer_frames(&mut state, msg_idx, bytes)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(crate) async fn read_object_batch_async(
+        &self,
+        msg_indices: &[usize],
+        obj_idx: usize,
+        options: &DecodeOptions,
+    ) -> Result<Vec<(GlobalMetadata, DataObjectDescriptor, Vec<u8>)>> {
+        self.ensure_all_layouts_batch_async(msg_indices).await?;
+
+        let mut byte_ranges = Vec::with_capacity(msg_indices.len());
+        let mut metas = Vec::with_capacity(msg_indices.len());
+        {
+            let state = self.lock_state()?;
+            for &msg_idx in msg_indices {
+                let layout = &state.layouts[msg_idx];
+                if let Some(ref index) = layout.index {
+                    Self::validate_index_access(index, obj_idx)?;
+                    byte_ranges.push(Self::checked_frame_range(
+                        layout.offset,
+                        layout.length,
+                        index.offsets[obj_idx],
+                        index.lengths[obj_idx],
+                    )?);
+                    metas.push(layout.global_metadata.clone().ok_or_else(|| {
+                        TensogramError::Remote("metadata not cached".to_string())
+                    })?);
+                } else {
+                    return Err(TensogramError::Remote(format!(
+                        "message {} has no index frame; batch decode requires indexed messages",
+                        msg_idx
+                    )));
+                }
+            }
+        }
+
+        let all_bytes = self
+            .store
+            .get_ranges(&self.path, &byte_ranges)
+            .await
+            .map_err(|e| TensogramError::Remote(e.to_string()))?;
+
+        let mut results = Vec::with_capacity(msg_indices.len());
+        for (frame_bytes, meta) in all_bytes.iter().zip(metas) {
+            let (desc, payload, _consumed) = framing::decode_data_object_frame(frame_bytes)?;
+            let decoded = crate::decode::decode_single_object(&desc, payload, options)?;
+            results.push((meta, desc, decoded));
+        }
+        Ok(results)
+    }
+
+    pub(crate) fn read_object_batch(
+        &self,
+        msg_indices: &[usize],
+        obj_idx: usize,
+        options: &DecodeOptions,
+    ) -> Result<Vec<(GlobalMetadata, DataObjectDescriptor, Vec<u8>)>> {
+        for &msg_idx in msg_indices {
+            let mut state = self
+                .state
+                .lock()
+                .map_err(|_| TensogramError::Remote("remote state lock poisoned".to_string()))?;
+            self.ensure_layout_eager_locked(&mut state, msg_idx)?;
+        }
+
+        let mut byte_ranges = Vec::with_capacity(msg_indices.len());
+        let mut metas = Vec::with_capacity(msg_indices.len());
+        {
+            let state = self
+                .state
+                .lock()
+                .map_err(|_| TensogramError::Remote("remote state lock poisoned".to_string()))?;
+            for &msg_idx in msg_indices {
+                let layout = &state.layouts[msg_idx];
+                if let Some(ref index) = layout.index {
+                    Self::validate_index_access(index, obj_idx)?;
+                    byte_ranges.push(Self::checked_frame_range(
+                        layout.offset,
+                        layout.length,
+                        index.offsets[obj_idx],
+                        index.lengths[obj_idx],
+                    )?);
+                    metas.push(layout.global_metadata.clone().ok_or_else(|| {
+                        TensogramError::Remote("metadata not cached".to_string())
+                    })?);
+                } else {
+                    return Err(TensogramError::Remote(format!(
+                        "message {} has no index frame; batch decode requires indexed messages",
+                        msg_idx
+                    )));
+                }
+            }
+        }
+
+        let store = self.store.clone();
+        let path = self.path.clone();
+        let all_bytes =
+            block_on_shared(async move { store.get_ranges(&path, &byte_ranges).await })?;
+
+        let mut results = Vec::with_capacity(msg_indices.len());
+        for (frame_bytes, meta) in all_bytes.iter().zip(metas) {
+            let (desc, payload, _consumed) = framing::decode_data_object_frame(frame_bytes)?;
+            let decoded = crate::decode::decode_single_object(&desc, payload, options)?;
+            results.push((meta, desc, decoded));
+        }
+        Ok(results)
+    }
+
+    pub(crate) async fn read_range_batch_async(
+        &self,
+        msg_indices: &[usize],
+        obj_idx: usize,
+        ranges: &[(u64, u64)],
+        options: &DecodeOptions,
+    ) -> Result<Vec<(DataObjectDescriptor, Vec<Vec<u8>>)>> {
+        // 1. Batch-discover all layouts (scan + batched header/footer fetch).
+        self.ensure_all_layouts_batch_async(msg_indices).await?;
+
+        // 2. Compute byte ranges for each message's data object frame.
+        let mut byte_ranges = Vec::with_capacity(msg_indices.len());
+        {
+            let state = self.lock_state()?;
+            for &msg_idx in msg_indices {
+                let layout = &state.layouts[msg_idx];
+                if let Some(ref index) = layout.index {
+                    Self::validate_index_access(index, obj_idx)?;
+                    let range = Self::checked_frame_range(
+                        layout.offset,
+                        layout.length,
+                        index.offsets[obj_idx],
+                        index.lengths[obj_idx],
+                    )?;
+                    byte_ranges.push(range);
+                } else {
+                    return Err(TensogramError::Remote(format!(
+                        "message {} has no index frame; batch range decode requires indexed messages",
+                        msg_idx
+                    )));
+                }
+            }
+        }
+
+        // 3. Single batched HTTP fetch for all frames.
+        let all_bytes = self
+            .store
+            .get_ranges(&self.path, &byte_ranges)
+            .await
+            .map_err(|e| TensogramError::Remote(e.to_string()))?;
+
+        // 4. Decode each frame locally.
+        let mut results = Vec::with_capacity(msg_indices.len());
+        for frame_bytes in &all_bytes {
+            let (desc, payload, _consumed) = framing::decode_data_object_frame(frame_bytes)?;
+            let parts = crate::decode::decode_range_from_payload(&desc, payload, ranges, options)?;
+            results.push((desc, parts));
+        }
+        Ok(results)
+    }
+
+    pub(crate) async fn read_range_async(
+        &self,
+        msg_idx: usize,
+        obj_idx: usize,
+        ranges: &[(u64, u64)],
+        options: &DecodeOptions,
+    ) -> Result<(DataObjectDescriptor, Vec<Vec<u8>>)> {
+        self.ensure_layout_eager_async(msg_idx).await?;
+        let layout = {
+            let state = self.lock_state()?;
+            state.layouts[msg_idx].clone()
+        };
+        let msg_offset = layout.offset;
+
+        if let Some(ref index) = layout.index {
+            Self::validate_index_access(index, obj_idx)?;
+
+            let range = Self::checked_frame_range(
+                msg_offset,
+                layout.length,
+                index.offsets[obj_idx],
+                index.lengths[obj_idx],
+            )?;
+            let frame_bytes = self.get_range_async(range).await?;
+            let (desc, payload, _consumed) = framing::decode_data_object_frame(&frame_bytes)?;
+            let parts = crate::decode::decode_range_from_payload(&desc, payload, ranges, options)?;
+            Ok((desc, parts))
+        } else {
+            let msg_bytes = self.read_message_async(msg_idx).await?;
+            crate::decode::decode_range(&msg_bytes, obj_idx, ranges, options)
         }
     }
 }

--- a/crates/tensogram-core/src/remote.rs
+++ b/crates/tensogram-core/src/remote.rs
@@ -987,6 +987,63 @@ impl RemoteBackend {
         Ok(results)
     }
 
+    pub(crate) fn read_object_batch(
+        &self,
+        msg_indices: &[usize],
+        obj_idx: usize,
+        options: &DecodeOptions,
+    ) -> Result<Vec<(GlobalMetadata, DataObjectDescriptor, Vec<u8>)>> {
+        for &msg_idx in msg_indices {
+            let mut state = self
+                .state
+                .lock()
+                .map_err(|_| TensogramError::Remote("remote state lock poisoned".to_string()))?;
+            self.ensure_layout_eager_locked(&mut state, msg_idx)?;
+        }
+
+        let mut byte_ranges = Vec::with_capacity(msg_indices.len());
+        let mut metas = Vec::with_capacity(msg_indices.len());
+        {
+            let state = self
+                .state
+                .lock()
+                .map_err(|_| TensogramError::Remote("remote state lock poisoned".to_string()))?;
+            for &msg_idx in msg_indices {
+                let layout = &state.layouts[msg_idx];
+                if let Some(ref index) = layout.index {
+                    Self::validate_index_access(index, obj_idx)?;
+                    byte_ranges.push(Self::checked_frame_range(
+                        layout.offset,
+                        layout.length,
+                        index.offsets[obj_idx],
+                        index.lengths[obj_idx],
+                    )?);
+                    metas.push(layout.global_metadata.clone().ok_or_else(|| {
+                        TensogramError::Remote("metadata not cached".to_string())
+                    })?);
+                } else {
+                    return Err(TensogramError::Remote(format!(
+                        "message {} has no index frame; batch decode requires indexed messages",
+                        msg_idx
+                    )));
+                }
+            }
+        }
+
+        let store = self.store.clone();
+        let path = self.path.clone();
+        let all_bytes =
+            block_on_shared(async move { store.get_ranges(&path, &byte_ranges).await })?;
+
+        let mut results = Vec::with_capacity(msg_indices.len());
+        for (frame_bytes, meta) in all_bytes.iter().zip(metas) {
+            let (desc, payload, _consumed) = framing::decode_data_object_frame(frame_bytes)?;
+            let decoded = crate::decode::decode_single_object(&desc, payload, options)?;
+            results.push((meta, desc, decoded));
+        }
+        Ok(results)
+    }
+
     pub(crate) fn read_range(
         &self,
         msg_idx: usize,
@@ -1974,63 +2031,6 @@ impl RemoteBackend {
             .get_ranges(&self.path, &byte_ranges)
             .await
             .map_err(|e| TensogramError::Remote(e.to_string()))?;
-
-        let mut results = Vec::with_capacity(msg_indices.len());
-        for (frame_bytes, meta) in all_bytes.iter().zip(metas) {
-            let (desc, payload, _consumed) = framing::decode_data_object_frame(frame_bytes)?;
-            let decoded = crate::decode::decode_single_object(&desc, payload, options)?;
-            results.push((meta, desc, decoded));
-        }
-        Ok(results)
-    }
-
-    pub(crate) fn read_object_batch(
-        &self,
-        msg_indices: &[usize],
-        obj_idx: usize,
-        options: &DecodeOptions,
-    ) -> Result<Vec<(GlobalMetadata, DataObjectDescriptor, Vec<u8>)>> {
-        for &msg_idx in msg_indices {
-            let mut state = self
-                .state
-                .lock()
-                .map_err(|_| TensogramError::Remote("remote state lock poisoned".to_string()))?;
-            self.ensure_layout_eager_locked(&mut state, msg_idx)?;
-        }
-
-        let mut byte_ranges = Vec::with_capacity(msg_indices.len());
-        let mut metas = Vec::with_capacity(msg_indices.len());
-        {
-            let state = self
-                .state
-                .lock()
-                .map_err(|_| TensogramError::Remote("remote state lock poisoned".to_string()))?;
-            for &msg_idx in msg_indices {
-                let layout = &state.layouts[msg_idx];
-                if let Some(ref index) = layout.index {
-                    Self::validate_index_access(index, obj_idx)?;
-                    byte_ranges.push(Self::checked_frame_range(
-                        layout.offset,
-                        layout.length,
-                        index.offsets[obj_idx],
-                        index.lengths[obj_idx],
-                    )?);
-                    metas.push(layout.global_metadata.clone().ok_or_else(|| {
-                        TensogramError::Remote("metadata not cached".to_string())
-                    })?);
-                } else {
-                    return Err(TensogramError::Remote(format!(
-                        "message {} has no index frame; batch decode requires indexed messages",
-                        msg_idx
-                    )));
-                }
-            }
-        }
-
-        let store = self.store.clone();
-        let path = self.path.clone();
-        let all_bytes =
-            block_on_shared(async move { store.get_ranges(&path, &byte_ranges).await })?;
 
         let mut results = Vec::with_capacity(msg_indices.len());
         for (frame_bytes, meta) in all_bytes.iter().zip(metas) {

--- a/crates/tensogram-core/src/remote.rs
+++ b/crates/tensogram-core/src/remote.rs
@@ -940,20 +940,15 @@ impl RemoteBackend {
         ranges: &[(u64, u64)],
         options: &DecodeOptions,
     ) -> Result<Vec<(DataObjectDescriptor, Vec<Vec<u8>>)>> {
-        for &msg_idx in msg_indices {
+        let mut byte_ranges = Vec::with_capacity(msg_indices.len());
+        {
             let mut state = self
                 .state
                 .lock()
                 .map_err(|_| TensogramError::Remote("remote state lock poisoned".to_string()))?;
-            self.ensure_layout_eager_locked(&mut state, msg_idx)?;
-        }
-
-        let mut byte_ranges = Vec::with_capacity(msg_indices.len());
-        {
-            let state = self
-                .state
-                .lock()
-                .map_err(|_| TensogramError::Remote("remote state lock poisoned".to_string()))?;
+            for &msg_idx in msg_indices {
+                self.ensure_layout_eager_locked(&mut state, msg_idx)?;
+            }
             for &msg_idx in msg_indices {
                 let layout = &state.layouts[msg_idx];
                 if let Some(ref index) = layout.index {
@@ -993,21 +988,16 @@ impl RemoteBackend {
         obj_idx: usize,
         options: &DecodeOptions,
     ) -> Result<Vec<(GlobalMetadata, DataObjectDescriptor, Vec<u8>)>> {
-        for &msg_idx in msg_indices {
+        let mut byte_ranges = Vec::with_capacity(msg_indices.len());
+        let mut metas = Vec::with_capacity(msg_indices.len());
+        {
             let mut state = self
                 .state
                 .lock()
                 .map_err(|_| TensogramError::Remote("remote state lock poisoned".to_string()))?;
-            self.ensure_layout_eager_locked(&mut state, msg_idx)?;
-        }
-
-        let mut byte_ranges = Vec::with_capacity(msg_indices.len());
-        let mut metas = Vec::with_capacity(msg_indices.len());
-        {
-            let state = self
-                .state
-                .lock()
-                .map_err(|_| TensogramError::Remote("remote state lock poisoned".to_string()))?;
+            for &msg_idx in msg_indices {
+                self.ensure_layout_eager_locked(&mut state, msg_idx)?;
+            }
             for &msg_idx in msg_indices {
                 let layout = &state.layouts[msg_idx];
                 if let Some(ref index) = layout.index {

--- a/crates/tensogram-core/tests/remote_http.rs
+++ b/crates/tensogram-core/tests/remote_http.rs
@@ -860,7 +860,7 @@ async fn test_async_remote_open_and_metadata() -> Result<(), Box<dyn Error>> {
     let msg = encode_test_message(vec![4], 42)?;
     let server = MockServer::start(msg).await?;
 
-    let mut file = TensogramFile::open_source_async(server.url()).await?;
+    let file = TensogramFile::open_source_async(server.url()).await?;
     assert!(file.is_remote());
     assert_eq!(file.message_count()?, 1);
 
@@ -878,7 +878,7 @@ async fn test_async_remote_decode_object() -> Result<(), Box<dyn Error>> {
     let msg = encode::encode(&meta, &[(&desc, &data)], &EncodeOptions::default())?;
     let server = MockServer::start(msg).await?;
 
-    let mut file = TensogramFile::open_source_async(server.url()).await?;
+    let file = TensogramFile::open_source_async(server.url()).await?;
     let (decoded_meta, decoded_desc, decoded_data) = file
         .decode_object_async(0, 0, &DecodeOptions::default())
         .await?;
@@ -896,7 +896,7 @@ async fn test_async_remote_decode_descriptors() -> Result<(), Box<dyn Error>> {
     let msg = encode_multi_object_message(&shapes, &fills)?;
     let server = MockServer::start(msg).await?;
 
-    let mut file = TensogramFile::open_source_async(server.url()).await?;
+    let file = TensogramFile::open_source_async(server.url()).await?;
     let (meta, descriptors) = file.decode_descriptors_async(0).await?;
     assert_eq!(meta.version, 2);
     assert_eq!(descriptors.len(), 2);
@@ -918,7 +918,7 @@ async fn test_async_vs_sync_parity() -> Result<(), Box<dyn Error>> {
     let (sync_meta, sync_desc, sync_data) =
         sync_file.decode_object(0, 0, &DecodeOptions::default())?;
 
-    let mut async_file = TensogramFile::open_source_async(server.url()).await?;
+    let async_file = TensogramFile::open_source_async(server.url()).await?;
     let (async_meta, async_desc, async_data) = async_file
         .decode_object_async(0, 0, &DecodeOptions::default())
         .await?;
@@ -935,7 +935,7 @@ async fn test_async_remote_read_message() -> Result<(), Box<dyn Error>> {
     let msg = encode_test_message(vec![4], 42)?;
     let server = MockServer::start(msg.clone()).await?;
 
-    let mut file = TensogramFile::open_source_async(server.url()).await?;
+    let file = TensogramFile::open_source_async(server.url()).await?;
     let remote_msg = file.read_message_async(0).await?;
     assert_eq!(remote_msg, msg);
     Ok(())
@@ -947,7 +947,7 @@ async fn test_async_remote_streaming_message() -> Result<(), Box<dyn Error>> {
     let msg = encode_streaming_message(vec![4], 42)?;
     let server = MockServer::start(msg).await?;
 
-    let mut file = TensogramFile::open_source_async(server.url()).await?;
+    let file = TensogramFile::open_source_async(server.url()).await?;
     assert!(file.is_remote());
 
     let meta = file.decode_metadata_async(0).await?;
@@ -967,7 +967,7 @@ async fn test_async_remote_object_out_of_range() -> Result<(), Box<dyn Error>> {
     let msg = encode_test_message(vec![4], 42)?;
     let server = MockServer::start(msg).await?;
 
-    let mut file = TensogramFile::open_source_async(server.url()).await?;
+    let file = TensogramFile::open_source_async(server.url()).await?;
     let result = file
         .decode_object_async(0, 5, &DecodeOptions::default())
         .await;
@@ -981,7 +981,7 @@ async fn test_async_remote_message_index_out_of_range() -> Result<(), Box<dyn Er
     let msg = encode_test_message(vec![4], 42)?;
     let server = MockServer::start(msg).await?;
 
-    let mut file = TensogramFile::open_source_async(server.url()).await?;
+    let file = TensogramFile::open_source_async(server.url()).await?;
     let result = file.decode_metadata_async(5).await;
     assert!(result.is_err());
     Ok(())
@@ -999,7 +999,7 @@ async fn test_async_remote_multi_message_scan() -> Result<(), Box<dyn Error>> {
 
     let server = MockServer::start(combined).await?;
 
-    let mut file = TensogramFile::open_source_async(server.url()).await?;
+    let file = TensogramFile::open_source_async(server.url()).await?;
     assert_eq!(file.message_count()?, 2);
 
     let meta0 = file.decode_metadata_async(0).await?;
@@ -1021,7 +1021,7 @@ async fn test_async_eager_layout_combines_scan_and_discover() -> Result<(), Box<
     combined.extend_from_slice(&msg2);
     let server = MockServer::start(combined).await?;
 
-    let mut file = TensogramFile::open_source_async(server.url()).await?;
+    let file = TensogramFile::open_source_async(server.url()).await?;
     server.reset_count();
     let (_, desc, data) = file
         .decode_object_async(1, 0, &DecodeOptions::default())
@@ -1038,7 +1038,7 @@ async fn test_async_eager_layout_streaming_falls_back() -> Result<(), Box<dyn Er
     let msg = encode_streaming_message(vec![4], 42)?;
     let server = MockServer::start(msg).await?;
 
-    let mut file = TensogramFile::open_source_async(server.url()).await?;
+    let file = TensogramFile::open_source_async(server.url()).await?;
     server.reset_count();
     let (_, desc, data) = file
         .decode_object_async(0, 0, &DecodeOptions::default())
@@ -1059,7 +1059,7 @@ async fn test_async_descriptor_only_matches_full_read() -> Result<(), Box<dyn Er
     let msg = encode_multi_object_message(&shapes, &fills)?;
     let server = MockServer::start(msg.clone()).await?;
 
-    let mut file = TensogramFile::open_source_async(server.url()).await?;
+    let file = TensogramFile::open_source_async(server.url()).await?;
     let (_, remote_descs) = file.decode_descriptors_async(0).await?;
 
     let (_, local_descs) = tensogram_core::decode::decode_descriptors(&msg)?;
@@ -1089,7 +1089,7 @@ async fn test_async_descriptor_only_large_frame_exercises_fast_path() -> Result<
     );
     let server = MockServer::start(msg.clone()).await?;
 
-    let mut file = TensogramFile::open_source_async(server.url()).await?;
+    let file = TensogramFile::open_source_async(server.url()).await?;
     let (_, remote_descs) = file.decode_descriptors_async(0).await?;
     let (_, local_descs) = tensogram_core::decode::decode_descriptors(&msg)?;
 
@@ -1169,7 +1169,7 @@ async fn test_async_remote_request_budget_header_indexed() -> Result<(), Box<dyn
     let msg = encode_test_message(vec![4], 42)?;
     let server = MockServer::start(msg).await?;
 
-    let mut file = TensogramFile::open_source_async(server.url()).await?;
+    let file = TensogramFile::open_source_async(server.url()).await?;
     let open_requests = server.request_count();
 
     server.reset_count();
@@ -1199,7 +1199,7 @@ async fn test_async_remote_lazy_open_only_reads_first_preamble() -> Result<(), B
     combined.extend_from_slice(&msg2);
     let server = MockServer::start(combined).await?;
 
-    let mut file = TensogramFile::open_source_async(server.url()).await?;
+    let file = TensogramFile::open_source_async(server.url()).await?;
 
     let (_, desc, data) = file
         .decode_object_async(0, 0, &DecodeOptions::default())
@@ -1225,7 +1225,7 @@ async fn test_async_remote_suffix_read_combines_streaming() -> Result<(), Box<dy
     let msg = encode_streaming_message(vec![4], 42)?;
     let server = MockServer::start(msg.clone()).await?;
 
-    let mut file = TensogramFile::open_source_async(server.url()).await?;
+    let file = TensogramFile::open_source_async(server.url()).await?;
     assert!(file.is_remote());
     assert_eq!(file.message_count()?, 1);
 
@@ -1258,7 +1258,7 @@ async fn test_async_remote_mixed_buffered_then_streaming() -> Result<(), Box<dyn
     combined.extend_from_slice(&streaming_msg);
 
     let server = MockServer::start(combined).await?;
-    let mut file = TensogramFile::open_source_async(server.url()).await?;
+    let file = TensogramFile::open_source_async(server.url()).await?;
     assert_eq!(file.message_count()?, 2);
 
     let (_, _, data0) = file
@@ -1283,7 +1283,7 @@ async fn test_async_remote_repeated_object_reads_use_cache() -> Result<(), Box<d
     let msg = encode_multi_object_message(&shapes, &fills)?;
     let server = MockServer::start(msg).await?;
 
-    let mut file = TensogramFile::open_source_async(server.url()).await?;
+    let file = TensogramFile::open_source_async(server.url()).await?;
     server.reset_count();
 
     // First object read
@@ -1324,7 +1324,7 @@ async fn test_async_remote_matches_local_decode() -> Result<(), Box<dyn Error>> 
         tensogram_core::decode::decode(&msg, &DecodeOptions::default())?;
 
     // Async remote decode
-    let mut remote_file = TensogramFile::open_source_async(server.url()).await?;
+    let remote_file = TensogramFile::open_source_async(server.url()).await?;
     let (remote_meta, remote_desc, remote_data) = remote_file
         .decode_object_async(0, 0, &DecodeOptions::default())
         .await?;
@@ -1345,7 +1345,7 @@ async fn test_async_remote_multi_object_decode_single() -> Result<(), Box<dyn Er
     let msg = encode_multi_object_message(&shapes, &fills)?;
     let server = MockServer::start(msg).await?;
 
-    let mut file = TensogramFile::open_source_async(server.url()).await?;
+    let file = TensogramFile::open_source_async(server.url()).await?;
 
     // Read only the second object
     let (_, desc, data) = file

--- a/crates/tensogram-python/Cargo.toml
+++ b/crates/tensogram-python/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2021"
 name = "tensogram"
 crate-type = ["cdylib"]
 
+[features]
+default = ["async"]
+async = ["tensogram-core/async", "dep:pyo3-async-runtimes"]
+
 [dependencies]
 tensogram-core = { path = "../tensogram-core", features = ["remote"] }
 tensogram-encodings = { path = "../tensogram-encodings" }
@@ -15,3 +19,4 @@ numpy = "0.28"
 ciborium = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"], optional = true }

--- a/crates/tensogram-python/pyproject.toml
+++ b/crates/tensogram-python/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=7.0", "pytest-asyncio>=1.0", "ruff>=0.15"]
+dev = ["pytest>=7.0", "pytest-asyncio>=0.23", "ruff>=0.15"]
 
 [tool.maturin]
 features = ["pyo3/extension-module"]

--- a/crates/tensogram-python/pyproject.toml
+++ b/crates/tensogram-python/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=7.0", "ruff>=0.15"]
+dev = ["pytest>=7.0", "pytest-asyncio>=1.0", "ruff>=0.15"]
 
 [tool.maturin]
 features = ["pyo3/extension-module"]

--- a/crates/tensogram-python/src/lib.rs
+++ b/crates/tensogram-python/src/lib.rs
@@ -12,6 +12,9 @@ use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedBytes;
 use pyo3::types::{PyBytes, PyDict, PyList};
 
+#[cfg(feature = "async")]
+use std::sync::Arc;
+
 use tensogram_core::validate::{
     validate_file as core_validate_file, validate_message, ValidateOptions, ValidationLevel,
 };
@@ -527,6 +530,86 @@ impl PyTensogramFile {
             .map_err(to_py_err)?;
 
         build_range_result(py, desc.dtype, parts, &ranges, join)
+    }
+
+    /// Batch-decode full objects across multiple messages. Remote only.
+    #[pyo3(signature = (msg_indices, obj_index, verify_hash=false, native_byte_order=true))]
+    fn file_decode_object_batch(
+        &self,
+        py: Python<'_>,
+        msg_indices: Vec<usize>,
+        obj_index: usize,
+        verify_hash: bool,
+        native_byte_order: bool,
+    ) -> PyResult<PyObject> {
+        let options = DecodeOptions {
+            verify_hash,
+            native_byte_order,
+            ..Default::default()
+        };
+
+        let batch = py
+            .detach(|| {
+                self.file
+                    .decode_object_batch(&msg_indices, obj_index, &options)
+            })
+            .map_err(to_py_err)?;
+
+        let py_results: Vec<PyObject> = batch
+            .into_iter()
+            .map(|(meta, desc, data)| {
+                let arr = bytes_to_numpy(py, &desc, &data)?;
+                let py_desc = PyDataObjectDescriptor {
+                    inner: desc.clone(),
+                }
+                .into_pyobject(py)?
+                .into_any()
+                .unbind();
+                let result = PyDict::new(py);
+                result.set_item(
+                    "metadata",
+                    PyMetadata { inner: meta }.into_pyobject(py)?,
+                )?;
+                result.set_item("descriptor", py_desc)?;
+                result.set_item("data", arr)?;
+                Ok(result.into_any().unbind())
+            })
+            .collect::<PyResult<_>>()?;
+        Ok(PyList::new(py, py_results)?.into_any().unbind())
+    }
+
+    /// Batch-decode a sub-array range from the same object across multiple
+    /// messages in a single HTTP round-trip. Remote only.
+    #[pyo3(signature = (msg_indices, obj_index, ranges, join=false, verify_hash=false, native_byte_order=true))]
+    #[allow(clippy::too_many_arguments)]
+    fn file_decode_range_batch(
+        &self,
+        py: Python<'_>,
+        msg_indices: Vec<usize>,
+        obj_index: usize,
+        ranges: Vec<(u64, u64)>,
+        join: bool,
+        verify_hash: bool,
+        native_byte_order: bool,
+    ) -> PyResult<PyObject> {
+        let options = DecodeOptions {
+            verify_hash,
+            native_byte_order,
+            ..Default::default()
+        };
+
+        let batch = py
+            .detach(|| {
+                self.file
+                    .decode_range_batch(&msg_indices, obj_index, &ranges, &options)
+            })
+            .map_err(to_py_err)?;
+
+        let py_results: Vec<PyObject> = batch
+            .into_iter()
+            .map(|(desc, parts)| build_range_result(py, desc.dtype, parts, &ranges, join))
+            .collect::<PyResult<_>>()?;
+        Ok(PyList::new(py, py_results)?.into_any().unbind())
     }
 
     fn is_remote(&self) -> bool {
@@ -1268,6 +1351,531 @@ fn py_validate_file(
 // Module definition
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// PyAsyncTensogramFile — async wrapper around TensogramFile
+// ---------------------------------------------------------------------------
+
+/// Async file-based Tensogram container for use with Python ``asyncio``.
+///
+/// Wraps :class:`TensogramFile` for non-blocking I/O.  Decode methods
+/// return coroutines that can be composed with ``asyncio.gather``::
+///
+///     f = await tensogram.AsyncTensogramFile.open("data.tgm")
+///     results = await asyncio.gather(
+///         f.file_decode_object(0, 0),
+///         f.file_decode_object(0, 1),
+///     )
+///
+/// A single handle supports truly concurrent operations (no mutex).
+#[cfg(feature = "async")]
+#[pyclass(name = "AsyncTensogramFile")]
+struct PyAsyncTensogramFile {
+    file: Arc<TensogramFile>,
+    cached_source: String,
+    cached_is_remote: bool,
+    cached_message_count: Arc<std::sync::OnceLock<usize>>,
+}
+
+#[cfg(feature = "async")]
+#[pymethods]
+impl PyAsyncTensogramFile {
+    /// Open a local file or remote URL asynchronously.
+    ///
+    /// Auto-detects remote URLs (``s3://``, ``gs://``, ``http://``, etc.)
+    /// when the ``remote`` feature is enabled.
+    ///
+    /// Returns a coroutine; use ``await``::
+    ///
+    ///     f = await AsyncTensogramFile.open("data.tgm")
+    #[staticmethod]
+    fn open<'py>(py: Python<'py>, source: &str) -> PyResult<Bound<'py, PyAny>> {
+        let source = source.to_string();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let file = TensogramFile::open_source_async(&source)
+                .await
+                .map_err(to_py_err)?;
+            let is_remote = file.is_remote();
+            let source_str = file.source();
+            let wrapped = PyAsyncTensogramFile {
+                file: Arc::new(file),
+                cached_source: source_str,
+                cached_is_remote: is_remote,
+                cached_message_count: Arc::new(std::sync::OnceLock::new()),
+            };
+            Python::attach(|py| Ok(wrapped.into_pyobject(py)?.into_any().unbind()))
+        })
+    }
+
+    /// Open a remote URL with explicit storage options.
+    ///
+    /// Args:
+    ///     source: Remote URL (``s3://``, ``gs://``, ``http://``, etc.).
+    ///     storage_options: Optional dict of provider credentials / config.
+    ///
+    /// Returns a coroutine; use ``await``::
+    ///
+    ///     f = await AsyncTensogramFile.open_remote("s3://bucket/data.tgm",
+    ///                                               {"region": "eu-west-1"})
+    #[staticmethod]
+    #[pyo3(signature = (source, storage_options=None))]
+    fn open_remote<'py>(
+        py: Python<'py>,
+        source: &str,
+        storage_options: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        // Validate storage_options eagerly — errors at call site, not on await.
+        let opts = match storage_options {
+            Some(dict) => {
+                let mut map = BTreeMap::new();
+                for (k, v) in dict.iter() {
+                    let key: String = k.extract()?;
+                    let val: String = v.extract::<String>().or_else(|_| {
+                        v.str().map(|s| s.to_string()).map_err(|_| {
+                            PyValueError::new_err(format!(
+                                "storage_options value for key '{key}' \
+                                     must be convertible to string"
+                            ))
+                        })
+                    })?;
+                    map.insert(key, val);
+                }
+                map
+            }
+            None => BTreeMap::new(),
+        };
+        let source = source.to_string();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let file = TensogramFile::open_remote_async(&source, &opts)
+                .await
+                .map_err(to_py_err)?;
+            let is_remote = file.is_remote();
+            let source_str = file.source();
+            let wrapped = PyAsyncTensogramFile {
+                file: Arc::new(file),
+                cached_source: source_str,
+                cached_is_remote: is_remote,
+                cached_message_count: Arc::new(std::sync::OnceLock::new()),
+            };
+            Python::attach(|py| Ok(wrapped.into_pyobject(py)?.into_any().unbind()))
+        })
+    }
+
+    // ── Async decode methods ─────────────────────────────────────────────
+
+    /// Decode message at *index* asynchronously.
+    ///
+    /// Returns ``Message(metadata, objects)`` — identical to the sync
+    /// :meth:`TensogramFile.decode_message`.
+    #[pyo3(signature = (index, verify_hash=None, native_byte_order=true))]
+    fn decode_message<'py>(
+        &self,
+        py: Python<'py>,
+        index: usize,
+        verify_hash: Option<bool>,
+        native_byte_order: bool,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let file = Arc::clone(&self.file);
+        let options = DecodeOptions {
+            verify_hash: verify_hash.unwrap_or(false),
+            native_byte_order,
+            ..Default::default()
+        };
+
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let (global_meta, data_objects) = file
+                .decode_message_async(index, &options)
+                .await
+                .map_err(to_py_err)?;
+            Python::attach(|py| {
+                let result_list = data_objects_to_python(py, &data_objects)?;
+                let msg = pack_message(py, PyMetadata { inner: global_meta }, result_list)?;
+                Ok(msg)
+            })
+        })
+    }
+
+    /// Decode only metadata for message *msg_index* asynchronously.
+    fn file_decode_metadata<'py>(
+        &self,
+        py: Python<'py>,
+        msg_index: usize,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let file = Arc::clone(&self.file);
+
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let meta = file
+                .decode_metadata_async(msg_index)
+                .await
+                .map_err(to_py_err)?;
+            Python::attach(|py| {
+                Ok(PyMetadata { inner: meta }
+                    .into_pyobject(py)?
+                    .into_any()
+                    .unbind())
+            })
+        })
+    }
+
+    /// Decode metadata and descriptors for message *msg_index* asynchronously.
+    fn file_decode_descriptors<'py>(
+        &self,
+        py: Python<'py>,
+        msg_index: usize,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let file = Arc::clone(&self.file);
+
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let (meta, descriptors) = file
+                .decode_descriptors_async(msg_index)
+                .await
+                .map_err(to_py_err)?;
+            Python::attach(|py| {
+                let desc_list: Vec<Py<PyAny>> = descriptors
+                    .iter()
+                    .map(|d| {
+                        Ok(PyDataObjectDescriptor { inner: d.clone() }
+                            .into_pyobject(py)?
+                            .into_any()
+                            .unbind())
+                    })
+                    .collect::<PyResult<_>>()?;
+                let result = PyDict::new(py);
+                result.set_item("metadata", PyMetadata { inner: meta }.into_pyobject(py)?)?;
+                result.set_item("descriptors", PyList::new(py, desc_list)?)?;
+                Ok(result.into_any().unbind())
+            })
+        })
+    }
+
+    /// Decode a single data object asynchronously.
+    ///
+    /// Returns ``dict(metadata=Metadata, descriptor=DataObjectDescriptor, data=ndarray)``.
+    #[pyo3(signature = (msg_index, obj_index, verify_hash=false, native_byte_order=true))]
+    fn file_decode_object<'py>(
+        &self,
+        py: Python<'py>,
+        msg_index: usize,
+        obj_index: usize,
+        verify_hash: bool,
+        native_byte_order: bool,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let file = Arc::clone(&self.file);
+        let options = DecodeOptions {
+            verify_hash,
+            native_byte_order,
+            ..Default::default()
+        };
+
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let (meta, desc, data) = file
+                .decode_object_async(msg_index, obj_index, &options)
+                .await
+                .map_err(to_py_err)?;
+            Python::attach(|py| {
+                let arr = bytes_to_numpy(py, &desc, &data)?;
+                let py_desc = PyDataObjectDescriptor {
+                    inner: desc.clone(),
+                }
+                .into_pyobject(py)?
+                .into_any()
+                .unbind();
+                let result = PyDict::new(py);
+                result.set_item("metadata", PyMetadata { inner: meta }.into_pyobject(py)?)?;
+                result.set_item("descriptor", py_desc)?;
+                result.set_item("data", arr)?;
+                Ok(result.into_any().unbind())
+            })
+        })
+    }
+
+    // ── Async read ───────────────────────────────────────────────────────
+
+    /// Raw wire-format bytes for the message at *index* (async).
+    fn read_message<'py>(&self, py: Python<'py>, index: usize) -> PyResult<Bound<'py, PyAny>> {
+        let file = Arc::clone(&self.file);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let bytes = file.read_message_async(index).await.map_err(to_py_err)?;
+            Python::attach(|py| Ok(PyBytes::new(py, &bytes).into_any().unbind()))
+        })
+    }
+
+    // ── Sync utility methods (no I/O, cached fields) ─────────────────────
+
+    /// Number of messages in the file (async, lazy scan on first call).
+    fn message_count<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        if let Some(&count) = self.cached_message_count.get() {
+            return pyo3_async_runtimes::tokio::future_into_py(py, async move { Ok(count) });
+        }
+        let file = Arc::clone(&self.file);
+        let cache = Arc::clone(&self.cached_message_count);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let count = file.message_count_async().await.map_err(to_py_err)?;
+            let _ = cache.set(count);
+            Ok(count)
+        })
+    }
+
+    /// Whether this file was opened from a remote URL.
+    fn is_remote(&self) -> bool {
+        self.cached_is_remote
+    }
+
+    /// The source path or URL this file was opened from.
+    fn source(&self) -> &str {
+        &self.cached_source
+    }
+
+    /// Batch-prefetch layouts for the given message indices (remote only).
+    fn prefetch_layouts<'py>(
+        &self,
+        py: Python<'py>,
+        msg_indices: Vec<usize>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let file = Arc::clone(&self.file);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            file.prefetch_layouts_async(&msg_indices)
+                .await
+                .map_err(to_py_err)?;
+            Ok(true)
+        })
+    }
+
+    // ── file_decode_range (native async for remote, spawn_blocking for local) ─
+
+    #[pyo3(signature = (msg_index, obj_index, ranges, join=false, verify_hash=false, native_byte_order=true))]
+    #[allow(clippy::too_many_arguments)]
+    fn file_decode_range<'py>(
+        &self,
+        py: Python<'py>,
+        msg_index: usize,
+        obj_index: usize,
+        ranges: Vec<(u64, u64)>,
+        join: bool,
+        verify_hash: bool,
+        native_byte_order: bool,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let file = Arc::clone(&self.file);
+        let options = DecodeOptions {
+            verify_hash,
+            native_byte_order,
+            ..Default::default()
+        };
+        let ranges_for_result = ranges.clone();
+
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let (desc, parts) = file
+                .decode_range_async(msg_index, obj_index, &ranges, &options)
+                .await
+                .map_err(to_py_err)?;
+            let dtype = desc.dtype;
+            Python::attach(|py| build_range_result(py, dtype, parts, &ranges_for_result, join))
+        })
+    }
+
+    /// Batch-decode full objects across multiple messages. Remote only.
+    #[pyo3(signature = (msg_indices, obj_index, verify_hash=false, native_byte_order=true))]
+    fn file_decode_object_batch<'py>(
+        &self,
+        py: Python<'py>,
+        msg_indices: Vec<usize>,
+        obj_index: usize,
+        verify_hash: bool,
+        native_byte_order: bool,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let file = Arc::clone(&self.file);
+        let options = DecodeOptions {
+            verify_hash,
+            native_byte_order,
+            ..Default::default()
+        };
+
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let batch = file
+                .decode_object_batch_async(&msg_indices, obj_index, &options)
+                .await
+                .map_err(to_py_err)?;
+
+            Python::attach(|py| {
+                let py_results: Vec<PyObject> = batch
+                    .into_iter()
+                    .map(|(meta, desc, data)| {
+                        let arr = bytes_to_numpy(py, &desc, &data)?;
+                        let py_desc = PyDataObjectDescriptor {
+                            inner: desc.clone(),
+                        }
+                        .into_pyobject(py)?
+                        .into_any()
+                        .unbind();
+                        let result = PyDict::new(py);
+                        result.set_item(
+                            "metadata",
+                            PyMetadata { inner: meta }.into_pyobject(py)?,
+                        )?;
+                        result.set_item("descriptor", py_desc)?;
+                        result.set_item("data", arr)?;
+                        Ok(result.into_any().unbind())
+                    })
+                    .collect::<PyResult<_>>()?;
+                Ok(PyList::new(py, py_results)?.into_any().unbind())
+            })
+        })
+    }
+
+    /// Batch-decode sub-array ranges across multiple messages. Remote only.
+    #[pyo3(signature = (msg_indices, obj_index, ranges, join=false, verify_hash=false, native_byte_order=true))]
+    #[allow(clippy::too_many_arguments)]
+    fn file_decode_range_batch<'py>(
+        &self,
+        py: Python<'py>,
+        msg_indices: Vec<usize>,
+        obj_index: usize,
+        ranges: Vec<(u64, u64)>,
+        join: bool,
+        verify_hash: bool,
+        native_byte_order: bool,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let file = Arc::clone(&self.file);
+        let options = DecodeOptions {
+            verify_hash,
+            native_byte_order,
+            ..Default::default()
+        };
+        let ranges_for_result = ranges.clone();
+
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let batch = file
+                .decode_range_batch_async(&msg_indices, obj_index, &ranges, &options)
+                .await
+                .map_err(to_py_err)?;
+
+            Python::attach(|py| {
+                let py_results: Vec<PyObject> = batch
+                    .into_iter()
+                    .map(|(desc, parts)| {
+                        build_range_result(py, desc.dtype, parts, &ranges_for_result, join)
+                    })
+                    .collect::<PyResult<_>>()?;
+                Ok(PyList::new(py, py_results)?.into_any().unbind())
+            })
+        })
+    }
+
+    /// All raw message bytes as a list of ``bytes`` objects (async).
+    fn messages<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let file = Arc::clone(&self.file);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let count = file.message_count_async().await.map_err(to_py_err)?;
+            let mut raw_msgs = Vec::with_capacity(count);
+            for i in 0..count {
+                let bytes = file.read_message_async(i).await.map_err(to_py_err)?;
+                raw_msgs.push(bytes);
+            }
+            Python::attach(|py| {
+                let items: Vec<PyObject> = raw_msgs
+                    .iter()
+                    .map(|m| PyBytes::new(py, m).into_any().unbind())
+                    .collect();
+                Ok(PyList::new(py, items)?.into_any().unbind())
+            })
+        })
+    }
+
+    // ── Async context manager ────────────────────────────────────────────
+
+    fn __aenter__<'py>(slf: Bound<'py, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let obj = slf.unbind();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move { Ok(obj) })
+    }
+
+    #[pyo3(signature = (_exc_type=None, _exc_val=None, _exc_tb=None))]
+    fn __aexit__<'py>(
+        &self,
+        py: Python<'py>,
+        _exc_type: Option<&Bound<'_, pyo3::PyAny>>,
+        _exc_val: Option<&Bound<'_, pyo3::PyAny>>,
+        _exc_tb: Option<&Bound<'_, pyo3::PyAny>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        pyo3_async_runtimes::tokio::future_into_py(py, async move { Ok(false) })
+    }
+
+    // ── __len__ (cached after first access via OnceLock) ───────────────
+
+    fn __len__(&self) -> PyResult<usize> {
+        if let Some(&count) = self.cached_message_count.get() {
+            return Ok(count);
+        }
+        let count = self.file.message_count().map_err(to_py_err)?;
+        let _ = self.cached_message_count.set(count);
+        Ok(count)
+    }
+
+    // ── Async iteration ──────────────────────────────────────────────────
+
+    fn __aiter__(&self, _py: Python<'_>) -> PyResult<PyAsyncTensogramFileIter> {
+        let count = self.__len__()?;
+        Ok(PyAsyncTensogramFileIter {
+            file: Arc::clone(&self.file),
+            index: std::sync::atomic::AtomicUsize::new(0),
+            count,
+        })
+    }
+
+    fn __repr__(&self) -> String {
+        format!("AsyncTensogramFile(source='{}')", self.cached_source)
+    }
+}
+
+#[cfg(feature = "async")]
+#[pyclass(name = "AsyncTensogramFileIter")]
+struct PyAsyncTensogramFileIter {
+    file: Arc<TensogramFile>,
+    index: std::sync::atomic::AtomicUsize,
+    count: usize,
+}
+
+#[cfg(feature = "async")]
+#[pymethods]
+impl PyAsyncTensogramFileIter {
+    fn __aiter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __anext__<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
+        let idx = self
+            .index
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if idx >= self.count {
+            return Ok(None);
+        }
+        let file = Arc::clone(&self.file);
+        let options = DecodeOptions::default();
+        Ok(Some(pyo3_async_runtimes::tokio::future_into_py(
+            py,
+            async move {
+                let (meta, objects) = file
+                    .decode_message_async(idx, &options)
+                    .await
+                    .map_err(to_py_err)?;
+                Python::attach(|py| {
+                    let result_list = data_objects_to_python(py, &objects)?;
+                    pack_message(py, PyMetadata { inner: meta }, result_list)
+                })
+            },
+        )?))
+    }
+
+    fn __len__(&self) -> usize {
+        let current = self.index.load(std::sync::atomic::Ordering::Relaxed);
+        self.count.saturating_sub(current)
+    }
+
+    fn __repr__(&self) -> String {
+        let current = self.index.load(std::sync::atomic::Ordering::Relaxed);
+        let remaining = self.count.saturating_sub(current);
+        format!("AsyncTensogramFileIter(position={current}, remaining={remaining})")
+    }
+}
+
 #[pyfunction]
 #[pyo3(name = "is_remote_url")]
 fn py_is_remote_url(source: &str) -> bool {
@@ -1295,6 +1903,10 @@ fn tensogram(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyFileIter>()?;
     m.add_class::<PyBufferIter>()?;
     m.add_class::<PyStreamingEncoder>()?;
+    #[cfg(feature = "async")]
+    m.add_class::<PyAsyncTensogramFile>()?;
+    #[cfg(feature = "async")]
+    m.add_class::<PyAsyncTensogramFileIter>()?;
     Ok(())
 }
 

--- a/crates/tensogram-python/src/lib.rs
+++ b/crates/tensogram-python/src/lib.rs
@@ -1625,7 +1625,7 @@ impl PyAsyncTensogramFile {
         &self.cached_source
     }
 
-    /// Batch-prefetch layouts for the given message indices (remote only).
+    /// Batch-prefetch layouts for the given message indices. No-op for local files.
     fn prefetch_layouts<'py>(
         &self,
         py: Python<'py>,

--- a/crates/tensogram-python/src/lib.rs
+++ b/crates/tensogram-python/src/lib.rs
@@ -579,7 +579,7 @@ impl PyTensogramFile {
     }
 
     /// Batch-decode a sub-array range from the same object across multiple
-    /// messages in a single HTTP round-trip. Remote only.
+    /// messages via batched HTTP. Remote only. Call ``prefetch_layouts`` first to avoid per-message discovery overhead.
     #[pyo3(signature = (msg_indices, obj_index, ranges, join=false, verify_hash=false, native_byte_order=true))]
     #[allow(clippy::too_many_arguments)]
     fn file_decode_range_batch(
@@ -1721,7 +1721,7 @@ impl PyAsyncTensogramFile {
         })
     }
 
-    /// Batch-decode sub-array ranges across multiple messages. Remote only.
+    /// Batch-decode sub-array ranges across multiple messages via batched HTTP. Remote only. Call ``prefetch_layouts`` first to avoid per-message discovery overhead.
     #[pyo3(signature = (msg_indices, obj_index, ranges, join=false, verify_hash=false, native_byte_order=true))]
     #[allow(clippy::too_many_arguments)]
     fn file_decode_range_batch<'py>(
@@ -1763,8 +1763,10 @@ impl PyAsyncTensogramFile {
     /// All raw message bytes as a list of ``bytes`` objects (async).
     fn messages<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let file = Arc::clone(&self.file);
+        let cache = Arc::clone(&self.cached_message_count);
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let count = file.message_count_async().await.map_err(to_py_err)?;
+            let _ = cache.set(count);
             let mut raw_msgs = Vec::with_capacity(count);
             for i in 0..count {
                 let bytes = file.read_message_async(i).await.map_err(to_py_err)?;

--- a/crates/tensogram-python/src/lib.rs
+++ b/crates/tensogram-python/src/lib.rs
@@ -492,7 +492,7 @@ impl PyTensogramFile {
             .map_err(to_py_err)?;
         let arr = bytes_to_numpy(py, &desc, &data)?;
         let py_desc = PyDataObjectDescriptor {
-            inner: desc.clone(),
+            inner: desc,
         }
         .into_pyobject(py)?
         .into_any()
@@ -560,7 +560,7 @@ impl PyTensogramFile {
             .map(|(meta, desc, data)| {
                 let arr = bytes_to_numpy(py, &desc, &data)?;
                 let py_desc = PyDataObjectDescriptor {
-                    inner: desc.clone(),
+                    inner: desc,
                 }
                 .into_pyobject(py)?
                 .into_any()
@@ -1571,7 +1571,7 @@ impl PyAsyncTensogramFile {
             Python::attach(|py| {
                 let arr = bytes_to_numpy(py, &desc, &data)?;
                 let py_desc = PyDataObjectDescriptor {
-                    inner: desc.clone(),
+                    inner: desc,
                 }
                 .into_pyobject(py)?
                 .into_any()
@@ -1698,7 +1698,7 @@ impl PyAsyncTensogramFile {
                     .map(|(meta, desc, data)| {
                         let arr = bytes_to_numpy(py, &desc, &data)?;
                         let py_desc = PyDataObjectDescriptor {
-                            inner: desc.clone(),
+                            inner: desc,
                         }
                         .into_pyobject(py)?
                         .into_any()

--- a/crates/tensogram-python/src/lib.rs
+++ b/crates/tensogram-python/src/lib.rs
@@ -579,7 +579,7 @@ impl PyTensogramFile {
     }
 
     /// Batch-decode a sub-array range from the same object across multiple
-    /// messages via batched HTTP. Remote only. Call ``prefetch_layouts`` first to avoid per-message discovery overhead.
+    /// messages via batched HTTP. Remote only.
     #[pyo3(signature = (msg_indices, obj_index, ranges, join=false, verify_hash=false, native_byte_order=true))]
     #[allow(clippy::too_many_arguments)]
     fn file_decode_range_batch(
@@ -1431,10 +1431,7 @@ impl PyAsyncTensogramFile {
                     let key: String = k.extract()?;
                     let val: String = v.extract::<String>().or_else(|_| {
                         v.str().map(|s| s.to_string()).map_err(|_| {
-                            PyValueError::new_err(format!(
-                                "storage_options value for key '{key}' \
-                                     must be convertible to string"
-                            ))
+                            PyValueError::new_err(format!("storage_options value for key '{key}' must be convertible to string"))
                         })
                     })?;
                     map.insert(key, val);
@@ -1636,7 +1633,7 @@ impl PyAsyncTensogramFile {
             file.prefetch_layouts_async(&msg_indices)
                 .await
                 .map_err(to_py_err)?;
-            Ok(true)
+            Ok(())
         })
     }
 

--- a/crates/tensogram-python/src/lib.rs
+++ b/crates/tensogram-python/src/lib.rs
@@ -1804,9 +1804,9 @@ impl PyAsyncTensogramFile {
         if let Some(&count) = self.cached_message_count.get() {
             return Ok(count);
         }
-        let count = self.file.message_count().map_err(to_py_err)?;
-        let _ = self.cached_message_count.set(count);
-        Ok(count)
+        Err(PyRuntimeError::new_err(
+            "message count not yet known; call 'await f.message_count()' first",
+        ))
     }
 
     // ── Async iteration ──────────────────────────────────────────────────

--- a/docs/src/guide/python-api.md
+++ b/docs/src/guide/python-api.md
@@ -363,7 +363,8 @@ For even more speed, split the work into chunks and run them concurrently:
 ```
 
 The sync `TensogramFile` also has `file_decode_range_batch` and
-`file_decode_object_batch` with the same signatures.
+`file_decode_object_batch` with the same signatures.  Both batch methods
+require a remote backend; calling them on a local file raises `OSError`.
 
 ### Layout prefetching
 
@@ -379,11 +380,14 @@ the internal layout metadata to avoid repeated discovery requests:
 
 ```python
     async with await tensogram.AsyncTensogramFile.open("data.tgm") as f:
+        await f.message_count()   # required before async for or len(f)
         async for meta, objects in f:
             print(objects[0][1].shape)
 ```
 
 Async iteration works on remote files (sync iteration does not).
+`await f.message_count()` must be called once before using `async for`
+or `len(f)`, to discover the message count without blocking the event loop.
 
 ### Other methods
 
@@ -391,8 +395,11 @@ Async iteration works on remote files (sync iteration does not).
     count = await f.message_count()
     raw = await f.read_message(0)
     all_raw = await f.messages()
-    print(f.is_remote(), f.source(), len(f))
+    print(f.is_remote(), f.source())
 ```
+
+> **Note:** `len(f)` is synchronous and may block on first call (triggers a
+> file scan). In async code, prefer `await f.message_count()`.
 
 ### When to use async vs sync
 

--- a/docs/src/guide/python-api.md
+++ b/docs/src/guide/python-api.md
@@ -341,8 +341,9 @@ When you need the same data from many messages, for example reading how a
 value at one grid point changes over 300 time steps, individual requests
 are slow because each one is a separate HTTP round-trip.
 
-`file_decode_range_batch` collects all the byte ranges and fetches them in
-a single call.  `file_decode_object_batch` does the same for full frames:
+`file_decode_range_batch` collects the requested element ranges across
+messages and fetches the underlying data in a batched HTTP call.
+`file_decode_object_batch` does the same for full frames:
 
 ```python
     indices = list(range(300))

--- a/docs/src/guide/python-api.md
+++ b/docs/src/guide/python-api.md
@@ -346,6 +346,8 @@ a single call.  `file_decode_object_batch` does the same for full frames:
 
 ```python
     indices = list(range(300))
+    row, col, grid = 100, 200, 528
+    offset = row * grid + col
 
     values = await f.file_decode_range_batch(indices, 0, [(offset, 1)], join=True)
 

--- a/docs/src/guide/python-api.md
+++ b/docs/src/guide/python-api.md
@@ -371,7 +371,8 @@ Before running many concurrent decodes on a remote file, prefetch
 the internal layout metadata to avoid repeated discovery requests:
 
 ```python
-    await f.prefetch_layouts(list(range(len(f))))
+    count = await f.message_count()
+    await f.prefetch_layouts(list(range(count)))
 ```
 
 ### Context manager and iteration

--- a/docs/src/guide/python-api.md
+++ b/docs/src/guide/python-api.md
@@ -297,7 +297,7 @@ For pre-encoded payloads, use `enc.write_object_pre_encoded(desc, raw_bytes)`.
 
 `AsyncTensogramFile` provides the same operations as `TensogramFile` but as
 `asyncio` coroutines.  A single handle supports truly concurrent operations
-with no internal locking.
+with no per-handle mutex; internal caches are thread-safe.
 
 ### Opening and decoding
 

--- a/docs/src/guide/python-api.md
+++ b/docs/src/guide/python-api.md
@@ -293,6 +293,116 @@ msg = enc.finish()  # returns complete message as bytes
 
 For pre-encoded payloads, use `enc.write_object_pre_encoded(desc, raw_bytes)`.
 
+## Async API
+
+`AsyncTensogramFile` provides the same operations as `TensogramFile` but as
+`asyncio` coroutines.  A single handle supports truly concurrent operations
+with no internal locking.
+
+### Opening and decoding
+
+```python
+import asyncio
+import tensogram
+
+async def main():
+    f = await tensogram.AsyncTensogramFile.open("forecast.tgm")
+
+    meta, objects = await f.decode_message(0)
+    result = await f.file_decode_object(0, 0)
+    print(result["data"].shape)
+
+asyncio.run(main())
+```
+
+For remote files with credentials:
+
+```python
+    f = await tensogram.AsyncTensogramFile.open_remote(
+        "s3://bucket/data.tgm", {"region": "eu-west-1"}
+    )
+```
+
+### Concurrent decoding with `asyncio.gather`
+
+Multiple decode calls run concurrently on a single handle:
+
+```python
+    results = await asyncio.gather(
+        f.file_decode_object(0, 0),
+        f.file_decode_object(1, 0),
+        f.file_decode_object(2, 0),
+    )
+```
+
+### Batch decoding from many messages at once
+
+When you need the same data from many messages, for example reading how a
+value at one grid point changes over 300 time steps, individual requests
+are slow because each one is a separate HTTP round-trip.
+
+`file_decode_range_batch` collects all the byte ranges and fetches them in
+a single call.  `file_decode_object_batch` does the same for full frames:
+
+```python
+    indices = list(range(300))
+
+    values = await f.file_decode_range_batch(indices, 0, [(offset, 1)], join=True)
+
+    frames = await f.file_decode_object_batch(indices, 0)
+```
+
+For even more speed, split the work into chunks and run them concurrently:
+
+```python
+    chunks = [indices[i::16] for i in range(16)]
+    batch_results = await asyncio.gather(
+        *[f.file_decode_range_batch(chunk, 0, [(offset, 1)], join=True)
+          for chunk in chunks]
+    )
+```
+
+The sync `TensogramFile` also has `file_decode_range_batch` and
+`file_decode_object_batch` with the same signatures.
+
+### Layout prefetching
+
+Before running many concurrent decodes on a remote file, prefetch
+the internal layout metadata to avoid repeated discovery requests:
+
+```python
+    await f.prefetch_layouts(list(range(len(f))))
+```
+
+### Context manager and iteration
+
+```python
+    async with await tensogram.AsyncTensogramFile.open("data.tgm") as f:
+        async for meta, objects in f:
+            print(objects[0][1].shape)
+```
+
+Async iteration works on remote files (sync iteration does not).
+
+### Other methods
+
+```python
+    count = await f.message_count()
+    raw = await f.read_message(0)
+    all_raw = await f.messages()
+    print(f.is_remote(), f.source(), len(f))
+```
+
+### When to use async vs sync
+
+| Scenario | Recommendation |
+|----------|---------------|
+| Script, CLI, or notebook | `TensogramFile` (sync) |
+| Inside an asyncio event loop | `AsyncTensogramFile` |
+| xarray or zarr | Sync (those frameworks are synchronous) |
+| Many concurrent remote reads | `asyncio.gather` on one `AsyncTensogramFile` |
+| Same data from many messages | `file_decode_range_batch` or `file_decode_object_batch` |
+
 ## Validation
 
 Two functions check whether messages and files are well-formed without consuming the data. See also the [CLI reference](../cli/validate.md).
@@ -404,3 +514,4 @@ See `examples/python/` for complete working examples:
 | `11_encode_pre_encoded.py` | Pre-encoded data API |
 | `12_convert_netcdf.py` | NetCDF → Tensogram conversion via CLI |
 | `13_validate.py` | Message and file validation |
+| `15_async_operations.py` | Async open, decode, and `asyncio.gather` |

--- a/docs/src/guide/python-api.md
+++ b/docs/src/guide/python-api.md
@@ -400,8 +400,8 @@ or `len(f)`, to discover the message count without blocking the event loop.
     print(f.is_remote(), f.source())
 ```
 
-> **Note:** `len(f)` is synchronous and may block on first call (triggers a
-> file scan). In async code, prefer `await f.message_count()`.
+> **Note:** `len(f)` requires a prior `await f.message_count()` call. Without
+> it, `len(f)` raises `RuntimeError`.
 
 ### When to use async vs sync
 

--- a/examples/python/15_async_operations.py
+++ b/examples/python/15_async_operations.py
@@ -10,6 +10,8 @@ Demonstrates:
 """
 
 import asyncio
+import os
+import shutil
 import tempfile
 
 import numpy as np
@@ -32,9 +34,8 @@ def create_test_file(path: str) -> None:
 
 
 async def main():
-    with tempfile.NamedTemporaryFile(suffix=".tgm", delete=False) as tmp:
-        path = tmp.name
-
+    tmpdir = tempfile.mkdtemp()
+    path = os.path.join(tmpdir, "test.tgm")
     create_test_file(path)
 
     f = await tensogram.AsyncTensogramFile.open(path)
@@ -65,16 +66,19 @@ async def main():
     values = await asyncio.gather(
         *[f.file_decode_range(i, 0, [(offset, 1)], join=True) for i in range(count)]
     )
-    print(f"\nGrid point [{row},{col}] across 20 messages:")
+    print(f"\nGrid point [{row},{col}] across {count} messages:")
     for i, arr in enumerate(values):
         print(f"  message {i}: value={float(arr[0]):.1f}")
 
-    # 6. Async context manager and iteration
+    # 4. Async context manager and iteration
     async with await tensogram.AsyncTensogramFile.open(path) as f2:
+        await f2.message_count()
         count = 0
         async for _meta, _objects in f2:
             count += 1
         print(f"\nAsync iteration: {count} messages")
+
+    shutil.rmtree(tmpdir)
 
 
 if __name__ == "__main__":

--- a/examples/python/15_async_operations.py
+++ b/examples/python/15_async_operations.py
@@ -41,7 +41,8 @@ async def main():
     print(f"Opened: {f}")
     print(f"  is_remote = {f.is_remote()}")
     print(f"  source    = {f.source()}")
-    print(f"  len       = {len(f)}")
+    count = await f.message_count()
+    print(f"  messages  = {count}")
 
     # 1. Single decode
     meta, objects = await f.decode_message(0)
@@ -62,7 +63,7 @@ async def main():
     row, col = 50, 100
     offset = row * 200 + col
     values = await asyncio.gather(
-        *[f.file_decode_range(i, 0, [(offset, 1)], join=True) for i in range(20)]
+        *[f.file_decode_range(i, 0, [(offset, 1)], join=True) for i in range(count)]
     )
     print(f"\nGrid point [{row},{col}] across 20 messages:")
     for i, arr in enumerate(values):

--- a/examples/python/15_async_operations.py
+++ b/examples/python/15_async_operations.py
@@ -1,0 +1,80 @@
+"""
+Example 15 — Async operations with AsyncTensogramFile
+=====================================================
+
+Demonstrates:
+  1. Async open and decode
+  2. Concurrent decodes with asyncio.gather
+  3. Reading one grid point from many messages concurrently
+  4. Async context manager and iteration
+"""
+
+import asyncio
+import tempfile
+
+import numpy as np
+import tensogram
+
+
+def create_test_file(path: str) -> None:
+    with tensogram.TensogramFile.create(path) as f:
+        for i in range(20):
+            meta = {"version": 2, "base": [{"step": i}]}
+            desc = {
+                "type": "ntensor",
+                "shape": [100, 200],
+                "dtype": "float32",
+                "encoding": "none",
+                "compression": "none",
+            }
+            data = np.random.randn(100, 200).astype(np.float32) + i * 10
+            f.append(meta, [(desc, data)])
+
+
+async def main():
+    with tempfile.NamedTemporaryFile(suffix=".tgm", delete=False) as tmp:
+        path = tmp.name
+
+    create_test_file(path)
+
+    f = await tensogram.AsyncTensogramFile.open(path)
+    print(f"Opened: {f}")
+    print(f"  is_remote = {f.is_remote()}")
+    print(f"  source    = {f.source()}")
+    print(f"  len       = {len(f)}")
+
+    # 1. Single decode
+    meta, objects = await f.decode_message(0)
+    print(f"\nDecode message 0: version={meta.version}, objects={len(objects)}")
+    print(f"  shape={objects[0][1].shape}, dtype={objects[0][1].dtype}")
+
+    # 2. Concurrent decodes with asyncio.gather
+    results = await asyncio.gather(
+        f.file_decode_object(0, 0),
+        f.file_decode_object(1, 0),
+        f.file_decode_object(2, 0),
+    )
+    print(f"\nGathered {len(results)} objects concurrently:")
+    for i, r in enumerate(results):
+        print(f"  message {i}: mean={r['data'].mean():.1f}")
+
+    # 3. Read one grid point from all 20 messages concurrently
+    row, col = 50, 100
+    offset = row * 200 + col
+    values = await asyncio.gather(
+        *[f.file_decode_range(i, 0, [(offset, 1)], join=True) for i in range(20)]
+    )
+    print(f"\nGrid point [{row},{col}] across 20 messages:")
+    for i, arr in enumerate(values):
+        print(f"  message {i}: value={float(arr[0]):.1f}")
+
+    # 6. Async context manager and iteration
+    async with await tensogram.AsyncTensogramFile.open(path) as f2:
+        count = 0
+        async for _meta, _objects in f2:
+            count += 1
+        print(f"\nAsync iteration: {count} messages")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -44,6 +44,7 @@ uv pip install -e tensogram-zarr/
 | `12_convert_netcdf.py` | Convert NetCDF → Tensogram via the CLI (uses `netCDF4` + `subprocess`) |
 | `13_validate.py` | Message and file validation at different levels |
 | `14_remote_access.py` | Remote file access over HTTP with `open_remote` and file-level decode APIs |
+| `15_async_operations.py` | Async open, decode, and `asyncio.gather` with `AsyncTensogramFile` |
 
 ## Module Structure
 

--- a/examples/rust/src/bin/12_convert_netcdf.rs
+++ b/examples/rust/src/bin/12_convert_netcdf.rs
@@ -80,7 +80,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("4. Wrote {}", out_path.display());
 
     // ── 5. Read it back with TensogramFile ──────────────────────────────
-    let mut tgm = TensogramFile::open(&out_path)?;
+    let tgm = TensogramFile::open(&out_path)?;
     let count = tgm.message_count()?;
     println!("5. message_count = {count}");
 

--- a/examples/rust/src/bin/14_remote_access.rs
+++ b/examples/rust/src/bin/14_remote_access.rs
@@ -52,7 +52,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert!(tensogram_core::remote::is_remote_url(&url));
     println!("is_remote_url = true");
 
-    let mut file = TensogramFile::open_source(&url)?;
+    let file = TensogramFile::open_source(&url)?;
     println!(
         "\nOpened: source={} is_remote={} messages={}",
         file.source(),

--- a/plans/DONE.md
+++ b/plans/DONE.md
@@ -3,6 +3,23 @@
 > For historical release notes, see `../CHANGELOG.md`.
 > For planned features, see `TODO.md`. For ideas, see `IDEAS.md`.
 
+## Python async bindings (completed)
+
+`AsyncTensogramFile` exposes all read/decode operations as `asyncio` coroutines
+via `pyo3-async-runtimes` + tokio.  A single handle supports truly concurrent
+operations (core async methods take `&self`, no mutex).
+
+| Component | What changed |
+|-----------|-------------|
+| `tensogram-core/file.rs` | All async methods `&mut self` → `&self`. Added `decode_range_async`, `decode_range_batch_async`, `decode_object_batch_async`, `prefetch_layouts_async`, `message_count_async`. Sync batch: `decode_range_batch`, `decode_object_batch`. |
+| `tensogram-core/remote.rs` | Added `read_range_async`, `read_range_batch_async`, `read_object_batch_async`, `ensure_all_layouts_batch_async` (batched layout discovery via `get_ranges`), `message_count_async`. Sync batch: `read_range_batch`, `read_object_batch`. |
+| `tensogram-python` | `PyAsyncTensogramFile` (20 methods, `Arc<TensogramFile>`, no mutex), `PyAsyncTensogramFileIter`, sync `file_decode_range_batch` and `file_decode_object_batch` on `PyTensogramFile`. `pyo3-async-runtimes` 0.28 dependency. |
+| Tests | 73 async/batch tests (`test_async.py`), shared fixtures (`conftest.py`). 407 total. |
+| Docs | `python-api.md` async section, example `15_async_operations.py`, examples README. |
+| CI | `pytest-asyncio` added, `--no-default-features` check. |
+| Rust examples | Fixed stale `let mut` from `&self` change in `12_convert_netcdf.rs`, `14_remote_access.rs`. |
+| Rust tests | Fixed 26 stale `let mut` in `remote_http.rs` and `file.rs` tests. |
+
 ## caller-endianness (completed)
 
 Decoded data is now always returned in the caller's native byte order by

--- a/plans/TODO.md
+++ b/plans/TODO.md
@@ -174,20 +174,22 @@ For speculative ideas, see `IDEAS.md`.
 
 ## Python Async Bindings
 
-- [ ] **Python asyncio support**:
-  - expose async methods via `pyo3-asyncio` or manual future wrapping
-  - `await file.decode_object_async(msg, obj)`, `await file.decode_range_async(...)`, etc.
-  - uses the native async Rust path (`ensure_layout_eager_async` → `scan_and_discover_next_async`)
-  - enables asyncio-native workflows (e.g., `asyncio.gather` for concurrent frame fetches on a single handle)
+- [x] **Python asyncio support**:
+  - `AsyncTensogramFile` class via `pyo3-async-runtimes` + tokio bridge
+  - all core async methods changed from `&mut self` to `&self` (no mutex needed)
+  - `file_decode_range_batch` and `file_decode_object_batch` for batched HTTP via `object_store::get_ranges`
+  - `prefetch_layouts` for layout warmup
+  - `asyncio.gather` achieves real I/O overlap on a single handle
+  - async context manager, async iteration, 20 methods total
+  - 73 tests, example `15_async_operations.py`
 
 ## Free-Threaded Python
 
-- [ ] **free-threaded Python (parallelism)**:
-  - declare `#[pymodule(gil_used = false)]` for Python 3.13+
-  - change `PyTensogramFile` methods from `&mut self` to `&self` with internal `Mutex`/`RwLock`
-  - replace `GILOnceCell` with `std::sync::OnceLock`
-  - test with `python3.13t`
-  - enables true parallel decode/encode across threads for the whole library
+- [x] **free-threaded Python (parallelism)** *(merged in v0.10.0)*:
+  - `#[pymodule(gil_used = false)]` declared
+  - `GILOnceCell` replaced with `std::sync::OnceLock`
+  - CI tests with Python 3.13t / 3.14t
+  - enables true parallel decode/encode across threads
 
 ## Code Quality
 

--- a/plans/python-async-bindings-phase2.md
+++ b/plans/python-async-bindings-phase2.md
@@ -1,0 +1,361 @@
+# Plan: AsyncTensogramFile — Phase 2 (Previously Deferred Features)
+
+**Status**: Implemented
+
+> **Note**: This plan was written for the TokioMutex-based architecture.
+> The implementation evolved to use `Arc<TensogramFile>` with `&self` async methods
+> (no mutex), eliminating all the `blocking_lock` complexity discussed below.
+> Also added: `decode_range_async`, `decode_range_batch_async` (batched HTTP),
+> `prefetch_layouts_async`, and sync `decode_range_batch`.
+**Branch**: `feature/python-async-bindings` (continuing)
+**Prerequisite**: Phase 1 complete (34 async tests, 10 methods)
+
+## 1. Goal
+
+Complete the `AsyncTensogramFile` API so it has full parity with sync `TensogramFile`
+for all read/decode operations.  After this phase, every read operation available on
+the sync class has an async equivalent.
+
+## 2. Features to implement
+
+| Feature | Sync equivalent | Notes |
+|---|---|---|
+| `file_decode_range` | `PyTensogramFile.file_decode_range` | No core async version; use `spawn_blocking` + sync path |
+| `__aenter__`/`__aexit__` | `__enter__`/`__exit__` | Async context manager protocol |
+| `__len__` | `__len__` | Sync `len(f)`, calls `message_count` under `spawn_blocking` |
+| `__aiter__`/`__anext__` | `__iter__`/`__next__` via `PyFileIter` | Async iteration yielding `Message` namedtuples |
+
+## 3. Implementation details
+
+### 3.1 `file_decode_range` (async)
+
+The core `TensogramFile::decode_range` is sync-only (no `decode_range_async` exists).
+The async binding wraps the sync call in `spawn_blocking`, following the same pattern
+as `message_count`.
+
+**Sync signature** (`lib.rs:509-535`):
+```python
+file_decode_range(msg_index, obj_index, ranges, join=False, verify_hash=False, native_byte_order=True)
+```
+
+**Async pattern**:
+```rust
+#[pyo3(signature = (msg_index, obj_index, ranges, join=false, verify_hash=false, native_byte_order=true))]
+#[allow(clippy::too_many_arguments)]
+fn file_decode_range<'py>(
+    &self,
+    py: Python<'py>,
+    msg_index: usize,
+    obj_index: usize,
+    ranges: Vec<(u64, u64)>,
+    join: bool,
+    verify_hash: bool,
+    native_byte_order: bool,
+) -> PyResult<Bound<'py, PyAny>> {
+    let file = Arc::clone(&self.file);
+    let options = DecodeOptions { verify_hash, native_byte_order, ..Default::default() };
+
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        let (desc, parts) = tokio::task::spawn_blocking(move || {
+            let f = file.blocking_lock();
+            f.decode_range(msg_index, obj_index, &ranges, &options)
+                .map_err(to_py_err)
+                .map(|r| (r, ranges))
+        })
+        .await
+        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("task join: {e}")))?
+        // Unpack: spawn_blocking returned (Result<(desc, parts)>, ranges)
+        // Actually, need to restructure — see implementation step for clean version
+        ?;
+        // NOTE: Actual implementation will capture `ranges` in the closure
+        // and pass both desc+parts+ranges to Python::attach for build_range_result.
+        todo!("see implementation step")
+    })
+}
+```
+
+**Key complexity**: `build_range_result` needs `py: Python`, `desc.dtype`, `parts`, `ranges`, `join`.
+All are `Send + 'static` except `py`.  We run `build_range_result` inside `Python::attach`
+after the `spawn_blocking` completes.
+
+**Clean implementation**:
+```rust
+fn file_decode_range<'py>(...) -> PyResult<Bound<'py, PyAny>> {
+    let file = Arc::clone(&self.file);
+    let options = DecodeOptions { ... };
+
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        let (desc, parts) = tokio::task::spawn_blocking(move || {
+            let f = file.blocking_lock();
+            f.decode_range(msg_index, obj_index, &ranges, &options).map_err(to_py_err)
+        })
+        .await
+        .map_err(|e| PyRuntimeError::new_err(format!("task join: {e}")))??;
+
+        let dtype = desc.dtype;
+        Python::attach(|py| build_range_result(py, dtype, parts, &ranges, join))
+    })
+}
+```
+
+**Problem**: `ranges` is moved into the `spawn_blocking` closure but also needed in
+`Python::attach`.  Fix: clone `ranges` before the closure, or restructure to return it.
+
+**Solution**: Clone ranges before spawn_blocking:
+```rust
+let ranges_for_result = ranges.clone();
+// ... spawn_blocking uses `ranges` ...
+// ... Python::attach uses `ranges_for_result` ...
+```
+
+### 3.2 `__aenter__` / `__aexit__` (async context manager)
+
+The sync `__enter__` returns `self`.  The sync `__exit__` returns `false` (don't suppress).
+
+For async:
+- `__aenter__` must return an awaitable that resolves to `self`.
+- `__aexit__` must return an awaitable that resolves to `false`.
+
+pyo3 0.28 does not have native async dunder support for `__aenter__`/`__aexit__`.
+We implement these as regular methods returning coroutines via `future_into_py`.
+
+```rust
+fn __aenter__<'py>(slf: Bound<'py, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+    let obj = slf.unbind();
+    pyo3_async_runtimes::tokio::future_into_py(py, async move { Ok(obj) })
+}
+
+#[pyo3(signature = (_exc_type=None, _exc_val=None, _exc_tb=None))]
+fn __aexit__<'py>(
+    &self,
+    py: Python<'py>,
+    _exc_type: Option<&Bound<'_, pyo3::PyAny>>,
+    _exc_val: Option<&Bound<'_, pyo3::PyAny>>,
+    _exc_tb: Option<&Bound<'_, pyo3::PyAny>>,
+) -> PyResult<Bound<'py, PyAny>> {
+    pyo3_async_runtimes::tokio::future_into_py(py, async move { Ok(false) })
+}
+```
+
+**Usage**:
+```python
+async with await tensogram.AsyncTensogramFile.open("data.tgm") as f:
+    result = await f.file_decode_object(0, 0)
+```
+
+Note: `async with await open(...)` is the correct Python pattern when the constructor
+is itself a coroutine.  The `await` resolves the open, then `async with` calls
+`__aenter__`/`__aexit__`.
+
+### 3.3 `__len__`
+
+The sync `__len__` calls `self.file.message_count()` which does lazy I/O.
+For the async class, we use `spawn_blocking` to avoid blocking the tokio worker,
+matching the `message_count()` pattern.
+
+```rust
+fn __len__(&self, py: Python<'_>) -> PyResult<usize> {
+    let file = Arc::clone(&self.file);
+    let count = std::thread::scope(|s| {
+        s.spawn(move || {
+            let f = file.blocking_lock();
+            f.message_count().map_err(to_py_err)
+        })
+        .join()
+        .map_err(|_| PyRuntimeError::new_err("thread panicked"))?
+    })?;
+    Ok(count)
+}
+```
+
+**Why `std::thread::scope` instead of `spawn_blocking`**: `__len__` is a sync dunder —
+it must return `usize` immediately, not a coroutine.  We can't use `await`.  We use
+a scoped thread to avoid blocking the current thread (which might be a tokio worker)
+while still avoiding `blocking_lock()` on the current thread.
+
+**Alternative** (simpler, acceptable for `__len__`): Just use `blocking_lock` directly.
+The rationale: `__len__` is called from sync Python code, never from inside a tokio
+runtime context.  Python's `len()` is inherently sync.
+
+```rust
+fn __len__(&self) -> PyResult<usize> {
+    self.file.blocking_lock().message_count().map_err(to_py_err)
+}
+```
+
+**Decision**: Use the simple `blocking_lock` approach.  `len()` is called from sync
+Python code.  If someone calls `len()` on an `AsyncTensogramFile` from within an
+async context, they've already accepted sync semantics.  Document this.
+
+### 3.4 `__aiter__` / `__anext__` (async iteration)
+
+The sync `__iter__` creates a `PyFileIter` that opens a separate file handle and
+iterates by index.  It does NOT work on remote files (raises RuntimeError).
+
+For async iteration, we need:
+1. An `AsyncTensogramFileIter` pyclass holding its own `Arc<TokioMutex<TensogramFile>>`
+   plus index/count state.
+2. `__aiter__` returns `self`.
+3. `__anext__` returns a coroutine that resolves to the next message or raises
+   `StopAsyncIteration`.
+
+**Unlike sync iteration**, async iteration CAN work on remote files since it uses
+the async decode path.
+
+```rust
+#[cfg(feature = "async")]
+#[pyclass(name = "AsyncTensogramFileIter")]
+struct PyAsyncTensogramFileIter {
+    file: Arc<TokioMutex<TensogramFile>>,
+    index: std::sync::atomic::AtomicUsize,
+    count: usize,
+}
+
+#[cfg(feature = "async")]
+#[pymethods]
+impl PyAsyncTensogramFileIter {
+    fn __aiter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __anext__<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
+        let idx = self.index.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if idx >= self.count {
+            return Ok(None); // StopAsyncIteration
+        }
+        let file = Arc::clone(&self.file);
+        let options = DecodeOptions::default();
+        Ok(Some(pyo3_async_runtimes::tokio::future_into_py(
+            py,
+            async move {
+                let (meta, objects) = {
+                    let mut f = file.lock().await;
+                    f.decode_message_async(idx, &options).await.map_err(to_py_err)?
+                };
+                Python::attach(|py| {
+                    let result_list = data_objects_to_python(py, &objects)?;
+                    pack_message(py, PyMetadata { inner: meta }, result_list)
+                })
+            },
+        )?))
+    }
+
+    fn __len__(&self) -> usize {
+        let current = self.index.load(std::sync::atomic::Ordering::Relaxed);
+        self.count.saturating_sub(current)
+    }
+
+    fn __repr__(&self) -> String {
+        let current = self.index.load(std::sync::atomic::Ordering::Relaxed);
+        let remaining = self.count.saturating_sub(current);
+        format!("AsyncTensogramFileIter(position={current}, remaining={remaining})")
+    }
+}
+```
+
+**`__aiter__` on `PyAsyncTensogramFile`**:
+```rust
+fn __aiter__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+    let file = Arc::clone(&self.file);
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        let count = {
+            let f = file.lock().await;
+            f.message_count().map_err(to_py_err)?
+        };
+        let iter = PyAsyncTensogramFileIter {
+            file,
+            index: std::sync::atomic::AtomicUsize::new(0),
+            count,
+        };
+        Python::attach(|py| Ok(iter.into_pyobject(py)?.into_any().unbind()))
+    })
+}
+```
+
+**Wait — `__aiter__` must return the iterator synchronously**, not as a coroutine.
+The Python async iteration protocol requires `__aiter__` to return the iterator object
+directly (not an awaitable).  Only `__anext__` returns awaitables.
+
+**Corrected `__aiter__`**: Get message count synchronously (using `blocking_lock` or
+cached count), construct the iterator, return it directly.
+
+```rust
+fn __aiter__(slf: Bound<'_, Self>, py: Python<'_>) -> PyResult<PyAsyncTensogramFileIter> {
+    let this = slf.borrow();
+    let file = Arc::clone(&this.file);
+    let count = file.blocking_lock().message_count().map_err(to_py_err)?;
+    Ok(PyAsyncTensogramFileIter {
+        file,
+        index: std::sync::atomic::AtomicUsize::new(0),
+        count,
+    })
+}
+```
+
+**Problem**: `blocking_lock()` can panic inside a tokio context.  But `__aiter__` is
+called by Python's `async for` machinery, which runs in the event loop thread (not a
+tokio worker).  This is safe in practice.
+
+**Better approach**: Cache message_count at first `__aiter__` call, or require the user
+to call `await f.message_count()` first.
+
+**Best approach**: Since we already have `message_count()` as async, we cache the result
+on the struct after first call.  But that adds complexity.
+
+**Simplest correct approach**: Use `blocking_lock()` in `__aiter__`.  Document that
+`async for f` may briefly block on first use if the message count hasn't been cached.
+This matches how the sync `__iter__` also does blocking I/O to scan offsets.
+
+## 4. Implementation steps
+
+### Step 1: `file_decode_range`
+- Add method to `PyAsyncTensogramFile` impl block
+- Test: basic range, join mode, out-of-range, parity with sync
+
+### Step 2: `__aenter__` / `__aexit__`
+- Add both methods to impl block
+- Test: `async with await open(...)` pattern, exception propagation
+
+### Step 3: `__len__`
+- Add `__len__` using `blocking_lock`
+- Test: `len(f)`, parity with sync len
+
+### Step 4: `__aiter__` / `__anext__`
+- Add `PyAsyncTensogramFileIter` pyclass
+- Add `__aiter__` on `PyAsyncTensogramFile`
+- Register new class in module
+- Test: `async for msg in f`, count, early break, parity with sync iter, remote iteration
+
+### Step 5: Documentation
+- Update `docs/src/guide/python-api.md` Async API section with new methods
+- Update API table in plan
+- Add iteration and context manager examples
+
+### Step 6: Tests
+Full test list for all new features.
+
+## 5. Test plan
+
+```
+# file_decode_range
+test_file_decode_range_basic
+test_file_decode_range_join
+test_file_decode_range_out_of_range
+test_file_decode_range_matches_sync
+
+# context manager
+test_async_context_manager
+test_async_context_manager_exception_propagates
+
+# __len__
+test_len
+test_len_matches_sync
+
+# async iteration
+test_aiter_all_messages
+test_aiter_count
+test_aiter_early_break
+test_aiter_matches_sync_iter
+test_aiter_repr
+test_aiter_remote  (async for on remote file — sync __iter__ can't do this)
+```

--- a/plans/python-async-bindings.md
+++ b/plans/python-async-bindings.md
@@ -1,0 +1,756 @@
+# Plan: Python Async Bindings
+
+**TODO.md item**: Python asyncio support
+**Status**: Implemented (branch `feature/python-async-bindings`)
+**Target**: v0.11.0
+
+> **Note**: This plan was written for the initial TokioMutex-based architecture.
+> The implementation evolved to use `Arc<TensogramFile>` with `&self` async methods
+> (no mutex). Code snippets below may reference the old design. See the actual
+> source code for the current implementation.
+
+## 1. Goal
+
+Expose the native async Rust path (`TensogramFile::*_async` methods) to Python as
+first-class `asyncio` coroutines.  The async API enables non-blocking I/O in
+asyncio-based applications and composable concurrency via `asyncio.gather`.
+
+```python
+import asyncio
+import tensogram
+
+async def main():
+    f = await tensogram.AsyncTensogramFile.open("s3://bucket/data.tgm")
+
+    # Multiple awaitable decode calls composed via gather.
+    # Same-handle calls are safe but serialised by an internal mutex;
+    # for true I/O overlap, use separate handles.
+    results = await asyncio.gather(
+        f.file_decode_object(0, 0),
+        f.file_decode_object(0, 1),
+        f.file_decode_object(0, 2),
+    )
+    for r in results:
+        print(r["data"].shape)
+
+asyncio.run(main())
+```
+
+### Concurrency semantics
+
+`AsyncTensogramFile` wraps a single `TensogramFile` behind `Arc<tokio::sync::Mutex>`.
+This means:
+
+- **Same-handle calls are safe**: multiple coroutines may reference the same handle.
+- **Same-handle calls are serialised**: the mutex is held for the duration of each I/O
+  operation, so `asyncio.gather` on one handle provides composability (other asyncio tasks
+  can run between operations) but not intra-handle I/O parallelism.
+- **Multi-handle calls overlap**: opening the same file/URL from multiple
+  `AsyncTensogramFile` instances provides true concurrent I/O.
+
+True same-handle parallelism would require refactoring core `TensogramFile` mutability
+(the async methods take `&mut self` due to lazy `OnceLock` initialisation).
+That is out of scope for this PR; the Foundation delivers correct asyncio integration.
+
+## 2. Architecture Decision
+
+### Approach: `pyo3-async-runtimes` + `tokio` bridge
+
+**Chosen**: `pyo3_async_runtimes::tokio::future_into_py` wrapping native Rust async.
+
+**Rationale**:
+- `pyo3-async-runtimes` 0.28.0 is released and compatible with pyo3 0.28 (tensogram's version).
+- Properly bridges tokio futures to Python `asyncio` awaitables with correct waker propagation.
+- Established pattern (e.g. nautilus_trader uses the same approach).
+- No manual channel plumbing or `experimental-async` feature needed.
+
+**Rejected alternatives**:
+- pyo3 `experimental-async` + manual `futures::channel::oneshot` bridging:
+  Correct but more boilerplate and requires manual waker management.
+- Blocking async via `block_on` inside `py.detach()`:
+  Already done by the sync API; does not enable `asyncio.gather` composition.
+
+### Internal structure
+
+```rust
+#[cfg(feature = "async")]
+#[pyclass(name = "AsyncTensogramFile")]
+struct PyAsyncTensogramFile {
+    file: Arc<tokio::sync::Mutex<TensogramFile>>,
+    cached_source: String,     // captured at construction, immutable
+    cached_is_remote: bool,    // captured at construction, immutable
+}
+```
+
+- `Arc` for shared ownership across concurrent async calls.
+- `tokio::sync::Mutex` for async-aware locking (`.lock().await` inside tokio context).
+- `cached_source`/`cached_is_remote`: plain fields captured at construction, avoiding
+  any mutex access for read-only queries.  These values never change after `open`.
+- Separate class from `PyTensogramFile` to avoid perturbing the existing sync API.
+
+### Return pattern
+
+Each async method follows this flow:
+1. Clone `Arc`, capture params (GIL held, cheap).
+2. Validate arguments eagerly (errors raised at call time, not when awaited).
+3. `future_into_py(py, async move { ... })` spawns on tokio.
+4. Inside future: acquire mutex, call `TensogramFile::*_async`, **release mutex**.
+5. `Python::attach(|py| ...)` to convert Rust data to Python objects (`Py<PyAny>`).
+6. Return `Py<PyAny>` (Send + 'static, GIL-independent).
+
+**Lock ordering**: the mutex is always released **before** `Python::attach()`.
+This prevents GIL/mutex deadlocks (same discipline as the sync path where `py.detach()`
+releases GIL before Rust work, here we release mutex before GIL re-acquisition).
+
+**Argument validation**: `open_remote` validates `storage_options` dict conversion
+**before** creating the coroutine.  Bad `storage_options` raises `ValueError` immediately
+at call time, not when awaited.  Same for any other argument parsing.
+
+### Tokio runtime
+
+`pyo3-async-runtimes` manages its own tokio runtime
+(`pyo3_async_runtimes::tokio::get_runtime()`).  The existing shared `OnceLock<Runtime>`
+in `remote.rs` continues to serve `block_on_shared()` calls from the sync API.
+The two runtimes are independent.
+
+For **local backends**: `TensogramFile::*_async` internally uses
+`tokio::task::spawn_blocking` for file I/O, which works on either runtime.
+
+For **remote backends**: `RemoteBackend` async methods run natively on whatever
+tokio runtime is active.  The shared runtime serves sync `block_on_shared()` calls.
+
+**Runtime init failure**: if `pyo3-async-runtimes` fails to create its tokio runtime,
+`future_into_py` raises `RuntimeError`.  This is analogous to the sync path where
+`shared_runtime()` returns `Err(TensogramError::Remote(...))`.
+
+## 3. Dependencies
+
+Add to `crates/tensogram-python/Cargo.toml`:
+
+```toml
+[features]
+default = ["async"]
+async = ["tensogram-core/async", "dep:pyo3-async-runtimes", "dep:tokio"]
+
+[dependencies]
+pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"], optional = true }
+tokio = { version = "1", features = ["sync"], optional = true }
+```
+
+This adds:
+- `pyo3-async-runtimes` 0.28 (bridges tokio futures to Python asyncio)
+- `tokio` 1.x with `sync` feature (direct dependency for `tokio::sync::Mutex`)
+
+Both gated behind the `async` feature.  All async Rust code behind `#[cfg(feature = "async")]`
+including imports:
+
+```rust
+#[cfg(feature = "async")]
+use std::sync::Arc;
+#[cfg(feature = "async")]
+use tokio::sync::Mutex as TokioMutex;
+```
+
+Feature gate: `async` is default-on.  The sync-only build path remains available via
+`--no-default-features`.  Adding `default = ["async"]` changes the default build of
+`tensogram-python`; this is intentional and must be verified through `maturin develop`
+(the real build tool), not just `cargo build`.
+
+Note: `tensogram-python` already hard-enables the `remote` feature on `tensogram-core`
+(line 11 of `Cargo.toml`: `features = ["remote"]`).  The `async` feature adds
+`tensogram-core/async` on top.  Therefore `open_source_async` (which requires
+`remote + async`) is always available when `async` is enabled.
+`--no-default-features` disables the Python async bindings but NOT remote support.
+
+## 4. Implementation Steps
+
+### Step 1: Cargo.toml & feature gate
+
+**Files**: `crates/tensogram-python/Cargo.toml`
+
+- Add `[features]` section with `default = ["async"]` and `async` feature
+- Add `pyo3-async-runtimes` and `tokio` dependencies (both optional, gated on `async`)
+- Verify `maturin develop` succeeds (default features, i.e. with async)
+- Verify `maturin develop --no-default-features` succeeds (sync-only)
+- Verify `cargo clippy -p tensogram-python` passes
+- Verify `cargo clippy -p tensogram-python --no-default-features` passes (no unused imports)
+
+### Step 2: Shared test infrastructure
+
+**Files**: `tests/python/conftest.py` (new), `tests/python/test_remote.py` (update)
+
+Extract **only pytest fixtures** to `tests/python/conftest.py` (pytest auto-discovers
+fixtures from `conftest.py`, but **not** plain functions):
+
+```python
+# tests/python/conftest.py
+import http.server
+import threading
+import numpy as np
+import pytest
+import tensogram
+
+
+def _make_handler(file_data: bytes):
+    """HTTP handler with Range support (moved from test_remote.py)."""
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def log_message(self, fmt, *args):
+            pass
+        def do_HEAD(self):
+            ...  # same as current test_remote.py
+        def do_GET(self):
+            ...  # same as current test_remote.py
+    return Handler
+
+
+@pytest.fixture
+def serve_tgm_bytes():
+    """Start mock HTTP server for given bytes, isolated per call."""
+    entries = []
+    def _serve(data: bytes) -> str:
+        handler = _make_handler(data)
+        server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        entries.append((server, thread))
+        return f"http://127.0.0.1:{port}/test.tgm"
+    yield _serve
+    for server, thread in entries:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.fixture
+def tgm_path(tmp_path):
+    """Create a local .tgm file with 3 messages for async testing.
+
+    Message i contains a float32 [10] array filled with float(i).
+    """
+    path = str(tmp_path / "test.tgm")
+    with tensogram.TensogramFile.create(path) as f:
+        for i in range(3):
+            meta = {"version": 2, "base": [{"index": i}]}
+            desc = {
+                "type": "ntensor", "shape": [10], "dtype": "float32",
+                "byte_order": "little", "encoding": "none",
+                "filter": "none", "compression": "none",
+            }
+            data = np.full(10, float(i), dtype=np.float32)
+            f.append(meta, [(desc, data)])
+    return path
+```
+
+Keep `make_global_meta`, `make_descriptor`, `encode_test_message` as module-local
+helper functions in each test file that needs them.  They are not fixtures and should
+not go in `conftest.py`.
+
+Update `test_remote.py`: remove the `serve_tgm_bytes` fixture definition (now in
+`conftest.py`).  Run `python -m pytest tests/python/test_remote.py -v` in isolation
+to verify no regressions.
+
+### Step 3: Minimal failing test (TDD anchor)
+
+**Files**: `tests/python/test_async.py` (new)
+
+Write a minimal async test that will fail until Step 5 is complete:
+
+```python
+import pytest
+import tensogram
+
+@pytest.mark.asyncio
+async def test_async_open_exists(tgm_path):
+    """TDD anchor: AsyncTensogramFile.open must exist and return a handle."""
+    f = await tensogram.AsyncTensogramFile.open(tgm_path)
+    assert f.source() == tgm_path
+
+@pytest.mark.asyncio
+async def test_async_decode_message_exists(tgm_path):
+    """TDD anchor: decode_message must return Message namedtuple."""
+    f = await tensogram.AsyncTensogramFile.open(tgm_path)
+    meta, objects = await f.decode_message(0)
+    assert meta.version == 2
+```
+
+### Step 4: `PyAsyncTensogramFile` class + static constructors
+
+**Files**: `crates/tensogram-python/src/lib.rs`
+
+Keep inline in `lib.rs`.  The file is ~1886 lines; async additions add ~200-250 lines.
+
+New `#[pyclass]`:
+
+```rust
+#[cfg(feature = "async")]
+#[pyclass(name = "AsyncTensogramFile")]
+struct PyAsyncTensogramFile {
+    file: Arc<TokioMutex<TensogramFile>>,
+    cached_source: String,
+    cached_is_remote: bool,
+}
+```
+
+Two static constructors returning Python coroutines:
+
+```python
+f = await AsyncTensogramFile.open("file.tgm")                     # auto-detect
+f = await AsyncTensogramFile.open_remote(url, {"key": "value"})   # explicit remote
+```
+
+Implementation pattern (`open`):
+```rust
+#[cfg(feature = "async")]
+#[pymethods]
+impl PyAsyncTensogramFile {
+    #[staticmethod]
+    fn open<'py>(py: Python<'py>, source: &str) -> PyResult<Bound<'py, PyAny>> {
+        let source = source.to_string();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let file = TensogramFile::open_source_async(&source).await.map_err(to_py_err)?;
+            let is_remote = file.is_remote();
+            let source_str = file.source();
+            let wrapped = PyAsyncTensogramFile {
+                file: Arc::new(TokioMutex::new(file)),
+                cached_source: source_str,
+                cached_is_remote: is_remote,
+            };
+            Python::attach(|py| Ok(wrapped.into_pyobject(py)?.into_any().unbind()))
+        })
+    }
+
+    #[staticmethod]
+    #[pyo3(signature = (source, storage_options=None))]
+    fn open_remote<'py>(
+        py: Python<'py>,
+        source: &str,
+        storage_options: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        // Validate storage_options EAGERLY (error at call time, not when awaited).
+        let opts = match storage_options {
+            Some(dict) => {
+                let mut map = std::collections::BTreeMap::new();
+                for (k, v) in dict.iter() {
+                    let key: String = k.extract()?;
+                    let val: String = v.extract::<String>().or_else(|_| {
+                        v.str()
+                            .map(|s| s.to_string())
+                            .map_err(|_| PyValueError::new_err(format!(
+                                "storage_options value for key '{key}' must be convertible to string"
+                            )))
+                    })?;
+                    map.insert(key, val);
+                }
+                map
+            }
+            None => std::collections::BTreeMap::new(),
+        };
+        let source = source.to_string();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let file = TensogramFile::open_remote_async(&source, &opts).await.map_err(to_py_err)?;
+            let is_remote = file.is_remote();
+            let source_str = file.source();
+            let wrapped = PyAsyncTensogramFile {
+                file: Arc::new(TokioMutex::new(file)),
+                cached_source: source_str,
+                cached_is_remote: is_remote,
+            };
+            Python::attach(|py| Ok(wrapped.into_pyobject(py)?.into_any().unbind()))
+        })
+    }
+}
+```
+
+### Step 5: Async decode methods
+
+Method names mirror the existing sync `PyTensogramFile` API exactly:
+
+| Async Python method | Sync Python equivalent | Rust async method | Returns |
+|---|---|---|---|
+| `decode_message(index, ...)` | `decode_message` | `decode_message_async` | `Message` namedtuple |
+| `file_decode_metadata(msg_index)` | `file_decode_metadata` | `decode_metadata_async` | `Metadata` |
+| `file_decode_descriptors(msg_index)` | `file_decode_descriptors` | `decode_descriptors_async` | `dict(metadata=..., descriptors=[...])` |
+| `file_decode_object(msg_index, obj_index, ...)` | `file_decode_object` | `decode_object_async` | `dict(metadata=..., descriptor=..., data=ndarray)` |
+
+All follow the same pattern (example: `file_decode_object`):
+
+```rust
+#[pyo3(signature = (msg_index, obj_index, verify_hash=false, native_byte_order=true))]
+fn file_decode_object<'py>(
+    &self,
+    py: Python<'py>,
+    msg_index: usize,
+    obj_index: usize,
+    verify_hash: bool,
+    native_byte_order: bool,
+) -> PyResult<Bound<'py, PyAny>> {
+    let file = Arc::clone(&self.file);
+    let options = DecodeOptions { verify_hash, native_byte_order, ..Default::default() };
+
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        // Async I/O — mutex held, no GIL.
+        let (meta, desc, data) = {
+            let mut f = file.lock().await;
+            f.decode_object_async(msg_index, obj_index, &options).await.map_err(to_py_err)?
+        };
+        // Mutex released.  Acquire GIL, build Python objects.
+        Python::attach(|py| {
+            let arr = bytes_to_numpy(py, &desc, &data)?;
+            let py_desc = PyDataObjectDescriptor { inner: desc }
+                .into_pyobject(py)?.into_any().unbind();
+            let result = PyDict::new(py);
+            result.set_item("metadata", PyMetadata { inner: meta }.into_pyobject(py)?)?;
+            result.set_item("descriptor", py_desc)?;
+            result.set_item("data", arr)?;
+            Ok(result.into_any().unbind())
+        })
+    })
+}
+```
+
+`decode_message` additionally calls `pack_message()` to return the `Message` namedtuple,
+matching the sync `decode_message` return type.
+
+### Step 6: Async `read_message` + sync utility methods
+
+```python
+msg_bytes: bytes = await f.read_message(index)   # async, wraps read_message_async
+is_remote: bool  = f.is_remote()                 # sync, reads cached field
+source: str      = f.source()                    # sync, reads cached field
+```
+
+```rust
+fn read_message<'py>(&self, py: Python<'py>, index: usize) -> PyResult<Bound<'py, PyAny>> {
+    let file = Arc::clone(&self.file);
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        let bytes = {
+            let mut f = file.lock().await;
+            f.read_message_async(index).await.map_err(to_py_err)?
+        };
+        Python::attach(|py| Ok(PyBytes::new(py, &bytes).into_any().unbind()))
+    })
+}
+
+fn is_remote(&self) -> bool {
+    self.cached_is_remote
+}
+
+fn source(&self) -> &str {
+    &self.cached_source
+}
+```
+
+**`message_count()` is deferred** from Foundation.  Reason: the only implementation would
+use `tokio::sync::Mutex::blocking_lock()`, which **panics** if called from within a tokio
+runtime context.  This is a hard panic-safety violation.  `message_count` will be added
+when core exposes `TensogramFile::message_count_async`, or users can open a sync
+`TensogramFile` handle to query the count.
+
+### Step 7: `__repr__` and module registration
+
+```rust
+fn __repr__(&self) -> String {
+    format!("AsyncTensogramFile(source='{}')", self.cached_source)
+}
+```
+
+Module registration (add to `#[pymodule]` in `lib.rs`):
+```rust
+#[cfg(feature = "async")]
+m.add_class::<PyAsyncTensogramFile>()?;
+```
+
+No changes needed to `__init__.py`: `from .tensogram import *` already re-exports all
+classes added via `m.add_class`.
+
+### Step 8: Full test suite
+
+**File**: `tests/python/test_async.py`
+
+Add `pytest-asyncio` to test dependencies.  Use explicit `@pytest.mark.asyncio` markers.
+
+```python
+# tests/python/test_async.py
+import asyncio
+
+import numpy as np
+import pytest
+
+import tensogram
+
+# ── Local helpers (not fixtures, not in conftest.py) ──
+
+def _encode_test_message(shape, fill=42.0):
+    meta = {"version": 2, "base": [{}]}
+    desc = {
+        "type": "ntensor", "shape": shape, "dtype": "float32",
+        "byte_order": "little", "encoding": "none",
+        "filter": "none", "compression": "none",
+    }
+    data = np.full(shape, fill, dtype=np.float32)
+    return tensogram.encode(meta, [(desc, data)])
+
+# ── Open tests ──
+
+@pytest.mark.asyncio
+async def test_open_local(tgm_path):
+    f = await tensogram.AsyncTensogramFile.open(tgm_path)
+    assert not f.is_remote()
+    assert f.source() == tgm_path
+
+@pytest.mark.asyncio
+async def test_open_remote(serve_tgm_bytes):
+    msg = _encode_test_message([4])
+    url = serve_tgm_bytes(msg)
+    f = await tensogram.AsyncTensogramFile.open(url)
+    assert f.is_remote()
+
+# ── Decode tests ──
+
+@pytest.mark.asyncio
+async def test_file_decode_object(tgm_path):
+    f = await tensogram.AsyncTensogramFile.open(tgm_path)
+    result = await f.file_decode_object(0, 0)
+    assert "metadata" in result
+    assert "descriptor" in result
+    assert "data" in result
+    np.testing.assert_allclose(result["data"], np.zeros(10, dtype=np.float32))
+
+@pytest.mark.asyncio
+async def test_decode_message(tgm_path):
+    f = await tensogram.AsyncTensogramFile.open(tgm_path)
+    meta, objects = await f.decode_message(1)
+    assert meta.version == 2
+    np.testing.assert_allclose(objects[0][1], np.ones(10, dtype=np.float32))
+
+@pytest.mark.asyncio
+async def test_file_decode_metadata(tgm_path):
+    f = await tensogram.AsyncTensogramFile.open(tgm_path)
+    meta = await f.file_decode_metadata(0)
+    assert meta.version == 2
+
+@pytest.mark.asyncio
+async def test_file_decode_descriptors(tgm_path):
+    f = await tensogram.AsyncTensogramFile.open(tgm_path)
+    result = await f.file_decode_descriptors(0)
+    assert len(result["descriptors"]) == 1
+
+# ── Gather tests (composability, not parallel I/O) ──
+
+@pytest.mark.asyncio
+async def test_gather_safe_on_same_handle(tgm_path):
+    """asyncio.gather on one handle is safe (serialised internally)."""
+    f = await tensogram.AsyncTensogramFile.open(tgm_path)
+    results = await asyncio.gather(
+        f.file_decode_object(0, 0),
+        f.file_decode_object(1, 0),
+        f.file_decode_object(2, 0),
+    )
+    for i, r in enumerate(results):
+        np.testing.assert_allclose(r["data"], np.full(10, float(i), dtype=np.float32))
+
+@pytest.mark.asyncio
+async def test_gather_mixed_operations(tgm_path):
+    """Concurrent metadata + object decodes on same handle."""
+    f = await tensogram.AsyncTensogramFile.open(tgm_path)
+    meta, obj = await asyncio.gather(
+        f.file_decode_metadata(0),
+        f.file_decode_object(1, 0),
+    )
+    assert meta.version == 2
+    assert obj["data"].shape == (10,)
+
+# ── Parity tests ──
+
+@pytest.mark.asyncio
+async def test_async_matches_sync(tgm_path):
+    """Async decode produces identical results to sync decode."""
+    sync_file = tensogram.TensogramFile.open(tgm_path)
+    sync_meta, sync_objects = sync_file.decode_message(0)
+
+    async_file = await tensogram.AsyncTensogramFile.open(tgm_path)
+    async_meta, async_objects = await async_file.decode_message(0)
+
+    assert sync_meta.version == async_meta.version
+    np.testing.assert_array_equal(sync_objects[0][1], async_objects[0][1])
+
+# ── Error tests ──
+
+@pytest.mark.asyncio
+async def test_open_nonexistent():
+    with pytest.raises(OSError):
+        await tensogram.AsyncTensogramFile.open("/nonexistent.tgm")
+
+@pytest.mark.asyncio
+async def test_decode_out_of_range(tgm_path):
+    f = await tensogram.AsyncTensogramFile.open(tgm_path)
+    with pytest.raises((ValueError, RuntimeError)):
+        await f.file_decode_object(999, 0)
+
+@pytest.mark.asyncio
+async def test_open_remote_bad_storage_options(serve_tgm_bytes):
+    """Bad storage_options raises ValueError at call time, not when awaited."""
+    msg = _encode_test_message([4])
+    url = serve_tgm_bytes(msg)
+
+    class Unconvertible:
+        def __str__(self):
+            raise RuntimeError("cannot convert")
+
+    with pytest.raises(ValueError, match="convertible to string"):
+        # Error must be raised HERE, not on await
+        tensogram.AsyncTensogramFile.open_remote(url, {"key": Unconvertible()})
+
+# ── Cancellation test ──
+
+@pytest.mark.asyncio
+async def test_cancel_then_reuse_handle(tgm_path):
+    """Cancelling an in-flight decode does not wedge the mutex."""
+    f = await tensogram.AsyncTensogramFile.open(tgm_path)
+
+    task = asyncio.create_task(f.file_decode_object(0, 0))
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    # Handle must still be usable after cancellation.
+    result = await f.file_decode_object(1, 0)
+    np.testing.assert_allclose(result["data"], np.ones(10, dtype=np.float32))
+
+# ── Remote async tests ──
+
+@pytest.mark.asyncio
+async def test_remote_async_decode(serve_tgm_bytes):
+    msg = _encode_test_message([4], fill=42.0)
+    url = serve_tgm_bytes(msg)
+    f = await tensogram.AsyncTensogramFile.open(url)
+    assert f.is_remote()
+    result = await f.file_decode_object(0, 0)
+    np.testing.assert_allclose(result["data"], np.full(4, 42.0, dtype=np.float32))
+
+@pytest.mark.asyncio
+async def test_remote_async_matches_sync(serve_tgm_bytes):
+    """Remote async decode matches remote sync decode."""
+    msg = _encode_test_message([10], fill=3.14)
+    url = serve_tgm_bytes(msg)
+
+    sync_file = tensogram.TensogramFile.open(url)
+    sync_result = sync_file.file_decode_object(0, 0)
+
+    async_file = await tensogram.AsyncTensogramFile.open(url)
+    async_result = await async_file.file_decode_object(0, 0)
+
+    np.testing.assert_array_equal(sync_result["data"], async_result["data"])
+
+# ── Repr test ──
+
+@pytest.mark.asyncio
+async def test_repr(tgm_path):
+    f = await tensogram.AsyncTensogramFile.open(tgm_path)
+    r = repr(f)
+    assert "AsyncTensogramFile" in r
+    assert tgm_path in r
+```
+
+### Step 9: Example
+
+**File**: `examples/python/15_async_operations.py`
+
+Self-contained example showing:
+1. Async open (local file, created inline)
+2. Sequential async decode
+3. Composing multiple decodes with `asyncio.gather` (with comment explaining
+   same-handle serialisation vs event-loop composability)
+4. Mixing async decode with other asyncio tasks (e.g. `asyncio.sleep`)
+
+### Step 10: Documentation
+
+Update the following files:
+
+- **`docs/src/guide/python-api.md`**: Add "Async API" section covering
+  `AsyncTensogramFile`, all methods, concurrency semantics, when to use async vs sync.
+- **`docs/src/guide/remote-access.md`**: Add note about async remote access via
+  `AsyncTensogramFile.open`.
+- **Examples table in docs**: Add entry for `15_async_operations.py`.
+
+### Step 11: CI
+
+**File**: `.github/workflows/ci.yml`
+
+No new test command needed; the existing `python -m pytest tests/python/ -v` already
+runs all files including `test_async.py`.
+
+Changes:
+- Add `pytest-asyncio` to `uv pip install` in **every** CI job that runs `tests/python/`
+  (standard Python job, free-threaded Python job if present).
+- Verify `conftest.py` extraction does not break `test_remote.py` (run it in isolation).
+- Add a verification step: `maturin develop --no-default-features` + basic sync test
+  to confirm the feature-gate produces no dead code warnings.
+
+## 5. API Surface Summary
+
+### `AsyncTensogramFile` class
+
+| Method | Signature | Returns | Notes |
+|---|---|---|---|
+| `open` | `await .open(source)` | `AsyncTensogramFile` | Static, auto-detects local/remote |
+| `open_remote` | `await .open_remote(source, storage_options=None)` | `AsyncTensogramFile` | Static, explicit remote |
+| `decode_message` | `await .decode_message(index, verify_hash=False, native_byte_order=True)` | `Message` namedtuple | Full message decode |
+| `file_decode_metadata` | `await .file_decode_metadata(msg_index)` | `Metadata` | Metadata only |
+| `file_decode_descriptors` | `await .file_decode_descriptors(msg_index)` | `dict` | Metadata + descriptors |
+| `file_decode_object` | `await .file_decode_object(msg_index, obj_index, verify_hash=False, native_byte_order=True)` | `dict` | Single object |
+| `read_message` | `await .read_message(index)` | `bytes` | Raw wire bytes |
+| `message_count` | `await .message_count()` | `int` | Async (locks mutex, calls sync count) |
+| `is_remote` | `.is_remote()` | `bool` | Sync (cached field) |
+| `source` | `.source()` | `str` | Sync (cached field) |
+| `__repr__` | `repr(f)` | `str` | Sync |
+
+### Deferred (not in Foundation)
+
+| Feature | Reason | Escalation trigger |
+|---|---|---|
+| `__aenter__`/`__aexit__` | No close/shutdown semantics exist | Add when `close()` is introduced |
+| `__len__` | Would need sync I/O on async class; use `await message_count()` instead | Revisit if needed |
+| `__aiter__`/`__anext__` | Complex protocol; gather covers primary use case | Add if user demand |
+| `file_decode_range` async | No `TensogramFile::decode_range_async` in core | Add when core exposes it |
+| Async encode | CPU-bound; `py.detach()` sync already optimal | No escalation expected |
+
+## 6. Risk Assessment
+
+### Resolved
+
+1. **pyo3-async-runtimes version**: 0.28.0 exists, compatible with pyo3 0.28.
+2. **Tokio runtime**: independent runtimes, no conflict.
+3. **GIL/mutex ordering**: mutex released before `Python::attach()` prevents deadlocks.
+4. **`remote` feature availability**: hard-enabled, so `open_source_async` always available.
+5. **`blocking_lock()` panic**: avoided by making `message_count()` fully async (locks mutex via `.lock().await`, not `blocking_lock`).
+6. **Argument validation timing**: `open_remote` validates `storage_options` eagerly.
+7. **Cancellation safety**: tokio mutex is cancel-safe; dropping the future while the
+   mutex is locked does not leave it wedged (tokio guarantees this).
+
+### Risks
+
+1. **Breaking `test_remote.py`**: Extracting `serve_tgm_bytes` to `conftest.py` must be
+   done carefully.  Run `test_remote.py` in isolation after extraction.
+2. **Two tokio runtimes**: if core async methods internally call `block_on_shared()` while
+   already running on the pyo3-async-runtimes tokio, the `block_on_shared` function handles
+   this correctly (block_in_place for multi-thread, scoped thread for current-thread).
+3. **`default = ["async"]` changes build surface**: Must verify through `maturin develop`,
+   not just `cargo build`.  CI should test both default and `--no-default-features` paths.
+
+### Open questions (to resolve during implementation)
+
+1. **`pytest-asyncio` mode**: Use `mode = "auto"` or explicit `@pytest.mark.asyncio`?
+   Recommendation: explicit markers for clarity.
+
+## 7. Non-Goals (out of scope)
+
+- **Async encode**: CPU-bound, `py.detach()` already optimal.
+- **Async xarray/zarr backends**: Synchronous frameworks; async benefit from direct API.
+- **Free-threaded Python**: Separate TODO item.  `AsyncTensogramFile` uses `Arc + Mutex`
+  internally, but end-to-end free-threaded readiness is a separate, broader effort.
+- **True same-handle parallel I/O**: Requires core `TensogramFile` mutability refactor.
+  Foundation provides correct asyncio integration; parallelism can be added later.

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,0 +1,99 @@
+"""Shared pytest fixtures for tensogram Python tests."""
+
+from __future__ import annotations
+
+import http.server
+import threading
+
+import numpy as np
+import pytest
+import tensogram
+
+
+def _make_handler(file_data: bytes):
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def log_message(self, fmt, *args):
+            pass
+
+        def do_HEAD(self):
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(file_data)))
+            self.send_header("Accept-Ranges", "bytes")
+            self.end_headers()
+
+        def do_GET(self):
+            data = file_data
+            range_header = self.headers.get("Range")
+            if range_header and range_header.startswith("bytes="):
+                range_spec = range_header[6:]
+                if range_spec.startswith("-"):
+                    suffix = int(range_spec[1:])
+                    start = max(0, len(data) - suffix)
+                    end = len(data)
+                else:
+                    parts = range_spec.split("-")
+                    start = int(parts[0])
+                    end = int(parts[1]) + 1 if parts[1] else len(data)
+                    end = min(end, len(data))
+                if start >= len(data):
+                    self.send_response(416)
+                    self.end_headers()
+                    return
+                chunk = data[start:end]
+                self.send_response(206)
+                self.send_header(
+                    "Content-Range", f"bytes {start}-{end - 1}/{len(data)}"
+                )
+                self.send_header("Content-Length", str(len(chunk)))
+                self.end_headers()
+                self.wfile.write(chunk)
+            else:
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+
+    return Handler
+
+
+@pytest.fixture
+def serve_tgm_bytes():
+    """Start a mock HTTP server with Range support, isolated per call."""
+    entries: list[tuple] = []
+
+    def _serve(data: bytes) -> str:
+        handler = _make_handler(data)
+        server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        entries.append((server, thread))
+        return f"http://127.0.0.1:{port}/test.tgm"
+
+    yield _serve
+
+    for server, thread in entries:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.fixture
+def tgm_path(tmp_path):
+    """Create a local .tgm with 3 messages (float32 [10], fill=0.0/1.0/2.0)."""
+    path = str(tmp_path / "test.tgm")
+    with tensogram.TensogramFile.create(path) as f:
+        for i in range(3):
+            meta = {"version": 2, "base": [{"index": i}]}
+            desc = {
+                "type": "ntensor",
+                "shape": [10],
+                "dtype": "float32",
+                "byte_order": "little",
+                "encoding": "none",
+                "filter": "none",
+                "compression": "none",
+            }
+            data = np.full(10, float(i), dtype=np.float32)
+            f.append(meta, [(desc, data)])
+    return path

--- a/tests/python/test_async.py
+++ b/tests/python/test_async.py
@@ -56,7 +56,7 @@ class TestAsyncOpen:
 
     @pytest.mark.asyncio
     async def test_open_nonexistent(self):
-        with pytest.raises(OSError, match="not found"):
+        with pytest.raises(OSError, match=r"[Nn]o such|not found"):
             await tensogram.AsyncTensogramFile.open("/nonexistent/path.tgm")
 
     @pytest.mark.asyncio

--- a/tests/python/test_async.py
+++ b/tests/python/test_async.py
@@ -384,14 +384,23 @@ class TestAsyncContextManager:
 
 class TestAsyncLen:
     @pytest.mark.asyncio
-    async def test_len(self, tgm_path):
+    async def test_len_after_message_count(self, tgm_path):
         f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        count = await f.message_count()
+        assert count == 3
         assert len(f) == 3
+
+    @pytest.mark.asyncio
+    async def test_len_without_message_count_raises(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        with pytest.raises(RuntimeError, match="message_count"):
+            len(f)
 
     @pytest.mark.asyncio
     async def test_len_matches_sync(self, tgm_path):
         sync_file = tensogram.TensogramFile.open(tgm_path)
         async_file = await tensogram.AsyncTensogramFile.open(tgm_path)
+        await async_file.message_count()
         assert len(sync_file) == len(async_file)
 
 
@@ -399,6 +408,7 @@ class TestAsyncIteration:
     @pytest.mark.asyncio
     async def test_aiter_all_messages(self, tgm_path):
         f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        await f.message_count()
         messages = []
         async for msg in f:
             messages.append(msg)
@@ -412,6 +422,7 @@ class TestAsyncIteration:
     @pytest.mark.asyncio
     async def test_aiter_early_break(self, tgm_path):
         f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        await f.message_count()
         count = 0
         async for _msg in f:
             count += 1
@@ -425,6 +436,7 @@ class TestAsyncIteration:
         sync_messages = list(sync_file)
 
         async_file = await tensogram.AsyncTensogramFile.open(tgm_path)
+        await async_file.message_count()
         async_messages = []
         async for msg in async_file:
             async_messages.append(msg)
@@ -439,6 +451,7 @@ class TestAsyncIteration:
         msg = _encode_test_message([4], fill=99.0)
         url = serve_tgm_bytes(msg)
         f = await tensogram.AsyncTensogramFile.open(url)
+        await f.message_count()
         messages = []
         async for m in f:
             messages.append(m)
@@ -450,6 +463,7 @@ class TestAsyncIteration:
     @pytest.mark.asyncio
     async def test_aiter_repr(self, tgm_path):
         f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        await f.message_count()
         it = f.__aiter__()
         r = repr(it)
         assert "AsyncTensogramFileIter" in r
@@ -459,6 +473,7 @@ class TestAsyncIteration:
     @pytest.mark.asyncio
     async def test_aiter_len(self, tgm_path):
         f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        await f.message_count()
         it = f.__aiter__()
         assert len(it) == 3
         await it.__anext__()
@@ -470,6 +485,7 @@ class TestAsyncIteration:
         with tensogram.TensogramFile.create(path):
             pass
         f = await tensogram.AsyncTensogramFile.open(path)
+        await f.message_count()
         messages = []
         async for msg in f:
             messages.append(msg)
@@ -478,6 +494,7 @@ class TestAsyncIteration:
     @pytest.mark.asyncio
     async def test_aiter_exhaustion(self, tgm_path):
         f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        await f.message_count()
         it = f.__aiter__()
         for _ in range(3):
             await it.__anext__()
@@ -487,6 +504,7 @@ class TestAsyncIteration:
     @pytest.mark.asyncio
     async def test_aiter_concurrent_iterators(self, tgm_path):
         f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        await f.message_count()
         it1 = f.__aiter__()
         it2 = f.__aiter__()
         msg1_first = await it1.__anext__()
@@ -522,6 +540,7 @@ class TestAsyncLenRemote:
         msg = _encode_test_message([4])
         url = serve_tgm_bytes(msg)
         f = await tensogram.AsyncTensogramFile.open(url)
+        await f.message_count()
         assert len(f) == 1
 
 

--- a/tests/python/test_async.py
+++ b/tests/python/test_async.py
@@ -1,0 +1,833 @@
+"""Tests for AsyncTensogramFile — Python asyncio bindings."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import numpy as np
+import pytest
+import tensogram
+
+
+def _encode_test_message(shape: list[int], fill: float = 42.0) -> bytes:
+    meta = {"version": 2, "base": [{}]}
+    desc = {
+        "type": "ntensor",
+        "shape": shape,
+        "dtype": "float32",
+        "byte_order": "little",
+        "encoding": "none",
+        "filter": "none",
+        "compression": "none",
+    }
+    data = np.full(shape, fill, dtype=np.float32)
+    return tensogram.encode(meta, [(desc, data)])
+
+
+class TestAsyncOpen:
+    @pytest.mark.asyncio
+    async def test_open_local(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        assert not f.is_remote()
+        assert f.source() == tgm_path
+
+    @pytest.mark.asyncio
+    async def test_open_remote(self, serve_tgm_bytes):
+        msg = _encode_test_message([4])
+        url = serve_tgm_bytes(msg)
+        f = await tensogram.AsyncTensogramFile.open(url)
+        assert f.is_remote()
+        assert f.source() == url
+
+    @pytest.mark.asyncio
+    async def test_open_remote_explicit(self, serve_tgm_bytes):
+        msg = _encode_test_message([4])
+        url = serve_tgm_bytes(msg)
+        f = await tensogram.AsyncTensogramFile.open_remote(url)
+        assert f.is_remote()
+
+    @pytest.mark.asyncio
+    async def test_open_remote_with_storage_options(self, serve_tgm_bytes):
+        msg = _encode_test_message([4])
+        url = serve_tgm_bytes(msg)
+        f = await tensogram.AsyncTensogramFile.open_remote(url, {"allow_http": "true"})
+        assert f.is_remote()
+
+    @pytest.mark.asyncio
+    async def test_open_nonexistent(self):
+        with pytest.raises(OSError, match="not found"):
+            await tensogram.AsyncTensogramFile.open("/nonexistent/path.tgm")
+
+    @pytest.mark.asyncio
+    async def test_repr(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        r = repr(f)
+        assert "AsyncTensogramFile" in r
+        assert tgm_path in r
+
+
+class TestAsyncMessageCount:
+    @pytest.mark.asyncio
+    async def test_message_count(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        count = await f.message_count()
+        assert count == 3
+
+    @pytest.mark.asyncio
+    async def test_message_count_single(self, serve_tgm_bytes):
+        msg = _encode_test_message([4])
+        url = serve_tgm_bytes(msg)
+        f = await tensogram.AsyncTensogramFile.open(url)
+        count = await f.message_count()
+        assert count == 1
+
+
+class TestAsyncDecode:
+    @pytest.mark.asyncio
+    async def test_decode_message(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        meta, objects = await f.decode_message(0)
+        assert meta.version == 2
+        assert len(objects) == 1
+        _desc, arr = objects[0]
+        assert arr.shape == (10,)
+        np.testing.assert_allclose(arr, np.zeros(10, dtype=np.float32))
+
+    @pytest.mark.asyncio
+    async def test_decode_message_with_verify_hash(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        meta, objects = await f.decode_message(0, verify_hash=True)
+        assert meta.version == 2
+        assert len(objects) == 1
+
+    @pytest.mark.asyncio
+    async def test_file_decode_metadata(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        meta = await f.file_decode_metadata(0)
+        assert meta.version == 2
+
+    @pytest.mark.asyncio
+    async def test_file_decode_descriptors(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        result = await f.file_decode_descriptors(0)
+        assert "metadata" in result
+        assert "descriptors" in result
+        descs = result["descriptors"]
+        assert len(descs) == 1
+        assert list(descs[0].shape) == [10]
+        assert descs[0].dtype == "float32"
+
+    @pytest.mark.asyncio
+    async def test_file_decode_object(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        result = await f.file_decode_object(0, 0)
+        assert "metadata" in result
+        assert "descriptor" in result
+        assert "data" in result
+        np.testing.assert_allclose(result["data"], np.zeros(10, dtype=np.float32))
+
+    @pytest.mark.asyncio
+    async def test_file_decode_object_second_message(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        result = await f.file_decode_object(1, 0)
+        np.testing.assert_allclose(result["data"], np.ones(10, dtype=np.float32))
+
+    @pytest.mark.asyncio
+    async def test_file_decode_object_third_message(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        result = await f.file_decode_object(2, 0)
+        np.testing.assert_allclose(result["data"], np.full(10, 2.0, dtype=np.float32))
+
+    @pytest.mark.asyncio
+    async def test_read_message(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        raw = await f.read_message(0)
+        assert isinstance(raw, bytes)
+        assert len(raw) > 0
+        meta, _ = tensogram.decode(raw)
+        assert meta.version == 2
+
+
+class TestAsyncGather:
+    @pytest.mark.asyncio
+    async def test_gather_decode_objects(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        results = await asyncio.gather(
+            f.file_decode_object(0, 0),
+            f.file_decode_object(1, 0),
+            f.file_decode_object(2, 0),
+        )
+        for i, r in enumerate(results):
+            np.testing.assert_allclose(
+                r["data"], np.full(10, float(i), dtype=np.float32)
+            )
+
+    @pytest.mark.asyncio
+    async def test_gather_mixed_operations(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        meta, obj = await asyncio.gather(
+            f.file_decode_metadata(0),
+            f.file_decode_object(1, 0),
+        )
+        assert meta.version == 2
+        assert obj["data"].shape == (10,)
+
+    @pytest.mark.asyncio
+    async def test_gather_all_messages(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        messages = await asyncio.gather(
+            f.decode_message(0),
+            f.decode_message(1),
+            f.decode_message(2),
+        )
+        for i, (meta, objects) in enumerate(messages):
+            assert meta.version == 2
+            np.testing.assert_allclose(
+                objects[0][1], np.full(10, float(i), dtype=np.float32)
+            )
+
+
+class TestAsyncParity:
+    @pytest.mark.asyncio
+    async def test_decode_message_matches_sync(self, tgm_path):
+        sync_file = tensogram.TensogramFile.open(tgm_path)
+        sync_meta, sync_objects = sync_file.decode_message(0)
+
+        async_file = await tensogram.AsyncTensogramFile.open(tgm_path)
+        async_meta, async_objects = await async_file.decode_message(0)
+
+        assert sync_meta.version == async_meta.version
+        assert len(sync_objects) == len(async_objects)
+        np.testing.assert_array_equal(sync_objects[0][1], async_objects[0][1])
+
+    @pytest.mark.asyncio
+    async def test_file_decode_object_matches_sync(self, tgm_path):
+        sync_file = tensogram.TensogramFile.open(tgm_path)
+        sync_result = sync_file.file_decode_object(0, 0)
+
+        async_file = await tensogram.AsyncTensogramFile.open(tgm_path)
+        async_result = await async_file.file_decode_object(0, 0)
+
+        np.testing.assert_array_equal(sync_result["data"], async_result["data"])
+
+    @pytest.mark.asyncio
+    async def test_read_message_matches_sync(self, tgm_path):
+        sync_file = tensogram.TensogramFile.open(tgm_path)
+        sync_raw = sync_file.read_message(0)
+
+        async_file = await tensogram.AsyncTensogramFile.open(tgm_path)
+        async_raw = await async_file.read_message(0)
+
+        assert sync_raw == async_raw
+
+
+class TestAsyncErrors:
+    @pytest.mark.asyncio
+    async def test_decode_message_out_of_range(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        with pytest.raises((ValueError, RuntimeError)):
+            await f.decode_message(999)
+
+    @pytest.mark.asyncio
+    async def test_file_decode_object_out_of_range(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        with pytest.raises((ValueError, RuntimeError)):
+            await f.file_decode_object(999, 0)
+
+    @pytest.mark.asyncio
+    async def test_file_decode_metadata_out_of_range(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        with pytest.raises((ValueError, RuntimeError)):
+            await f.file_decode_metadata(999)
+
+    @pytest.mark.asyncio
+    async def test_file_decode_descriptors_out_of_range(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        with pytest.raises((ValueError, RuntimeError)):
+            await f.file_decode_descriptors(999)
+
+    @pytest.mark.asyncio
+    async def test_read_message_out_of_range(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        with pytest.raises((ValueError, RuntimeError)):
+            await f.read_message(999)
+
+    @pytest.mark.asyncio
+    async def test_decode_message_verify_hash_mismatch(self, tmp_path):
+        path = str(tmp_path / "corrupt.tgm")
+        msg = _encode_test_message([4])
+        corrupt = bytearray(msg)
+        corrupt[-5] ^= 0xFF
+        with open(path, "wb") as fh:
+            fh.write(corrupt)
+        f = await tensogram.AsyncTensogramFile.open(path)
+        with pytest.raises((ValueError, RuntimeError)):
+            await f.decode_message(0, verify_hash=True)
+
+    @pytest.mark.asyncio
+    async def test_open_remote_bad_storage_options(self, serve_tgm_bytes):
+        msg = _encode_test_message([4])
+        url = serve_tgm_bytes(msg)
+
+        class Unconvertible:
+            def __str__(self):
+                raise RuntimeError("cannot convert")
+
+        with pytest.raises(ValueError, match="convertible to string"):
+            tensogram.AsyncTensogramFile.open_remote(url, {"key": Unconvertible()})
+
+    @pytest.mark.asyncio
+    async def test_cancel_then_reuse_handle(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+
+        fut = f.file_decode_object(0, 0)
+        task = asyncio.ensure_future(fut)
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+        result = await f.file_decode_object(1, 0)
+        np.testing.assert_allclose(result["data"], np.ones(10, dtype=np.float32))
+
+
+class TestAsyncRemote:
+    @pytest.mark.asyncio
+    async def test_remote_decode_object(self, serve_tgm_bytes):
+        msg = _encode_test_message([4], fill=42.0)
+        url = serve_tgm_bytes(msg)
+        f = await tensogram.AsyncTensogramFile.open(url)
+        assert f.is_remote()
+        result = await f.file_decode_object(0, 0)
+        np.testing.assert_allclose(result["data"], np.full(4, 42.0, dtype=np.float32))
+
+    @pytest.mark.asyncio
+    async def test_remote_decode_message(self, serve_tgm_bytes):
+        msg = _encode_test_message([6], fill=7.0)
+        url = serve_tgm_bytes(msg)
+        f = await tensogram.AsyncTensogramFile.open(url)
+        meta, objects = await f.decode_message(0)
+        assert meta.version == 2
+        np.testing.assert_allclose(objects[0][1], np.full(6, 7.0, dtype=np.float32))
+
+    @pytest.mark.asyncio
+    async def test_remote_matches_sync(self, serve_tgm_bytes):
+        msg = _encode_test_message([10], fill=3.14)
+        url = serve_tgm_bytes(msg)
+
+        sync_file = tensogram.TensogramFile.open(url)
+        sync_result = sync_file.file_decode_object(0, 0)
+
+        async_file = await tensogram.AsyncTensogramFile.open(url)
+        async_result = await async_file.file_decode_object(0, 0)
+
+        np.testing.assert_array_equal(sync_result["data"], async_result["data"])
+
+    @pytest.mark.asyncio
+    async def test_remote_read_message(self, serve_tgm_bytes):
+        msg = _encode_test_message([4])
+        url = serve_tgm_bytes(msg)
+        f = await tensogram.AsyncTensogramFile.open(url)
+        raw = await f.read_message(0)
+        assert isinstance(raw, bytes)
+        assert len(raw) > 0
+
+
+class TestAsyncDecodeRange:
+    @pytest.mark.asyncio
+    async def test_file_decode_range_basic(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        result = await f.file_decode_range(0, 0, [(0, 5)])
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0].shape == (5,)
+
+    @pytest.mark.asyncio
+    async def test_file_decode_range_join(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        result = await f.file_decode_range(0, 0, [(0, 3), (7, 3)], join=True)
+        assert not isinstance(result, list)
+        assert result.shape == (6,)
+
+    @pytest.mark.asyncio
+    async def test_file_decode_range_out_of_range(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        with pytest.raises((ValueError, RuntimeError)):
+            await f.file_decode_range(999, 0, [(0, 5)])
+
+    @pytest.mark.asyncio
+    async def test_file_decode_range_matches_sync(self, tgm_path):
+        sync_file = tensogram.TensogramFile.open(tgm_path)
+        sync_result = sync_file.file_decode_range(0, 0, [(0, 5), (5, 5)])
+
+        async_file = await tensogram.AsyncTensogramFile.open(tgm_path)
+        async_result = await async_file.file_decode_range(0, 0, [(0, 5), (5, 5)])
+
+        for s, a in zip(sync_result, async_result):
+            np.testing.assert_array_equal(s, a)
+
+
+class TestAsyncContextManager:
+    @pytest.mark.asyncio
+    async def test_async_with(self, tgm_path):
+        async with await tensogram.AsyncTensogramFile.open(tgm_path) as f:
+            meta, _objects = await f.decode_message(0)
+            assert meta.version == 2
+
+    @pytest.mark.asyncio
+    async def test_async_with_exception_propagates(self, tgm_path):
+        with pytest.raises(ValueError, match="test error"):  # noqa: PT012
+            async with await tensogram.AsyncTensogramFile.open(tgm_path) as f:
+                await f.decode_message(0)
+                raise ValueError("test error")
+
+
+class TestAsyncLen:
+    @pytest.mark.asyncio
+    async def test_len(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        assert len(f) == 3
+
+    @pytest.mark.asyncio
+    async def test_len_matches_sync(self, tgm_path):
+        sync_file = tensogram.TensogramFile.open(tgm_path)
+        async_file = await tensogram.AsyncTensogramFile.open(tgm_path)
+        assert len(sync_file) == len(async_file)
+
+
+class TestAsyncIteration:
+    @pytest.mark.asyncio
+    async def test_aiter_all_messages(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        messages = []
+        async for msg in f:
+            messages.append(msg)
+        assert len(messages) == 3
+        for i, (meta, objects) in enumerate(messages):
+            assert meta.version == 2
+            np.testing.assert_allclose(
+                objects[0][1], np.full(10, float(i), dtype=np.float32)
+            )
+
+    @pytest.mark.asyncio
+    async def test_aiter_early_break(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        count = 0
+        async for _msg in f:
+            count += 1
+            if count == 1:
+                break
+        assert count == 1
+
+    @pytest.mark.asyncio
+    async def test_aiter_matches_sync(self, tgm_path):
+        sync_file = tensogram.TensogramFile.open(tgm_path)
+        sync_messages = list(sync_file)
+
+        async_file = await tensogram.AsyncTensogramFile.open(tgm_path)
+        async_messages = []
+        async for msg in async_file:
+            async_messages.append(msg)
+
+        assert len(sync_messages) == len(async_messages)
+        for (s_meta, s_objs), (a_meta, a_objs) in zip(sync_messages, async_messages):
+            assert s_meta.version == a_meta.version
+            np.testing.assert_array_equal(s_objs[0][1], a_objs[0][1])
+
+    @pytest.mark.asyncio
+    async def test_aiter_remote(self, serve_tgm_bytes):
+        msg = _encode_test_message([4], fill=99.0)
+        url = serve_tgm_bytes(msg)
+        f = await tensogram.AsyncTensogramFile.open(url)
+        messages = []
+        async for m in f:
+            messages.append(m)
+        assert len(messages) == 1
+        np.testing.assert_allclose(
+            messages[0][1][0][1], np.full(4, 99.0, dtype=np.float32)
+        )
+
+    @pytest.mark.asyncio
+    async def test_aiter_repr(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        it = f.__aiter__()
+        r = repr(it)
+        assert "AsyncTensogramFileIter" in r
+        assert "position=0" in r
+        assert "remaining=3" in r
+
+    @pytest.mark.asyncio
+    async def test_aiter_len(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        it = f.__aiter__()
+        assert len(it) == 3
+        await it.__anext__()
+        assert len(it) == 2
+
+    @pytest.mark.asyncio
+    async def test_aiter_empty_file(self, tmp_path):
+        path = str(tmp_path / "empty.tgm")
+        with tensogram.TensogramFile.create(path):
+            pass
+        f = await tensogram.AsyncTensogramFile.open(path)
+        messages = []
+        async for msg in f:
+            messages.append(msg)
+        assert len(messages) == 0
+
+    @pytest.mark.asyncio
+    async def test_aiter_exhaustion(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        it = f.__aiter__()
+        for _ in range(3):
+            await it.__anext__()
+        with pytest.raises(StopAsyncIteration):
+            await it.__anext__()
+
+    @pytest.mark.asyncio
+    async def test_aiter_concurrent_iterators(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        it1 = f.__aiter__()
+        it2 = f.__aiter__()
+        msg1_first = await it1.__anext__()
+        msg2_first = await it2.__anext__()
+        assert msg1_first[0].version == msg2_first[0].version
+        assert len(it1) == 2
+        assert len(it2) == 2
+
+
+class TestAsyncDecodeRangeRemote:
+    @pytest.mark.asyncio
+    async def test_file_decode_range_remote(self, serve_tgm_bytes):
+        msg = _encode_test_message([10], fill=5.0)
+        url = serve_tgm_bytes(msg)
+        f = await tensogram.AsyncTensogramFile.open(url)
+        result = await f.file_decode_range(0, 0, [(0, 5)])
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0].shape == (5,)
+
+    @pytest.mark.asyncio
+    async def test_file_decode_range_remote_join(self, serve_tgm_bytes):
+        msg = _encode_test_message([10], fill=7.0)
+        url = serve_tgm_bytes(msg)
+        f = await tensogram.AsyncTensogramFile.open(url)
+        result = await f.file_decode_range(0, 0, [(0, 3), (7, 3)], join=True)
+        assert result.shape == (6,)
+
+
+class TestAsyncLenRemote:
+    @pytest.mark.asyncio
+    async def test_len_remote(self, serve_tgm_bytes):
+        msg = _encode_test_message([4])
+        url = serve_tgm_bytes(msg)
+        f = await tensogram.AsyncTensogramFile.open(url)
+        assert len(f) == 1
+
+
+class TestAsyncMessages:
+    @pytest.mark.asyncio
+    async def test_messages_returns_list_of_bytes(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        msgs = await f.messages()
+        assert isinstance(msgs, list)
+        assert len(msgs) == 3
+        for m in msgs:
+            assert isinstance(m, bytes)
+
+    @pytest.mark.asyncio
+    async def test_messages_matches_sync(self, tgm_path):
+        sync_file = tensogram.TensogramFile.open(tgm_path)
+        sync_msgs = sync_file.messages()
+
+        async_file = await tensogram.AsyncTensogramFile.open(tgm_path)
+        async_msgs = await async_file.messages()
+
+        assert len(sync_msgs) == len(async_msgs)
+        for s, a in zip(sync_msgs, async_msgs):
+            assert s == a
+
+    @pytest.mark.asyncio
+    async def test_messages_remote(self, serve_tgm_bytes):
+        msg = _encode_test_message([4])
+        url = serve_tgm_bytes(msg)
+        f = await tensogram.AsyncTensogramFile.open(url)
+        msgs = await f.messages()
+        assert len(msgs) == 1
+        assert isinstance(msgs[0], bytes)
+
+
+class TestAsyncBatchRange:
+    @pytest.mark.asyncio
+    async def test_batch_basic(self, serve_tgm_bytes):
+        meta = {"version": 2, "base": [{}]}
+        desc = {
+            "type": "ntensor",
+            "shape": [10],
+            "dtype": "float32",
+            "byte_order": "little",
+            "encoding": "none",
+            "filter": "none",
+            "compression": "none",
+        }
+        data = b""
+        for i in range(3):
+            arr = np.full(10, float(i), dtype=np.float32)
+            data += tensogram.encode(meta, [(desc, arr)])
+        url = serve_tgm_bytes(data)
+        f = await tensogram.AsyncTensogramFile.open(url)
+        results = await f.file_decode_range_batch([0, 1, 2], 0, [(0, 5)], join=True)
+        assert isinstance(results, list)
+        assert len(results) == 3
+        for i, arr in enumerate(results):
+            np.testing.assert_allclose(arr[:5], np.full(5, float(i), dtype=np.float32))
+
+    @pytest.mark.asyncio
+    async def test_batch_matches_individual(self, serve_tgm_bytes):
+        meta = {"version": 2, "base": [{}]}
+        desc = {
+            "type": "ntensor",
+            "shape": [10],
+            "dtype": "float32",
+            "byte_order": "little",
+            "encoding": "none",
+            "filter": "none",
+            "compression": "none",
+        }
+        data = b""
+        for i in range(3):
+            arr = np.full(10, float(i), dtype=np.float32)
+            data += tensogram.encode(meta, [(desc, arr)])
+        url = serve_tgm_bytes(data)
+        f = await tensogram.AsyncTensogramFile.open(url)
+
+        batch = await f.file_decode_range_batch([0, 1, 2], 0, [(2, 3)], join=True)
+        individual = []
+        for idx in range(3):
+            r = await f.file_decode_range(idx, 0, [(2, 3)], join=True)
+            individual.append(r)
+
+        for b, i in zip(batch, individual):
+            np.testing.assert_array_equal(b, i)
+
+    @pytest.mark.asyncio
+    async def test_batch_empty_indices(self, serve_tgm_bytes):
+        msg = _encode_test_message([10])
+        url = serve_tgm_bytes(msg)
+        f = await tensogram.AsyncTensogramFile.open(url)
+        results = await f.file_decode_range_batch([], 0, [(0, 5)], join=True)
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_batch_out_of_range(self, serve_tgm_bytes):
+        msg = _encode_test_message([10])
+        url = serve_tgm_bytes(msg)
+        f = await tensogram.AsyncTensogramFile.open(url)
+        with pytest.raises((ValueError, RuntimeError)):
+            await f.file_decode_range_batch([999], 0, [(0, 5)], join=True)
+
+
+class TestAsyncBatchObject:
+    @pytest.mark.asyncio
+    async def test_batch_basic(self, serve_tgm_bytes):
+        meta = {"version": 2, "base": [{}]}
+        desc = {
+            "type": "ntensor",
+            "shape": [10],
+            "dtype": "float32",
+            "byte_order": "little",
+            "encoding": "none",
+            "filter": "none",
+            "compression": "none",
+        }
+        data = b""
+        for i in range(3):
+            arr = np.full(10, float(i), dtype=np.float32)
+            data += tensogram.encode(meta, [(desc, arr)])
+        url = serve_tgm_bytes(data)
+        f = await tensogram.AsyncTensogramFile.open(url)
+        results = await f.file_decode_object_batch([0, 1, 2], 0)
+        assert isinstance(results, list)
+        assert len(results) == 3
+        for i, r in enumerate(results):
+            assert "data" in r
+            assert "metadata" in r
+            assert "descriptor" in r
+            np.testing.assert_allclose(
+                r["data"], np.full(10, float(i), dtype=np.float32)
+            )
+
+    @pytest.mark.asyncio
+    async def test_batch_matches_individual(self, serve_tgm_bytes):
+        meta = {"version": 2, "base": [{}]}
+        desc = {
+            "type": "ntensor",
+            "shape": [10],
+            "dtype": "float32",
+            "byte_order": "little",
+            "encoding": "none",
+            "filter": "none",
+            "compression": "none",
+        }
+        data = b""
+        for i in range(3):
+            arr = np.full(10, float(i), dtype=np.float32)
+            data += tensogram.encode(meta, [(desc, arr)])
+        url = serve_tgm_bytes(data)
+        f = await tensogram.AsyncTensogramFile.open(url)
+        batch = await f.file_decode_object_batch([0, 1, 2], 0)
+        for i in range(3):
+            individual = await f.file_decode_object(i, 0)
+            np.testing.assert_array_equal(batch[i]["data"], individual["data"])
+
+    @pytest.mark.asyncio
+    async def test_batch_empty(self, serve_tgm_bytes):
+        msg = _encode_test_message([10])
+        url = serve_tgm_bytes(msg)
+        f = await tensogram.AsyncTensogramFile.open(url)
+        results = await f.file_decode_object_batch([], 0)
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_batch_out_of_range(self, serve_tgm_bytes):
+        msg = _encode_test_message([10])
+        url = serve_tgm_bytes(msg)
+        f = await tensogram.AsyncTensogramFile.open(url)
+        with pytest.raises((ValueError, RuntimeError)):
+            await f.file_decode_object_batch([999], 0)
+
+
+class TestSyncBatchObject:
+    def test_batch_basic(self, serve_tgm_bytes):
+        meta = {"version": 2, "base": [{}]}
+        desc = {
+            "type": "ntensor",
+            "shape": [10],
+            "dtype": "float32",
+            "byte_order": "little",
+            "encoding": "none",
+            "filter": "none",
+            "compression": "none",
+        }
+        data = b""
+        for i in range(3):
+            arr = np.full(10, float(i), dtype=np.float32)
+            data += tensogram.encode(meta, [(desc, arr)])
+        url = serve_tgm_bytes(data)
+        f = tensogram.TensogramFile.open(url)
+        results = f.file_decode_object_batch([0, 1, 2], 0)
+        assert len(results) == 3
+        for i, r in enumerate(results):
+            np.testing.assert_allclose(
+                r["data"], np.full(10, float(i), dtype=np.float32)
+            )
+
+    def test_batch_matches_individual(self, serve_tgm_bytes):
+        meta = {"version": 2, "base": [{}]}
+        desc = {
+            "type": "ntensor",
+            "shape": [10],
+            "dtype": "float32",
+            "byte_order": "little",
+            "encoding": "none",
+            "filter": "none",
+            "compression": "none",
+        }
+        data = b""
+        for i in range(3):
+            arr = np.full(10, float(i), dtype=np.float32)
+            data += tensogram.encode(meta, [(desc, arr)])
+        url = serve_tgm_bytes(data)
+        f = tensogram.TensogramFile.open(url)
+        batch = f.file_decode_object_batch([0, 1, 2], 0)
+        for i in range(3):
+            individual = f.file_decode_object(i, 0)
+            np.testing.assert_array_equal(batch[i]["data"], individual["data"])
+
+
+class TestSyncBatchRange:
+    def test_batch_basic(self, serve_tgm_bytes):
+        meta = {"version": 2, "base": [{}]}
+        desc = {
+            "type": "ntensor",
+            "shape": [10],
+            "dtype": "float32",
+            "byte_order": "little",
+            "encoding": "none",
+            "filter": "none",
+            "compression": "none",
+        }
+        data = b""
+        for i in range(3):
+            arr = np.full(10, float(i), dtype=np.float32)
+            data += tensogram.encode(meta, [(desc, arr)])
+        url = serve_tgm_bytes(data)
+        f = tensogram.TensogramFile.open(url)
+        results = f.file_decode_range_batch([0, 1, 2], 0, [(0, 5)], join=True)
+        assert isinstance(results, list)
+        assert len(results) == 3
+        for i, arr in enumerate(results):
+            np.testing.assert_allclose(arr[:5], np.full(5, float(i), dtype=np.float32))
+
+    def test_batch_matches_individual(self, serve_tgm_bytes):
+        meta = {"version": 2, "base": [{}]}
+        desc = {
+            "type": "ntensor",
+            "shape": [10],
+            "dtype": "float32",
+            "byte_order": "little",
+            "encoding": "none",
+            "filter": "none",
+            "compression": "none",
+        }
+        data = b""
+        for i in range(3):
+            arr = np.full(10, float(i), dtype=np.float32)
+            data += tensogram.encode(meta, [(desc, arr)])
+        url = serve_tgm_bytes(data)
+        f = tensogram.TensogramFile.open(url)
+
+        batch = f.file_decode_range_batch([0, 1, 2], 0, [(2, 3)], join=True)
+        individual = []
+        for idx in range(3):
+            r = f.file_decode_range(idx, 0, [(2, 3)], join=True)
+            individual.append(r)
+
+        for b, i in zip(batch, individual):
+            np.testing.assert_array_equal(b, i)
+
+
+class TestAsyncPrefetchLayouts:
+    @pytest.mark.asyncio
+    async def test_prefetch_then_decode(self, serve_tgm_bytes):
+        msg = _encode_test_message([10], fill=7.0)
+        url = serve_tgm_bytes(msg)
+        f = await tensogram.AsyncTensogramFile.open(url)
+        await f.prefetch_layouts([0])
+        result = await f.file_decode_object(0, 0)
+        np.testing.assert_allclose(result["data"], np.full(10, 7.0, dtype=np.float32))
+
+    @pytest.mark.asyncio
+    async def test_prefetch_empty(self, serve_tgm_bytes):
+        msg = _encode_test_message([10])
+        url = serve_tgm_bytes(msg)
+        f = await tensogram.AsyncTensogramFile.open(url)
+        await f.prefetch_layouts([])
+
+    @pytest.mark.asyncio
+    async def test_prefetch_idempotent(self, serve_tgm_bytes):
+        msg = _encode_test_message([10])
+        url = serve_tgm_bytes(msg)
+        f = await tensogram.AsyncTensogramFile.open(url)
+        await f.prefetch_layouts([0])
+        await f.prefetch_layouts([0])
+        result = await f.file_decode_object(0, 0)
+        assert result["data"].shape == (10,)
+
+    @pytest.mark.asyncio
+    async def test_prefetch_out_of_range(self, serve_tgm_bytes):
+        msg = _encode_test_message([10])
+        url = serve_tgm_bytes(msg)
+        f = await tensogram.AsyncTensogramFile.open(url)
+        with pytest.raises((ValueError, RuntimeError)):
+            await f.prefetch_layouts([999])

--- a/tests/python/test_async.py
+++ b/tests/python/test_async.py
@@ -816,6 +816,32 @@ class TestSyncBatchRange:
             np.testing.assert_array_equal(b, i)
 
 
+class TestBatchLocalFileError:
+    """Batch methods require remote backend; calling on local files must raise."""
+
+    def test_sync_object_batch_raises_on_local(self, tgm_path):
+        f = tensogram.TensogramFile.open(tgm_path)
+        with pytest.raises(OSError, match="remote backend"):
+            f.file_decode_object_batch([0, 1], 0)
+
+    def test_sync_range_batch_raises_on_local(self, tgm_path):
+        f = tensogram.TensogramFile.open(tgm_path)
+        with pytest.raises(OSError, match="remote backend"):
+            f.file_decode_range_batch([0, 1], 0, [(0, 5)])
+
+    @pytest.mark.asyncio
+    async def test_async_object_batch_raises_on_local(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        with pytest.raises(OSError, match="remote backend"):
+            await f.file_decode_object_batch([0, 1], 0)
+
+    @pytest.mark.asyncio
+    async def test_async_range_batch_raises_on_local(self, tgm_path):
+        f = await tensogram.AsyncTensogramFile.open(tgm_path)
+        with pytest.raises(OSError, match="remote backend"):
+            await f.file_decode_range_batch([0, 1], 0, [(0, 5)])
+
+
 class TestAsyncPrefetchLayouts:
     @pytest.mark.asyncio
     async def test_prefetch_then_decode(self, serve_tgm_bytes):

--- a/tests/python/test_remote.py
+++ b/tests/python/test_remote.py
@@ -2,88 +2,13 @@
 
 from __future__ import annotations
 
-import http.server
-import threading
 from typing import Any
 
 import numpy as np
 import pytest
 import tensogram
 
-# ---------------------------------------------------------------------------
-# Mock HTTP server with Range support
-# ---------------------------------------------------------------------------
-
-
-def _make_handler(file_data: bytes):
-    class Handler(http.server.BaseHTTPRequestHandler):
-        def log_message(self, fmt, *args):
-            pass
-
-        def do_HEAD(self):
-            self.send_response(200)
-            self.send_header("Content-Length", str(len(file_data)))
-            self.send_header("Accept-Ranges", "bytes")
-            self.end_headers()
-
-        def do_GET(self):
-            data = file_data
-            range_header = self.headers.get("Range")
-            if range_header and range_header.startswith("bytes="):
-                range_spec = range_header[6:]
-                if range_spec.startswith("-"):
-                    suffix = int(range_spec[1:])
-                    start = max(0, len(data) - suffix)
-                    end = len(data)
-                else:
-                    parts = range_spec.split("-")
-                    start = int(parts[0])
-                    end = int(parts[1]) + 1 if parts[1] else len(data)
-                    end = min(end, len(data))
-                if start >= len(data):
-                    self.send_response(416)
-                    self.end_headers()
-                    return
-                chunk = data[start:end]
-                self.send_response(206)
-                self.send_header("Content-Range", f"bytes {start}-{end - 1}/{len(data)}")
-                self.send_header("Content-Length", str(len(chunk)))
-                self.end_headers()
-                self.wfile.write(chunk)
-            else:
-                self.send_response(200)
-                self.send_header("Content-Length", str(len(data)))
-                self.end_headers()
-                self.wfile.write(data)
-
-    return Handler
-
-
-@pytest.fixture
-def serve_tgm_bytes():
-    """Fixture that starts a mock HTTP server for given bytes, isolated per call."""
-    entries: list[tuple] = []
-
-    def _serve(data: bytes) -> str:
-        handler = _make_handler(data)
-        server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
-        port = server.server_address[1]
-        thread = threading.Thread(target=server.serve_forever, daemon=True)
-        thread.start()
-        entries.append((server, thread))
-        return f"http://127.0.0.1:{port}/test.tgm"
-
-    yield _serve
-
-    for server, thread in entries:
-        server.shutdown()
-        server.server_close()
-        thread.join(timeout=5)
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
+# serve_tgm_bytes fixture is auto-discovered from conftest.py
 
 
 def make_global_meta(version: int = 2, **extra: Any) -> dict[str, Any]:


### PR DESCRIPTION
### Summary
Adds `AsyncTensogramFile` — a full async Python API for tensogram, enabling `asyncio.gather` concurrency and batched HTTP fetching for remote files.
### What changed
**Core (`tensogram-core`):**
- All async methods changed from `&mut self` to `&self` — a single handle now supports truly concurrent operations with no mutex
- Added `decode_range_async` and `decode_range_batch_async` (were missing entirely)
- Added `decode_object_batch_async` for fetching many full frames in one call
- Added `prefetch_layouts_async` for batched layout discovery via `object_store::get_ranges`
- Added `message_count_async` for non-blocking message scanning
- Sync batch equivalents: `decode_range_batch`, `decode_object_batch`
- Fixed 27 stale `let mut` across tests and examples from the `&self` change
**Python bindings (`tensogram-python`):**
- `AsyncTensogramFile`: 20 methods, backed by `Arc<TensogramFile>` (no mutex)
- `AsyncTensogramFileIter`: async iteration protocol, works on remote files
- Sync `file_decode_range_batch` and `file_decode_object_batch` on `TensogramFile`
- `pyo3-async-runtimes` 0.28, feature-gated behind `async` (default on)
### Batch API
When reading the same data from many messages (e.g. a value at one grid point across 300 time steps), individual requests are slow because each is a separate HTTP round-trip. The batch API collects all byte ranges and fetches them in one `object_store::get_ranges` call. Combined with `asyncio.gather`, this gives both batched HTTP and concurrency:
```python
chunks = [indices[i::16] for i in range(16)]
results = await asyncio.gather(
    *[f.file_decode_range_batch(chunk, 0, [(offset, 1)], join=True)
      for chunk in chunks]
)
```
Tests
- 73 new async/batch tests in test_async.py
- Shared fixtures extracted to conftest.py
- 407 total tests passing (401 + 6 new sync batch)
- Workspace clippy clean, ruff clean, --no-default-features builds clean
Docs
- python-api.md: async API section with working code examples
- examples/python/15_async_operations.py: async open, gather, batch, iteration
- Examples README updated


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/dev-section/tensogram/pull-requests/PR-33
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->