### PR TITLE
Docs/reorganize documentation

### DIFF
--- a/.github/workflows/docs-sites.yaml
+++ b/.github/workflows/docs-sites.yaml
@@ -1,6 +1,6 @@
 # Builds mdBook docs and publishes them to ECMWF Sites:
-# - PRs get preview publish/unpublish under `dev-section/pull-requests`.
-# - Pushes to `main`/tags publish canonical docs under `dev-section`.
+# - PRs get preview publish/unpublish under `tensogram/pull-requests`.
+# - Pushes to `main`/tags publish canonical docs under `tensogram`.
 # - Manual runs are build-only by default; publish is opt-in.
 name: Docs Sites Publish
 
@@ -115,12 +115,12 @@ jobs:
     with:
       artifact-id: ${{ needs.build-docs.outputs.artifact-id }}
       space: docs
-      name: dev-section
-      path: tensogram/pull-requests
+      name: tensogram
+      path: pull-requests
       link-tag: PREVIEW-PUBLISH-TENSOGRAM-DOCS
       link-text: "Docs Preview"
     secrets:
-      sites-token: ${{ secrets.ECMWF_SITES_DOCS_DEV_SECTION_TOKEN }}
+      sites-token: ${{ secrets.ECMWF_SITES_DOCS_TENSOGRAM_TOKEN }}
 
   # Remove preview docs when PR is closed to avoid stale preview content.
   preview-unpublish:
@@ -128,10 +128,10 @@ jobs:
     uses: ecmwf/reusable-workflows/.github/workflows/pr-preview-unpublish.yml@5a1d1cb1442aa632f7823e4088d639b980627afc
     with:
       space: docs
-      name: dev-section
-      path: tensogram/pull-requests
+      name: tensogram
+      path: pull-requests
     secrets:
-      sites-token: ${{ secrets.ECMWF_SITES_DOCS_DEV_SECTION_TOKEN }}
+      sites-token: ${{ secrets.ECMWF_SITES_DOCS_TENSOGRAM_TOKEN }}
 
   # Compute a safe publish id used for docs publish path segments.
   # This prevents malformed or path-like values from workflow inputs/tags.
@@ -198,8 +198,8 @@ jobs:
     with:
       artifact-id: ${{ needs.build-docs.outputs.artifact-id }}
       space: docs
-      name: dev-section
-      path: tensogram
+      name: tensogram
+      path: ""
       # Use sanitized id from compute-publish-id.
       id: ${{ needs.compute-publish-id.outputs.publish-id }}
       # Keep stable aliases only for push events:
@@ -207,4 +207,4 @@ jobs:
       # - main publish => latest
       softlink: ${{ github.event_name == 'push' && (github.ref_type == 'tag' && 'stable' || github.ref_name == 'main' && 'latest') || '' }}
     secrets:
