### PR TITLE
Chore/upgrade rust edition 2024

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing. This guide will get you from zero t
 
 ## Prerequisites
 
-- **Rust 1.75+** (`rustup install stable`)
+- **Rust 1.85+** (`rustup install stable`)
 - **C compiler** (for libaec, zfp, blosc2 FFI dependencies)
 - Optional: Python 3.9+ and `uv` for Python bindings (`pip install uv` or https://docs.astral.sh/uv/getting-started/installation/)
 - Optional: Node ≥ 20 and `wasm-pack` (`cargo install wasm-pack`) for the TypeScript wrapper

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,12 +243,12 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbindgen"
-version = "0.27.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fce8dd7fcfcbf3a0a87d8f515194b49d6135acab73e18bd380d1d93bb1a15eb"
+checksum = "befbfd072a8e81c02f8c507aefce431fe5e7d051f83d48a23ffc9b9fe5a11799"
 dependencies = [
  "clap",
- "heck 0.4.1",
+ "heck",
  "indexmap",
  "log",
  "proc-macro2",
@@ -382,7 +382,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -806,12 +806,6 @@ dependencies = [
  "serde_derive",
  "winreg",
 ]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -2029,11 +2023,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2439,44 +2433,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "serde",
+ "indexmap",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.22.27"
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_write",
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -3083,9 +3075,12 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
+
+[[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 
 [[package]]
 name = "winreg"
@@ -3114,7 +3109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "wit-parser",
 ]
 
@@ -3125,7 +3120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "indexmap",
  "prettyplease",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = [
     "rust/tensogram-core",
     "rust/tensogram-encodings",

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tensogram-rust-examples"
 version = "0.13.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [[bin]]

--- a/examples/rust/src/bin/01_encode_decode.rs
+++ b/examples/rust/src/bin/01_encode_decode.rs
@@ -18,8 +18,8 @@
 use std::collections::BTreeMap;
 
 use tensogram_core::{
-    decode, encode, ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions,
-    GlobalMetadata,
+    ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions, GlobalMetadata, decode,
+    encode,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/examples/rust/src/bin/02_mars_metadata.rs
+++ b/examples/rust/src/bin/02_mars_metadata.rs
@@ -21,8 +21,8 @@ use std::collections::BTreeMap;
 
 use ciborium::Value;
 use tensogram_core::{
-    decode, decode_metadata, encode, ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype,
-    EncodeOptions, GlobalMetadata,
+    ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions, GlobalMetadata, decode,
+    decode_metadata, encode,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -78,10 +78,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     fn get_mars_key<'a>(map: &'a Value, key: &str) -> Option<&'a str> {
         if let Value::Map(entries) = map {
             for (k, v) in entries {
-                if matches!(k, Value::Text(s) if s == key) {
-                    if let Value::Text(t) = v {
-                        return Some(t);
-                    }
+                if matches!(k, Value::Text(s) if s == key)
+                    && let Value::Text(t) = v
+                {
+                    return Some(t);
                 }
             }
         }

--- a/examples/rust/src/bin/03_simple_packing.rs
+++ b/examples/rust/src/bin/03_simple_packing.rs
@@ -22,8 +22,8 @@ use std::collections::BTreeMap;
 
 use ciborium::Value;
 use tensogram_core::{
-    decode, encode, ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions,
-    GlobalMetadata,
+    ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions, GlobalMetadata, decode,
+    encode,
 };
 use tensogram_encodings::simple_packing;
 

--- a/examples/rust/src/bin/04_shuffle_filter.rs
+++ b/examples/rust/src/bin/04_shuffle_filter.rs
@@ -24,8 +24,8 @@ use std::collections::BTreeMap;
 
 use ciborium::Value;
 use tensogram_core::{
-    decode, encode, ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions,
-    GlobalMetadata,
+    ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions, GlobalMetadata, decode,
+    encode,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/examples/rust/src/bin/05_multi_object.rs
+++ b/examples/rust/src/bin/05_multi_object.rs
@@ -21,8 +21,8 @@ use std::collections::BTreeMap;
 
 use ciborium::Value;
 use tensogram_core::{
-    decode, decode_object, encode, ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype,
-    EncodeOptions, GlobalMetadata,
+    ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions, GlobalMetadata, decode,
+    decode_object, encode,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/examples/rust/src/bin/06_hash_verification.rs
+++ b/examples/rust/src/bin/06_hash_verification.rs
@@ -19,8 +19,8 @@
 use std::collections::BTreeMap;
 
 use tensogram_core::{
-    decode, encode, ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions,
-    GlobalMetadata, HashAlgorithm, TensogramError,
+    ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions, GlobalMetadata,
+    HashAlgorithm, TensogramError, decode, encode,
 };
 
 fn make_descriptor() -> DataObjectDescriptor {

--- a/examples/rust/src/bin/07_scan_buffer.rs
+++ b/examples/rust/src/bin/07_scan_buffer.rs
@@ -22,8 +22,8 @@ use std::collections::BTreeMap;
 
 use ciborium::Value;
 use tensogram_core::{
-    decode_metadata, encode, scan, ByteOrder, DataObjectDescriptor, Dtype, EncodeOptions,
-    GlobalMetadata,
+    ByteOrder, DataObjectDescriptor, Dtype, EncodeOptions, GlobalMetadata, decode_metadata, encode,
+    scan,
 };
 
 fn make_message(param: &str, step: i64) -> Vec<u8> {

--- a/examples/rust/src/bin/08_decode_variants.rs
+++ b/examples/rust/src/bin/08_decode_variants.rs
@@ -20,8 +20,8 @@
 use std::collections::BTreeMap;
 
 use tensogram_core::{
-    decode, decode_metadata, decode_object, decode_range, encode, ByteOrder, DataObjectDescriptor,
-    DecodeOptions, Dtype, EncodeOptions, GlobalMetadata,
+    ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions, GlobalMetadata, decode,
+    decode_metadata, decode_object, decode_range, encode,
 };
 
 fn make_descriptor(shape: Vec<u64>, dtype: Dtype) -> DataObjectDescriptor {

--- a/examples/rust/src/bin/09_file_api.rs
+++ b/examples/rust/src/bin/09_file_api.rs
@@ -25,8 +25,8 @@ use std::collections::BTreeMap;
 
 use ciborium::Value;
 use tensogram_core::{
-    decode_metadata, scan, ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions,
-    GlobalMetadata, TensogramFile,
+    ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions, GlobalMetadata,
+    TensogramFile, decode_metadata, scan,
 };
 
 fn make_forecast_message(
@@ -169,10 +169,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn get_text<'a>(map: &'a Value, key: &str) -> &'a str {
     if let Value::Map(entries) = map {
         for (k, v) in entries {
-            if matches!(k, Value::Text(s) if s == key) {
-                if let Value::Text(t) = v {
-                    return t;
-                }
+            if matches!(k, Value::Text(s) if s == key)
+                && let Value::Text(t) = v
+            {
+                return t;
             }
         }
     }
@@ -182,11 +182,11 @@ fn get_text<'a>(map: &'a Value, key: &str) -> &'a str {
 fn get_int(map: &Value, key: &str) -> i64 {
     if let Value::Map(entries) = map {
         for (k, v) in entries {
-            if matches!(k, Value::Text(s) if s == key) {
-                if let Value::Integer(i) = v {
-                    let n: i128 = (*i).into();
-                    return n as i64;
-                }
+            if matches!(k, Value::Text(s) if s == key)
+                && let Value::Integer(i) = v
+            {
+                let n: i128 = (*i).into();
+                return n as i64;
             }
         }
     }

--- a/examples/rust/src/bin/10_iterators.rs
+++ b/examples/rust/src/bin/10_iterators.rs
@@ -20,8 +20,8 @@ use std::collections::BTreeMap;
 
 use ciborium::Value;
 use tensogram_core::{
-    decode, messages, objects, objects_metadata, ByteOrder, DataObjectDescriptor, DecodeOptions,
-    Dtype, EncodeOptions, GlobalMetadata, TensogramFile,
+    ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions, GlobalMetadata,
+    TensogramFile, decode, messages, objects, objects_metadata,
 };
 
 fn make_message(param: &str, fill: u8) -> (GlobalMetadata, DataObjectDescriptor, Vec<u8>) {
@@ -165,10 +165,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn get_text<'a>(map: &'a Value, key: &str) -> &'a str {
     if let Value::Map(entries) = map {
         for (k, v) in entries {
-            if matches!(k, Value::Text(s) if s == key) {
-                if let Value::Text(t) = v {
-                    return t;
-                }
+            if matches!(k, Value::Text(s) if s == key)
+                && let Value::Text(t) = v
+            {
+                return t;
             }
         }
     }

--- a/examples/rust/src/bin/11_encode_pre_encoded.rs
+++ b/examples/rust/src/bin/11_encode_pre_encoded.rs
@@ -18,8 +18,8 @@ use std::collections::BTreeMap;
 
 use ciborium::Value;
 use tensogram_core::{
-    decode, encode_pre_encoded, ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype,
-    EncodeOptions, GlobalMetadata,
+    ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions, GlobalMetadata, decode,
+    encode_pre_encoded,
 };
 use tensogram_encodings::pipeline::{CompressionType, EncodingType, FilterType, PipelineConfig};
 use tensogram_encodings::{pipeline, simple_packing};

--- a/examples/rust/src/bin/11_streaming.rs
+++ b/examples/rust/src/bin/11_streaming.rs
@@ -20,7 +20,7 @@ use std::io::BufWriter;
 
 use tensogram_core::streaming::StreamingEncoder;
 use tensogram_core::{
-    decode, ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions, GlobalMetadata,
+    ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions, GlobalMetadata, decode,
 };
 
 fn make_descriptor(shape: Vec<u64>) -> DataObjectDescriptor {

--- a/examples/rust/src/bin/12_convert_netcdf.rs
+++ b/examples/rust/src/bin/12_convert_netcdf.rs
@@ -29,8 +29,8 @@ use std::io::Write;
 use std::path::PathBuf;
 
 use tempfile::tempdir;
-use tensogram_core::{decode_metadata, TensogramFile};
-use tensogram_netcdf::{convert_netcdf_file, ConvertOptions, DataPipeline, SplitBy};
+use tensogram_core::{TensogramFile, decode_metadata};
+use tensogram_netcdf::{ConvertOptions, DataPipeline, SplitBy, convert_netcdf_file};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ── 1. Locate a fixture from the tensogram-netcdf crate ──────────────

--- a/examples/rust/src/bin/13_validate.rs
+++ b/examples/rust/src/bin/13_validate.rs
@@ -14,8 +14,8 @@
 use std::collections::BTreeMap;
 
 use tensogram_core::{
-    encode, validate_message, ByteOrder, DataObjectDescriptor, Dtype, EncodeOptions,
-    GlobalMetadata, ValidateOptions, ValidationLevel,
+    ByteOrder, DataObjectDescriptor, Dtype, EncodeOptions, GlobalMetadata, ValidateOptions,
+    ValidationLevel, encode, validate_message,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/examples/rust/src/bin/16_multi_threaded_pipeline.rs
+++ b/examples/rust/src/bin/16_multi_threaded_pipeline.rs
@@ -25,8 +25,8 @@ use std::collections::BTreeMap;
 use std::time::Instant;
 
 use tensogram_core::{
-    decode, encode, framing, ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions,
-    GlobalMetadata,
+    ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions, GlobalMetadata, decode,
+    encode, framing,
 };
 
 fn encoded_payloads(msg: &[u8]) -> Vec<Vec<u8>> {

--- a/plans/RELEASE.md
+++ b/plans/RELEASE.md
@@ -1,0 +1,866 @@
+# Tensogram Release Plan — crates.io + PyPI
+
+> **Status**: DRAFT — pending decisions marked with ⚠️  
+> **Target version**: 0.13.0  
+> **Scope**: Complete — every publishable artifact ships  
+
+---
+
+## Summary
+
+Tensogram is a Rust workspace of 13 crates plus 3 Python packages. None of them
+have ever been published to crates.io or PyPI. This plan gets every publishable
+artifact onto both registries in a single coordinated release, and creates the CI
+workflows so future releases are push-button.
+
+The work breaks into two parts:
+
+1. **Manifest fixes** (Steps 1–10) — the crates today fail `cargo publish`
+   because inter-crate dependencies lack version numbers, most Cargo.toml files
+   are missing required metadata (license, description, readme), and there's a
+   thiserror version split. These are all concrete edits to existing files.
+
+2. **CI workflows + release command** (Steps 11–15) — four new GitHub Actions
+   workflows (crates.io publish, PyPI maturin wheels, PyPI pure-Python extras,
+   preflight validation) plus extending the existing `make-release` LLM command
+   with publishing steps. The crates.io workflow publishes 10 crates sequentially
+   with index-polling. The PyPI workflow builds native wheels for Linux x86_64
+   and macOS (both arches) via `maturin-action`. The pure Python packages use
+   ECMWF's existing `cd-pypi.yml` reusable workflow.
+
+The release day is a 12-step runbook where every step is a manual gate — no
+irreversible action fires automatically. Platforms: Linux x86_64, macOS x86_64,
+macOS arm64. No Windows, no Linux aarch64.
+
+Five decisions are needed before work starts: the SPDX licence expression for
+the SZ3 crate, whether to ship free-threaded 3.13t wheels, the MSRV, verifying
+the PyPI API token is still valid, and how to handle system-library deps in the
+publish workflow.
+
+---
+
+## Goal
+
+Publish all tensogram Rust crates on crates.io and all Python packages on PyPI
+in a single coordinated release, with CI workflows that make future releases
+repeatable.
+
+## What ships
+
+**crates.io** — 10 crates:
+
+| Crate | Publish order | Why it exists |
+|-------|:---:|---|
+| `tensogram-szip` | 1 | Pure-Rust AEC/SZIP codec, no C deps, useful standalone |
+| `tensogram-sz3-sys` | 2 | FFI bindings for SZ3 lossy compressor, vendors C++ source |
+| `tensogram-sz3` | 3 | Safe high-level SZ3 API |
+| `tensogram-encodings` | 4 | Encoding pipeline — the codec registry all higher crates use |
+| `tensogram-core` | 5 | **The primary library.** Encode, decode, file I/O, streaming |
+| `tensogram-grib` | 6 | GRIB→tensogram converter (requires system ecCodes at build time) |
+| `tensogram-netcdf` | 7 | NetCDF→tensogram converter (requires system libnetcdf at build time) |
+| `tensogram-ffi` | 8 | C FFI layer — produces `libtensogram.so`/`.a` + generated header |
+| `tensogram-cli` | 9 | The `tensogram` CLI binary (`cargo install tensogram-cli`) |
+| `tensogram-wasm` | 10 | WebAssembly bindings via wasm-bindgen (also usable as `rlib`) |
+
+**PyPI** — 3 packages:
+
+| Package | Build system | Why it exists |
+|---------|---|---|
+| `tensogram` | maturin (PyO3 native extension) | Python bindings — encode/decode/file API with NumPy |
+| `tensogram-xarray` | hatchling (pure Python) | `xr.open_dataset("f.tgm", engine="tensogram")` |
+| `tensogram-zarr` | hatchling (pure Python) | Zarr v3 store backend |
+
+**Not publishing** (with reason):
+
+| Crate | Why |
+|-------|-----|
+| `tensogram-benchmarks` | Internal. Already `publish = false` |
+| `tensogram-rust-examples` | Internal. Already `publish = false` |
+
+---
+
+## Step 1 — Version bump to 0.13.0
+
+**What**: Bump version from 0.12.0 to 0.13.0 in every manifest and the VERSION
+file.
+
+**Why**: The metadata and packaging changes we're about to make are a material
+change to the published contract. 0.12.0 has already been tagged internally. A
+fresh minor version communicates "this is the first public release" clearly.
+
+**Files**: The existing `/make-release` command already bumps `VERSION` and all
+`Cargo.toml`/`pyproject.toml` files (though it is currently missing
+`tensogram-sz3` and `tensogram-sz3-sys` — fixed in Step 15). After Step 3, the
+version string also appears in inter-crate dependency pins (`version = "=X.Y.Z"`
+in path deps), which the updated `make-release` command must cover too.
+
+---
+
+## Step 2 — Guard non-public crates
+
+**What**: Add `publish = false` to `[package]` in:
+
+```
+python/bindings/Cargo.toml
+```
+
+**Why**: The Python bindings crate (`tensogram-python`) is built via maturin and
+published as a PyPI wheel — it must never go to crates.io. `benchmarks` and
+`examples/rust` already have `publish = false`.
+
+---
+
+## Step 3 — Add version numbers to all inter-crate path dependencies
+
+**What**: Every internal dependency that uses `path = "..."` must also specify
+`version = "=0.13.0"`.
+
+**Why**: `cargo publish` strips the `path` and resolves from the registry. Without
+a version, the publish is rejected outright. Using exact pin (`=0.13.0`) because
+in the 0.x semver range even minor bumps can break — this ensures consumers get
+exactly the version that was tested together.
+
+**Ongoing impact**: Once these version pins exist, every future version bump
+must update them too — not just the `[package] version` fields. The
+`make-release` command (Step 15) is updated to cover this.
+
+**Root `Cargo.toml`** — workspace dependency table:
+
+```toml
+tensogram-szip = { path = "rust/tensogram-szip", version = "=0.13.0" }
+tensogram-sz3 = { path = "rust/tensogram-sz3", version = "=0.13.0" }
+tensogram-sz3-sys = { path = "rust/tensogram-sz3-sys", version = "=0.13.0" }
+```
+
+**`rust/tensogram-sz3/Cargo.toml`**:
+
+```toml
+tensogram-sz3-sys = { path = "../tensogram-sz3-sys", version = "=0.13.0" }
+```
+
+**`rust/tensogram-core/Cargo.toml`**:
+
+```toml
+tensogram-encodings = { path = "../tensogram-encodings", version = "=0.13.0", default-features = false }
+```
+
+**`rust/tensogram-grib/Cargo.toml`**:
+
+```toml
+tensogram-core = { path = "../tensogram-core", version = "=0.13.0" }
+tensogram-encodings = { path = "../tensogram-encodings", version = "=0.13.0" }
+```
+
+**`rust/tensogram-netcdf/Cargo.toml`**:
+
+```toml
+tensogram-core = { path = "../tensogram-core", version = "=0.13.0" }
+tensogram-encodings = { path = "../tensogram-encodings", version = "=0.13.0" }
+```
+
+**`rust/tensogram-cli/Cargo.toml`**:
+
+```toml
+tensogram-core = { path = "../tensogram-core", version = "=0.13.0" }
+tensogram-grib = { path = "../tensogram-grib", version = "=0.13.0", optional = true }
+tensogram-netcdf = { path = "../tensogram-netcdf", version = "=0.13.0", optional = true }
+```
+
+**`rust/tensogram-ffi/Cargo.toml`**:
+
+```toml
+tensogram-core = { path = "../tensogram-core", version = "=0.13.0" }
+tensogram-encodings = { path = "../tensogram-encodings", version = "=0.13.0" }
+```
+
+**`rust/tensogram-wasm/Cargo.toml`**:
+
+```toml
+tensogram-core = { path = "../tensogram-core", version = "=0.13.0", default-features = false, features = [...] }
+```
+
+---
+
+## Step 4 — Fix thiserror version split in tensogram-sz3
+
+**What**: Change `thiserror = "1"` to `thiserror.workspace = true` in
+`rust/tensogram-sz3/Cargo.toml` and update the crate's source for thiserror v2.
+
+**Why**: The workspace uses thiserror 2 everywhere else. Having v1 in sz3 pulls
+**both** v1 and v2 into the dependency tree of every consumer. That's ~30KB of
+unnecessary compilation and two versions of the same thing in `Cargo.lock`.
+thiserror v2 is nearly API-identical — migration is usually just re-running
+`cargo check` and fixing any compile errors.
+
+---
+
+## Step 5 — Resolve licence expression for sz3 crates
+
+**What**: Fix the licence metadata for `tensogram-sz3-sys` and `tensogram-sz3`.
+
+**Why**: Two problems exist today:
+
+1. Both crates claim `Apache-2.0 OR MIT`, but the repository has **no MIT
+   licence text**. The top-level `LICENSE` is Apache-2.0 only. Claiming MIT
+   without the grant text is legally meaningless.
+
+2. `tensogram-sz3-sys` vendors the SZ3 header-only library. That tree contains
+   **two** third-party licences:
+   - `SZ3/copyright-and-BSD-license.txt` — a 4-clause BSD-like licence from
+     UChicago Argonne (covers the SZ3 core)
+   - `SZ3/include/SZ3/utils/ska_hash/LICENSE.txt` — **Boost Software License
+     1.0** (covers the ska flat hash map)
+
+   The SPDX `license` field must reflect what actually ships in the crate
+   tarball. The vendored tree also contains `SZ3/tools/pysz/` (a whole Python
+   package with its own LICENSE) — that directory must be excluded from the
+   tarball (Step 7 handles this).
+
+⚠️ **Decision needed** — pick one:
+
+- **Option A** (recommended): Standardise our code to `Apache-2.0` (matching
+  the rest of the project) and use `license-file` on `tensogram-sz3-sys` to
+  point to a composite `LICENSES.md` that includes our Apache-2.0 grant plus the
+  two vendored licence texts. Drop the `OR MIT` claim entirely since there is no
+  MIT text.
+
+  Concrete steps for this option:
+  1. Create `rust/tensogram-sz3-sys/LICENSES.md` containing the full text of:
+     Apache-2.0 (our code), Argonne BSD (SZ3 core), Boost-1.0 (ska_hash).
+  2. Set `license-file = "LICENSES.md"` in `rust/tensogram-sz3-sys/Cargo.toml`
+     (remove the `license` field — `license` and `license-file` are mutually
+     exclusive).
+  3. Add `"LICENSES.md"` to the Step 7 include list (replacing `"LICENSE"`).
+  4. `tensogram-sz3` (which contains no vendored code) gets
+     `license = "Apache-2.0"` (remove `OR MIT`).
+
+- **Option B**: Add an MIT licence file to the repo and keep dual-licence on our
+  wrapper code. Use `license = "(Apache-2.0 OR MIT) AND BSL-1.0"` on sz3-sys
+  (since the Argonne licence is close to BSD but not standard SPDX, a
+  `license-file` is more accurate).
+
+Either way: ensure both `SZ3/copyright-and-BSD-license.txt` and
+`SZ3/include/SZ3/utils/ska_hash/LICENSE.txt` are included in the crate tarball
+(Step 7 covers this), and the `THIRD_PARTY_LICENSES` file is updated to cover
+vendored-in-tarball source explicitly.
+
+---
+
+## Step 6 — Add package metadata to all 10 publishable crates
+
+**What**: Add the full `[package]` metadata block to every publishable crate.
+
+**Why**: crates.io requires `license` (or `license-file`) and `description`.
+Without `repository`, `homepage`, `documentation`, the crate page has no links.
+Without `readme`, the page is blank. Without `keywords`/`categories`, the crate
+is unfindable. This is the difference between a professional release and a
+placeholder.
+
+Template (adapt `name`, `description`, `keywords`, `categories` per crate):
+
+```toml
+[package]
+name = "tensogram-core"
+version = "0.13.0"
+edition = "2024"
+license = "Apache-2.0"
+description = "Fast binary N-tensor message format for scientific data — encode, decode, stream"
+repository = "https://github.com/ecmwf/tensogram"
+homepage = "https://github.com/ecmwf/tensogram"
+documentation = "https://docs.rs/tensogram-core"
+readme = "README.md"
+keywords = ["tensogram", "tensor", "scientific-data", "encoding", "serialization"]
+categories = ["science", "encoding"]
+authors = ["ECMWF <software-support@ecmwf.int>"]
+rust-version = "TBD"   # see Step 8
+```
+
+Suggested per-crate descriptions:
+
+| Crate | description |
+|-------|-------------|
+| `tensogram-szip` | (keep existing) "Pure-Rust CCSDS 121.0-B-3 Adaptive Entropy Coding (AEC/SZIP) — encode, decode, and range decode" |
+| `tensogram-sz3-sys` | (keep existing) "Clean-room FFI bindings for the SZ3 lossy compression library" |
+| `tensogram-sz3` | (keep existing) "High-level SZ3 compression API for Tensogram" |
+| `tensogram-encodings` | "Encoding pipeline and compression codec registry for the Tensogram message format" |
+| `tensogram-core` | "Fast binary N-tensor message format for scientific data — encode, decode, file I/O, streaming" |
+| `tensogram-grib` | "GRIB to Tensogram format converter using ecCodes" |
+| `tensogram-netcdf` | "NetCDF to Tensogram format converter" |
+| `tensogram-ffi` | "C FFI bindings for the Tensogram N-tensor message format library" |
+| `tensogram-cli` | "CLI for inspecting, converting, and manipulating Tensogram .tgm files" |
+| `tensogram-wasm` | (keep existing) "WebAssembly bindings for the Tensogram N-tensor message format" |
+
+---
+
+## Step 7 — Create per-crate README files and set include lists
+
+**What**: Create a short `README.md` inside each of the 10 publishable crate
+directories. Add an explicit `[package] include` list where needed.
+
+**Why (README)**: crates.io renders the crate's README as its landing page. No
+README = blank page. Each README should be 20–40 lines: what the crate does, a
+minimal usage example, and a link to the full repository docs. Do **not** use
+symlinks to the root README — they break on Windows and `cargo package` may not
+follow them.
+
+**Why (include)**: Only needed where the default `cargo package` would ship
+unwanted files. Most crates are clean (`src/` + `Cargo.toml`) and can use Cargo
+defaults safely. Add explicit include lists only for crates with vendored source,
+build scripts, or extra artefacts.
+
+For `tensogram-sz3-sys` (vendored C++ source + build script). The include list
+must be precise — the full `SZ3/` tree contains tools, a Python package, and
+test data that are not needed and add licence surface. The `build.rs` only reads
+`SZ3/CMakeLists.txt` (version parsing), `SZ3/include/SZ3/version.hpp.in`
+(template), and the `SZ3/include/` headers:
+
+```toml
+include = [
+    "src/**",
+    "build.rs",
+    "cpp/sz3_ffi.cpp",
+    "SZ3/CMakeLists.txt",
+    "SZ3/include/**",
+    "SZ3/copyright-and-BSD-license.txt",
+    "Cargo.toml",
+    "README.md",
+    "LICENSES.md",       # composite license-file (Step 5 Option A)
+]
+```
+
+Note: if using `license-file = "LICENSES.md"`, Cargo auto-includes it even
+without the explicit entry, but listing it makes the intent obvious. If
+Option B is chosen instead, replace `LICENSES.md` with `LICENSE`.
+
+This excludes `SZ3/tools/` (H5Z-SZ3, pysz, mdz, paraview — none used by the
+build), `SZ3/SZ3Config.cmake.in`, and `SZ3/README.md`. The `ska_hash/LICENSE.txt`
+(Boost-1.0) is included via the `SZ3/include/**` glob — that's intentional since
+the headers reference it.
+
+For `tensogram-ffi` (has build.rs + cbindgen):
+
+```toml
+include = ["src/**", "build.rs", "cbindgen.toml", "Cargo.toml", "README.md", "LICENSE"]
+```
+
+After adding, verify with `cargo package --list -p <crate>` for each.
+
+---
+
+## Step 8 — Determine and set rust-version (MSRV)
+
+**What**: Find the minimum supported Rust version and set `rust-version` in all
+10 publishable crates.
+
+**Why**: Cargo uses this field to give users a clear error ("your Rust is too
+old") instead of cryptic compilation failures. It's also displayed on crates.io
+and used by CI tools like `cargo-msrv`.
+
+**How**: Run `cargo +1.85.0 check --workspace` (or use `cargo-msrv find`).
+Given edition 2024 and deps like pyo3 0.28 / object_store 0.13, expect MSRV
+around **1.85+**.
+
+---
+
+## Step 9 — Complete Python package metadata
+
+**What**: Add missing metadata to all three `pyproject.toml` files.
+
+**Why**: PyPI renders the metadata on the package page. Without `description`,
+`authors`, `classifiers`, and project URLs, the package looks abandoned or
+untrustworthy. Classifiers also control how PyPI indexes and filters the package.
+
+**`python/bindings/pyproject.toml`** — add to `[project]`:
+
+```toml
+description = "Fast binary N-tensor message format for scientific data"
+license = "Apache-2.0"
+authors = [{name = "ECMWF", email = "software-support@ecmwf.int"}]
+readme = "README.md"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Rust",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Atmospheric Science",
+]
+
+[project.urls]
+Homepage = "https://github.com/ecmwf/tensogram"
+Repository = "https://github.com/ecmwf/tensogram"
+Documentation = "https://github.com/ecmwf/tensogram/tree/main/docs"
+Changelog = "https://github.com/ecmwf/tensogram/blob/main/CHANGELOG.md"
+```
+
+Also create `python/bindings/README.md` — PyPI uses this as the long description.
+
+**`python/tensogram-xarray/pyproject.toml`** and
+**`python/tensogram-zarr/pyproject.toml`** — add `authors`, `classifiers`,
+`[project.urls]` (same pattern), and pin the tensogram dependency:
+
+```toml
+dependencies = [
+    "tensogram>=0.13.0,<0.14",
+    # ... rest unchanged
+]
+```
+
+**Why pin**: These packages are tightly coupled to the native `tensogram`
+extension. A semver-minor bump in 0.x can break the internal API. Pinning to
+`>=0.13.0,<0.14` ensures users don't end up with an incompatible combination.
+
+---
+
+## Step 10 — Add docs.rs build hints
+
+**What**: Add `[package.metadata.docs.rs]` to crates that need it and verify
+the `documentation` URL is correct for every published crate.
+
+**Why**: docs.rs auto-builds documentation for every crate published to
+crates.io. If the build fails (missing system libraries, C++ compilation
+timeout), the documentation page is blank and the `documentation` link in the
+crate metadata is broken.
+
+Crate-by-crate strategy:
+
+| Crate | docs.rs risk | Action |
+|-------|-------------|--------|
+| `tensogram-szip` | None (pure Rust) | Default is fine |
+| `tensogram-sz3-sys` | C++17 compilation | `all-features = true`, may need extended timeout |
+| `tensogram-sz3` | Transitive C++ | Default is fine |
+| `tensogram-encodings` | Compiles 6 native codecs | `all-features = true` |
+| `tensogram-core` | Transitive native codecs | `all-features = true` |
+| `tensogram-grib` | **Will fail** — needs system eccodes | Set `documentation` to repo docs instead of docs.rs |
+| `tensogram-netcdf` | **Will fail** — needs system libnetcdf | Set `documentation` to repo docs instead of docs.rs |
+| `tensogram-ffi` | Needs cbindgen | May work, monitor |
+| `tensogram-cli` | Binary crate, optional grib/netcdf | `default-features = true` (skip grib/netcdf features) |
+| `tensogram-wasm` | **Will fail** — wasm-only deps (`js-sys`, `getrandom` with `js`) don't compile on x86_64 | Set `default-target = "wasm32-unknown-unknown"` in `[package.metadata.docs.rs]` |
+
+For crates where docs.rs will fail, set `documentation` to the project
+documentation site instead of `https://docs.rs/...`:
+
+```toml
+documentation = "https://github.com/ecmwf/tensogram/tree/main/docs"
+```
+
+---
+
+## Step 11 — Create the crates.io publish workflow
+
+**What**: Create `.github/workflows/publish-crates.yml` — a single workflow that
+publishes all 10 crates in dependency order with index polling between each.
+
+**Why (single workflow, not 10 separate ones)**: The crates have a strict
+dependency chain. Publishing them as separate workflows would require manual
+coordination. A single workflow with sequential steps and polling ensures each
+crate is available on the crates.io index before its dependents try to publish.
+
+**Why (inline, not reusable workflow)**: The ECMWF `publish-rust-crate.yml`
+reusable workflow handles one crate at a time. Calling it 10 times via
+`workflow_call` jobs doesn't allow inserting index-polling steps between calls.
+Inlining the logic (which is simple: checkout, toolchain, `cargo publish`, poll)
+gives full control over sequencing. The reusable workflow is only 167 lines and
+easy to replicate.
+
+**Why (workflow_dispatch, not on-tag)**: Publishing to crates.io is irreversible.
+We want a manual trigger with a protected environment requiring approval, not an
+automatic trigger that fires the moment someone pushes a tag.
+
+**Design**:
+
+```
+trigger: workflow_dispatch
+environment: "crates-io" (protected, requires reviewer approval)
+runner: ubuntu-24.04
+
+for each crate in publish order:
+  1. check if version already exists on crates.io (skip if yes)
+  2. cargo publish -p <crate> --locked
+  3. poll crates.io API until version appears in index (10s intervals, 5min timeout)
+  4. proceed to next crate
+```
+
+The "skip if already published" check makes the workflow **idempotent** — safe to
+re-run after partial failures without republishing already-succeeded crates.
+Only allow re-runs from the same tag/SHA — any code change requires a new
+version.
+
+Publish order (matches dependency graph):
+
+```
+ 1. tensogram-szip          (leaf — no internal deps)
+ 2. tensogram-sz3-sys        (leaf — no internal deps)
+ 3. tensogram-sz3            (depends on 2)
+ 4. tensogram-encodings      (depends on 1, 3 via features)
+ 5. tensogram-core           (depends on 4)
+ 6. tensogram-grib           (depends on 5, 4)    ← --manifest-path, needs eccodes
+ 7. tensogram-netcdf         (depends on 5, 4)    ← --manifest-path, needs libnetcdf
+ 8. tensogram-ffi            (depends on 5, 4)
+ 9. tensogram-cli            (depends on 5, 6 optional, 7 optional)
+10. tensogram-wasm           (depends on 5)        ← --manifest-path, wasm target
+```
+
+**Excluded crates**: `tensogram-grib`, `tensogram-netcdf`, and `tensogram-wasm`
+are in the workspace `exclude` list. They cannot be published with
+`cargo publish -p ...` — they need
+`cargo publish --manifest-path rust/<crate>/Cargo.toml`.
+
+**System dependencies**: The `cargo publish` verification step compiles the
+crate. `tensogram-grib` needs `eccodes` (C library), `tensogram-netcdf` needs
+`libnetcdf`. The publish workflow runner must have these installed, or pass
+`--no-verify` for these two crates (acceptable since CI already tests them on
+macOS). Using `--no-verify` skips the compile check but still validates the
+tarball. Preferred: install the libs via apt on the ubuntu runner.
+
+**Wasm target**: `tensogram-wasm` depends on `js-sys`, `getrandom` with `js`
+feature, etc. — these only compile for `wasm32-unknown-unknown`. Use
+`--no-verify` for this crate (CI tests it separately with `wasm-pack test`),
+or `--target wasm32-unknown-unknown` if the runner has the wasm target installed.
+
+---
+
+## Step 12 — Create the PyPI publish workflow for tensogram
+
+**What**: Create `.github/workflows/publish-pypi-tensogram.yml` — builds native
+wheels and uploads to PyPI.
+
+**Why (custom, not reusable workflow)**: None of the ECMWF reusable workflows
+support maturin. `cd-pypi.yml` uses `python -m build` (pure Python only).
+`cd-pypi-binwheel.yml` uses cibuildwheel (not maturin). We need
+`PyO3/maturin-action`.
+
+**Why (wheels only, no sdist)**: The `python/bindings/Cargo.toml` references
+`../../rust/tensogram-core` via relative path. An sdist would not include the
+Rust workspace source tree, so `pip install --no-binary` would fail. Until the
+layout is restructured to bundle Rust source in the sdist, ship wheels only.
+
+**Design**:
+
+```
+trigger: workflow_dispatch
+environment: "pypi" (protected)
+
+build matrix:
+  - os: ubuntu-latest,  target: x86_64     (Linux)
+  - os: macos-13,       target: x86_64     (Intel Mac)
+  - os: macos-14,       target: aarch64    (Apple Silicon)
+
+python versions: 3.9, 3.10, 3.11, 3.12, 3.13
+
+steps per matrix entry:
+  1. checkout full repo
+  2. PyO3/maturin-action — build wheel in python/bindings/
+     use `maturin build --release` (NOT `maturin publish` — that would also
+     attempt an sdist)
+  3. upload wheel as artifact
+
+final job (after all matrix entries):
+  1. download all wheel artifacts
+  2. twine check dist/*
+  3. twine upload dist/* (PYPI_API_TOKEN)
+```
+
+⚠️ **Decision: free-threaded Python 3.13t wheels?** The CI already tests 3.13t
+on Linux and the README advertises GIL-free support. If we publish that claim
+without shipping cp313t wheels, users on free-threaded Python can't install the
+package. Options:
+- Add cp313t to the matrix for linux x86_64 (where CI already proves it works)
+- Or remove the free-threaded claim from the README until wheels ship
+
+**TestPyPI rehearsal**: Before the real publish, run the same workflow targeting
+TestPyPI (`PYPI_TEST_API_TOKEN`) and verify:
+```bash
+pip install --index-url https://test.pypi.org/simple/ \
+            --extra-index-url https://pypi.org/simple/ \
+            tensogram==0.13.0
+python -c "import tensogram; print('ok')"
+```
+The `--extra-index-url` is required because tensogram depends on NumPy, which
+is on the real PyPI, not TestPyPI. Without it, pip can't resolve the dependency.
+This catches metadata and wheel-tag issues before the irreversible real upload.
+
+---
+
+## Step 13 — Create the PyPI publish workflow for xarray + zarr
+
+**What**: Create `.github/workflows/publish-pypi-extras.yml` using the ECMWF
+`cd-pypi.yml` reusable workflow.
+
+**Why (reusable workflow works here)**: Both packages are pure Python with
+hatchling. The `cd-pypi.yml` workflow does exactly what's needed: `python -m
+build` → `twine check` → `twine upload`.
+
+**Design**:
+
+```yaml
+jobs:
+  xarray:
+    uses: ecmwf/reusable-workflows/.github/workflows/cd-pypi.yml@main
+    with:
+      working-directory: python/tensogram-xarray/
+    secrets: inherit
+
+  zarr:
+    uses: ecmwf/reusable-workflows/.github/workflows/cd-pypi.yml@main
+    with:
+      working-directory: python/tensogram-zarr/
+    secrets: inherit
+```
+
+**Tag requirement**: `cd-pypi.yml` gates on `github.ref_type == 'tag'` — it
+refuses the real PyPI upload if dispatched from a branch. The workflow **must
+be dispatched from the release tag** (e.g. `0.13.0`), not from `main`. For
+TestPyPI validation during development, use the `testpypi: true` input to
+bypass the tag gate.
+
+**Important**: These packages `pip install tensogram` as a dependency during
+their own install. If PyPI hasn't fully propagated the `tensogram` wheels yet,
+the `pip install` (and therefore the user install of xarray/zarr) will fail.
+The release runbook (step 9) includes a propagation wait before triggering this
+workflow.
+
+---
+
+## Step 14 — Create the preflight validation workflow
+
+**What**: Create `.github/workflows/release-preflight.yml` — validates
+everything is correct before any irreversible publish.
+
+**Why**: crates.io and PyPI publishes cannot be undone. A preflight workflow
+catches metadata errors, broken tarballs, and version mismatches *before* we
+commit to the registry. It also serves as documentation of what "ready to
+release" means.
+
+**Design**:
+
+```
+trigger: workflow_dispatch (input: expected version string)
+runner: same environment as publish workflow (needs eccodes + libnetcdf)
+
+steps:
+  1. checkout
+  2. assert VERSION file == input version == every first-party Cargo.toml and
+     pyproject.toml version. IMPORTANT: exclude vendored third-party files —
+     `rust/tensogram-sz3-sys/SZ3/tools/pysz/pyproject.toml` has version "1.0.3"
+     and must NOT be checked or bumped. Scope to the explicit file list from
+     Step 1 / make-release.
+  3. cargo fmt --check
+  4. cargo clippy --workspace --all-targets -- -D warnings
+  5. cargo test --workspace
+  6. cargo test --manifest-path rust/tensogram-grib/Cargo.toml   (excluded from workspace)
+  7. cargo test --manifest-path rust/tensogram-netcdf/Cargo.toml  (excluded from workspace)
+  8. for each of the 10 publishable crates:
+       cargo package --list (verify tarball contents — no surprises)
+       cargo publish --dry-run  (full verification including dependency resolution)
+     in publish order, so that each depends on the previous being valid.
+     Use --manifest-path for grib, netcdf, and wasm.
+     Use --no-verify for wasm (wasm32 target, won't compile on x86_64 runner).
+  9. maturin build --release in python/bindings/ (verify Python wheel builds)
+ 10. python -m build for xarray and zarr
+ 11. twine check on all Python dist/ artifacts
+```
+
+**First-release caveat**: `cargo publish --dry-run` for non-leaf crates (core,
+encodings, etc.) **will fail** on the first release because their internal
+dependencies don't exist on crates.io yet. This is expected, not a bug. For the
+first release, use `cargo package --no-verify` for non-leaf crates instead —
+it validates the tarball contents without attempting registry dependency
+resolution. On subsequent releases (where all deps are already on crates.io),
+the full `--dry-run` will work for all 10 crates. The preflight's primary job
+is catching metadata errors and tarball surprises, not compiling from registry.
+
+---
+
+## Step 15 — Extend make-release command
+
+**What**: Update **both** `.claude/commands/make-release.md` and
+`.opencode/commands/make-release.md` (they are identical copies — both must stay
+in sync, or one must be deleted and replaced with a symlink/include).
+
+**Why**: The project already has a working LLM-driven release command that
+handles pre-release checks, version bumping, changelog, commit, tag, push, and
+GitHub release creation. We extend it rather than creating a parallel script.
+
+Changes needed to both `make-release.md` files:
+
+1. **Fix missing crates in the version-bump list.** The current command lists
+   11 crates but is **missing `tensogram-sz3` and `tensogram-sz3-sys`**. Add
+   them.
+
+2. **Add inter-crate dependency version bumping.** After Step 3 adds
+   `version = "=X.Y.Z"` to path dependencies, every future version bump must
+   also update those pins. The current stale-version grep catches `[package]
+   version` fields, but the command must explicitly note that dependency version
+   pins need updating too. The locations are:
+   - Root `Cargo.toml` workspace deps (szip, sz3, sz3-sys entries)
+   - `rust/tensogram-sz3/Cargo.toml` dep on sz3-sys
+   - `rust/tensogram-core/Cargo.toml` dep on encodings
+   - `rust/tensogram-grib/Cargo.toml` deps on core + encodings
+   - `rust/tensogram-netcdf/Cargo.toml` deps on core + encodings
+   - `rust/tensogram-cli/Cargo.toml` deps on core + grib + netcdf
+   - `rust/tensogram-ffi/Cargo.toml` deps on core + encodings
+   - `rust/tensogram-wasm/Cargo.toml` dep on core
+
+3. **Scope the stale-version grep to first-party files only.** The vendored
+   `rust/tensogram-sz3-sys/SZ3/tools/pysz/pyproject.toml` contains
+   `version = "1.0.3"` — a naive `grep -r 'version = "OLD"' --include='pyproject.toml'`
+   will match it and either fail the check or (worse) mutate vendored source.
+   Restrict the grep to the three first-party pyproject.toml paths explicitly:
+   ```bash
+   grep 'version = "OLD"' \
+     python/bindings/pyproject.toml \
+     python/tensogram-xarray/pyproject.toml \
+     python/tensogram-zarr/pyproject.toml
+   ```
+
+4. **Reorder: publishing goes BEFORE tag and GitHub release.** The current
+   command flow is: version bump → commit → push → tag → GitHub release. The
+   new flow must be: version bump → commit → push → preflight → publish →
+   smoke tests → tag → GitHub release. This matches the runbook. Do NOT place
+   the publish steps after "Create GitHub Release" — that would announce a
+   release before artifacts exist.
+
+5. **Fix Python pre-release checks.** The current command runs xarray/zarr
+   `pytest` without first installing the packages into the venv. Add:
+   ```bash
+   uv pip install -e "python/tensogram-xarray/[dask]"
+   uv pip install -e python/tensogram-zarr/
+   ```
+   before the pytest lines.
+
+6. **Add excluded-crate tests** to the pre-release checks section:
+   ```bash
+   cargo test --manifest-path rust/tensogram-grib/Cargo.toml
+   cargo test --manifest-path rust/tensogram-netcdf/Cargo.toml
+   ```
+
+7. **Add a "Publish to Registries" section** (after commit+push, before tag):
+   - Run `release-preflight.yml` (workflow_dispatch) — must pass
+   - Run `publish-crates.yml` (workflow_dispatch) — 10 crates sequentially
+   - Smoke-test Rust: `cargo add tensogram-core@X.Y.Z` in a fresh project
+   - Run `publish-pypi-tensogram.yml` (workflow_dispatch) — native wheels
+   - Wait for PyPI propagation, then smoke-test Python
+   - Run `publish-pypi-extras.yml` (dispatch from the **release tag**, since
+     `cd-pypi.yml` is tag-gated) — xarray + zarr
+   - Wait for PyPI propagation, then smoke-test extras
+
+---
+
+## Release day runbook
+
+Once all code changes from Steps 1–10 are merged to `main`, run the release.
+The first 2 steps below are already handled by `/make-release 0.13.0`. The
+rest are the new additions.
+
+```
+ ── make-release handles these ──────────────────────────────────────────
+ 1. Pre-release checks                       (fmt, clippy, test, python, docs)
+ 2. Version bump + changelog + commit + push  (all manifests + dep version pins)
+ ── new: preflight + publish ────────────────────────────────────────────
+ 3. Run release-preflight.yml on main        → must be all green
+ 4. git tag 0.13.0 on the preflight commit   → git push --tags
+ 5. Run publish-crates.yml (dispatch on tag) → 10 crates published sequentially
+ 6. Smoke test Rust (from a fresh dir, not the repo):
+      cd $(mktemp -d) && cargo init smoke && cd smoke
+      cargo add tensogram-core@0.13.0
+      cargo build                            → must compile
+ 7. Run publish-pypi-tensogram.yml           → wheels on PyPI
+ 8. Wait for PyPI to serve tensogram==0.13.0 (poll: pip download tensogram==0.13.0)
+ 9. Smoke test Python (from a fresh venv):
+      python -m venv /tmp/tgm && source /tmp/tgm/bin/activate
+      pip install tensogram==0.13.0
+      python -c "import tensogram; print('ok')"
+10. Run publish-pypi-extras.yml (dispatch from the release tag) → xarray + zarr
+11. Wait + smoke test extras (same fresh venv):
+      pip install tensogram-xarray==0.13.0 tensogram-zarr==0.13.0
+      python -c "import tensogram_xarray; import tensogram_zarr; print('ok')"
+12. Create GitHub Release (0.13.0)           → public announcement
+```
+
+Note: `make-release` currently creates the GitHub release (step 12) and the
+tag (step 4) as part of its flow. For the first public release, we insert the
+preflight and publishing steps between the commit/push and the tag/release
+creation. After the first release, the updated `make-release` command handles
+the full flow including publishing.
+
+Every numbered step is a manual gate. Proceed only after the previous step
+succeeds. If any step fails, stop and fix — don't push through.
+
+**Why tag AFTER preflight**: If preflight fails, a public tag would point at
+unreleased or broken state. By running preflight first, we know the commit is
+good before stamping it with a version tag.
+
+**Why smoke tests from outside the repo**: Testing from a checkout doesn't
+prove the published artifact works. A fresh `cargo init` or `python -m venv`
+with only registry dependencies is the real consumer experience.
+
+**If something fails after partial publish**: crates.io publishes are
+irreversible. If crate 5 of 10 fails due to a transient error (network, index
+lag), re-run the same workflow at the same version — the skip-if-already-published
+check will skip the first 4. If the failure is a real bug requiring a code fix,
+bump to 0.13.1 and re-publish all 10 crates at the new version (the skip check
+only helps for same-version retries, not cross-version).
+
+---
+
+## Decisions needed before starting
+
+| # | Question | Recommendation | Impact if deferred |
+|---|----------|----------------|--------------------|
+| 1 | Licence for `tensogram-sz3-sys` — the vendored SZ3 tree has Argonne BSD-like + Boost-1.0 licences, and repo has no MIT text | Drop the `OR MIT` claim, use `license = "Apache-2.0"` for our code, use `license-file` for sz3-sys composite | Blocks publish of sz3-sys, sz3, and all downstream |
+| 2 | Free-threaded 3.13t wheels — CI tests it, README claims it | Either ship cp313t wheels or remove the claim | Credibility issue if claim is unsubstantiated |
+| 3 | MSRV (`rust-version`) | Set to the oldest toolchain the release workflow actually uses | Non-blocking but looks unprofessional without it |
+| 4 | `PYPI_API_TOKEN` — verify it's still valid and scoped (3 years old) | Test with `twine upload --repository testpypi` | Blocks all PyPI uploads |
+| 5 | System libs in publish workflow — grib needs eccodes, netcdf needs libnetcdf | Either install via apt or use `--no-verify` for those 2 crates | Blocks publish of grib, netcdf, cli |
+
+---
+
+## Files created or modified (complete list)
+
+**New files** (16):
+
+```
+.github/workflows/release-preflight.yml
+.github/workflows/publish-crates.yml
+.github/workflows/publish-pypi-tensogram.yml
+.github/workflows/publish-pypi-extras.yml
+rust/tensogram-core/README.md
+rust/tensogram-encodings/README.md
+rust/tensogram-szip/README.md
+rust/tensogram-sz3/README.md
+rust/tensogram-sz3-sys/README.md
+rust/tensogram-sz3-sys/LICENSES.md           (composite license-file, if Option A)
+rust/tensogram-grib/README.md
+rust/tensogram-netcdf/README.md
+rust/tensogram-ffi/README.md
+rust/tensogram-cli/README.md
+rust/tensogram-wasm/README.md
+python/bindings/README.md
+```
+
+**Modified files** (18):
+
+```
+VERSION                                     → 0.13.0
+Cargo.toml (root)                           → versioned workspace deps
+rust/tensogram-core/Cargo.toml              → full metadata + versioned dep
+rust/tensogram-encodings/Cargo.toml         → full metadata + description
+rust/tensogram-szip/Cargo.toml              → full metadata
+rust/tensogram-sz3/Cargo.toml               → fix thiserror, licence, metadata
+rust/tensogram-sz3-sys/Cargo.toml           → licence + license-file, metadata, include list
+rust/tensogram-grib/Cargo.toml              → full metadata + versioned deps
+rust/tensogram-netcdf/Cargo.toml            → full metadata + versioned deps
+rust/tensogram-cli/Cargo.toml               → full metadata + versioned deps
+rust/tensogram-ffi/Cargo.toml               → full metadata + versioned deps
+rust/tensogram-wasm/Cargo.toml              → full metadata + versioned dep + docs.rs target
+python/bindings/Cargo.toml                  → publish = false + version bump
+python/bindings/pyproject.toml              → full metadata
+python/tensogram-xarray/pyproject.toml      → metadata + pin tensogram dep
+python/tensogram-zarr/pyproject.toml        → metadata + pin tensogram dep
+.claude/commands/make-release.md            → add sz3 crates, dep version bumping, publish steps
+.opencode/commands/make-release.md          → keep in sync with .claude copy
+```
+
+Plus version bumps in all other crates (benchmarks, examples) to keep
+everything in sync.

--- a/python/bindings/Cargo.toml
+++ b/python/bindings/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tensogram-python"
 version = "0.13.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 name = "tensogram"

--- a/rust/benchmarks/Cargo.toml
+++ b/rust/benchmarks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tensogram-benchmarks"
 version = "0.13.0"
-edition = "2021"
+edition = "2024"
 publish = false
 description = "Performance benchmarks for the Tensogram encoding pipeline"
 

--- a/rust/benchmarks/benches/encode_pre_encoded.rs
+++ b/rust/benchmarks/benches/encode_pre_encoded.rs
@@ -19,10 +19,10 @@
 
 use std::collections::BTreeMap;
 
-use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use tensogram_core::{
-    encode, encode_pre_encoded, framing, ByteOrder, DataObjectDescriptor, Dtype, EncodeOptions,
-    GlobalMetadata,
+    ByteOrder, DataObjectDescriptor, Dtype, EncodeOptions, GlobalMetadata, encode,
+    encode_pre_encoded, framing,
 };
 use tensogram_encodings::simple_packing::compute_params;
 

--- a/rust/benchmarks/src/codec_matrix.rs
+++ b/rust/benchmarks/src/codec_matrix.rs
@@ -17,7 +17,7 @@ use tensogram_encodings::{
 
 use crate::constants::AEC_DATA_PREPROCESS;
 use crate::datagen::generate_weather_field;
-use crate::report::{compute_fidelity, compute_timing_stats, BenchmarkResult};
+use crate::report::{BenchmarkResult, compute_fidelity, compute_timing_stats};
 use crate::{BenchmarkError, BenchmarkRun, CaseFailure};
 
 // ── Case descriptor ──────────────────────────────────────────────────────────

--- a/rust/benchmarks/src/grib_comparison.rs
+++ b/rust/benchmarks/src/grib_comparison.rs
@@ -16,12 +16,12 @@ use tensogram_encodings::{ByteOrder, CompressionType, EncodingType, FilterType, 
 
 use crate::constants::AEC_DATA_PREPROCESS;
 use crate::datagen::generate_weather_field;
-use crate::report::{compute_fidelity, compute_timing_stats, BenchmarkResult};
+use crate::report::{BenchmarkResult, compute_fidelity, compute_timing_stats};
 use crate::{BenchmarkError, BenchmarkRun, CaseFailure};
 
 // ── ecCodes C API (raw) ──────────────────────────────────────────────────────
 
-extern "C" {
+unsafe extern "C" {
     fn codes_grib_handle_new_from_samples(ctx: *mut c_void, name: *const i8) -> *mut c_void;
     fn codes_handle_new_from_message_copy(
         ctx: *mut c_void,

--- a/rust/benchmarks/src/threads_scaling.rs
+++ b/rust/benchmarks/src/threads_scaling.rs
@@ -20,10 +20,10 @@ use tensogram_encodings::{
     Blosc2Codec, ByteOrder, CompressionType, EncodingType, FilterType, PipelineConfig,
 };
 
+use crate::BenchmarkError;
 use crate::constants::AEC_DATA_PREPROCESS;
 use crate::datagen::generate_weather_field;
 use crate::report::compute_timing_stats;
-use crate::BenchmarkError;
 
 type ConfigBuilder = Box<dyn Fn(u32, &[f64]) -> Result<PipelineConfig, BenchmarkError>>;
 

--- a/rust/benchmarks/tests/smoke.rs
+++ b/rust/benchmarks/tests/smoke.rs
@@ -9,7 +9,7 @@
 use tensogram_benchmarks::codec_matrix::run_codec_matrix;
 use tensogram_benchmarks::datagen::generate_weather_field;
 use tensogram_benchmarks::report::{
-    compute_fidelity, format_table, BenchmarkResult, Fidelity, TimingStats,
+    BenchmarkResult, Fidelity, TimingStats, compute_fidelity, format_table,
 };
 
 fn make_stats(ms: f64) -> TimingStats {

--- a/rust/tensogram-cli/Cargo.toml
+++ b/rust/tensogram-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tensogram-cli"
 version = "0.13.0"
-edition = "2021"
+edition = "2024"
 
 [[bin]]
 name = "tensogram"

--- a/rust/tensogram-cli/src/commands/convert_grib.rs
+++ b/rust/tensogram-cli/src/commands/convert_grib.rs
@@ -9,7 +9,7 @@
 use std::io::Write;
 use std::path::Path;
 
-use tensogram_grib::{convert_grib_file, ConvertOptions, DataPipeline, Grouping};
+use tensogram_grib::{ConvertOptions, DataPipeline, Grouping, convert_grib_file};
 
 use crate::encoding_args::PipelineArgs;
 

--- a/rust/tensogram-cli/src/commands/convert_netcdf.rs
+++ b/rust/tensogram-cli/src/commands/convert_netcdf.rs
@@ -9,7 +9,7 @@
 use std::io::Write;
 use std::path::Path;
 
-use tensogram_netcdf::{convert_netcdf_file, ConvertOptions, DataPipeline, SplitBy};
+use tensogram_netcdf::{ConvertOptions, DataPipeline, SplitBy, convert_netcdf_file};
 
 use crate::encoding_args::PipelineArgs;
 
@@ -33,7 +33,7 @@ pub fn run(
             return Err(format!(
                 "unknown --split-by value '{other}'; expected file, variable, or record"
             )
-            .into())
+            .into());
         }
     };
 

--- a/rust/tensogram-cli/src/commands/copy.rs
+++ b/rust/tensogram-cli/src/commands/copy.rs
@@ -9,7 +9,7 @@
 use std::io::Write;
 use std::path::PathBuf;
 
-use tensogram_core::{decode_metadata, TensogramFile};
+use tensogram_core::{TensogramFile, decode_metadata};
 
 use crate::filter::{self, lookup_key};
 
@@ -36,10 +36,10 @@ pub fn run(
         for i in 0..count {
             let msg = in_file.read_message(i)?;
             let metadata = decode_metadata(&msg)?;
-            if let Some(ref clause) = clause {
-                if !filter::matches(&metadata, clause) {
-                    continue;
-                }
+            if let Some(ref clause) = clause
+                && !filter::matches(&metadata, clause)
+            {
+                continue;
             }
             out.write_all(&msg)?;
         }
@@ -48,10 +48,10 @@ pub fn run(
         for i in 0..count {
             let msg = in_file.read_message(i)?;
             let metadata = decode_metadata(&msg)?;
-            if let Some(ref clause) = clause {
-                if !filter::matches(&metadata, clause) {
-                    continue;
-                }
+            if let Some(ref clause) = clause
+                && !filter::matches(&metadata, clause)
+            {
+                continue;
             }
 
             let out_name = expand_placeholders(output, &metadata);

--- a/rust/tensogram-cli/src/commands/dump.rs
+++ b/rust/tensogram-cli/src/commands/dump.rs
@@ -8,7 +8,7 @@
 
 use std::path::PathBuf;
 
-use tensogram_core::{decode, decode_metadata, DecodeOptions, TensogramFile};
+use tensogram_core::{DecodeOptions, TensogramFile, decode, decode_metadata};
 
 use crate::filter;
 use crate::output;
@@ -38,10 +38,10 @@ pub fn run(
             // Decode metadata first for cheap filtering
             let metadata = decode_metadata(&msg)?;
 
-            if let Some(ref clause) = clause {
-                if !filter::matches(&metadata, clause) {
-                    continue;
-                }
+            if let Some(ref clause) = clause
+                && !filter::matches(&metadata, clause)
+            {
+                continue;
             }
 
             // Decode full message to access per-object descriptors

--- a/rust/tensogram-cli/src/commands/get.rs
+++ b/rust/tensogram-cli/src/commands/get.rs
@@ -8,7 +8,7 @@
 
 use std::path::PathBuf;
 
-use tensogram_core::{decode_metadata, TensogramFile};
+use tensogram_core::{TensogramFile, decode_metadata};
 
 use crate::filter::{self, lookup_key};
 
@@ -33,10 +33,10 @@ pub fn run(
             let msg = file.read_message(i)?;
             let metadata = decode_metadata(&msg)?;
 
-            if let Some(ref clause) = clause {
-                if !filter::matches(&metadata, clause) {
-                    continue;
-                }
+            if let Some(ref clause) = clause
+                && !filter::matches(&metadata, clause)
+            {
+                continue;
             }
 
             // Strict: error on missing key

--- a/rust/tensogram-cli/src/commands/info.rs
+++ b/rust/tensogram-cli/src/commands/info.rs
@@ -8,7 +8,7 @@
 
 use std::path::PathBuf;
 
-use tensogram_core::{decode_metadata, TensogramFile};
+use tensogram_core::{TensogramFile, decode_metadata};
 
 /// Print summary information for one or more Tensogram files.
 pub fn run(files: &[PathBuf]) -> Result<(), Box<dyn std::error::Error>> {

--- a/rust/tensogram-cli/src/commands/ls.rs
+++ b/rust/tensogram-cli/src/commands/ls.rs
@@ -8,7 +8,7 @@
 
 use std::path::PathBuf;
 
-use tensogram_core::{decode_metadata, TensogramFile};
+use tensogram_core::{TensogramFile, decode_metadata};
 
 use crate::filter;
 use crate::output;
@@ -42,10 +42,10 @@ pub fn run(
             let msg = file.read_message(i)?;
             let metadata = decode_metadata(&msg)?;
 
-            if let Some(ref clause) = clause {
-                if !filter::matches(&metadata, clause) {
-                    continue;
-                }
+            if let Some(ref clause) = clause
+                && !filter::matches(&metadata, clause)
+            {
+                continue;
             }
 
             if json {

--- a/rust/tensogram-cli/src/commands/merge.rs
+++ b/rust/tensogram-cli/src/commands/merge.rs
@@ -11,7 +11,7 @@ use std::io::Write;
 use std::path::Path;
 
 use tensogram_core::{
-    decode, encode, DecodeOptions, EncodeOptions, GlobalMetadata, TensogramFile, RESERVED_KEY,
+    DecodeOptions, EncodeOptions, GlobalMetadata, RESERVED_KEY, TensogramFile, decode, encode,
 };
 
 /// Merge strategy for conflicting metadata keys.
@@ -55,13 +55,13 @@ fn merge_key(
             map.insert(key, value);
         }
         MergeStrategy::Error => {
-            if let Some(existing) = map.get(&key) {
-                if existing != &value {
-                    return Err(format!(
-                        "conflicting values for key '{key}' (use --strategy first or last to resolve)"
-                    )
-                    .into());
-                }
+            if let Some(existing) = map.get(&key)
+                && existing != &value
+            {
+                return Err(format!(
+                    "conflicting values for key '{key}' (use --strategy first or last to resolve)"
+                )
+                .into());
             }
             map.insert(key, value);
         }

--- a/rust/tensogram-cli/src/commands/reshuffle.rs
+++ b/rust/tensogram-cli/src/commands/reshuffle.rs
@@ -9,7 +9,7 @@
 use std::io::Write;
 use std::path::Path;
 
-use tensogram_core::{decode, encode, DecodeOptions, EncodeOptions, TensogramFile, RESERVED_KEY};
+use tensogram_core::{DecodeOptions, EncodeOptions, RESERVED_KEY, TensogramFile, decode, encode};
 
 /// Reshuffle frames inside messages: move footer frames to header position.
 ///
@@ -67,8 +67,8 @@ pub fn run(input: &Path, output: &Path, threads: u32) -> Result<(), Box<dyn std:
 mod tests {
     use super::*;
     use tensogram_core::{
-        decode, ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions,
-        GlobalMetadata,
+        ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions, GlobalMetadata,
+        decode,
     };
 
     fn make_test_file(dir: &std::path::Path) -> std::path::PathBuf {

--- a/rust/tensogram-cli/src/commands/set.rs
+++ b/rust/tensogram-cli/src/commands/set.rs
@@ -11,8 +11,8 @@ use std::io::Write;
 use std::path::PathBuf;
 
 use tensogram_core::{
-    decode, decode_metadata, encode, DataObjectDescriptor, DecodeOptions, EncodeOptions,
-    GlobalMetadata, TensogramFile, RESERVED_KEY,
+    DataObjectDescriptor, DecodeOptions, EncodeOptions, GlobalMetadata, RESERVED_KEY,
+    TensogramFile, decode, decode_metadata, encode,
 };
 
 use crate::filter;
@@ -250,7 +250,7 @@ fn insert_nested_cbor_value(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tensogram_core::{encode, ByteOrder, DataObjectDescriptor, Dtype, GlobalMetadata};
+    use tensogram_core::{ByteOrder, DataObjectDescriptor, Dtype, GlobalMetadata, encode};
 
     fn make_global_meta() -> GlobalMetadata {
         GlobalMetadata {
@@ -377,10 +377,12 @@ mod tests {
         // Second message should be unchanged
         let m1 = f.read_message(1).unwrap();
         let meta1_out = decode_metadata(&m1).unwrap();
-        assert!(meta1_out
-            .base
-            .iter()
-            .all(|entry| entry.get("source").is_none()));
+        assert!(
+            meta1_out
+                .base
+                .iter()
+                .all(|entry| entry.get("source").is_none())
+        );
         assert_eq!(meta1_out.extra.get("source"), None);
     }
 

--- a/rust/tensogram-cli/src/commands/split.rs
+++ b/rust/tensogram-cli/src/commands/split.rs
@@ -9,7 +9,7 @@
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use tensogram_core::{decode, encode, DecodeOptions, EncodeOptions, TensogramFile, RESERVED_KEY};
+use tensogram_core::{DecodeOptions, EncodeOptions, RESERVED_KEY, TensogramFile, decode, encode};
 
 /// Split a multi-object message into separate single-object messages.
 ///
@@ -272,17 +272,21 @@ mod tests {
         // Verify first split has param=2t
         let msg0 = std::fs::read(dir.path().join("split_meta_0000.tgm")).unwrap();
         let meta0 = tensogram_core::decode_metadata(&msg0).unwrap();
-        assert!(meta0
-            .base
-            .iter()
-            .any(|e| e.get("param") == Some(&ciborium::Value::Text("2t".into()))));
+        assert!(
+            meta0
+                .base
+                .iter()
+                .any(|e| e.get("param") == Some(&ciborium::Value::Text("2t".into())))
+        );
 
         // Verify second split has param=msl
         let msg1 = std::fs::read(dir.path().join("split_meta_0001.tgm")).unwrap();
         let meta1 = tensogram_core::decode_metadata(&msg1).unwrap();
-        assert!(meta1
-            .base
-            .iter()
-            .any(|e| e.get("param") == Some(&ciborium::Value::Text("msl".into()))));
+        assert!(
+            meta1
+                .base
+                .iter()
+                .any(|e| e.get("param") == Some(&ciborium::Value::Text("msl".into())))
+        );
     }
 }

--- a/rust/tensogram-cli/src/commands/validate.rs
+++ b/rust/tensogram-cli/src/commands/validate.rs
@@ -10,8 +10,8 @@ use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 use tensogram_core::{
-    validate_file, FileIssue, FileValidationReport, IssueSeverity, ValidateOptions,
-    ValidationReport,
+    FileIssue, FileValidationReport, IssueSeverity, ValidateOptions, ValidationReport,
+    validate_file,
 };
 
 /// Custom error to signal validation failure (exit code 1) without process::exit.

--- a/rust/tensogram-core/Cargo.toml
+++ b/rust/tensogram-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tensogram-core"
 version = "0.13.0"
-edition = "2021"
+edition = "2024"
 
 [features]
 default = ["szip", "zstd", "lz4", "blosc2", "zfp", "sz3", "threads"]

--- a/rust/tensogram-core/src/decode.rs
+++ b/rust/tensogram-core/src/decode.rs
@@ -245,10 +245,10 @@ pub fn decode_range_from_payload(
         ));
     }
 
-    if options.verify_hash {
-        if let Some(ref hash_desc) = desc.hash {
-            hash::verify_hash(payload_bytes, hash_desc)?;
-        }
+    if options.verify_hash
+        && let Some(ref hash_desc) = desc.hash
+    {
+        hash::verify_hash(payload_bytes, hash_desc)?;
     }
 
     let shape_product = desc
@@ -355,10 +355,10 @@ fn decode_single_object_with_backend(
     backend: pipeline::CompressionBackend,
     intra_codec_threads: u32,
 ) -> Result<Vec<u8>> {
-    if options.verify_hash {
-        if let Some(ref hash_desc) = desc.hash {
-            hash::verify_hash(payload_bytes, hash_desc)?;
-        }
+    if options.verify_hash
+        && let Some(ref hash_desc) = desc.hash
+    {
+        hash::verify_hash(payload_bytes, hash_desc)?;
     }
 
     let shape_product = desc
@@ -385,7 +385,7 @@ fn decode_single_object_with_backend(
 mod tests {
     use super::*;
     use crate::dtype::Dtype;
-    use crate::encode::{encode, EncodeOptions};
+    use crate::encode::{EncodeOptions, encode};
     use crate::types::ByteOrder;
     use std::collections::BTreeMap;
 

--- a/rust/tensogram-core/src/encode.rs
+++ b/rust/tensogram-core/src/encode.rs
@@ -11,7 +11,7 @@ use std::collections::BTreeMap;
 use crate::dtype::Dtype;
 use crate::error::{Result, TensogramError};
 use crate::framing::{self, EncodedObject};
-use crate::hash::{compute_hash, HashAlgorithm};
+use crate::hash::{HashAlgorithm, compute_hash};
 use crate::metadata::RESERVED_KEY;
 use crate::types::{DataObjectDescriptor, GlobalMetadata, HashDescriptor};
 #[cfg(feature = "blosc2")]
@@ -543,7 +543,7 @@ pub(crate) fn build_pipeline_config_with_backend(
         other => {
             return Err(TensogramError::Encoding(format!(
                 "unknown encoding: {other}"
-            )))
+            )));
         }
     };
 
@@ -611,7 +611,7 @@ pub(crate) fn build_pipeline_config_with_backend(
                 other => {
                     return Err(TensogramError::Encoding(format!(
                         "unknown blosc2 codec: {other}"
-                    )))
+                    )));
                 }
             };
             let clevel_i64 = get_i64_param(&desc.params, "blosc2_clevel").unwrap_or(5);
@@ -640,7 +640,7 @@ pub(crate) fn build_pipeline_config_with_backend(
                 _ => {
                     return Err(TensogramError::Metadata(
                         "missing required parameter: zfp_mode".to_string(),
-                    ))
+                    ));
                 }
             };
             let mode = match mode_str.as_str() {
@@ -662,7 +662,7 @@ pub(crate) fn build_pipeline_config_with_backend(
                 other => {
                     return Err(TensogramError::Encoding(format!(
                         "unknown zfp_mode: {other}"
-                    )))
+                    )));
                 }
             };
             CompressionType::Zfp { mode }
@@ -674,7 +674,7 @@ pub(crate) fn build_pipeline_config_with_backend(
                 _ => {
                     return Err(TensogramError::Metadata(
                         "missing required parameter: sz3_error_bound_mode".to_string(),
-                    ))
+                    ));
                 }
             };
             let bound_val = get_f64_param(&desc.params, "sz3_error_bound")?;
@@ -685,7 +685,7 @@ pub(crate) fn build_pipeline_config_with_backend(
                 other => {
                     return Err(TensogramError::Encoding(format!(
                         "unknown sz3_error_bound_mode: {other}"
-                    )))
+                    )));
                 }
             };
             CompressionType::Sz3 { error_bound }
@@ -693,7 +693,7 @@ pub(crate) fn build_pipeline_config_with_backend(
         other => {
             return Err(TensogramError::Encoding(format!(
                 "unknown compression: {other}"
-            )))
+            )));
         }
     };
 
@@ -883,7 +883,7 @@ pub(crate) fn validate_no_szip_offsets_for_non_szip(desc: &DataObjectDescriptor)
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::decode::{decode, DecodeOptions};
+    use crate::decode::{DecodeOptions, decode};
     use crate::types::{ByteOrder, GlobalMetadata};
     use std::collections::BTreeMap;
 

--- a/rust/tensogram-core/src/file.rs
+++ b/rust/tensogram-core/src/file.rs
@@ -1052,8 +1052,8 @@ mod tests {
     }
 
     #[test]
-    fn test_local_decode_range_multiple_ranges(
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_local_decode_range_multiple_ranges()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
         let path = dir.path().join("range_multi.tgm");
 
@@ -1076,8 +1076,8 @@ mod tests {
     }
 
     #[test]
-    fn test_local_decode_range_invalid_object_index(
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_local_decode_range_invalid_object_index()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
         let path = dir.path().join("range_bad_obj.tgm");
 
@@ -1102,8 +1102,8 @@ mod tests {
     }
 
     #[test]
-    fn test_local_decode_range_invalid_message_index(
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_local_decode_range_invalid_message_index()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
         let path = dir.path().join("range_bad_msg.tgm");
 
@@ -1171,8 +1171,8 @@ mod tests {
 
     #[cfg(feature = "async")]
     #[tokio::test]
-    async fn test_async_open_nonexistent_file(
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    async fn test_async_open_nonexistent_file()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
         let result = TensogramFile::open_async("/tmp/nonexistent_tensogram_file_12345.tgm").await;
         match result {
             Ok(_) => panic!("expected error for nonexistent file"),
@@ -1189,8 +1189,8 @@ mod tests {
 
     #[cfg(feature = "async")]
     #[tokio::test]
-    async fn test_async_message_index_out_of_range(
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    async fn test_async_message_index_out_of_range()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
         let path = dir.path().join("async_oor.tgm");
 
@@ -1217,8 +1217,8 @@ mod tests {
 
     #[cfg(feature = "async")]
     #[tokio::test]
-    async fn test_async_decode_metadata_out_of_range(
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    async fn test_async_decode_metadata_out_of_range()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
         let path = dir.path().join("async_meta_oor.tgm");
 
@@ -1337,8 +1337,8 @@ mod tests {
     }
 
     #[test]
-    fn test_source_returns_path_string_for_local(
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_source_returns_path_string_for_local()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
         let path = dir.path().join("source_test.tgm");
 
@@ -1381,8 +1381,8 @@ mod tests {
     // ── Coverage closers ─────────────────────────────────────────────────
 
     #[test]
-    fn test_create_in_nested_path_creates_parent(
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_create_in_nested_path_creates_parent()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
         // Exercises the `fs::create_dir_all(parent)` branch in `create()`.
         let dir = tempfile::tempdir()?;
         let deep_path = dir.path().join("a").join("b").join("c").join("deep.tgm");
@@ -1411,8 +1411,8 @@ mod tests {
     /// environments the test's premise cannot be deterministically met.
     #[cfg(unix)]
     #[test]
-    fn test_create_in_nonwritable_location_returns_io_error(
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_create_in_nonwritable_location_returns_io_error()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
         use std::os::unix::fs::PermissionsExt;
 
         let dir = tempfile::tempdir()?;
@@ -1458,8 +1458,8 @@ mod tests {
     }
 
     #[test]
-    fn test_read_message_from_deleted_file_errors(
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_read_message_from_deleted_file_errors()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
         // TensogramFile is path-backed: each read reopens the file. If the
         // underlying path disappears out from under an open handle, the
         // next read_message call must surface a typed I/O error rather
@@ -1551,8 +1551,8 @@ mod tests {
     }
 
     #[test]
-    fn test_decode_message_out_of_range_clearly_errors(
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_decode_message_out_of_range_clearly_errors()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
         let path = dir.path().join("oor.tgm");
         let mut file = TensogramFile::create(&path)?;
@@ -1602,8 +1602,8 @@ mod tests {
     // ── open_source dispatches to local backend ──────────────────────────
 
     #[test]
-    fn test_open_source_local_path_source_and_path_accessors(
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_open_source_local_path_source_and_path_accessors()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
         let path = dir.path().join("open_src_acc.tgm");
 
@@ -1801,8 +1801,8 @@ mod tests {
     // ── decode_descriptors via file ──────────────────────────────────────
 
     #[test]
-    fn test_file_decode_descriptors_msg_out_of_range(
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_file_decode_descriptors_msg_out_of_range()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
         let path = dir.path().join("desc_oor.tgm");
 
@@ -1825,8 +1825,8 @@ mod tests {
     // ── decode_metadata via file with out-of-range index ─────────────────
 
     #[test]
-    fn test_file_decode_metadata_out_of_range(
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_file_decode_metadata_out_of_range()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
         let path = dir.path().join("meta_oor.tgm");
 
@@ -1901,8 +1901,8 @@ mod tests {
     // ── decode_range out-of-bounds element range ─────────────────────────
 
     #[test]
-    fn test_local_decode_range_out_of_bounds_elements(
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_local_decode_range_out_of_bounds_elements()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
         let path = dir.path().join("range_oob.tgm");
 
@@ -1967,8 +1967,8 @@ mod tests {
 
     #[cfg(feature = "async")]
     #[tokio::test]
-    async fn test_async_decode_object_out_of_range(
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    async fn test_async_decode_object_out_of_range()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
         let path = dir.path().join("async_obj_oor.tgm");
 
@@ -2028,8 +2028,8 @@ mod tests {
 
     #[cfg(feature = "async")]
     #[tokio::test]
-    async fn test_async_decode_descriptors_out_of_range(
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    async fn test_async_decode_descriptors_out_of_range()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
         let path = dir.path().join("async_descs_oor.tgm");
 

--- a/rust/tensogram-core/src/framing.rs
+++ b/rust/tensogram-core/src/framing.rs
@@ -12,8 +12,8 @@ use crate::error::{Result, TensogramError};
 use crate::metadata::{self, RESERVED_KEY};
 use crate::types::{DataObjectDescriptor, GlobalMetadata, HashFrame, IndexFrame};
 use crate::wire::{
-    DataObjectFlags, FrameHeader, FrameType, MessageFlags, Postamble, Preamble,
-    DATA_OBJECT_FOOTER_SIZE, FRAME_END, FRAME_HEADER_SIZE, MAGIC, POSTAMBLE_SIZE, PREAMBLE_SIZE,
+    DATA_OBJECT_FOOTER_SIZE, DataObjectFlags, FRAME_END, FRAME_HEADER_SIZE, FrameHeader, FrameType,
+    MAGIC, MessageFlags, POSTAMBLE_SIZE, PREAMBLE_SIZE, Postamble, Preamble,
 };
 
 // ── Frame-level primitives ───────────────────────────────────────────────────
@@ -876,62 +876,60 @@ pub fn scan_file(file: &mut (impl std::io::Read + std::io::Seek)) -> Result<Vec<
             break;
         }
 
-        if &preamble_buf[..MAGIC.len()] == MAGIC {
-            if let Ok(preamble) = Preamble::read_from(&preamble_buf) {
-                if preamble.total_length > 0 {
-                    let Ok(total) = usize::try_from(preamble.total_length) else {
-                        pos += 1;
+        if &preamble_buf[..MAGIC.len()] == MAGIC
+            && let Ok(preamble) = Preamble::read_from(&preamble_buf)
+        {
+            if preamble.total_length > 0 {
+                let Ok(total) = usize::try_from(preamble.total_length) else {
+                    pos += 1;
+                    continue;
+                };
+                if pos + total <= file_len {
+                    // Read end magic to validate
+                    let end_magic_offset = pos + total - 8;
+                    file.seek(SeekFrom::Start(end_magic_offset as u64))?;
+                    let mut end_buf = [0u8; 8];
+                    if file.read_exact(&mut end_buf).is_ok() && &end_buf == crate::wire::END_MAGIC {
+                        messages.push((pos, total));
+                        pos += total;
                         continue;
-                    };
-                    if pos + total <= file_len {
-                        // Read end magic to validate
-                        let end_magic_offset = pos + total - 8;
-                        file.seek(SeekFrom::Start(end_magic_offset as u64))?;
-                        let mut end_buf = [0u8; 8];
-                        if file.read_exact(&mut end_buf).is_ok()
-                            && &end_buf == crate::wire::END_MAGIC
-                        {
-                            messages.push((pos, total));
-                            pos += total;
-                            continue;
-                        }
                     }
-                } else {
-                    // Streaming mode: scan forward for END_MAGIC
-                    // Read in chunks to find the terminator
-                    let mut search_pos = pos + PREAMBLE_SIZE;
-                    let mut found = false;
-                    let chunk_size = 4096;
-                    let mut chunk = vec![0u8; chunk_size];
+                }
+            } else {
+                // Streaming mode: scan forward for END_MAGIC
+                // Read in chunks to find the terminator
+                let mut search_pos = pos + PREAMBLE_SIZE;
+                let mut found = false;
+                let chunk_size = 4096;
+                let mut chunk = vec![0u8; chunk_size];
 
-                    while search_pos + 8 <= file_len {
-                        file.seek(SeekFrom::Start(search_pos as u64))?;
-                        let to_read = (file_len - search_pos).min(chunk_size);
-                        let buf = &mut chunk[..to_read];
-                        if file.read_exact(buf).is_err() {
+                while search_pos + 8 <= file_len {
+                    file.seek(SeekFrom::Start(search_pos as u64))?;
+                    let to_read = (file_len - search_pos).min(chunk_size);
+                    let buf = &mut chunk[..to_read];
+                    if file.read_exact(buf).is_err() {
+                        break;
+                    }
+
+                    // Search for END_MAGIC in this chunk
+                    for i in 0..to_read.saturating_sub(7) {
+                        if &buf[i..i + 8] == crate::wire::END_MAGIC {
+                            let end_pos = search_pos + i;
+                            let msg_len = end_pos + 8 - pos;
+                            messages.push((pos, msg_len));
+                            pos = end_pos + 8;
+                            found = true;
                             break;
                         }
-
-                        // Search for END_MAGIC in this chunk
-                        for i in 0..to_read.saturating_sub(7) {
-                            if &buf[i..i + 8] == crate::wire::END_MAGIC {
-                                let end_pos = search_pos + i;
-                                let msg_len = end_pos + 8 - pos;
-                                messages.push((pos, msg_len));
-                                pos = end_pos + 8;
-                                found = true;
-                                break;
-                            }
-                        }
-                        if found {
-                            break;
-                        }
-                        // Overlap by 7 bytes to catch END_MAGIC spanning chunks
-                        search_pos += to_read.saturating_sub(7);
                     }
                     if found {
-                        continue;
+                        break;
                     }
+                    // Overlap by 7 bytes to catch END_MAGIC spanning chunks
+                    search_pos += to_read.saturating_sub(7);
+                }
+                if found {
+                    continue;
                 }
             }
         }

--- a/rust/tensogram-core/src/hash.rs
+++ b/rust/tensogram-core/src/hash.rs
@@ -74,7 +74,7 @@ mod tests {
         let data = b"hello world";
         let hash = compute_hash(data, HashAlgorithm::Xxh3);
         assert_eq!(hash.len(), 16); // 64-bit = 16 hex chars
-                                    // Verify deterministic
+        // Verify deterministic
         assert_eq!(hash, compute_hash(data, HashAlgorithm::Xxh3));
     }
 

--- a/rust/tensogram-core/src/iter.rs
+++ b/rust/tensogram-core/src/iter.rs
@@ -70,7 +70,7 @@ pub fn objects(buf: &[u8], options: DecodeOptions) -> Result<ObjectIter> {
 
 /// Return an iterator over the [`DataObjectDescriptor`]s in a message without
 /// decoding any payload data.
-pub fn objects_metadata(buf: &[u8]) -> Result<impl Iterator<Item = DataObjectDescriptor>> {
+pub fn objects_metadata(buf: &[u8]) -> Result<impl Iterator<Item = DataObjectDescriptor> + use<>> {
     let msg = framing::decode_message(buf)?;
     Ok(msg
         .objects
@@ -138,12 +138,11 @@ impl Iterator for ObjectIter {
         let (ref desc, ref payload_bytes) = self.objects[i];
 
         // Verify hash if requested
-        if self.options.verify_hash {
-            if let Some(ref hash_desc) = desc.hash {
-                if let Err(e) = crate::hash::verify_hash(payload_bytes, hash_desc) {
-                    return Some(Err(e));
-                }
-            }
+        if self.options.verify_hash
+            && let Some(ref hash_desc) = desc.hash
+            && let Err(e) = crate::hash::verify_hash(payload_bytes, hash_desc)
+        {
+            return Some(Err(e));
         }
 
         let shape_product = match desc
@@ -155,7 +154,7 @@ impl Iterator for ObjectIter {
             None => {
                 return Some(Err(crate::error::TensogramError::Metadata(
                     "shape product overflow".to_string(),
-                )))
+                )));
             }
         };
         let num_elements = match usize::try_from(shape_product) {
@@ -163,7 +162,7 @@ impl Iterator for ObjectIter {
             Err(_) => {
                 return Some(Err(crate::error::TensogramError::Metadata(
                     "element count overflows usize".to_string(),
-                )))
+                )));
             }
         };
 
@@ -254,7 +253,7 @@ mod tests {
     use super::*;
     use crate::decode::DecodeOptions;
     use crate::dtype::Dtype;
-    use crate::encode::{encode, EncodeOptions};
+    use crate::encode::{EncodeOptions, encode};
     use crate::types::{ByteOrder, DataObjectDescriptor, GlobalMetadata};
     use std::collections::BTreeMap;
 

--- a/rust/tensogram-core/src/lib.rs
+++ b/rust/tensogram-core/src/lib.rs
@@ -30,19 +30,19 @@ pub mod validate;
 pub mod wire;
 
 pub use decode::{
-    decode, decode_descriptors, decode_metadata, decode_object, decode_range,
-    decode_range_from_payload, DecodeOptions,
+    DecodeOptions, decode, decode_descriptors, decode_metadata, decode_object, decode_range,
+    decode_range_from_payload,
 };
 pub use dtype::Dtype;
-pub use encode::{encode, encode_pre_encoded, EncodeOptions};
+pub use encode::{EncodeOptions, encode, encode_pre_encoded};
 pub use error::{Result, TensogramError};
 pub use file::TensogramFile;
 pub use framing::{scan, scan_file};
-pub use hash::{compute_hash, verify_hash, HashAlgorithm};
-pub use iter::{messages, objects, objects_metadata, FileMessageIter, MessageIter, ObjectIter};
-pub use metadata::{compute_common, verify_canonical_cbor, RESERVED_KEY};
+pub use hash::{HashAlgorithm, compute_hash, verify_hash};
+pub use iter::{FileMessageIter, MessageIter, ObjectIter, messages, objects, objects_metadata};
+pub use metadata::{RESERVED_KEY, compute_common, verify_canonical_cbor};
 pub use parallel::{DEFAULT_PARALLEL_THRESHOLD_BYTES, ENV_THREADS};
-pub use pipeline::{apply_pipeline, DataPipeline};
+pub use pipeline::{DataPipeline, apply_pipeline};
 pub use streaming::StreamingEncoder;
 pub use tensogram_encodings::pipeline::CompressionBackend;
 pub use types::{
@@ -50,8 +50,8 @@ pub use types::{
     IndexFrame,
 };
 pub use validate::{
-    validate_buffer, validate_file, validate_message, FileIssue, FileValidationReport, IssueCode,
-    IssueSeverity, ValidateOptions, ValidationIssue, ValidationLevel, ValidationReport,
+    FileIssue, FileValidationReport, IssueCode, IssueSeverity, ValidateOptions, ValidationIssue,
+    ValidationLevel, ValidationReport, validate_buffer, validate_file, validate_message,
 };
 pub use wire::{FrameType, MessageFlags};
 

--- a/rust/tensogram-core/src/metadata.rs
+++ b/rust/tensogram-core/src/metadata.rs
@@ -94,7 +94,7 @@ pub fn cbor_to_index(cbor_bytes: &[u8]) -> Result<IndexFrame> {
         _ => {
             return Err(TensogramError::Metadata(
                 "index CBOR is not a map".to_string(),
-            ))
+            ));
         }
     };
 
@@ -164,7 +164,7 @@ pub fn cbor_to_hash_frame(cbor_bytes: &[u8]) -> Result<HashFrame> {
         _ => {
             return Err(TensogramError::Metadata(
                 "hash frame CBOR is not a map".to_string(),
-            ))
+            ));
         }
     };
 
@@ -187,7 +187,7 @@ pub fn cbor_to_hash_frame(cbor_bytes: &[u8]) -> Result<HashFrame> {
                     _ => {
                         return Err(TensogramError::Metadata(
                             "hash_type must be text".to_string(),
-                        ))
+                        ));
                     }
                 };
             }
@@ -205,7 +205,7 @@ pub fn cbor_to_hash_frame(cbor_bytes: &[u8]) -> Result<HashFrame> {
                     _ => {
                         return Err(TensogramError::Metadata(
                             "hashes must be an array".to_string(),
-                        ))
+                        ));
                     }
                 };
             }
@@ -406,13 +406,13 @@ fn verify_canonical_value(value: &ciborium::Value) -> Result<()> {
                     TensogramError::Metadata(format!("CBOR key serialisation failed: {e}"))
                 })?;
 
-                if let Some(ref prev) = prev_key_bytes {
-                    if key_bytes <= *prev {
-                        return Err(TensogramError::Metadata(format!(
-                            "CBOR map keys not in canonical order: key {:?} should come before {:?}",
-                            prev, key_bytes
-                        )));
-                    }
+                if let Some(ref prev) = prev_key_bytes
+                    && key_bytes <= *prev
+                {
+                    return Err(TensogramError::Metadata(format!(
+                        "CBOR map keys not in canonical order: key {:?} should come before {:?}",
+                        prev, key_bytes
+                    )));
                 }
                 prev_key_bytes = Some(key_bytes);
 

--- a/rust/tensogram-core/src/pipeline.rs
+++ b/rust/tensogram-core/src/pipeline.rs
@@ -251,8 +251,8 @@ mod tests {
     use std::collections::BTreeMap;
 
     use super::*;
-    use crate::types::ByteOrder;
     use crate::Dtype;
+    use crate::types::ByteOrder;
 
     fn mk_desc() -> DataObjectDescriptor {
         DataObjectDescriptor {

--- a/rust/tensogram-core/src/remote.rs
+++ b/rust/tensogram-core/src/remote.rs
@@ -13,7 +13,9 @@
 
 use std::collections::BTreeMap;
 use std::ops::Range;
-use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
+#[cfg(feature = "async")]
+use std::sync::MutexGuard;
+use std::sync::{Arc, Mutex, OnceLock};
 
 use bytes::Bytes;
 use object_store::path::Path as ObjectPath;
@@ -26,8 +28,8 @@ use crate::framing;
 use crate::metadata;
 use crate::types::{DataObjectDescriptor, GlobalMetadata, IndexFrame};
 use crate::wire::{
-    DataObjectFlags, FrameHeader, FrameType, MessageFlags, Postamble, Preamble,
-    DATA_OBJECT_FOOTER_SIZE, FRAME_END, FRAME_HEADER_SIZE, MAGIC, POSTAMBLE_SIZE, PREAMBLE_SIZE,
+    DATA_OBJECT_FOOTER_SIZE, DataObjectFlags, FRAME_END, FRAME_HEADER_SIZE, FrameHeader, FrameType,
+    MAGIC, MessageFlags, POSTAMBLE_SIZE, PREAMBLE_SIZE, Postamble, Preamble,
 };
 
 // ── URL scheme detection ─────────────────────────────────────────────────────
@@ -182,6 +184,7 @@ impl RemoteBackend {
         &self.source_url
     }
 
+    #[cfg(feature = "async")]
     fn lock_state(&self) -> Result<MutexGuard<'_, RemoteState>> {
         self.state
             .lock()

--- a/rust/tensogram-core/src/streaming.rs
+++ b/rust/tensogram-core/src/streaming.rs
@@ -10,18 +10,17 @@ use std::collections::BTreeMap;
 use std::io::Write;
 
 use crate::encode::{
-    build_pipeline_config, populate_base_entries, populate_reserved_provenance,
+    EncodeOptions, build_pipeline_config, populate_base_entries, populate_reserved_provenance,
     validate_no_szip_offsets_for_non_szip, validate_object, validate_szip_block_offsets,
-    EncodeOptions,
 };
 use crate::error::{Result, TensogramError};
 use crate::framing::EncodedObject;
-use crate::hash::{compute_hash, HashAlgorithm};
+use crate::hash::{HashAlgorithm, compute_hash};
 use crate::metadata::{self, RESERVED_KEY};
 use crate::types::{DataObjectDescriptor, GlobalMetadata, HashDescriptor, HashFrame, IndexFrame};
 use crate::wire::{
-    FrameHeader, FrameType, MessageFlags, Postamble, Preamble, FRAME_END, FRAME_HEADER_SIZE,
-    PREAMBLE_SIZE,
+    FRAME_END, FRAME_HEADER_SIZE, FrameHeader, FrameType, MessageFlags, PREAMBLE_SIZE, Postamble,
+    Preamble,
 };
 use tensogram_encodings::pipeline;
 
@@ -389,11 +388,11 @@ impl<W: Write> StreamingEncoder<W> {
                 )));
             }
             for (i, prec) in self.preceder_payloads.iter().enumerate() {
-                if let Some(prec_map) = prec {
-                    if i < enriched_meta.base.len() {
-                        for (k, v) in prec_map {
-                            enriched_meta.base[i].insert(k.clone(), v.clone());
-                        }
+                if let Some(prec_map) = prec
+                    && i < enriched_meta.base.len()
+                {
+                    for (k, v) in prec_map {
+                        enriched_meta.base[i].insert(k.clone(), v.clone());
                     }
                 }
             }
@@ -503,10 +502,10 @@ fn write_padding(writer: &mut impl Write, bytes_written: &mut u64) -> std::io::R
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::decode::{decode, DecodeOptions};
-    use crate::encode::{encode, EncodeOptions};
-    use crate::types::{ByteOrder, DataObjectDescriptor};
     use crate::Dtype;
+    use crate::decode::{DecodeOptions, decode};
+    use crate::encode::{EncodeOptions, encode};
+    use crate::types::{ByteOrder, DataObjectDescriptor};
     use std::collections::BTreeMap;
 
     fn make_descriptor(shape: Vec<u64>) -> DataObjectDescriptor {

--- a/rust/tensogram-core/src/validate/fidelity.rs
+++ b/rust/tensogram-core/src/validate/fidelity.rs
@@ -493,7 +493,25 @@ fn scan_complex128(
     }
     for (idx, chunk) in chunks.enumerate() {
         // See scan_f32 for the rationale of this slice-pattern idiom.
-        let &[r0, r1, r2, r3, r4, r5, r6, r7, i0, i1, i2, i3, i4, i5, i6, i7] = chunk else {
+        let &[
+            r0,
+            r1,
+            r2,
+            r3,
+            r4,
+            r5,
+            r6,
+            r7,
+            i0,
+            i1,
+            i2,
+            i3,
+            i4,
+            i5,
+            i6,
+            i7,
+        ] = chunk
+        else {
             continue;
         };
         let real_bytes = [r0, r1, r2, r3, r4, r5, r6, r7];

--- a/rust/tensogram-core/src/validate/integrity.rs
+++ b/rust/tensogram-core/src/validate/integrity.rs
@@ -167,74 +167,73 @@ pub(crate) fn validate_integrity(
         }
 
         // Decompression check (requires parsed descriptor, skipped in checksum-only mode)
-        if !checksum_only {
-            if let Some(ref desc) = obj.descriptor {
-                if desc.compression != "none" || desc.encoding != "none" || desc.filter != "none" {
-                    let shape_product = desc
-                        .shape
-                        .iter()
-                        .try_fold(1u64, |acc, &x| acc.checked_mul(x));
-                    let num_elements = match shape_product {
-                        Some(product) => match usize::try_from(product) {
-                            Ok(n) => Some(n),
-                            Err(_) => {
-                                obj.decode_state = DecodeState::DecodeFailed;
-                                issues.push(err(
-                                    IssueCode::PipelineConfigFailed,
-                                    ValidationLevel::Integrity,
-                                    Some(i),
-                                    Some(obj.frame_offset),
-                                    format!("shape product {} does not fit in usize", product),
-                                ));
-                                None
-                            }
-                        },
-                        None => {
-                            // Shape overflow already reported at Level 2
-                            obj.decode_state = DecodeState::DecodeFailed;
-                            None
-                        }
-                    };
-                    if let Some(num_elements) = num_elements {
-                        match build_pipeline_config(desc, num_elements, desc.dtype) {
-                            Ok(config) => {
-                                match tensogram_encodings::pipeline::decode_pipeline(
-                                    obj.payload,
-                                    &config,
-                                    false,
-                                ) {
-                                    Ok(decoded) => {
-                                        if cache_decoded {
-                                            obj.decode_state = DecodeState::Decoded(decoded);
-                                        }
-                                    }
-                                    Err(e) => {
-                                        obj.decode_state = DecodeState::DecodeFailed;
-                                        issues.push(err(
-                                            IssueCode::DecodePipelineFailed,
-                                            ValidationLevel::Integrity,
-                                            Some(i),
-                                            Some(obj.frame_offset),
-                                            format!("decode pipeline failed: {e}"),
-                                        ));
-                                    }
+        if !checksum_only
+            && let Some(ref desc) = obj.descriptor
+            && (desc.compression != "none" || desc.encoding != "none" || desc.filter != "none")
+        {
+            let shape_product = desc
+                .shape
+                .iter()
+                .try_fold(1u64, |acc, &x| acc.checked_mul(x));
+            let num_elements = match shape_product {
+                Some(product) => match usize::try_from(product) {
+                    Ok(n) => Some(n),
+                    Err(_) => {
+                        obj.decode_state = DecodeState::DecodeFailed;
+                        issues.push(err(
+                            IssueCode::PipelineConfigFailed,
+                            ValidationLevel::Integrity,
+                            Some(i),
+                            Some(obj.frame_offset),
+                            format!("shape product {} does not fit in usize", product),
+                        ));
+                        None
+                    }
+                },
+                None => {
+                    // Shape overflow already reported at Level 2
+                    obj.decode_state = DecodeState::DecodeFailed;
+                    None
+                }
+            };
+            if let Some(num_elements) = num_elements {
+                match build_pipeline_config(desc, num_elements, desc.dtype) {
+                    Ok(config) => {
+                        match tensogram_encodings::pipeline::decode_pipeline(
+                            obj.payload,
+                            &config,
+                            false,
+                        ) {
+                            Ok(decoded) => {
+                                if cache_decoded {
+                                    obj.decode_state = DecodeState::Decoded(decoded);
                                 }
                             }
                             Err(e) => {
                                 obj.decode_state = DecodeState::DecodeFailed;
                                 issues.push(err(
-                                    IssueCode::PipelineConfigFailed,
+                                    IssueCode::DecodePipelineFailed,
                                     ValidationLevel::Integrity,
                                     Some(i),
                                     Some(obj.frame_offset),
-                                    format!("cannot build pipeline config: {e}"),
+                                    format!("decode pipeline failed: {e}"),
                                 ));
                             }
                         }
                     }
+                    Err(e) => {
+                        obj.decode_state = DecodeState::DecodeFailed;
+                        issues.push(err(
+                            IssueCode::PipelineConfigFailed,
+                            ValidationLevel::Integrity,
+                            Some(i),
+                            Some(obj.frame_offset),
+                            format!("cannot build pipeline config: {e}"),
+                        ));
+                    }
                 }
             }
-        } // if !checksum_only
+        }
     }
 
     any_checked && all_verified

--- a/rust/tensogram-core/src/validate/metadata.rs
+++ b/rust/tensogram-core/src/validate/metadata.rs
@@ -27,16 +27,14 @@ pub(crate) fn validate_metadata(
     for (ft, payload) in &walk.meta_frames {
         match ft {
             FrameType::HeaderMetadata | FrameType::FooterMetadata => {
-                if check_canonical {
-                    if let Err(e) = metadata::verify_canonical_cbor(payload) {
-                        issues.push(warn(
-                            IssueCode::MetadataCborNonCanonical,
-                            ValidationLevel::Metadata,
-                            None,
-                            None,
-                            format!("metadata CBOR is not canonical: {e}"),
-                        ));
-                    }
+                if check_canonical && let Err(e) = metadata::verify_canonical_cbor(payload) {
+                    issues.push(warn(
+                        IssueCode::MetadataCborNonCanonical,
+                        ValidationLevel::Metadata,
+                        None,
+                        None,
+                        format!("metadata CBOR is not canonical: {e}"),
+                    ));
                 }
                 match metadata::cbor_to_global_metadata(payload) {
                     Ok(meta) => {
@@ -154,16 +152,14 @@ pub(crate) fn validate_metadata(
     // Validate preceder metadata frames
     for (ft, payload) in &walk.meta_frames {
         if *ft == FrameType::PrecederMetadata {
-            if check_canonical {
-                if let Err(e) = metadata::verify_canonical_cbor(payload) {
-                    issues.push(warn(
-                        IssueCode::PrecederCborNonCanonical,
-                        ValidationLevel::Metadata,
-                        None,
-                        None,
-                        format!("preceder metadata CBOR is not canonical: {e}"),
-                    ));
-                }
+            if check_canonical && let Err(e) = metadata::verify_canonical_cbor(payload) {
+                issues.push(warn(
+                    IssueCode::PrecederCborNonCanonical,
+                    ValidationLevel::Metadata,
+                    None,
+                    None,
+                    format!("preceder metadata CBOR is not canonical: {e}"),
+                ));
             }
             match metadata::cbor_to_global_metadata(payload) {
                 Ok(prec) => {
@@ -200,33 +196,31 @@ pub(crate) fn validate_metadata(
 
     // base.len() vs object count
     let obj_count = objects.len();
-    if let Some(base_len) = meta_base_len {
-        if base_len > obj_count {
-            issues.push(err(
-                IssueCode::BaseCountExceedsObjects,
-                ValidationLevel::Metadata,
-                None,
-                None,
-                format!(
-                    "metadata base has {} entries but message has {} data objects",
-                    base_len, obj_count
-                ),
-            ));
-        }
+    if let Some(base_len) = meta_base_len
+        && base_len > obj_count
+    {
+        issues.push(err(
+            IssueCode::BaseCountExceedsObjects,
+            ValidationLevel::Metadata,
+            None,
+            None,
+            format!(
+                "metadata base has {} entries but message has {} data objects",
+                base_len, obj_count
+            ),
+        ));
     }
 
     // Per-object descriptor validation — parse and cache in ObjectContext
     for (i, obj) in objects.iter_mut().enumerate() {
-        if check_canonical {
-            if let Err(e) = metadata::verify_canonical_cbor(obj.cbor_bytes) {
-                issues.push(warn(
-                    IssueCode::DescriptorCborNonCanonical,
-                    ValidationLevel::Metadata,
-                    Some(i),
-                    None,
-                    format!("descriptor CBOR is not canonical: {e}"),
-                ));
-            }
+        if check_canonical && let Err(e) = metadata::verify_canonical_cbor(obj.cbor_bytes) {
+            issues.push(warn(
+                IssueCode::DescriptorCborNonCanonical,
+                ValidationLevel::Metadata,
+                Some(i),
+                None,
+                format!("descriptor CBOR is not canonical: {e}"),
+            ));
         }
 
         let desc = match metadata::cbor_to_object_descriptor(obj.cbor_bytes) {

--- a/rust/tensogram-core/src/validate/mod.rs
+++ b/rust/tensogram-core/src/validate/mod.rs
@@ -247,10 +247,10 @@ pub fn validate_buffer(buf: &[u8], options: &ValidateOptions) -> FileValidationR
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::encode::{encode, EncodeOptions};
+    use crate::Dtype;
+    use crate::encode::{EncodeOptions, encode};
     use crate::types::{DataObjectDescriptor, GlobalMetadata};
     use crate::wire::{FRAME_HEADER_SIZE, POSTAMBLE_SIZE, PREAMBLE_SIZE};
-    use crate::Dtype;
     use std::collections::BTreeMap;
     use tensogram_encodings::ByteOrder;
 
@@ -898,10 +898,12 @@ mod tests {
         let msg = make_float64_message(&[f64::NEG_INFINITY, 1.0]);
         let report = validate_message(&msg, &full_opts());
         assert!(!report.is_ok());
-        assert!(report
-            .issues
-            .iter()
-            .any(|i| i.code == IssueCode::InfDetected));
+        assert!(
+            report
+                .issues
+                .iter()
+                .any(|i| i.code == IssueCode::InfDetected)
+        );
     }
 
     #[test]
@@ -909,10 +911,12 @@ mod tests {
         let msg = make_float32_message_le(&[1.0, f32::NAN, 3.0]);
         let report = validate_message(&msg, &full_opts());
         assert!(!report.is_ok());
-        assert!(report
-            .issues
-            .iter()
-            .any(|i| i.code == IssueCode::NanDetected));
+        assert!(
+            report
+                .issues
+                .iter()
+                .any(|i| i.code == IssueCode::NanDetected)
+        );
     }
 
     #[test]
@@ -920,10 +924,12 @@ mod tests {
         let msg = make_float32_message_le(&[f32::INFINITY]);
         let report = validate_message(&msg, &full_opts());
         assert!(!report.is_ok());
-        assert!(report
-            .issues
-            .iter()
-            .any(|i| i.code == IssueCode::InfDetected));
+        assert!(
+            report
+                .issues
+                .iter()
+                .any(|i| i.code == IssueCode::InfDetected)
+        );
     }
 
     #[test]
@@ -1034,10 +1040,12 @@ mod tests {
         .unwrap();
         let report = validate_message(&msg, &full_opts());
         assert!(!report.is_ok());
-        assert!(report
-            .issues
-            .iter()
-            .any(|i| i.code == IssueCode::InfDetected));
+        assert!(
+            report
+                .issues
+                .iter()
+                .any(|i| i.code == IssueCode::InfDetected)
+        );
     }
 
     #[test]
@@ -1067,10 +1075,12 @@ mod tests {
         .unwrap();
         let report = validate_message(&msg, &full_opts());
         assert!(!report.is_ok());
-        assert!(report
-            .issues
-            .iter()
-            .any(|i| i.code == IssueCode::NanDetected));
+        assert!(
+            report
+                .issues
+                .iter()
+                .any(|i| i.code == IssueCode::NanDetected)
+        );
     }
 
     #[test]
@@ -1760,7 +1770,7 @@ mod tests {
 
         // Build data object frame manually with patched CBOR
         use crate::wire::{
-            DataObjectFlags, DATA_OBJECT_FOOTER_SIZE, FRAME_END, FRAME_HEADER_SIZE, FRAME_MAGIC,
+            DATA_OBJECT_FOOTER_SIZE, DataObjectFlags, FRAME_END, FRAME_HEADER_SIZE, FRAME_MAGIC,
         };
         let payload = vec![0u8; 32];
         let cbor_offset = (FRAME_HEADER_SIZE + payload.len()) as u64;
@@ -1788,11 +1798,11 @@ mod tests {
     fn cbor_map_set(value: &mut ciborium::Value, key: &str, new_val: ciborium::Value) {
         if let ciborium::Value::Map(pairs) = value {
             for (k, v) in pairs.iter_mut() {
-                if let ciborium::Value::Text(s) = k {
-                    if s == key {
-                        *v = new_val;
-                        return;
-                    }
+                if let ciborium::Value::Text(s) = k
+                    && s == key
+                {
+                    *v = new_val;
+                    return;
                 }
             }
             // Key not found, add it
@@ -3377,10 +3387,12 @@ mod tests {
             .collect();
         let msg = make_raw_object_message(Dtype::Bfloat16, bytes, vec![2]);
         let report = validate_message(&msg, &full_opts());
-        assert!(report
-            .issues
-            .iter()
-            .any(|i| i.code == IssueCode::NanDetected));
+        assert!(
+            report
+                .issues
+                .iter()
+                .any(|i| i.code == IssueCode::NanDetected)
+        );
     }
 
     #[test]
@@ -3393,10 +3405,12 @@ mod tests {
             .collect();
         let msg = make_raw_object_message(Dtype::Bfloat16, bytes, vec![2]);
         let report = validate_message(&msg, &full_opts());
-        assert!(report
-            .issues
-            .iter()
-            .any(|i| i.code == IssueCode::InfDetected));
+        assert!(
+            report
+                .issues
+                .iter()
+                .any(|i| i.code == IssueCode::InfDetected)
+        );
     }
 
     #[test]
@@ -3410,10 +3424,12 @@ mod tests {
         bytes.extend_from_slice(&1.0f32.to_le_bytes());
         let msg = make_raw_object_message(Dtype::Complex64, bytes, vec![2]);
         let report = validate_message(&msg, &full_opts());
-        assert!(report
-            .issues
-            .iter()
-            .any(|i| i.code == IssueCode::NanDetected));
+        assert!(
+            report
+                .issues
+                .iter()
+                .any(|i| i.code == IssueCode::NanDetected)
+        );
     }
 
     #[test]
@@ -3425,10 +3441,12 @@ mod tests {
         bytes.extend_from_slice(&1.0f32.to_le_bytes());
         let msg = make_raw_object_message(Dtype::Complex64, bytes, vec![2]);
         let report = validate_message(&msg, &full_opts());
-        assert!(report
-            .issues
-            .iter()
-            .any(|i| i.code == IssueCode::InfDetected));
+        assert!(
+            report
+                .issues
+                .iter()
+                .any(|i| i.code == IssueCode::InfDetected)
+        );
     }
 
     #[test]
@@ -3441,10 +3459,12 @@ mod tests {
         bytes.extend_from_slice(&1.0f64.to_le_bytes());
         let msg = make_raw_object_message(Dtype::Complex128, bytes, vec![2]);
         let report = validate_message(&msg, &full_opts());
-        assert!(report
-            .issues
-            .iter()
-            .any(|i| i.code == IssueCode::NanDetected));
+        assert!(
+            report
+                .issues
+                .iter()
+                .any(|i| i.code == IssueCode::NanDetected)
+        );
     }
 
     #[test]
@@ -3456,10 +3476,12 @@ mod tests {
         bytes.extend_from_slice(&1.0f64.to_le_bytes());
         let msg = make_raw_object_message(Dtype::Complex128, bytes, vec![2]);
         let report = validate_message(&msg, &full_opts());
-        assert!(report
-            .issues
-            .iter()
-            .any(|i| i.code == IssueCode::InfDetected));
+        assert!(
+            report
+                .issues
+                .iter()
+                .any(|i| i.code == IssueCode::InfDetected)
+        );
     }
 
     // ── Coverage closers: validate/metadata.rs DescriptorCborNonCanonical
@@ -3718,7 +3740,7 @@ mod tests {
         msg.extend_from_slice(&0u16.to_be_bytes());
         msg.extend_from_slice(&0u32.to_be_bytes());
         msg.extend_from_slice(&0u64.to_be_bytes()); // streaming
-                                                    // Bogus postamble (wrong end magic)
+        // Bogus postamble (wrong end magic)
         msg.extend_from_slice(&(PREAMBLE_SIZE as u64).to_be_bytes());
         msg.extend_from_slice(b"BOGUSMAG");
         let report = validate_message(&msg, &ValidateOptions::default());

--- a/rust/tensogram-core/src/validate/structure.rs
+++ b/rust/tensogram-core/src/validate/structure.rs
@@ -9,9 +9,9 @@
 //! Level 1: Structure validation — raw byte walking.
 
 use crate::wire::{
-    self, DataObjectFlags, FrameHeader, FrameType, MessageFlags, Postamble, Preamble,
-    DATA_OBJECT_FOOTER_SIZE, FRAME_END, FRAME_HEADER_SIZE, FRAME_MAGIC, MAGIC, POSTAMBLE_SIZE,
-    PREAMBLE_SIZE,
+    self, DATA_OBJECT_FOOTER_SIZE, DataObjectFlags, FRAME_END, FRAME_HEADER_SIZE, FRAME_MAGIC,
+    FrameHeader, FrameType, MAGIC, MessageFlags, POSTAMBLE_SIZE, PREAMBLE_SIZE, Postamble,
+    Preamble,
 };
 
 use super::types::*;

--- a/rust/tensogram-core/tests/cross_language_pre_encoded.rs
+++ b/rust/tensogram-core/tests/cross_language_pre_encoded.rs
@@ -29,8 +29,8 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use tensogram_core::{
-    decode, encode_pre_encoded, ByteOrder, DataObjectDescriptor, Dtype, EncodeOptions,
-    GlobalMetadata,
+    ByteOrder, DataObjectDescriptor, Dtype, EncodeOptions, GlobalMetadata, decode,
+    encode_pre_encoded,
 };
 
 // ── Deterministic input ────────────────────────────────────────────────────

--- a/rust/tensogram-core/tests/edge_cases.rs
+++ b/rust/tensogram-core/tests/edge_cases.rs
@@ -97,7 +97,7 @@ fn dtype_swap_unit_size_all_variants() {
     // Complex types: swap each scalar component independently
     assert_eq!(Dtype::Complex64.swap_unit_size(), 4); // two float32
     assert_eq!(Dtype::Complex128.swap_unit_size(), 8); // two float64
-                                                       // Bitmask: no swap
+    // Bitmask: no swap
     assert_eq!(Dtype::Bitmask.swap_unit_size(), 0);
 }
 
@@ -562,10 +562,12 @@ fn unknown_compression_rejected() {
 
     let result = encode(&meta, &[(&desc, &data)], &EncodeOptions::default());
     assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("unknown compression"));
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("unknown compression")
+    );
 }
 
 #[test]
@@ -1115,10 +1117,12 @@ fn blosc2_unknown_codec_rejected() {
         &EncodeOptions::default(),
     );
     assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("unknown blosc2 codec"));
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("unknown blosc2 codec")
+    );
 }
 
 #[test]
@@ -1315,10 +1319,12 @@ fn sz3_missing_mode_rejected() {
         &EncodeOptions::default(),
     );
     assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("sz3_error_bound_mode"));
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("sz3_error_bound_mode")
+    );
 }
 
 #[test]
@@ -1337,10 +1343,12 @@ fn sz3_unknown_mode_rejected() {
         &EncodeOptions::default(),
     );
     assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("unknown sz3_error_bound_mode"));
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("unknown sz3_error_bound_mode")
+    );
 }
 
 // ── 27. Shuffle filter with compression ──────────────────────────────────────

--- a/rust/tensogram-core/tests/golden_files.rs
+++ b/rust/tensogram-core/tests/golden_files.rs
@@ -189,7 +189,7 @@ fn test_golden_files_are_deterministic() {
     // messages and compare metadata + payload data. Byte-exact comparison
     // is not possible because provenance fields (uuid, time) are
     // nondeterministic.
-    use tensogram_core::decode::{decode, DecodeOptions};
+    use tensogram_core::decode::{DecodeOptions, decode};
 
     let dir = golden_dir();
     let decode_opts = DecodeOptions::default();
@@ -262,7 +262,7 @@ fn test_golden_simple_f32() {
     // Verify payload values
     let bytes = &objects[0].1;
     assert_eq!(bytes.len(), 16); // 4 * 4 bytes
-                                 // Decoded bytes are in native byte order (native_byte_order=true default).
+    // Decoded bytes are in native byte order (native_byte_order=true default).
     let values: Vec<f32> = bytes
         .chunks_exact(4)
         .map(|c| f32::from_ne_bytes(c.try_into().unwrap()))

--- a/rust/tensogram-core/tests/integration_pre_encoded.rs
+++ b/rust/tensogram-core/tests/integration_pre_encoded.rs
@@ -31,8 +31,8 @@ use std::collections::BTreeMap;
 
 use tensogram_core::framing;
 use tensogram_core::{
-    decode, decode_range, encode, encode_pre_encoded, ByteOrder, DataObjectDescriptor,
-    DecodeOptions, Dtype, EncodeOptions, GlobalMetadata, HashDescriptor, StreamingEncoder,
+    ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions, GlobalMetadata,
+    HashDescriptor, StreamingEncoder, decode, decode_range, encode, encode_pre_encoded,
 };
 use tensogram_encodings::simple_packing;
 

--- a/rust/tensogram-core/tests/remote_http.rs
+++ b/rust/tensogram-core/tests/remote_http.rs
@@ -11,8 +11,8 @@
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use http_body_util::Full;
 use hyper::body::Bytes;
@@ -26,7 +26,7 @@ use tensogram_core::decode::DecodeOptions;
 use tensogram_core::encode::{self, EncodeOptions};
 use tensogram_core::file::TensogramFile;
 use tensogram_core::types::{ByteOrder, DataObjectDescriptor, GlobalMetadata};
-use tensogram_core::{is_remote_url, Dtype};
+use tensogram_core::{Dtype, is_remote_url};
 
 // ── Test helpers ─────────────────────────────────────────────────────────────
 

--- a/rust/tensogram-core/tests/threads_determinism.rs
+++ b/rust/tensogram-core/tests/threads_determinism.rs
@@ -27,8 +27,8 @@
 use std::collections::BTreeMap;
 
 use tensogram_core::{
-    decode, encode, ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions,
-    GlobalMetadata,
+    ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions, GlobalMetadata, decode,
+    encode,
 };
 
 /// Extract just the encoded payload bytes of each object from a

--- a/rust/tensogram-core/tests/threads_proptest.rs
+++ b/rust/tensogram-core/tests/threads_proptest.rs
@@ -27,8 +27,8 @@ use std::collections::BTreeMap;
 use proptest::prelude::*;
 
 use tensogram_core::{
-    decode, encode, ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions,
-    GlobalMetadata,
+    ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions, GlobalMetadata, decode,
+    encode,
 };
 
 #[derive(Debug, Clone)]

--- a/rust/tensogram-encodings/Cargo.toml
+++ b/rust/tensogram-encodings/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tensogram-encodings"
 version = "0.13.0"
-edition = "2021"
+edition = "2024"
 
 [features]
 default = ["szip", "zstd", "lz4", "blosc2", "zfp", "sz3", "threads"]

--- a/rust/tensogram-encodings/src/compression/blosc2.rs
+++ b/rust/tensogram-encodings/src/compression/blosc2.rs
@@ -58,11 +58,7 @@ pub struct Blosc2Compressor {
 /// where an explicit 1 is the canonical single-threaded setting.
 #[inline]
 fn blosc2_nthreads(n: u32) -> usize {
-    if n == 0 {
-        1
-    } else {
-        n as usize
-    }
+    if n == 0 { 1 } else { n as usize }
 }
 
 impl Blosc2Compressor {

--- a/rust/tensogram-encodings/src/pipeline.rs
+++ b/rust/tensogram-encodings/src/pipeline.rs
@@ -441,7 +441,8 @@ pub fn encode_pipeline(
     };
 
     // Step 3: Compression
-    match build_compressor(&config.compression, config)? {
+    let compressor = build_compressor(&config.compression, config)?;
+    match compressor {
         None => Ok(PipelineResult {
             encoded_bytes: filtered.into_owned(),
             block_offsets: None,
@@ -483,7 +484,8 @@ pub fn encode_pipeline_f64(
         ),
     };
 
-    match build_compressor(&config.compression, config)? {
+    let compressor = build_compressor(&config.compression, config)?;
+    match compressor {
         None => Ok(PipelineResult {
             encoded_bytes: filtered.into_owned(),
             block_offsets: None,

--- a/rust/tensogram-encodings/src/simple_packing.rs
+++ b/rust/tensogram-encodings/src/simple_packing.rs
@@ -205,10 +205,8 @@ pub fn encode_with_threads(
     #[cfg(not(feature = "threads"))]
     let parallel = false;
 
-    if !parallel {
-        if let Some(i) = values.iter().position(|v| v.is_nan()) {
-            return Err(PackingError::NanValue(i));
-        }
+    if !parallel && let Some(i) = values.iter().position(|v| v.is_nan()) {
+        return Err(PackingError::NanValue(i));
     }
 
     if params.bits_per_value == 0 {

--- a/rust/tensogram-encodings/src/zfp_ffi.rs
+++ b/rust/tensogram-encodings/src/zfp_ffi.rs
@@ -156,22 +156,24 @@ unsafe fn set_mode(
     mode: &ZfpMode,
     ztype: zfp_sys_cc::zfp_type,
 ) -> Result<(), CompressionError> {
-    match mode {
-        ZfpMode::FixedRate { rate } => {
-            // dims=1 for 1D, zfp_false=0 for non-aligned
-            zfp_sys_cc::zfp_stream_set_rate(zfp, *rate, ztype, 1, 0);
-        }
-        ZfpMode::FixedPrecision { precision } => {
-            zfp_sys_cc::zfp_stream_set_precision(zfp, *precision);
-        }
-        ZfpMode::FixedAccuracy { tolerance } => {
-            let ret = zfp_sys_cc::zfp_stream_set_accuracy(zfp, *tolerance);
-            if ret == 0.0 {
-                return Err(err("zfp_stream_set_accuracy returned 0"));
+    unsafe {
+        match mode {
+            ZfpMode::FixedRate { rate } => {
+                // dims=1 for 1D, zfp_false=0 for non-aligned
+                zfp_sys_cc::zfp_stream_set_rate(zfp, *rate, ztype, 1, 0);
+            }
+            ZfpMode::FixedPrecision { precision } => {
+                zfp_sys_cc::zfp_stream_set_precision(zfp, *precision);
+            }
+            ZfpMode::FixedAccuracy { tolerance } => {
+                let ret = zfp_sys_cc::zfp_stream_set_accuracy(zfp, *tolerance);
+                if ret == 0.0 {
+                    return Err(err("zfp_stream_set_accuracy returned 0"));
+                }
             }
         }
+        Ok(())
     }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/rust/tensogram-ffi/Cargo.toml
+++ b/rust/tensogram-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tensogram-ffi"
 version = "0.13.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]
@@ -14,4 +14,4 @@ ciborium.workspace = true
 serde.workspace = true
 
 [build-dependencies]
-cbindgen = "0.27"
+cbindgen = "0.29"

--- a/rust/tensogram-ffi/build.rs
+++ b/rust/tensogram-ffi/build.rs
@@ -10,11 +10,10 @@ fn main() {
     let crate_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let config = cbindgen::Config::from_file("cbindgen.toml").unwrap_or_default();
 
-    if let Ok(bindings) = cbindgen::Builder::new()
+    cbindgen::Builder::new()
         .with_crate(&crate_dir)
         .with_config(config)
         .generate()
-    {
-        bindings.write_to_file("tensogram.h");
-    }
+        .expect("cbindgen failed to generate tensogram.h")
+        .write_to_file("tensogram.h");
 }

--- a/rust/tensogram-ffi/src/lib.rs
+++ b/rust/tensogram-ffi/src/lib.rs
@@ -41,12 +41,12 @@ use std::ptr;
 use std::slice;
 
 use tensogram_core::validate::{
-    validate_file as core_validate_file, validate_message, ValidateOptions, ValidationLevel,
+    ValidateOptions, ValidationLevel, validate_file as core_validate_file, validate_message,
 };
 use tensogram_core::{
-    decode, decode_metadata, decode_object, decode_range, encode, encode_pre_encoded, scan,
     DataObjectDescriptor, DecodeOptions, EncodeOptions, GlobalMetadata, HashAlgorithm,
-    StreamingEncoder, TensogramError, TensogramFile, RESERVED_KEY,
+    RESERVED_KEY, StreamingEncoder, TensogramError, TensogramFile, decode, decode_metadata,
+    decode_object, decode_range, encode, encode_pre_encoded, scan,
 };
 
 // ---------------------------------------------------------------------------
@@ -95,7 +95,7 @@ fn set_last_error(msg: &str) {
 
 /// Returns a pointer to the last error message, or NULL if no error.
 /// The pointer is valid until the next FFI call on the same thread.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_last_error() -> *const c_char {
     LAST_ERROR.with(|cell| {
         cell.borrow()
@@ -117,7 +117,7 @@ pub struct TgmBytes {
 }
 
 /// Free a byte buffer returned by `tgm_encode`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_bytes_free(buf: TgmBytes) {
     if !buf.data.is_null() {
         unsafe {
@@ -396,39 +396,41 @@ unsafe fn collect_data_slices<'a>(
     data_lens: *const usize,
     num_objects: usize,
 ) -> Result<Vec<&'a [u8]>, (TgmError, String)> {
-    if num_objects == 0 {
-        return Ok(vec![]);
-    }
-    if data_ptrs.is_null() || data_lens.is_null() {
-        return Err((
-            TgmError::InvalidArg,
-            "null data_ptrs or data_lens".to_string(),
-        ));
-    }
-    let ptrs = slice::from_raw_parts(data_ptrs, num_objects);
-    let lens = slice::from_raw_parts(data_lens, num_objects);
-    for (i, (&p, &l)) in ptrs.iter().zip(lens.iter()).enumerate() {
-        if p.is_null() && l > 0 {
+    unsafe {
+        if num_objects == 0 {
+            return Ok(vec![]);
+        }
+        if data_ptrs.is_null() || data_lens.is_null() {
             return Err((
                 TgmError::InvalidArg,
-                format!("null data pointer at index {i}"),
+                "null data_ptrs or data_lens".to_string(),
             ));
         }
-    }
-    Ok(ptrs
-        .iter()
-        .zip(lens.iter())
-        .map(|(&p, &l)| {
-            if l == 0 {
-                // Avoid calling slice::from_raw_parts with a potentially null
-                // pointer when length is zero — that is UB even for zero-length
-                // slices per the Rust reference.
-                &[] as &[u8]
-            } else {
-                slice::from_raw_parts(p, l)
+        let ptrs = slice::from_raw_parts(data_ptrs, num_objects);
+        let lens = slice::from_raw_parts(data_lens, num_objects);
+        for (i, (&p, &l)) in ptrs.iter().zip(lens.iter()).enumerate() {
+            if p.is_null() && l > 0 {
+                return Err((
+                    TgmError::InvalidArg,
+                    format!("null data pointer at index {i}"),
+                ));
             }
-        })
-        .collect())
+        }
+        Ok(ptrs
+            .iter()
+            .zip(lens.iter())
+            .map(|(&p, &l)| {
+                if l == 0 {
+                    // Avoid calling slice::from_raw_parts with a potentially null
+                    // pointer when length is zero — that is UB even for zero-length
+                    // slices per the Rust reference.
+                    &[] as &[u8]
+                } else {
+                    slice::from_raw_parts(p, l)
+                }
+            })
+            .collect())
+    }
 }
 
 /// Parse and validate the common arguments for `tgm_encode` / `tgm_file_append`.
@@ -445,34 +447,36 @@ unsafe fn parse_encode_args<'a>(
     hash_algo: *const c_char,
     threads: u32,
 ) -> Result<ParsedEncode<'a>, (TgmError, String)> {
-    let (global_metadata, descriptors) =
-        parse_encode_json(json_str).map_err(|e| (TgmError::Metadata, e))?;
+    unsafe {
+        let (global_metadata, descriptors) =
+            parse_encode_json(json_str).map_err(|e| (TgmError::Metadata, e))?;
 
-    if descriptors.len() != num_objects {
-        return Err((
-            TgmError::InvalidArg,
-            format!(
-                "descriptors array length {} does not match num_objects {}",
-                descriptors.len(),
-                num_objects
-            ),
-        ));
+        if descriptors.len() != num_objects {
+            return Err((
+                TgmError::InvalidArg,
+                format!(
+                    "descriptors array length {} does not match num_objects {}",
+                    descriptors.len(),
+                    num_objects
+                ),
+            ));
+        }
+
+        let data_slices = collect_data_slices(data_ptrs, data_lens, num_objects)?;
+        let hash_algorithm = parse_hash_algo(hash_algo)?;
+        let options = EncodeOptions {
+            hash_algorithm,
+            threads,
+            ..Default::default()
+        };
+
+        Ok(ParsedEncode {
+            global_metadata,
+            descriptors,
+            data_slices,
+            options,
+        })
     }
-
-    let data_slices = collect_data_slices(data_ptrs, data_lens, num_objects)?;
-    let hash_algorithm = parse_hash_algo(hash_algo)?;
-    let options = EncodeOptions {
-        hash_algorithm,
-        threads,
-        ..Default::default()
-    };
-
-    Ok(ParsedEncode {
-        global_metadata,
-        descriptors,
-        data_slices,
-        options,
-    })
 }
 
 // ---------------------------------------------------------------------------
@@ -492,7 +496,7 @@ unsafe fn parse_encode_args<'a>(
 ///
 /// On success returns `TgmError::Ok` and fills `out` with the encoded bytes.
 /// The caller must free `out` with `tgm_bytes_free`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_encode(
     metadata_json: *const c_char,
     data_ptrs: *const *const u8,
@@ -590,7 +594,7 @@ pub extern "C" fn tgm_encode(
 ///
 /// On success returns `TgmError::Ok` and fills `out` with the encoded message.
 /// The caller must free `out` with `tgm_bytes_free`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_encode_pre_encoded(
     metadata_json: *const c_char,
     data_ptrs: *const *const u8,
@@ -670,7 +674,7 @@ pub extern "C" fn tgm_encode_pre_encoded(
 ///
 /// On success, fills `out` with a `TgmMessage` handle.
 /// Free with `tgm_message_free`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_decode(
     buf: *const u8,
     buf_len: usize,
@@ -720,7 +724,7 @@ pub extern "C" fn tgm_decode(
 }
 
 /// Decode only the global metadata (no payload bytes are read).
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_decode_metadata(
     buf: *const u8,
     buf_len: usize,
@@ -755,7 +759,7 @@ pub extern "C" fn tgm_decode_metadata(
 ///
 /// On success, fills `out` with a `TgmMessage` handle containing exactly
 /// one object (at index 0). The global metadata covers the whole message.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_decode_object(
     buf: *const u8,
     buf_len: usize,
@@ -818,7 +822,7 @@ pub extern "C" fn tgm_decode_object(
 /// `out_count`: filled with the number of buffers written to `out`.
 ///
 /// Free each returned buffer with `tgm_bytes_free`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(clippy::too_many_arguments)]
 pub extern "C" fn tgm_decode_range(
     buf: *const u8,
@@ -915,7 +919,7 @@ pub extern "C" fn tgm_decode_range(
 ///
 /// Returns a `TgmScanResult` handle. Access entries with `tgm_scan_count`
 /// and `tgm_scan_entry`. Free with `tgm_scan_free`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_scan(
     buf: *const u8,
     buf_len: usize,
@@ -941,29 +945,27 @@ pub extern "C" fn tgm_scan(
 
 /// # Safety: caller must pass valid, non-null pointer from tgm_scan.
 unsafe fn as_scan(result: *const TgmScanResult) -> Option<&'static TgmScanResult> {
-    if result.is_null() {
-        None
-    } else {
-        Some(&*result)
+    unsafe {
+        if result.is_null() {
+            None
+        } else {
+            Some(&*result)
+        }
     }
 }
 
 /// # Safety: caller must pass valid, non-null pointer from tgm_decode*.
 unsafe fn as_msg(msg: *const TgmMessage) -> Option<&'static TgmMessage> {
-    if msg.is_null() {
-        None
-    } else {
-        Some(&*msg)
-    }
+    unsafe { if msg.is_null() { None } else { Some(&*msg) } }
 }
 
 /// Returns the number of messages found by `tgm_scan`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_scan_count(result: *const TgmScanResult) -> usize {
     unsafe { as_scan(result).map(|r| r.entries.len()).unwrap_or(0) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_scan_entry(result: *const TgmScanResult, index: usize) -> TgmScanEntry {
     let fallback = TgmScanEntry {
         offset: usize::MAX,
@@ -991,7 +993,7 @@ pub extern "C" fn tgm_scan_entry(result: *const TgmScanResult, index: usize) -> 
 }
 
 /// Free a scan result handle.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_scan_free(result: *mut TgmScanResult) {
     if !result.is_null() {
         unsafe {
@@ -1005,7 +1007,7 @@ pub extern "C" fn tgm_scan_free(result: *mut TgmScanResult) {
 // ---------------------------------------------------------------------------
 
 /// Returns the wire format version from a decoded message.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_message_version(msg: *const TgmMessage) -> u64 {
     unsafe {
         as_msg(msg)
@@ -1017,20 +1019,20 @@ pub extern "C" fn tgm_message_version(msg: *const TgmMessage) -> u64 {
 /// Returns the number of decoded objects in this message handle.
 /// For `tgm_decode` this equals the total object count; for
 /// `tgm_decode_object` this is always 1.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_message_num_objects(msg: *const TgmMessage) -> usize {
     unsafe { as_msg(msg).map(|m| m.objects.len()).unwrap_or(0) }
 }
 
 /// Returns the number of decoded payload buffers.
 /// Equivalent to `tgm_message_num_objects` — kept for ABI compatibility.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_message_num_decoded(msg: *const TgmMessage) -> usize {
     unsafe { as_msg(msg).map(|m| m.objects.len()).unwrap_or(0) }
 }
 
 /// Returns the number of dimensions for object at index.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_object_ndim(msg: *const TgmMessage, index: usize) -> u64 {
     unsafe {
         as_msg(msg)
@@ -1042,7 +1044,7 @@ pub extern "C" fn tgm_object_ndim(msg: *const TgmMessage, index: usize) -> u64 {
 
 /// Returns a pointer to the shape array. Length is `tgm_object_ndim()`.
 /// The pointer is valid until the message is freed.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_object_shape(msg: *const TgmMessage, index: usize) -> *const u64 {
     unsafe {
         as_msg(msg)
@@ -1053,7 +1055,7 @@ pub extern "C" fn tgm_object_shape(msg: *const TgmMessage, index: usize) -> *con
 }
 
 /// Returns a pointer to the strides array. Length is `tgm_object_ndim()`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_object_strides(msg: *const TgmMessage, index: usize) -> *const u64 {
     unsafe {
         as_msg(msg)
@@ -1065,7 +1067,7 @@ pub extern "C" fn tgm_object_strides(msg: *const TgmMessage, index: usize) -> *c
 
 /// Returns the dtype as a null-terminated string (e.g. "float32").
 /// The pointer is valid until the message is freed.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_object_dtype(msg: *const TgmMessage, index: usize) -> *const c_char {
     unsafe {
         as_msg(msg)
@@ -1079,7 +1081,7 @@ pub extern "C" fn tgm_object_dtype(msg: *const TgmMessage, index: usize) -> *con
 /// `decoded_index` is the index into the decoded objects array (0 for the
 /// first decoded object, regardless of the original object index).
 /// `out_len` receives the byte length.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_object_data(
     msg: *const TgmMessage,
     decoded_index: usize,
@@ -1105,7 +1107,7 @@ pub extern "C" fn tgm_object_data(
 
 /// Returns the encoding string for a data object descriptor (e.g. "none", "simple_packing").
 /// The pointer is valid until the message is freed.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_payload_encoding(msg: *const TgmMessage, index: usize) -> *const c_char {
     unsafe {
         as_msg(msg)
@@ -1116,7 +1118,7 @@ pub extern "C" fn tgm_payload_encoding(msg: *const TgmMessage, index: usize) -> 
 }
 
 /// Returns 1 if the object descriptor has a hash, 0 otherwise.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_payload_has_hash(msg: *const TgmMessage, index: usize) -> i32 {
     unsafe {
         as_msg(msg)
@@ -1128,7 +1130,7 @@ pub extern "C" fn tgm_payload_has_hash(msg: *const TgmMessage, index: usize) -> 
 
 /// Extract a metadata handle from a decoded message.
 /// The metadata handle is independent — free it separately with `tgm_metadata_free`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_message_metadata(
     msg: *const TgmMessage,
     out: *mut *mut TgmMetadata,
@@ -1149,7 +1151,7 @@ pub extern "C" fn tgm_message_metadata(
 }
 
 /// Returns the object type string (e.g. "ndarray"). Valid until message freed.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_object_type(msg: *const TgmMessage, index: usize) -> *const c_char {
     unsafe {
         as_msg(msg)
@@ -1160,7 +1162,7 @@ pub extern "C" fn tgm_object_type(msg: *const TgmMessage, index: usize) -> *cons
 }
 
 /// Returns the byte order string ("big" or "little"). Valid until message freed.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_object_byte_order(msg: *const TgmMessage, index: usize) -> *const c_char {
     unsafe {
         as_msg(msg)
@@ -1171,7 +1173,7 @@ pub extern "C" fn tgm_object_byte_order(msg: *const TgmMessage, index: usize) ->
 }
 
 /// Returns the filter string (e.g. "none", "shuffle"). Valid until message freed.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_object_filter(msg: *const TgmMessage, index: usize) -> *const c_char {
     unsafe {
         as_msg(msg)
@@ -1182,7 +1184,7 @@ pub extern "C" fn tgm_object_filter(msg: *const TgmMessage, index: usize) -> *co
 }
 
 /// Returns the compression string (e.g. "none", "zstd"). Valid until message freed.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_object_compression(msg: *const TgmMessage, index: usize) -> *const c_char {
     unsafe {
         as_msg(msg)
@@ -1193,7 +1195,7 @@ pub extern "C" fn tgm_object_compression(msg: *const TgmMessage, index: usize) -
 }
 
 /// Returns the hash type string ("xxh3") or NULL if no hash. Valid until message freed.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_object_hash_type(msg: *const TgmMessage, index: usize) -> *const c_char {
     unsafe {
         as_msg(msg)
@@ -1205,7 +1207,7 @@ pub extern "C" fn tgm_object_hash_type(msg: *const TgmMessage, index: usize) -> 
 }
 
 /// Returns the hash value hex string or NULL if no hash. Valid until message freed.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_object_hash_value(msg: *const TgmMessage, index: usize) -> *const c_char {
     unsafe {
         as_msg(msg)
@@ -1217,7 +1219,7 @@ pub extern "C" fn tgm_object_hash_value(msg: *const TgmMessage, index: usize) ->
 }
 
 /// Free a decoded message handle.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_message_free(msg: *mut TgmMessage) {
     if !msg.is_null() {
         unsafe {
@@ -1231,7 +1233,7 @@ pub extern "C" fn tgm_message_free(msg: *mut TgmMessage) {
 // ---------------------------------------------------------------------------
 
 /// Returns the wire format version from metadata.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_metadata_version(meta: *const TgmMetadata) -> u64 {
     if meta.is_null() {
         return 0;
@@ -1242,7 +1244,7 @@ pub extern "C" fn tgm_metadata_version(meta: *const TgmMetadata) -> u64 {
 /// Returns the number of objects described in the global metadata.
 ///
 /// Returns the length of the `base` array, which has one entry per data object.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_metadata_num_objects(meta: *const TgmMetadata) -> usize {
     if meta.is_null() {
         return 0;
@@ -1253,7 +1255,7 @@ pub extern "C" fn tgm_metadata_num_objects(meta: *const TgmMetadata) -> usize {
 /// Look up a string value by dot-notation key (e.g. "mars.class").
 /// Returns NULL if the key is not found or is not a string.
 /// The pointer is valid until the metadata handle is freed.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_metadata_get_string(
     meta: *const TgmMetadata,
     key: *const c_char,
@@ -1284,7 +1286,7 @@ pub extern "C" fn tgm_metadata_get_string(
 
 /// Look up an integer value by dot-notation key.
 /// Returns `default_val` if the key is not found or is not an integer.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_metadata_get_int(
     meta: *const TgmMetadata,
     key: *const c_char,
@@ -1304,7 +1306,7 @@ pub extern "C" fn tgm_metadata_get_int(
 }
 
 /// Look up a float value by dot-notation key.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_metadata_get_float(
     meta: *const TgmMetadata,
     key: *const c_char,
@@ -1324,7 +1326,7 @@ pub extern "C" fn tgm_metadata_get_float(
 }
 
 /// Free a metadata handle.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_metadata_free(meta: *mut TgmMetadata) {
     if !meta.is_null() {
         unsafe {
@@ -1338,7 +1340,7 @@ pub extern "C" fn tgm_metadata_free(meta: *mut TgmMetadata) {
 // ---------------------------------------------------------------------------
 
 /// Open an existing Tensogram file for reading.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_file_open(path: *const c_char, out: *mut *mut TgmFile) -> TgmError {
     if path.is_null() || out.is_null() {
         set_last_error("null argument");
@@ -1370,7 +1372,7 @@ pub extern "C" fn tgm_file_open(path: *const c_char, out: *mut *mut TgmFile) -> 
 }
 
 /// Create a new Tensogram file for writing.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_file_create(path: *const c_char, out: *mut *mut TgmFile) -> TgmError {
     if path.is_null() || out.is_null() {
         set_last_error("null argument");
@@ -1402,7 +1404,7 @@ pub extern "C" fn tgm_file_create(path: *const c_char, out: *mut *mut TgmFile) -
 }
 
 /// Count messages in the file (may trigger lazy scan).
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_file_message_count(file: *mut TgmFile, out_count: *mut usize) -> TgmError {
     if file.is_null() || out_count.is_null() {
         set_last_error("null argument");
@@ -1426,7 +1428,7 @@ pub extern "C" fn tgm_file_message_count(file: *mut TgmFile, out_count: *mut usi
 
 /// Decode message at `index` from the file.
 /// On success fills `out` with a `TgmMessage` handle.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_file_decode_message(
     file: *mut TgmFile,
     index: usize,
@@ -1477,7 +1479,7 @@ pub extern "C" fn tgm_file_decode_message(
 
 /// Read raw message bytes at `index`.
 /// On success fills `out` with a `TgmBytes` buffer.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_file_read_message(
     file: *mut TgmFile,
     index: usize,
@@ -1512,7 +1514,7 @@ pub extern "C" fn tgm_file_read_message(
 }
 
 /// Append raw message bytes to the file.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_file_append_raw(
     file: *mut TgmFile,
     buf: *const u8,
@@ -1555,7 +1557,7 @@ pub extern "C" fn tgm_file_append_raw(
 
 /// Returns the file path as a null-terminated string.
 /// The pointer is valid until the file handle is closed.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_file_path(file: *const TgmFile) -> *const c_char {
     if file.is_null() {
         return ptr::null();
@@ -1565,7 +1567,7 @@ pub extern "C" fn tgm_file_path(file: *const TgmFile) -> *const c_char {
 
 /// Encode and append a message to the file.
 /// Same JSON schema as `tgm_encode` for `metadata_json`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_file_append(
     file: *mut TgmFile,
     metadata_json: *const c_char,
@@ -1623,7 +1625,7 @@ pub extern "C" fn tgm_file_append(
 }
 
 /// Close a file handle and release resources.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_file_close(file: *mut TgmFile) {
     if !file.is_null() {
         unsafe {
@@ -1773,7 +1775,7 @@ fn lookup_float_key(global_metadata: &GlobalMetadata, key: &str) -> Option<f64> 
 ///
 /// Returns TgmError::Ok on success, filling the out-params.
 /// Returns Encoding error if data contains NaN.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_simple_packing_compute_params(
     values: *const f64,
     num_values: usize,
@@ -1825,7 +1827,7 @@ pub struct TgmBufferIter {
 ///
 /// Scans `buf` once and stores message boundaries. The buffer must remain
 /// valid and unmodified until `tgm_buffer_iter_free` is called.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_buffer_iter_create(
     buf: *const u8,
     buf_len: usize,
@@ -1849,7 +1851,7 @@ pub extern "C" fn tgm_buffer_iter_create(
 }
 
 /// Return the total number of messages in the buffer iterator.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_buffer_iter_count(iter: *const TgmBufferIter) -> usize {
     if iter.is_null() {
         return 0;
@@ -1862,7 +1864,7 @@ pub extern "C" fn tgm_buffer_iter_count(iter: *const TgmBufferIter) -> usize {
 ///
 /// Returns `TgmError::Ok` if a message is available, `TgmError::EndOfIter`
 /// when iteration is exhausted.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_buffer_iter_next(
     iter: *mut TgmBufferIter,
     out_buf: *mut *const u8,
@@ -1886,7 +1888,7 @@ pub extern "C" fn tgm_buffer_iter_next(
 }
 
 /// Free a buffer iterator handle.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_buffer_iter_free(iter: *mut TgmBufferIter) {
     if !iter.is_null() {
         unsafe {
@@ -1904,7 +1906,7 @@ pub struct TgmFileIter {
 ///
 /// Scans the file to locate message boundaries. The file handle remains
 /// usable after this call.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_file_iter_create(file: *mut TgmFile, out: *mut *mut TgmFileIter) -> TgmError {
     if file.is_null() || out.is_null() {
         set_last_error("null argument");
@@ -1932,7 +1934,7 @@ pub extern "C" fn tgm_file_iter_create(file: *mut TgmFile, out: *mut *mut TgmFil
 ///
 /// Returns `TgmError::Ok` when a message is available, `TgmError::EndOfIter`
 /// when iteration is exhausted.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_file_iter_next(iter: *mut TgmFileIter, out: *mut TgmBytes) -> TgmError {
     if iter.is_null() || out.is_null() {
         set_last_error("null argument");
@@ -1962,7 +1964,7 @@ pub extern "C" fn tgm_file_iter_next(iter: *mut TgmFileIter, out: *mut TgmBytes)
 }
 
 /// Free a file iterator handle.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_file_iter_free(iter: *mut TgmFileIter) {
     if !iter.is_null() {
         unsafe {
@@ -1984,7 +1986,7 @@ pub struct TgmObjectIter {
 /// Parses metadata once, then decodes each object on demand when
 /// `tgm_object_iter_next` is called. The global metadata from the
 /// original message is preserved in each yielded `TgmMessage`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_object_iter_create(
     buf: *const u8,
     buf_len: usize,
@@ -2031,7 +2033,7 @@ pub extern "C" fn tgm_object_iter_create(
 /// Returns `TgmError::Ok` when an object is available, `TgmError::EndOfIter`
 /// when iteration is exhausted. Free each yielded `TgmMessage` with
 /// `tgm_message_free`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_object_iter_next(
     iter: *mut TgmObjectIter,
     out: *mut *mut TgmMessage,
@@ -2072,7 +2074,7 @@ pub extern "C" fn tgm_object_iter_next(
 }
 
 /// Free an object iterator handle.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_object_iter_free(iter: *mut TgmObjectIter) {
     if !iter.is_null() {
         unsafe {
@@ -2090,7 +2092,7 @@ pub extern "C" fn tgm_object_iter_free(iter: *mut TgmObjectIter) {
 ///
 /// Accepts a raw integer and matches by value so that invalid discriminants
 /// from C callers do not trigger undefined behaviour in Rust.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_error_string(err: TgmError) -> *const c_char {
     // Convert to integer for safe matching — C callers may pass invalid values.
     let code = err as i32;
@@ -5288,7 +5290,7 @@ mod tests {
 /// Returns `TGM_ERROR_OK` on success, fills `out` with a `tgm_bytes_t`
 /// containing the hex-encoded hash string (NOT null-terminated).
 /// Free with `tgm_bytes_free`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_compute_hash(
     data: *const u8,
     data_len: usize,
@@ -5402,7 +5404,7 @@ fn parse_streaming_metadata_json(json_str: &str) -> Result<GlobalMetadata, Strin
 /// On success fills `out` with a `TgmStreamingEncoder` handle.
 /// Free with `tgm_streaming_encoder_free` or finalize with
 /// `tgm_streaming_encoder_finish`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_streaming_encoder_create(
     path: *const c_char,
     metadata_json: *const c_char,
@@ -5496,7 +5498,7 @@ pub extern "C" fn tgm_streaming_encoder_create(
 ///
 /// Must be followed by exactly one `tgm_streaming_encoder_write` call
 /// before another preceder or `tgm_streaming_encoder_finish`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_streaming_encoder_write_preceder(
     enc: *mut TgmStreamingEncoder,
     metadata_json: *const c_char,
@@ -5550,7 +5552,7 @@ pub extern "C" fn tgm_streaming_encoder_write_preceder(
 /// `descriptor_json` is a JSON object with the descriptor fields
 /// (type, ndim, shape, strides, dtype, byte_order, encoding, filter,
 /// compression, etc.).
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_streaming_encoder_write(
     enc: *mut TgmStreamingEncoder,
     descriptor_json: *const c_char,
@@ -5615,7 +5617,7 @@ pub extern "C" fn tgm_streaming_encoder_write(
 ///
 /// Any `hash` field embedded in the descriptor JSON is ignored — the
 /// library always recomputes the hash from the caller's bytes.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_streaming_encoder_write_pre_encoded(
     enc: *mut TgmStreamingEncoder,
     descriptor_json: *const c_char,
@@ -5662,7 +5664,7 @@ pub extern "C" fn tgm_streaming_encoder_write_pre_encoded(
 }
 
 /// Return the number of objects written so far.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_streaming_encoder_count(enc: *const TgmStreamingEncoder) -> usize {
     if enc.is_null() {
         return 0;
@@ -5674,7 +5676,7 @@ pub extern "C" fn tgm_streaming_encoder_count(enc: *const TgmStreamingEncoder) -
 ///
 /// After calling this, the handle is still valid but empty — the caller
 /// must still call `tgm_streaming_encoder_free` to release it.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_streaming_encoder_finish(enc: *mut TgmStreamingEncoder) -> TgmError {
     if enc.is_null() {
         set_last_error("null argument");
@@ -5702,7 +5704,7 @@ pub extern "C" fn tgm_streaming_encoder_finish(enc: *mut TgmStreamingEncoder) ->
 }
 
 /// Free a streaming encoder without finalizing (abandons the output).
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_streaming_encoder_free(enc: *mut TgmStreamingEncoder) {
     if !enc.is_null() {
         unsafe {
@@ -5768,7 +5770,7 @@ fn parse_validate_options(
 /// the issues are in the JSON report). Returns `TGM_ERROR_INVALID_ARG`
 /// for argument validation failures (null pointers, invalid level string),
 /// or `TGM_ERROR_ENCODING` if JSON serialization of the report fails.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_validate(
     buf: *const u8,
     buf_len: usize,
@@ -5834,7 +5836,7 @@ pub extern "C" fn tgm_validate(
 /// Returns `TGM_ERROR_IO` if the file cannot be opened or read.
 /// Returns `TGM_ERROR_INVALID_ARG` for null pointers or invalid level.
 /// Returns `TGM_ERROR_ENCODING` if JSON serialization of the report fails.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn tgm_validate_file(
     path: *const c_char,
     level: *const c_char,

--- a/rust/tensogram-ffi/src/lib.rs
+++ b/rust/tensogram-ffi/src/lib.rs
@@ -396,41 +396,39 @@ unsafe fn collect_data_slices<'a>(
     data_lens: *const usize,
     num_objects: usize,
 ) -> Result<Vec<&'a [u8]>, (TgmError, String)> {
-    unsafe {
-        if num_objects == 0 {
-            return Ok(vec![]);
-        }
-        if data_ptrs.is_null() || data_lens.is_null() {
+    if num_objects == 0 {
+        return Ok(vec![]);
+    }
+    if data_ptrs.is_null() || data_lens.is_null() {
+        return Err((
+            TgmError::InvalidArg,
+            "null data_ptrs or data_lens".to_string(),
+        ));
+    }
+    let ptrs = unsafe { slice::from_raw_parts(data_ptrs, num_objects) };
+    let lens = unsafe { slice::from_raw_parts(data_lens, num_objects) };
+    for (i, (&p, &l)) in ptrs.iter().zip(lens.iter()).enumerate() {
+        if p.is_null() && l > 0 {
             return Err((
                 TgmError::InvalidArg,
-                "null data_ptrs or data_lens".to_string(),
+                format!("null data pointer at index {i}"),
             ));
         }
-        let ptrs = slice::from_raw_parts(data_ptrs, num_objects);
-        let lens = slice::from_raw_parts(data_lens, num_objects);
-        for (i, (&p, &l)) in ptrs.iter().zip(lens.iter()).enumerate() {
-            if p.is_null() && l > 0 {
-                return Err((
-                    TgmError::InvalidArg,
-                    format!("null data pointer at index {i}"),
-                ));
-            }
-        }
-        Ok(ptrs
-            .iter()
-            .zip(lens.iter())
-            .map(|(&p, &l)| {
-                if l == 0 {
-                    // Avoid calling slice::from_raw_parts with a potentially null
-                    // pointer when length is zero — that is UB even for zero-length
-                    // slices per the Rust reference.
-                    &[] as &[u8]
-                } else {
-                    slice::from_raw_parts(p, l)
-                }
-            })
-            .collect())
     }
+    Ok(ptrs
+        .iter()
+        .zip(lens.iter())
+        .map(|(&p, &l)| {
+            if l == 0 {
+                // Avoid calling slice::from_raw_parts with a potentially null
+                // pointer when length is zero — that is UB even for zero-length
+                // slices per the Rust reference.
+                &[] as &[u8]
+            } else {
+                unsafe { slice::from_raw_parts(p, l) }
+            }
+        })
+        .collect())
 }
 
 /// Parse and validate the common arguments for `tgm_encode` / `tgm_file_append`.
@@ -447,36 +445,34 @@ unsafe fn parse_encode_args<'a>(
     hash_algo: *const c_char,
     threads: u32,
 ) -> Result<ParsedEncode<'a>, (TgmError, String)> {
-    unsafe {
-        let (global_metadata, descriptors) =
-            parse_encode_json(json_str).map_err(|e| (TgmError::Metadata, e))?;
+    let (global_metadata, descriptors) =
+        parse_encode_json(json_str).map_err(|e| (TgmError::Metadata, e))?;
 
-        if descriptors.len() != num_objects {
-            return Err((
-                TgmError::InvalidArg,
-                format!(
-                    "descriptors array length {} does not match num_objects {}",
-                    descriptors.len(),
-                    num_objects
-                ),
-            ));
-        }
-
-        let data_slices = collect_data_slices(data_ptrs, data_lens, num_objects)?;
-        let hash_algorithm = parse_hash_algo(hash_algo)?;
-        let options = EncodeOptions {
-            hash_algorithm,
-            threads,
-            ..Default::default()
-        };
-
-        Ok(ParsedEncode {
-            global_metadata,
-            descriptors,
-            data_slices,
-            options,
-        })
+    if descriptors.len() != num_objects {
+        return Err((
+            TgmError::InvalidArg,
+            format!(
+                "descriptors array length {} does not match num_objects {}",
+                descriptors.len(),
+                num_objects
+            ),
+        ));
     }
+
+    let data_slices = unsafe { collect_data_slices(data_ptrs, data_lens, num_objects) }?;
+    let hash_algorithm = parse_hash_algo(hash_algo)?;
+    let options = EncodeOptions {
+        hash_algorithm,
+        threads,
+        ..Default::default()
+    };
+
+    Ok(ParsedEncode {
+        global_metadata,
+        descriptors,
+        data_slices,
+        options,
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/rust/tensogram-grib/Cargo.toml
+++ b/rust/tensogram-grib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tensogram-grib"
 version = "0.13.0"
-edition = "2021"
+edition = "2024"
 description = "GRIB to Tensogram format converter using ecCodes"
 
 [dependencies]

--- a/rust/tensogram-grib/src/converter.rs
+++ b/rust/tensogram-grib/src/converter.rs
@@ -14,10 +14,10 @@ use eccodes::{CodesFile, FallibleIterator, KeyRead, ProductKind};
 
 use tensogram_core::pipeline::apply_pipeline;
 use tensogram_core::types::{ByteOrder, DataObjectDescriptor, GlobalMetadata};
-use tensogram_core::{encode, DataPipeline, Dtype, EncodeOptions};
+use tensogram_core::{DataPipeline, Dtype, EncodeOptions, encode};
 
 use crate::error::GribError;
-use crate::metadata::{extract_all_namespace_keys, extract_mars_keys, GribKeySet};
+use crate::metadata::{GribKeySet, extract_all_namespace_keys, extract_mars_keys};
 
 /// Options for GRIB → Tensogram conversion.
 #[derive(Debug, Clone)]
@@ -104,16 +104,18 @@ pub fn convert_grib_file(path: &Path, options: &ConvertOptions) -> Result<Vec<Ve
 
         let ni: i64 = msg.read_key("Ni").unwrap_or(0);
         let nj: i64 = msg.read_key("Nj").unwrap_or(0);
-        let shape = if ni > 0 && nj > 0 {
-            let nj = u64::try_from(nj)
-                .map_err(|_| GribError::InvalidData("Nj out of u64 range".into()))?;
-            let ni = u64::try_from(ni)
-                .map_err(|_| GribError::InvalidData("Ni out of u64 range".into()))?;
-            vec![nj, ni] // row-major: [lat, lon]
-        } else {
-            vec![u64::try_from(values.len())
-                .map_err(|_| GribError::InvalidData("numberOfPoints out of u64 range".into()))?]
-        };
+        let shape =
+            if ni > 0 && nj > 0 {
+                let nj = u64::try_from(nj)
+                    .map_err(|_| GribError::InvalidData("Nj out of u64 range".into()))?;
+                let ni = u64::try_from(ni)
+                    .map_err(|_| GribError::InvalidData("Ni out of u64 range".into()))?;
+                vec![nj, ni] // row-major: [lat, lon]
+            } else {
+                vec![u64::try_from(values.len()).map_err(|_| {
+                    GribError::InvalidData("numberOfPoints out of u64 range".into())
+                })?]
+            };
 
         grib_messages.push(GribExtracted {
             keys,
@@ -152,10 +154,10 @@ fn convert_one_to_one(
         if !msg.keys.keys.is_empty() {
             entry.insert("mars".to_string(), btree_to_cbor_map(&msg.keys.keys));
         }
-        if let Some(grib) = &msg.grib_keys {
-            if !grib.is_empty() {
-                entry.insert("grib".to_string(), nested_btree_to_cbor_map(grib));
-            }
+        if let Some(grib) = &msg.grib_keys
+            && !grib.is_empty()
+        {
+            entry.insert("grib".to_string(), nested_btree_to_cbor_map(grib));
         }
 
         let global_meta = GlobalMetadata {
@@ -191,10 +193,10 @@ fn convert_merge_all(
             if !msg.keys.keys.is_empty() {
                 entry.insert("mars".to_string(), btree_to_cbor_map(&msg.keys.keys));
             }
-            if let Some(grib) = &msg.grib_keys {
-                if !grib.is_empty() {
-                    entry.insert("grib".to_string(), nested_btree_to_cbor_map(grib));
-                }
+            if let Some(grib) = &msg.grib_keys
+                && !grib.is_empty()
+            {
+                entry.insert("grib".to_string(), nested_btree_to_cbor_map(grib));
             }
             entry
         })

--- a/rust/tensogram-grib/src/lib.rs
+++ b/rust/tensogram-grib/src/lib.rs
@@ -23,7 +23,7 @@ pub mod converter;
 pub mod error;
 pub mod metadata;
 
-pub use converter::{convert_grib_file, ConvertOptions, Grouping};
+pub use converter::{ConvertOptions, Grouping, convert_grib_file};
 pub use error::GribError;
 // `DataPipeline` lives in `tensogram-core::pipeline` — both GRIB and
 // NetCDF converters share the same type so they cannot drift. Re-export

--- a/rust/tensogram-grib/src/metadata.rs
+++ b/rust/tensogram-grib/src/metadata.rs
@@ -58,10 +58,10 @@ fn read_namespace_keys(
     // Phase 2: read each key's value dynamically.
     let mut keys = BTreeMap::new();
     for key_name in &key_names {
-        if let Ok(val) = msg.read_key_dynamic(key_name) {
-            if let Some(cbor) = dynamic_to_cbor(val) {
-                keys.insert(key_name.clone(), cbor);
-            }
+        if let Ok(val) = msg.read_key_dynamic(key_name)
+            && let Some(cbor) = dynamic_to_cbor(val)
+        {
+            keys.insert(key_name.clone(), cbor);
         }
     }
 

--- a/rust/tensogram-grib/tests/integration.rs
+++ b/rust/tensogram-grib/tests/integration.rs
@@ -14,8 +14,8 @@
 use std::path::{Path, PathBuf};
 
 use ciborium::Value as CborValue;
-use tensogram_core::{decode, DecodeOptions};
-use tensogram_grib::{convert_grib_file, ConvertOptions, Grouping};
+use tensogram_core::{DecodeOptions, decode};
+use tensogram_grib::{ConvertOptions, Grouping, convert_grib_file};
 
 /// Path to the testdata directory.
 fn testdata() -> PathBuf {

--- a/rust/tensogram-netcdf/Cargo.toml
+++ b/rust/tensogram-netcdf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tensogram-netcdf"
 version = "0.13.0"
-edition = "2021"
+edition = "2024"
 description = "NetCDF to Tensogram format converter"
 
 [dependencies]

--- a/rust/tensogram-netcdf/src/converter.rs
+++ b/rust/tensogram-netcdf/src/converter.rs
@@ -10,12 +10,12 @@ use std::collections::BTreeMap;
 use std::path::Path;
 
 use ciborium::Value as CborValue;
-use netcdf::types::{FloatType, IntType, NcVariableType};
 use netcdf::AttributeValue;
+use netcdf::types::{FloatType, IntType, NcVariableType};
 
 use tensogram_core::pipeline::apply_pipeline;
 use tensogram_core::types::{ByteOrder, DataObjectDescriptor, GlobalMetadata};
-use tensogram_core::{encode, DataPipeline, Dtype};
+use tensogram_core::{DataPipeline, Dtype, encode};
 
 use crate::error::NetcdfError;
 use crate::metadata::{attr_value_to_cbor, extract_cf_attrs, extract_var_attrs};
@@ -87,10 +87,10 @@ fn build_base_entry(
         base_entry.insert("netcdf".to_string(), cbor_map_from(netcdf_meta));
     }
 
-    if let Some(cf) = cf_meta {
-        if !cf.is_empty() {
-            base_entry.insert("cf".to_string(), cbor_map_from(cf));
-        }
+    if let Some(cf) = cf_meta
+        && !cf.is_empty()
+    {
+        base_entry.insert("cf".to_string(), cbor_map_from(cf));
     }
 
     base_entry
@@ -121,12 +121,12 @@ pub fn convert_netcdf_file(
 
     let file_path_str = path.to_string_lossy().to_string();
 
-    if let Ok(mut groups) = file.groups() {
-        if groups.next().is_some() {
-            eprintln!(
-                "warning: {file_path_str}: sub-groups found; only root-group variables are converted"
-            );
-        }
+    if let Ok(mut groups) = file.groups()
+        && groups.next().is_some()
+    {
+        eprintln!(
+            "warning: {file_path_str}: sub-groups found; only root-group variables are converted"
+        );
     }
 
     let global_attrs = extract_global_attrs(&file);
@@ -279,11 +279,11 @@ fn read_and_unpack(
     })?;
 
     for v in &mut vals {
-        if let Some(fv) = fill_value {
-            if (*v - fv).abs() < f64::EPSILON * fv.abs().max(1.0) {
-                *v = f64::NAN;
-                continue;
-            }
+        if let Some(fv) = fill_value
+            && (*v - fv).abs() < f64::EPSILON * fv.abs().max(1.0)
+        {
+            *v = f64::NAN;
+            continue;
         }
         if let Some(sf) = scale_factor {
             *v *= sf;

--- a/rust/tensogram-netcdf/src/lib.rs
+++ b/rust/tensogram-netcdf/src/lib.rs
@@ -34,7 +34,7 @@ pub mod converter;
 pub mod error;
 pub mod metadata;
 
-pub use converter::{convert_netcdf_file, ConvertOptions, SplitBy};
+pub use converter::{ConvertOptions, SplitBy, convert_netcdf_file};
 pub use error::NetcdfError;
 // `DataPipeline` lives in `tensogram-core::pipeline` — both GRIB and
 // NetCDF converters share the same type so they cannot drift. Re-export

--- a/rust/tensogram-netcdf/tests/integration.rs
+++ b/rust/tensogram-netcdf/tests/integration.rs
@@ -14,8 +14,8 @@
 // DecodedObject = (DataObjectDescriptor, Vec<u8>)
 // Access descriptor via .0, data bytes via .1
 
-use tensogram_core::{decode, DecodeOptions, Dtype};
-use tensogram_netcdf::{convert_netcdf_file, ConvertOptions, DataPipeline, NetcdfError, SplitBy};
+use tensogram_core::{DecodeOptions, Dtype, decode};
+use tensogram_netcdf::{ConvertOptions, DataPipeline, NetcdfError, SplitBy, convert_netcdf_file};
 
 fn testdata(name: &str) -> std::path::PathBuf {
     let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));

--- a/rust/tensogram-sz3-sys/Cargo.toml
+++ b/rust/tensogram-sz3-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tensogram-sz3-sys"
 version = "0.13.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 description = "Clean-room FFI bindings for the SZ3 lossy compression library"
 links = "sz3"

--- a/rust/tensogram-sz3-sys/build.rs
+++ b/rust/tensogram-sz3-sys/build.rs
@@ -93,9 +93,14 @@ fn main() {
         }
     }
 
-    // OpenMP support (optional)
+    let target = env::var("TARGET").unwrap_or_default();
+
     if cfg!(feature = "openmp") {
-        build.flag("-fopenmp");
+        if target.contains("msvc") {
+            build.flag("/openmp");
+        } else {
+            build.flag("-fopenmp");
+        }
     }
 
     build.compile("sz3_ffi");
@@ -106,18 +111,26 @@ fn main() {
     println!("cargo:rerun-if-changed=cpp/sz3_ffi.cpp");
     println!("cargo:rerun-if-changed=build.rs");
 
-    // The zstd-sys crate already links libzstd into the final binary through
-    // its own build script.  We depend on it in Cargo.toml, so Cargo ensures
-    // it is linked.  No additional `rustc-link-lib=zstd` is needed here.
-
-    // Link C++ standard library
-    let target = env::var("TARGET").unwrap_or_default();
     if target.contains("apple") || target.contains("freebsd") {
         println!("cargo:rustc-link-lib=c++");
     } else if target.contains("linux") || target.contains("android") {
         println!("cargo:rustc-link-lib=stdc++");
     }
-    // On Windows with MSVC the C++ stdlib is linked automatically.
+
+    if cfg!(feature = "openmp") {
+        if target.contains("msvc") {
+            // MSVC links the OpenMP runtime automatically via /openmp
+        } else if target.contains("apple") {
+            println!("cargo:rustc-link-lib=omp");
+        } else if target.contains("linux") || target.contains("android") {
+            println!("cargo:rustc-link-lib=gomp");
+        } else {
+            panic!(
+                "openmp feature is not supported on target '{target}'; \
+                 disable it or add linker configuration for this platform"
+            );
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/rust/tensogram-sz3-sys/src/lib.rs
+++ b/rust/tensogram-sz3-sys/src/lib.rs
@@ -43,7 +43,7 @@ pub struct SZ3_Config {
 // ---------------------------------------------------------------------------
 
 macro_rules! impl_sz3_type {
-    ($mod_name:ident, $rust_ty:ty, $data_type:expr, $suffix:ident) => {
+    ($mod_name:ident, $rust_ty:ty, $data_type:expr_2021, $suffix:ident) => {
         pub mod $mod_name {
             use super::SZ3_Config;
 
@@ -53,7 +53,7 @@ macro_rules! impl_sz3_type {
             /// SZ3 `dataType` discriminant for this type.
             pub const DATA_TYPE_TYPE: u8 = $data_type;
 
-            extern "C" {
+            unsafe extern "C" {
                 #[link_name = concat!("sz3_compress_size_bound_", stringify!($suffix))]
                 pub fn compress_size_bound(config: SZ3_Config) -> usize;
 
@@ -91,7 +91,7 @@ impl_sz3_type!(impl_i64, i64, 9, i64);
 // Top-level helpers
 // ---------------------------------------------------------------------------
 
-extern "C" {
+unsafe extern "C" {
     /// Parse a compressed SZ3 blob and return its configuration **without**
     /// decompressing the payload.  The returned `SZ3_Config::dims` pointer is
     /// heap-allocated; free it with [`sz3_dealloc_size_t`].

--- a/rust/tensogram-sz3/Cargo.toml
+++ b/rust/tensogram-sz3/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tensogram-sz3"
 version = "0.13.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 description = "High-level SZ3 compression API for Tensogram"
 

--- a/rust/tensogram-sz3/src/lib.rs
+++ b/rust/tensogram-sz3/src/lib.rs
@@ -522,7 +522,9 @@ pub enum SZ3Error {
     UnsupportedAlgorithm(u32),
     #[error("unsupported SZ3 error bound mode: {0}")]
     UnsupportedErrorBound(u32),
-    #[error("cannot decompress array with dimensions {found:?} to array with different dimensions {expected:?}")]
+    #[error(
+        "cannot decompress array with dimensions {found:?} to array with different dimensions {expected:?}"
+    )]
     DecompressedDimsMismatch {
         found: Vec<usize>,
         expected: Vec<usize>,

--- a/rust/tensogram-szip/Cargo.toml
+++ b/rust/tensogram-szip/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tensogram-szip"
 version = "0.13.0"
-edition = "2021"
+edition = "2024"
 description = "Pure-Rust CCSDS 121.0-B-3 Adaptive Entropy Coding (AEC/SZIP) — encode, decode, and range decode"
 
 [dependencies]

--- a/rust/tensogram-szip/src/decoder.rs
+++ b/rust/tensogram-szip/src/decoder.rs
@@ -16,11 +16,11 @@
 //! 2. For split/SE/zero: read reference AFTER ID (if first block)
 //! 3. For uncomp: reference is embedded in block data (no separate read)
 
+use crate::AecError;
+use crate::AecParams;
 use crate::bitstream::BitReader;
 use crate::params;
 use crate::preprocessor;
-use crate::AecError;
-use crate::AecParams;
 
 /// Second Extension lookup table.
 struct SeTable {

--- a/rust/tensogram-szip/src/encoder.rs
+++ b/rust/tensogram-szip/src/encoder.rs
@@ -18,11 +18,11 @@
 //! and the encoder processes entries `[ref..block_size)` where `ref=1`
 //! for the first block (skipping the dummy) and `ref=0` thereafter.
 
+use crate::AecError;
+use crate::AecParams;
 use crate::bitstream::BitWriter;
 use crate::params;
 use crate::preprocessor;
-use crate::AecError;
-use crate::AecParams;
 
 /// Encode data using the CCSDS 121.0-B-3 adaptive entropy coder.
 ///

--- a/rust/tensogram-szip/src/lib.rs
+++ b/rust/tensogram-szip/src/lib.rs
@@ -40,8 +40,8 @@ mod preprocessor;
 
 pub use error::AecError;
 pub use params::{
-    AecParams, AEC_ALLOW_K13, AEC_DATA_3BYTE, AEC_DATA_MSB, AEC_DATA_PREPROCESS, AEC_DATA_SIGNED,
-    AEC_NOT_ENFORCE, AEC_PAD_RSI, AEC_RESTRICTED,
+    AEC_ALLOW_K13, AEC_DATA_3BYTE, AEC_DATA_MSB, AEC_DATA_PREPROCESS, AEC_DATA_SIGNED,
+    AEC_NOT_ENFORCE, AEC_PAD_RSI, AEC_RESTRICTED, AecParams,
 };
 
 /// Compress data using CCSDS 121.0-B-3 adaptive entropy coding.

--- a/rust/tensogram-szip/src/preprocessor.rs
+++ b/rust/tensogram-szip/src/preprocessor.rs
@@ -34,11 +34,7 @@ pub(crate) fn preprocess_unsigned(samples: &[u32], xmax: u32) -> (u32, Vec<u32>)
 
         let d = if x_curr >= x_prev {
             let delta = x_curr - x_prev;
-            if delta <= x_prev {
-                2 * delta
-            } else {
-                x_curr
-            }
+            if delta <= x_prev { 2 * delta } else { x_curr }
         } else {
             let delta = x_prev - x_curr;
             if delta <= xmax - x_prev {

--- a/rust/tensogram-szip/tests/error_paths.rs
+++ b/rust/tensogram-szip/tests/error_paths.rs
@@ -12,8 +12,8 @@
 //! produce clean errors (not panics).
 
 use tensogram_szip::{
-    aec_compress, aec_decompress, aec_decompress_range, AecParams, AEC_DATA_PREPROCESS,
-    AEC_NOT_ENFORCE, AEC_RESTRICTED,
+    AEC_DATA_PREPROCESS, AEC_NOT_ENFORCE, AEC_RESTRICTED, AecParams, aec_compress, aec_decompress,
+    aec_decompress_range,
 };
 
 fn default_params() -> AecParams {

--- a/rust/tensogram-szip/tests/ffi_crosscheck.rs
+++ b/rust/tensogram-szip/tests/ffi_crosscheck.rs
@@ -12,7 +12,7 @@
 //! Run with: cargo test -p tensogram-szip --test ffi_crosscheck
 
 use tensogram_szip::{
-    AecParams, AEC_DATA_MSB, AEC_DATA_PREPROCESS, AEC_DATA_SIGNED, AEC_NOT_ENFORCE,
+    AEC_DATA_MSB, AEC_DATA_PREPROCESS, AEC_DATA_SIGNED, AEC_NOT_ENFORCE, AecParams,
 };
 
 // ── Helpers: libaec FFI wrappers ─────────────────────────────────────────────

--- a/rust/tensogram-szip/tests/libaec_parity.rs
+++ b/rust/tensogram-szip/tests/libaec_parity.rs
@@ -17,8 +17,8 @@
 //! Source: https://gitlab.dkrz.de/dkrz-sw/libaec/-/tree/master/tests
 
 use tensogram_szip::{
-    aec_compress, aec_decompress, aec_decompress_range, AecParams, AEC_DATA_3BYTE, AEC_DATA_MSB,
-    AEC_DATA_PREPROCESS, AEC_DATA_SIGNED,
+    AEC_DATA_3BYTE, AEC_DATA_MSB, AEC_DATA_PREPROCESS, AEC_DATA_SIGNED, AecParams, aec_compress,
+    aec_decompress, aec_decompress_range,
 };
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -511,11 +511,7 @@ mod rsi_block_access {
         }
         let size = {
             let nb = (bps as usize).div_ceil(8);
-            if nb == 3 {
-                3
-            } else {
-                nb
-            }
+            if nb == 3 { 3 } else { nb }
         };
         let rsi_bytes = rsi as usize * bs as usize * size;
         for (idx, _) in offsets.iter().enumerate() {
@@ -553,11 +549,7 @@ mod rsi_block_access {
                     for &bps in &bps_list {
                         let size = {
                             let nb = (bps as usize).div_ceil(8);
-                            if nb == 3 {
-                                3
-                            } else {
-                                nb
-                            }
+                            if nb == 3 { 3 } else { nb }
                         };
 
                         // Zero data
@@ -584,11 +576,7 @@ mod rsi_block_access {
         for &bps in &[8u32, 16, 24, 32] {
             let size = {
                 let nb = (bps as usize).div_ceil(8);
-                if nb == 3 {
-                    3
-                } else {
-                    nb
-                }
+                if nb == 3 { 3 } else { nb }
             };
             let data = make_incr(nvalues, bps, size, false);
             test_config(nvalues, 128, 16, bps, &data);

--- a/rust/tensogram-szip/tests/proptest_roundtrip.rs
+++ b/rust/tensogram-szip/tests/proptest_roundtrip.rs
@@ -14,8 +14,8 @@
 use proptest::prelude::*;
 use proptest::strategy::ValueTree;
 use tensogram_szip::{
-    aec_compress, aec_compress_no_offsets, aec_decompress, AecParams, AEC_DATA_MSB,
-    AEC_DATA_PREPROCESS, AEC_DATA_SIGNED, AEC_RESTRICTED,
+    AEC_DATA_MSB, AEC_DATA_PREPROCESS, AEC_DATA_SIGNED, AEC_RESTRICTED, AecParams, aec_compress,
+    aec_compress_no_offsets, aec_decompress,
 };
 
 // ── Strategies ──────────────────────────────────────────────────────────────
@@ -44,16 +44,12 @@ fn arb_params() -> impl Strategy<Value = AecParams> {
         })
 }
 
-fn arb_data(params: &AecParams) -> impl Strategy<Value = Vec<u8>> {
+fn arb_data(params: &AecParams) -> impl Strategy<Value = Vec<u8>> + use<> {
     let bps = params.bits_per_sample;
     let msb = params.flags & AEC_DATA_MSB != 0;
     let byte_width = {
         let nbytes = (bps as usize).div_ceil(8);
-        if nbytes == 3 {
-            3
-        } else {
-            nbytes
-        }
+        if nbytes == 3 { 3 } else { nbytes }
     };
     let mask = if bps == 32 {
         u32::MAX

--- a/rust/tensogram-szip/tests/stress.rs
+++ b/rust/tensogram-szip/tests/stress.rs
@@ -12,8 +12,8 @@
 //! patterns, flag combinations, large inputs, and range decode boundaries.
 
 use tensogram_szip::{
-    aec_compress, aec_decompress, aec_decompress_range, AecParams, AEC_DATA_MSB,
-    AEC_DATA_PREPROCESS, AEC_DATA_SIGNED, AEC_NOT_ENFORCE, AEC_PAD_RSI, AEC_RESTRICTED,
+    AEC_DATA_MSB, AEC_DATA_PREPROCESS, AEC_DATA_SIGNED, AEC_NOT_ENFORCE, AEC_PAD_RSI,
+    AEC_RESTRICTED, AecParams, aec_compress, aec_decompress, aec_decompress_range,
 };
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -80,11 +80,7 @@ fn make_noise(n_samples: usize, bps: u32, seed: u32, msb: bool) -> Vec<u8> {
 
 fn byte_width(bps: u32) -> usize {
     let nbytes = (bps as usize).div_ceil(8);
-    if nbytes == 3 {
-        3
-    } else {
-        nbytes
-    }
+    if nbytes == 3 { 3 } else { nbytes }
 }
 
 fn write_sample(out: &mut Vec<u8>, val: u32, bw: usize, msb: bool) {

--- a/rust/tensogram-wasm/Cargo.toml
+++ b/rust/tensogram-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tensogram-wasm"
 version = "0.13.0"
-edition = "2021"
+edition = "2024"
 description = "WebAssembly bindings for the Tensogram N-tensor message format"
 
 [lib]


### PR DESCRIPTION
## Summary
Migrate the entire workspace (13 crates) from Rust edition 2021 to 2024, applying all required code changes, fixing pre-existing build issues discovered along the way, and updating documentation.
## Changes
### Edition migration (`6851a73`)
- Set `edition = "2024"` in all 13 `Cargo.toml` files
- Set `resolver = "3"` in the workspace root
- Add explicit `unsafe` blocks inside `unsafe fn` bodies (`unsafe_op_in_unsafe_fn`)
- Use `unsafe extern "C"` for FFI declarations in `tensogram-sz3-sys`
- Use `expr_2021` macro fragment specifier in `tensogram-sz3-sys`
- Add `+ use<>` annotations for `impl Trait` lifetime capture rules
- Bind temporaries before tail match expressions to fix drop order
- Collapse nested `if`/`if let` into `if let` chains (newly stable idiom)
- Bump `cbindgen` 0.27 → 0.29 for edition 2024 parser support
### Bug fixes
- **`tensogram-core`** (`854495e`): Gate `lock_state` and `MutexGuard` import behind `#[cfg(feature = "async")]` — eliminates `dead_code` warning when building with `remote` but without `async`
- **`tensogram-sz3-sys`** (`75e5483`): Link the OpenMP runtime library when the `openmp` feature is enabled — previously compiled with `-fopenmp` but never linked the runtime, causing undefined `GOMP_*` symbols. Now handles Linux (`gomp`), macOS (`omp`), MSVC (`/openmp`, auto-links), and panics on unsupported targets
- **`tensogram-ffi`** (`772257e`): Fail hard when cbindgen cannot generate the C header — previously silently swallowed errors, risking stale `tensogram.h`
### Documentation (`cb42ebf`)
- `CONTRIBUTING.md`: MSRV 1.75+ → 1.85+
- `plans/RELEASE.md`: Edition template 2021 → 2024, MSRV guidance 1.85+, verification step `cargo +1.75.0` → `+1.85.0`
## Validation
| Check | Result |
|---|---|
| `cargo fmt --all -- --check` | ✅ |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | ✅ zero warnings |
| `cargo clippy -p tensogram-core --features "remote,async" -- -D warnings` | ✅ |
| `cargo check --manifest-path python/bindings/Cargo.toml --no-default-features` | ✅ zero warnings |
| `cargo clippy --manifest-path rust/tensogram-grib/Cargo.toml -- -D warnings` | ✅ |
| `cargo clippy --manifest-path rust/tensogram-netcdf/Cargo.toml -- -D warnings` | ✅ |
| `cargo test --workspace --all-features` | ✅ 49 suites, 1300+ tests, 0 failures |
| Generated `tensogram.h` C header | ✅ identical to pre-migration |

## Contributor Licence Agreement

By submitting this pull request, I confirm that my contribution is made under
the terms of the [Apache License 2.0](LICENSE) and that I have the right to
submit it under this licence. I agree to the terms of the
[ECMWF Contributor Licence Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).


<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-43
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->