-      sites-token: ${{ secrets.ECMWF_SITES_DOCS_DEV_SECTION_TOKEN }}
+      sites-token: ${{ secrets.ECMWF_SITES_DOCS_TENSOGRAM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -150,12 +150,25 @@ For general enquiries about ECMWF software, visit the
 
 ## Documentation
 
-- [mdbook docs](docs/) — full developer guide (`cd docs && mdbook build`)
+Full documentation is available online at **[sites.ecmwf.int/docs/tensogram/main](https://sites.ecmwf.int/docs/tensogram/main)**.
+
+The source markdown files live under [`docs/src/`](docs/src/) and are easy to browse directly on GitHub.
+
+To build and serve locally:
+
+```bash
+cargo install mdbook mdbook-mermaid mdbook-tabs
+mdbook serve docs/
+```
+
+Then open `http://localhost:3000`.
+
+### Other resources
+
 - [Architecture](ARCHITECTURE.md) — crate structure and design decisions
 - [Contributing](CONTRIBUTING.md) — setup and workflow
 - [Code of Conduct](CODE_OF_CONDUCT.md) — community guidelines
 - [Changelog](CHANGELOG.md) — release history
-- [Python API](docs/src/guide/python-api.md) — encoding, decoding, file API, validation
 
 ## Repository Layout
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@
   <a href="https://github.com/ecmwf/codex/raw/refs/heads/main/Project%20Maturity#emerging">
     <img src="https://github.com/ecmwf/codex/raw/refs/heads/main/Project%20Maturity/emerging_badge.svg" alt="Emerging">
   </a>
+  <a href="https://sites.ecmwf.int/docs/tensogram/main">
+    <img src="https://img.shields.io/badge/docs-online-blue" alt="Documentation">
+  </a>
 </p>
 
 > [!IMPORTANT]

--- a/cpp/include/tensogram.hpp
+++ b/cpp/include/tensogram.hpp
@@ -112,6 +112,12 @@ public:
     invalid_arg_error(tgm_error code, const std::string& msg) : error(code, msg) {}
 };
 
+/// Thrown when a remote object-store operation fails (S3/GCS/Azure/HTTP).
+class remote_error : public error {
+public:
+    remote_error(tgm_error code, const std::string& msg) : error(code, msg) {}
+};
+
 // ============================================================
 // detail — error checking helper
 // ============================================================
@@ -132,6 +138,7 @@ inline void check(tgm_error err) {
         case TGM_ERROR_IO:            throw io_error(err, message);
         case TGM_ERROR_HASH_MISMATCH: throw hash_mismatch_error(err, message);
         case TGM_ERROR_INVALID_ARG:   throw invalid_arg_error(err, message);
+        case TGM_ERROR_REMOTE:        throw remote_error(err, message);
         case TGM_ERROR_END_OF_ITER:   throw error(err, message);
         default:                      throw error(err, message);
     }

--- a/docs/src/encodings/compression.md
+++ b/docs/src/encodings/compression.md
@@ -147,9 +147,9 @@ flowchart TD
     D -->|"Best ratio"| N["blosc2 or zstd"]
     D -->|"Need random access"| O["blosc2"]
 
-    style E fill:#e8f5e9,stroke:#388e3c
-    style I fill:#e8f5e9,stroke:#388e3c
-    style O fill:#e8f5e9,stroke:#388e3c
+    style E fill:#388e3c,stroke:#2e7d32,color:#fff
+    style I fill:#388e3c,stroke:#2e7d32,color:#fff
+    style O fill:#388e3c,stroke:#2e7d32,color:#fff
 ```
 
 | Use case | Recommended | Why |

--- a/docs/src/encodings/simple-packing.md
+++ b/docs/src/encodings/simple-packing.md
@@ -28,8 +28,8 @@ flowchart TD
 
     A --> B --> C --> D --> E
 
-    style A fill:#e8f5e9,stroke:#388e3c
-    style E fill:#e3f2fd,stroke:#1565c0
+    style A fill:#388e3c,stroke:#2e7d32,color:#fff
+    style E fill:#1565c0,stroke:#0d47a1,color:#fff
 ```
 
 ## Limitations and Edge Cases

--- a/docs/src/format/wire-format.md
+++ b/docs/src/format/wire-format.md
@@ -9,30 +9,30 @@ All integer fields are **big-endian** (network byte order).
 A Tensogram message is built from three sections: a **header** (preamble + optional frames), one or more **data object frames**, and a **footer** (optional frames + postamble).
 
 ```
-┌──────────────────────────────────────────────────────────────┐
-│  PREAMBLE           magic, version, flags, length  (24 B)    │
-├──────────────────────────────────────────────────────────────┤
-│  HEADER METADATA FRAME    CBOR global metadata   (optional)  │
-├──────────────────────────────────────────────────────────────┤
-│  HEADER INDEX FRAME       CBOR object offsets    (optional)   │
-├──────────────────────────────────────────────────────────────┤
-│  HEADER HASH FRAME        CBOR object hashes     (optional)   │
-├──────────────────────────────────────────────────────────────┤
-│  PRECEDER METADATA FRAME  per-object metadata      (optional)  │
-│  DATA OBJECT FRAME 0      header + payload + descriptor       │
-│  PRECEDER METADATA FRAME  per-object metadata      (optional)  │
-│  DATA OBJECT FRAME 1      ...                                 │
-│  DATA OBJECT FRAME 2      (no preceder)                       │
-│  ...                      (any number of objects)             │
-├──────────────────────────────────────────────────────────────┤
-│  FOOTER HASH FRAME        CBOR object hashes     (optional)   │
-├──────────────────────────────────────────────────────────────┤
-│  FOOTER INDEX FRAME       CBOR object offsets    (optional)   │
-├──────────────────────────────────────────────────────────────┤
-│  FOOTER METADATA FRAME    CBOR global metadata   (optional)   │
-├──────────────────────────────────────────────────────────────┤
-│  POSTAMBLE          first_footer_offset, end_magic (16 B)     │
-└──────────────────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────────────┐
+│  PREAMBLE                  magic, version, flags, length  (24 B)   │
+├────────────────────────────────────────────────────────────────────┤
+│  HEADER METADATA FRAME     CBOR global metadata      (optional)    │
+├────────────────────────────────────────────────────────────────────┤
+│  HEADER INDEX FRAME        CBOR object offsets       (optional)    │
+├────────────────────────────────────────────────────────────────────┤
+│  HEADER HASH FRAME         CBOR object hashes        (optional)    │
+├────────────────────────────────────────────────────────────────────┤
+│  PRECEDER METADATA FRAME   per-object metadata       (optional)    │
+│  DATA OBJECT FRAME 0       header + payload + descriptor           │
+│  PRECEDER METADATA FRAME   per-object metadata       (optional)    │
+│  DATA OBJECT FRAME 1       ...                                     │
+│  DATA OBJECT FRAME 2       (no preceder)                           │
+│  ...                       (any number of objects)                 │
+├────────────────────────────────────────────────────────────────────┤
+│  FOOTER HASH FRAME         CBOR object hashes        (optional)    │
+├────────────────────────────────────────────────────────────────────┤
+│  FOOTER INDEX FRAME        CBOR object offsets       (optional)    │
+├────────────────────────────────────────────────────────────────────┤
+│  FOOTER METADATA FRAME     CBOR global metadata      (optional)    │
+├────────────────────────────────────────────────────────────────────┤
+│  POSTAMBLE                 first_footer_offset, end_magic  (16 B)  │
+└────────────────────────────────────────────────────────────────────┘
 ```
 
 At least one metadata frame (header or footer) must be present — messages cannot exist without metadata. Index and hash frames are optional but highly encouraged. By default, the encoder places them in the header when writing to a buffer, or in the footer when streaming.

--- a/docs/src/guide/benchmarks.md
+++ b/docs/src/guide/benchmarks.md
@@ -119,9 +119,9 @@ flowchart TD
     T --> F[Fidelity check]
     F --> R[Print report]
 
-    style G fill:#e8f4e8
-    style T fill:#e8e8f4
-    style F fill:#f4e8e8
+    style G fill:#388e3c,stroke:#2e7d32,color:#fff
+    style T fill:#1565c0,stroke:#0d47a1,color:#fff
+    style F fill:#c62828,stroke:#b71c1c,color:#fff
 ```
 
 Each timed iteration runs a full encode → decode cycle. After all iterations

--- a/docs/src/guide/encode-pre-encoded.md
+++ b/docs/src/guide/encode-pre-encoded.md
@@ -152,18 +152,23 @@ let msg = encode_pre_encoded(
 // decode_range works because szip_block_offsets is present.
 ```
 
-## How it works (mermaid)
+## How it works
 
 ```mermaid
-flowchart LR
-    A[Caller bytes] -->|encode_pre_encoded| B[validate_object]
-    B --> C[validate_szip_block_offsets]
-    C --> D[Recompute hash]
+flowchart TD
+    subgraph pre["encode_pre_encoded path"]
+        A[Caller bytes] --> B[validate_object]
+        B --> C[validate_szip_block_offsets]
+        C --> D[Recompute hash]
+    end
+
+    subgraph normal["encode path"]
+        G[Caller bytes] --> H[Run encoding pipeline]
+        H --> D
+    end
+
     D --> E[Wrap in CBOR framing]
     E --> F[Wire message]
-    
-    G[Caller bytes] -.->|encode| H[Run pipeline]
-    H -.-> D
 ```
 
 The pre-encoded path skips the pipeline entirely. The wire format is identical.

--- a/docs/src/guide/error-handling.md
+++ b/docs/src/guide/error-handling.md
@@ -15,6 +15,7 @@ returns an error code (C). No library code panics.
 | **Object** | Invalid descriptor, object index out of range | `TensogramError::Object` | `ValueError` | `object_error` | `TGM_ERROR_OBJECT (5)` |
 | **I/O** | File not found, permission denied, disk full | `TensogramError::Io` | `OSError` | `io_error` | `TGM_ERROR_IO (6)` |
 | **Hash Mismatch** | Payload integrity check fails on `verify_hash=True` | `TensogramError::HashMismatch` | `RuntimeError` | `hash_mismatch_error` | `TGM_ERROR_HASH_MISMATCH (7)` |
+| **Remote** | S3/GCS/Azure/HTTP object-store failure | `TensogramError::Remote` | `OSError` | `remote_error` | `TGM_ERROR_REMOTE (10)` |
 | **Invalid Arg** | NULL pointer or invalid argument in C/C++ FFI | — | — | `invalid_arg_error` | `TGM_ERROR_INVALID_ARG (8)` |
 
 ## Error Paths by Operation
@@ -219,7 +220,7 @@ except RuntimeError as e:
     # Hash verification mismatch
     print(f"integrity error: {e}")
 except OSError as e:
-    # File I/O errors
+    # File I/O and Remote (S3/GCS/Azure/HTTP) errors
     print(f"I/O error: {e}")
 
 # File errors

--- a/docs/src/guide/file-api.md
+++ b/docs/src/guide/file-api.md
@@ -113,8 +113,8 @@ flowchart TD
     C -- "lookup offset for object 2" --> D
     D --> E
 
-    style A fill:#e8f5e9,stroke:#388e3c
-    style E fill:#e3f2fd,stroke:#1565c0
+    style A fill:#388e3c,stroke:#2e7d32,color:#fff
+    style E fill:#1565c0,stroke:#0d47a1,color:#fff
 ```
 
 ## File Layout Diagram

--- a/rust/tensogram-ffi/src/lib.rs
+++ b/rust/tensogram-ffi/src/lib.rs
@@ -4152,7 +4152,7 @@ mod tests {
         check(super::TgmError::HashMismatch, "hash mismatch");
         check(super::TgmError::InvalidArg, "invalid argument");
         check(super::TgmError::EndOfIter, "end of iteration");
-        check(super::TgmError::Remote, "unknown error");
+        check(super::TgmError::Remote, "remote error");
     }
 
     // ── tgm_bytes_free safety ──

--- a/rust/tensogram-ffi/src/lib.rs
+++ b/rust/tensogram-ffi/src/lib.rs
@@ -2070,6 +2070,7 @@ pub extern "C" fn tgm_error_string(err: TgmError) -> *const c_char {
         7 => b"hash mismatch\0",
         8 => b"invalid argument\0",
         9 => b"end of iteration\0",
+        10 => b"remote error\0",
         _ => b"unknown error\0",
     };
     s.as_ptr() as *const c_char


### PR DESCRIPTION
## Summary
Reorganize documentation publishing and fix various docs issues.
## Changes
### CI: Docs publishing URL update
- Migrate docs-sites workflow from `dev-section` namespace to `tensogram` namespace
- Canonical docs now publish to `sites.ecmwf.int/hub/view/docs/tensogram/`
- PR previews publish under `tensogram/pull-requests/`
- Updated secret reference to `ECMWF_SITES_DOCS_TENSOGRAM_TOKEN`
### Docs: Diagram and rendering fixes
- Fix wire-format overview ASCII table — border widths were inconsistent across rows
- Improve pre-encoded data API mermaid diagram — restructured from cramped horizontal layout to top-down flow with labeled subgraphs
- Remove "(mermaid)" from section title
- Fix low-contrast mermaid node colors in file-api, benchmarks, simple-packing, and compression pages — swapped pastel fills for solid colors with white text
### Fix: Add missing Remote error support
- `tgm_error_string()` in FFI now returns `"remote error"` for code 10 (previously fell through to `"unknown error"`)
- Added `remote_error` C++ exception class and wired it into `detail::check()`
- Updated error-handling docs with the Remote error category and Python mapping

## Contributor Licence Agreement

By submitting this pull request, I confirm that my contribution is made under
the terms of the [Apache License 2.0](LICENSE) and that I have the right to
submit it under this licence. I agree to the terms of the
[ECMWF Contributor Licence Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).


<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-39
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->