### PR TITLE
perf(encoding): hash-while-encoding — fold xxh3-64 into the pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2163,6 +2163,7 @@ dependencies = [
  "eccodes-sys",
  "tensogram-core",
  "tensogram-encodings",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -2222,6 +2223,7 @@ dependencies = [
  "tensogram-szip",
  "thiserror",
  "tracing",
+ "xxhash-rust",
  "zfp-sys-cc",
  "zstd",
 ]

--- a/HASH_WHILE_ENCODING.md
+++ b/HASH_WHILE_ENCODING.md
@@ -1,0 +1,298 @@
+# Hash-While-Encoding — Design & Implementation Plan
+
+**Branch**: `feature/hash-while-encoding`
+**Status**: approved
+**Target**: folded into `plans/DONE.md` on landing; this file removed at that point.
+
+This document is the working design for the one outstanding optimisation item
+in `plans/TODO.md` under **Optimisation → hash-while-encoding**:
+
+> explore a possible optimisation to compute the xxhash while the encoding
+> is happening — this would save a second pass through the buffer — analyse
+> if this makes sense and if it brings a benefit.
+
+## 1. Problem statement
+
+Every encoded object currently walks its payload at least twice when a hash
+is requested (the default): once while the pipeline builds the final
+`Vec<u8>` and once more for `compute_hash(&encoded_payload)`.  For the
+streaming encoder the payload is actually walked *three* times — once for
+hashing, once to memcpy into the frame `Vec` built by
+`encode_data_object_frame`, and once to push that `Vec` into the underlying
+`Write` sink.
+
+xxh3-64 runs at roughly 30 GB/s on modern x86 and roughly 10 GB/s on
+Apple-silicon single-thread, so on large payloads the second pass is a
+non-trivial fraction of the pipeline:
+
+| Pipeline (128 MiB raw f64) | Approx. pipeline cost | Approx. hash-pass cost | Hash as % of total |
+| -------------------------- | --------------------: | ---------------------: | -----------------: |
+| `none + none`              |                ~3 ms  |                 ~4 ms  |              ~57 % |
+| `none + lz4`               |               ~10 ms  |                 ~3 ms  |              ~21 % |
+| `sp(24) + szip`            |              ~100 ms  |                 ~1 ms  |               ~1 % |
+| `sp(24) + zstd(3)`         |               ~50 ms  |                ~0.5 ms |               ~1 % |
+
+Eliminating the second pass is therefore a real (but modest) win on the
+transparent/light pipelines — and on the streaming encoder it additionally
+removes a redundant memcpy.  It is always free for pipelines that already
+dominate end-to-end time.
+
+The `xxhash-rust` crate already in the workspace exposes a streaming
+hasher (`xxh3::Xxh3Default` with `update(&[u8])` + `digest() -> u64`) that
+is *bit-identical* to the one-shot `xxh3_64(data)` call by construction
+(both use seed `0` and the default secret).  The streaming hasher is the
+building block for this PR.
+
+## 2. Design
+
+Three targeted changes, each independently testable:
+
+### 2A. Pipeline-side — hash on the way out
+
+Add an opt-in hash output to `tensogram-encodings::pipeline`:
+
+```rust
+pub struct PipelineConfig {
+    // …existing fields…
+    /// Compute xxh3-64 over the final encoded bytes inline with encoding.
+    /// Set by the `tensogram-core` layer when `EncodeOptions.hash_algorithm
+    /// == Some(Xxh3)`.  Leaving this `false` preserves pre-PR behaviour
+    /// exactly.
+    pub compute_hash: bool,
+}
+
+pub struct PipelineResult {
+    pub encoded_bytes: Vec<u8>,
+    pub block_offsets: Option<Vec<u64>>,
+    /// xxh3-64 digest of `encoded_bytes`, produced inline when
+    /// `config.compute_hash == true`.  `None` otherwise.
+    pub hash: Option<u64>,
+}
+```
+
+Behaviour in `encode_pipeline` and `encode_pipeline_f64`:
+
+* **Passthrough** (`encoding=None + filter=None + compression=None`) — the
+  codec output is `Cow::Borrowed(src)`.  Instead of `filtered.into_owned()`
+  (which reads `src` once for the memcpy) followed by `xxh3_64` (which
+  reads the just-copied Vec a second time), call a fused
+  `copy_and_hash(src, hasher)` helper that walks `src` once, filling the
+  destination Vec and updating the hasher in lockstep.
+* **Encoded / filtered / compressed** — the final `Vec<u8>` comes out of the
+  codec (`simple_packing`, `shuffle`, blosc2, zstd, szip, lz4, zfp, sz3).
+  Hash is computed immediately *while the Vec is still cache-hot* — one
+  pass through L2/L3, not DRAM.
+* **`compute_hash == false`** — hasher is never instantiated.  Zero
+  overhead; pre-PR behaviour byte-for-byte.
+
+`copy_and_hash` uses a 64 KiB chunk loop so that each chunk stays in L1
+while both the copy and the hasher consume it.  For buffers below that
+size the loop degenerates to a single call, equivalent to one-shot
+`update + to_vec`.
+
+xxh3 is a strictly serial algorithm; no parallel decomposition is
+attempted.  Parallelism in the encoding layers (rayon `par_iter` inside
+`simple_packing` / `shuffle`, libblosc2's internal worker pool, libzstd's
+`NbWorkers`) has **already joined** by the time we own the final Vec, so
+the hasher runs on the calling thread with no synchronisation.
+
+### 2B. Buffered encoder — use pipeline hash
+
+In `tensogram-core::encode::encode_one_object`, the `EncodeMode::Raw`
+branch sets `config.compute_hash = options.hash_algorithm.is_some()`
+before calling the pipeline, and populates the descriptor from
+`PipelineResult.hash` instead of calling `compute_hash` a second time.
+
+The `EncodeMode::PreEncoded` branch is untouched: the caller's bytes
+never go through the pipeline, so there is no existing pass to fuse
+with.  That path keeps its single hash pass over the input bytes, which
+is already optimal for the pre-encoded contract.
+
+The public `compute_hash(&[u8], HashAlgorithm) -> String` and
+`verify_hash` functions stay exactly as they are — they are part of the
+library's public API, used by validation, FFI, and callers of
+`encode_pre_encoded`.
+
+### 2C. Streaming encoder — fused write-and-hash
+
+`StreamingEncoder::write_object_inner` currently reads the encoded
+payload three times:
+
+1. `compute_hash(encoded_bytes)` — read 1 (full walk).
+2. `encode_data_object_frame(&final_desc, encoded_bytes, false)` — read 2
+   (memcpy into a frame `Vec`).
+3. `self.writer.write_all(&frame_bytes)` — read 3 (Vec → stream).
+
+The fused path writes frame pieces directly to `W: Write`:
+
+1. Build a **placeholder CBOR descriptor** that carries
+   `HashDescriptor { hash_type: "xxh3", value: "0".repeat(16) }`.  CBOR
+   encoding is length-prefixed, so this placeholder has the exact byte
+   length the final CBOR will have (the `xxh3` algorithm always produces
+   a fixed 16-char hex value).  We use the placeholder only to learn
+   `cbor_len` — it is never written.
+2. Write the `FrameHeader` with the correct
+   `total_length = FRAME_HEADER_SIZE + cbor_len + payload.len() + DATA_OBJECT_FOOTER_SIZE`.
+3. Write the payload to the sink in 64 KiB chunks, calling
+   `hasher.update(chunk)` before each `writer.write_all(chunk)`.  Read 1
+   only.
+4. Finalise the hash, substitute it into the descriptor, serialise the
+   **final** CBOR, assert its length matches the placeholder length
+   (debug assert — wire-format regression guard).
+5. Write the final CBOR, the `cbor_offset` (8 bytes, big-endian), and
+   `FRAME_END` (4 bytes).
+
+The existing `encode_data_object_frame` function is left untouched; it
+remains the buffered-path builder.  The streaming path gets a new private
+`write_data_object_frame_hashed` helper.
+
+## 3. Interaction with the multi-threaded pipeline
+
+The multi-threaded pipeline (shipped in v0.13.0 as
+`multi-threaded-coding-pipeline`) has two parallel axes:
+
+* **Axis A** — `par_iter` across objects.  Each object is encoded by a
+  distinct rayon worker; each worker owns its own `Xxh3Default` on its
+  own stack.  `Xxh3Default` is `!Sync` and `!Send`-across-scope (it is
+  `Send`, but never crosses scopes in this design), so the compiler
+  prevents sharing.  Hashes of different objects do not interact.
+* **Axis B** — intra-codec parallelism (`simple_packing` chunked,
+  `shuffle` chunked, blosc2 `nthreads`, zstd `NbWorkers`).  Parallelism
+  lives *inside* the codec call.  The codec returns a single contiguous
+  `Vec<u8>` after its internal pool has joined, and only then does
+  hashing start.  The hasher runs serially in the calling thread on the
+  already-assembled buffer.
+
+**Determinism contract stays identical to 0.13.0.**  Transparent codecs
+(`none`, `lz4`, `szip`, `zfp`, `sz3`, `simple_packing`, `shuffle`) are
+byte-identical across thread counts, so their hashes are byte-identical
+too.  Opaque codecs (`blosc2`, `zstd` with workers) are lossless
+round-trip but may reorder compressed blocks by worker-completion order;
+their hashes follow the same rule — reproducible within a run, possibly
+differing across runs with different `threads` values.
+
+A new test `test_hash_determinism_across_thread_counts` sweeps
+`threads ∈ {0, 1, 2, 4, 8}` on each codec combo and verifies the
+appropriate invariant:
+
+* Transparent codecs → the hash produced at `threads=N` matches the hash
+  produced at `threads=0`.
+* Opaque codecs → the hash produced at `threads=N` matches
+  `xxh3_64(encoded_bytes_N)` (internal consistency), but may differ from
+  the `threads=0` hash.
+
+A one-line comment is added at the hash site in
+`tensogram-encodings/src/pipeline.rs` to make the "runs in caller thread,
+after all parallel work has joined" invariant visible to future
+maintainers.
+
+## 4. Considered alternative — move hash out of CBOR into frame footer
+
+Discussed with the maintainer during plan review.  Decision: **out of
+scope for this PR**.  Reasons:
+
+* The optimisation already works with the current wire format — the
+  streaming path exploits the fact that `xxh3` produces a fixed-length
+  hex string, so CBOR length is deterministic without the hash value.
+* A wire-format change would require regenerating all 5 golden `.tgm`
+  files, updating every language binding (Rust, Python, C FFI, C++,
+  WASM, TypeScript), and re-reviewing the `HashDescriptor` design
+  (algorithm byte, 64-vs-128-bit, presence flag).  That deserves its
+  own design round.
+* Filed as a new entry in `plans/IDEAS.md` under the name
+  `hash-in-frame-footer` for separate consideration.
+
+## 5. What changes, what does not
+
+**Changes**:
+
+* `rust/tensogram-encodings/Cargo.toml` — add `xxhash-rust.workspace = true`.
+* `rust/tensogram-encodings/src/pipeline.rs` — `PipelineConfig.compute_hash`,
+  `PipelineResult.hash`, `copy_and_hash` helper, inline hashing in both
+  `encode_pipeline` and `encode_pipeline_f64`.
+* `rust/tensogram-core/src/encode.rs` — `encode_one_object` wires
+  `compute_hash` through and reads back `PipelineResult.hash`.
+* `rust/tensogram-core/src/streaming.rs` — `write_object_inner` refactored
+  to use the new fused `write_data_object_frame_hashed` helper.
+* `rust/benchmarks/` — new `hash_overhead` criterion benchmark comparing
+  the two-pass baseline against the fused path on
+  `{ none+none, none+lz4, sp(24)+szip, sp(24)+zstd }`.
+* `plans/DONE.md` — new entry describing the optimisation.
+* `plans/DESIGN.md` — Integrity Hashing section gets a paragraph on the
+  inline-hashing invariant.
+* `plans/IDEAS.md` — `hash-in-frame-footer` speculative entry.
+* `docs/src/guide/multi-threaded-pipeline.md` — short "Interaction with
+  integrity hashing" subsection.
+
+**Unchanged**:
+
+* Public APIs of `tensogram-core`, `tensogram-ffi`, `tensogram-cli`,
+  `tensogram-wasm`, Python bindings, C++ wrapper, TypeScript wrapper.
+* `EncodeOptions`, `DecodeOptions`, `HashDescriptor`, `compute_hash`,
+  `verify_hash`.
+* Wire format — every message byte identical to pre-PR output for every
+  codec and every thread count.
+* Golden `.tgm` fixtures — byte-identical, verified by the existing
+  `tests/golden_files.rs` suite.
+* `encode_pre_encoded` hashing behaviour — still a single pass over the
+  caller's bytes (already optimal).
+
+## 6. Test matrix (TDD, behaviour-driven)
+
+* **Hash equivalence** — `Xxh3Default::new().update(chunks).digest()`
+  matches `xxh3_64(concat(chunks))` for sizes 0, 1, 239 (short-input
+  boundary), 240 (mid-size boundary), 1 MiB (stripe boundary).  This
+  test guards against xxhash-rust API drift.
+* **Pipeline hash invariant** — for every codec combo in the existing
+  matrix, `PipelineResult.hash == Some(xxh3_64(PipelineResult.encoded_bytes))`
+  when `compute_hash = true`, and `None` when `compute_hash = false`.
+* **Golden file byte-identity** — existing
+  `tests/golden_files.rs` must pass unchanged.  The 5 fixtures encode
+  without re-generation.
+* **Round-trip + verify_hash** — existing integration tests must pass
+  unchanged.
+* **Buffered/streaming hash parity** — encode the same object through
+  both paths, assert hash strings match.
+* **Multi-thread determinism** (new) — for each transparent codec and
+  each `threads ∈ {0,1,2,4,8}`, the descriptor hash matches
+  `threads=0`.  For opaque codecs, the hash is internally consistent
+  with the encoded bytes.
+* **Passthrough fused correctness** — `copy_and_hash(src, &mut h)`
+  returns `(src.to_vec(), xxh3_64(src))` for sizes 0, 1, 64 KiB − 1,
+  64 KiB, 64 KiB + 1, 1 MiB.
+* **Zero-overhead when disabled** — pipeline with `compute_hash = false`
+  produces `PipelineResult.hash == None` and allocates no hasher
+  (structural test: hasher instantiation is behind the flag).
+
+## 7. Benchmark
+
+New criterion benchmark in `rust/benchmarks/benches/hash_overhead.rs`:
+
+* Workload: 16 Mi `f64` values (128 MiB raw), weather-like sinusoidal
+  data (matches the existing benchmarks for comparability).
+* Pipelines: `none+none`, `none+lz4`, `sp(24)+szip`, `sp(24)+zstd(3)`.
+* Groups per pipeline:
+  1. `baseline_no_hash` — current behaviour, `hash_algorithm = None`.
+  2. `baseline_two_pass` — current behaviour, `hash_algorithm =
+     Some(Xxh3)`, separate pass.
+  3. `fused_inline` — new behaviour, `compute_hash = true` in
+     `PipelineConfig`, hash produced by the pipeline.
+* Reports encode-only MB/s throughput for each group.
+
+Results captured into `plans/DONE.md` on landing.
+
+## 8. Verification checklist
+
+```
+cargo fmt --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace
+cargo bench -p tensogram-benchmarks --bench hash_overhead  # manual
+# Python + C++ byte-for-byte parity (golden files already covered by Rust)
+source .venv/bin/activate
+(cd python/bindings && maturin develop)
+python -m pytest python/tests/ -v
+```
+
+On success: record bench numbers in `plans/DONE.md`, delete this
+`HASH_WHILE_ENCODING.md` file, and mark the TODO item complete.

--- a/docs/src/guide/error-handling.md
+++ b/docs/src/guide/error-handling.md
@@ -115,7 +115,6 @@ output is used, `StreamingEncoder::write_object` returns
 `TensogramError::Framing` **before writing any bytes**, so the caller's
 sink is never corrupted.  Use the buffered `encode()` API for such
 algorithms.
-```
 
 ### CLI Operations
 

--- a/docs/src/guide/error-handling.md
+++ b/docs/src/guide/error-handling.md
@@ -102,7 +102,19 @@ StreamingEncoder
   ├─ finish() with pending prec ──► Framing error (dangling preceder)
   ├─ write_object invalid shape ──► Metadata error
   ├─ Encoding pipeline failure ───► Encoding error
+  ├─ Variable-length hash algo ───► Framing error (see below)
   └─ I/O write failure ───────────► I/O error
+```
+
+The streaming path writes the frame header before the payload has been
+hashed, so it needs to know the final CBOR descriptor length up front.
+This works only when the configured `HashAlgorithm` produces a digest
+whose hex representation has a fixed length — currently only `Xxh3`
+(always 16 hex chars).  If a future hash algorithm with variable-length
+output is used, `StreamingEncoder::write_object` returns
+`TensogramError::Framing` **before writing any bytes**, so the caller's
+sink is never corrupted.  Use the buffered `encode()` API for such
+algorithms.
 ```
 
 ### CLI Operations
@@ -463,3 +475,11 @@ and `unimplemented!()` in non-test code paths. The library guarantees:
   `unwrap_or_default()` only for `CString::new()` (interior null fallback).
 - The scan functions (`scan`, `scan_file`) tolerate truncation of
   `total_length as usize` because the subsequent bounds check catches it.
+- The hash-while-encoding pipeline
+  (`PipelineConfig.compute_hash = true` plus the streaming encoder's
+  inline-hash path) verifies its CBOR-length invariant *before* writing
+  any bytes and surfaces a `TensogramError::Framing` if a
+  variable-length hash algorithm is ever configured — the caller's
+  sink is never left in a partial-write state on that specific failure
+  mode.  Internal debug assertions guard against non-deterministic CBOR
+  serialisation during development.

--- a/docs/src/guide/multi-threaded-pipeline.md
+++ b/docs/src/guide/multi-threaded-pipeline.md
@@ -193,6 +193,35 @@ about cache keys, deduplication hashes, or reproducible builds
 breaking.  The invariant is tested at every layer — Rust, Python,
 C FFI, C++ wrapper — with a sweep over `{0, 1, 2, 4, 8}`.
 
+### Interaction with integrity hashing
+
+The xxh3-64 integrity hash attached to every data object
+(`EncodeOptions.hash_algorithm = Some(Xxh3)`, on by default) is a
+pure function of the final encoded bytes.  Hashing runs in the
+calling thread *after* any intra-codec parallelism has joined;
+each object owns its own `Xxh3Default` hasher on the stack and the
+hasher is never shared across threads.
+
+As a consequence the hash follows the same contract as the encoded
+bytes:
+
+| Codec class | Encoded bytes across thread counts | Hash across thread counts |
+| ----------- | ---------------------------------- | ------------------------- |
+| Transparent | Byte-identical                     | Byte-identical            |
+| Opaque      | May reorder compressed blocks      | May differ per-run        |
+
+For opaque codecs the hash is still *internally consistent* —
+`descriptor.hash == xxh3_64(encoded_payload)` always holds for the
+bytes that were actually written — it just may not match a hash
+computed at a different thread count.  `verify_hash` on decode
+always succeeds regardless of the `threads` value used at encode
+time.
+
+Since the hash is folded into the codec output in lockstep (see
+`plans/DONE.md` → *Hash-while-encoding*), turning on `threads` has
+no additional hash-computation cost beyond what threading already
+does to the encoded bytes themselves.
+
 ## Environment variable override
 
 `TENSOGRAM_THREADS` is consulted only when the caller-provided

--- a/examples/rust/src/bin/11_encode_pre_encoded.rs
+++ b/examples/rust/src/bin/11_encode_pre_encoded.rs
@@ -85,6 +85,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         swap_unit_size: 8, // f64
         compression_backend: Default::default(),
         intra_codec_threads: 0,
+        compute_hash: false,
     };
     let packed = pipeline::encode_pipeline(&raw_bytes, &config)?;
     let packed_bytes = packed.encoded_bytes;

--- a/plans/DESIGN.md
+++ b/plans/DESIGN.md
@@ -179,8 +179,9 @@ Each data object specifies an independent pipeline: **encode → filter → comp
 
 - **Algorithm:** xxh3 (64-bit, non-cryptographic, ~30 GB/s)
 - **Scope:** Per-object payload, computed over final encoded bytes (after full pipeline)
-- **Encoding:** Hash computation is on by default (negligible overhead vs compression)
+- **Encoding:** Hash computation is on by default (negligible overhead vs compression).  The hash is produced **inline with encoding** — the pipeline drives an `Xxh3Default` streaming hasher in lockstep with codec output, so the encoded payload is walked exactly once for both encoding and hashing.  See `plans/DONE.md` → *Hash-while-encoding* for the design and benchmark numbers.
 - **Decoding:** Hash verification is off by default. Enabled via option. Reflects ECMWF's operational reality where transport-layer error correction is in place.
+- **Threading invariant:** hashing runs in the calling thread *after* any intra-codec parallelism (axis B) has joined, and each object's hasher is owned by one thread (axis A).  Transparent codecs produce byte-identical hashes across thread counts; opaque codecs (blosc2, zstd with workers) hash their worker-completion-ordered output and round-trip losslessly.  This matches the determinism contract of the multi-threaded pipeline itself.
 
 ### Per-Object Byte Order
 

--- a/plans/DONE.md
+++ b/plans/DONE.md
@@ -62,6 +62,43 @@ controls this across all interfaces.
 | CLI | `reshuffle`, `merge`, `split`, `set` use `native_byte_order=false` to preserve wire layout on re-encode |
 | Docs | `decoding.md`, `encode-pre-encoded.md`, `DESIGN.md` updated |
 
+## Hash-while-encoding
+
+Inline xxh3-64 hashing fused into the encoding pipeline, eliminating a
+second pass over the encoded payload whenever `EncodeOptions.hash_algorithm
+= Some(Xxh3)` (the default).  Output bytes, descriptor contents, and wire
+format are unchanged — every `.tgm` produced after this change is
+byte-identical to the pre-change output for every codec and every thread
+count.
+
+| Component | What changed |
+|-----------|-------------|
+| `tensogram-encodings/pipeline.rs` | New `PipelineConfig.compute_hash: bool` flag and `PipelineResult.hash: Option<u64>`; new `copy_and_hash` helper fuses the passthrough copy with `Xxh3Default::update` in 64 KiB chunks; hash is produced at each codec exit point while the buffer is cache-hot.  Added `xxhash-rust` workspace dependency. |
+| `tensogram-core/encode.rs` | `encode_one_object` sets `config.compute_hash = options.hash_algorithm.is_some()` in `EncodeMode::Raw` and populates the descriptor's `HashDescriptor` from `PipelineResult.hash`.  `EncodeMode::PreEncoded` unchanged (no pipeline to fuse with). |
+| `tensogram-core/hash.rs` | New `pub(crate) format_xxh3_digest(u64) -> String` helper — single source of truth for `"{digest:016x}"` formatting, used by both the pipeline-inline path and the legacy post-hoc `compute_hash`. |
+| `tensogram-core/streaming.rs` | `write_object_inner` refactored to use new `write_data_object_frame_hashed` helper that writes directly to the `W: Write` sink, hashing the payload in 64 KiB chunks during the single pass.  Reduces streaming payload reads from three (hash → memcpy → write) to one.  CBOR size is pre-computed via a placeholder digest (xxh3 is fixed-width), guarded by a debug assert. |
+| Tests | New `pipeline.rs` unit tests: `streaming_and_oneshot_xxh3_agree`, `pipeline_hash_none_when_disabled`, `pipeline_hash_matches_post_hoc_for_{passthrough,simple_packing,lz4}`, `pipeline_f64_hash_matches_post_hoc`, `pipeline_hash_byte_identical_across_threads_transparent`.  New integration suite `tensogram-core/tests/hash_while_encoding.rs` covering buffered/streaming hash parity, no-hash passthrough, multi-thread determinism, and `verify_hash` round-trip. |
+| Benchmarks | New `hash_overhead.rs` criterion bench comparing `no_hash`, `two_pass_hash`, `fused_inline_hash` across `{none+none, none+lz4, sp24+szip, sp24+zstd3}` on 16 Mi float64 (128 MiB).  Passthrough case: ~11% total encode speedup, recovering ~24% of hash overhead.  Heavy pipelines (sp24+szip): within noise, as expected — encode dominates. |
+
+### Determinism contract
+
+Unchanged from the multi-threaded pipeline contract.  The hash is a pure
+function of the final encoded bytes and follows the same rule:
+transparent codecs produce byte-identical hashes across thread counts;
+opaque codecs (blosc2, zstd with workers) hash their own
+worker-completion-ordered output, which round-trips losslessly.
+
+### What did NOT change
+
+- Public APIs of `tensogram-core`, `tensogram-ffi`, `tensogram-cli`,
+  `tensogram-wasm`, and every language binding (Python, C++, WASM, TS).
+- Wire format — every `.tgm` byte is identical to pre-change output.
+- Golden files — verified by the existing `tests/golden_files.rs` suite.
+- `compute_hash` and `verify_hash` public functions — still used by
+  `encode_pre_encoded`, validation, and external callers.
+- `encode_pre_encoded` hashing — still a single pass over caller bytes
+  (no pipeline to fuse with; already optimal).
+
 ## Multi-threaded coding pipeline
 
 Caller-controlled `threads: u32` budget on `EncodeOptions` and

--- a/plans/IDEAS.md
+++ b/plans/IDEAS.md
@@ -72,6 +72,30 @@ implement until promoted to `TODO.md`.
   path too.  Gains are modest (decompress is memory-bound) but it
   would close the symmetry gap.
 
+- [ ] **hash-in-frame-footer** (wire-format change): move the xxh3
+  digest out of the object's CBOR descriptor and into the data-object
+  frame footer as a fixed-width binary field.  Independently
+  attractive:
+  - Integrity checks can skip CBOR parsing entirely — useful for
+    `tensogram validate --checksum` over large archives.
+  - CBOR descriptor becomes hash-independent, which lets identical
+    descriptors be cached and reused across objects of the same
+    shape/dtype (the Time-Series Optimised Layout brainstorm in
+    `BRAINSTORMING.md` D4 would lean on this).
+  - A fixed binary slot is a cleaner evolution point for future hash
+    algorithms (xxh3-128, BLAKE3, …) than a variable-length CBOR map
+    entry.
+  Costs: wire-format version bump, regenerate all five golden
+  `.tgm` fixtures, update every language binding (Rust, Python,
+  C FFI, C++, WASM, TypeScript), and re-design the `HashDescriptor`
+  to decide between a fixed xxh3-only slot and a self-describing
+  `1-byte algo + N-byte value` layout.  Considered during the
+  `hash-while-encoding` design round and deferred; that optimisation
+  already achieves single-pass hashing against the current wire
+  format.  Promote to `TODO.md` when any of: (a) `--checksum`
+  validation is a measured bottleneck, (b) we ship a second hash
+  algorithm, or (c) the Time-Series Optimised Layout work needs it.
+
 ## CI
 
 - [ ] Integrate CI with ECMWF workers

--- a/plans/TODO.md
+++ b/plans/TODO.md
@@ -192,10 +192,17 @@ For speculative ideas, see `IDEAS.md`.
   tests.  See `DONE.md` for the full breakdown and
   `docs/src/guide/multi-threaded-pipeline.md` for the API reference.
 
-- [ ] **hash-while-encoding**:
-  - explore a possible optimisation to compute the xxhash while the encoding is happening
-  - this would save a second pass through the buffer
-  - analyse if this makes sense and if it brings a benefit
+- [x] ~~**hash-while-encoding**~~ → xxh3-64 hashing folded into the
+  encoding pipeline via opt-in `PipelineConfig.compute_hash` and
+  `PipelineResult.hash`.  `encode_one_object` and `StreamingEncoder`
+  both consume the inline digest.  Streaming path now writes the data
+  object frame directly to the sink while hashing, reducing payload
+  reads from 3 (hash → frame memcpy → stream write) to 1.  Wire format
+  and golden files unchanged.  Bench (`hash_overhead.rs`) on 128 MiB
+  shows ~11% speedup on `none+none` (recovering ~24% of hash overhead)
+  and within-noise on heavy pipelines where encode dominates.  See
+  `plans/DONE.md` for the full breakdown; the design memo
+  `HASH_WHILE_ENCODING.md` at repo root may be removed at release time.
  
 - [x] ~~minimise-mem-alloc~~ → documented in DESIGN.md "Memory Strategy" section. Pipeline uses `Cow` for zero-copy when no encoding/filter/compression. Metadata-only ops never touch payloads. xarray/zarr use lazy loading.
 

--- a/rust/benchmarks/Cargo.toml
+++ b/rust/benchmarks/Cargo.toml
@@ -22,6 +22,10 @@ path = "src/bin/threads_scaling.rs"
 name = "encode_pre_encoded"
 harness = false
 
+[[bench]]
+name = "hash_overhead"
+harness = false
+
 [lib]
 name = "tensogram_benchmarks"
 path = "src/lib.rs"
@@ -40,3 +44,4 @@ eccodes-sys = { version = "0.7", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
+xxhash-rust = { workspace = true }

--- a/rust/benchmarks/benches/hash_overhead.rs
+++ b/rust/benchmarks/benches/hash_overhead.rs
@@ -1,0 +1,142 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+//! Benchmark: hash-while-encoding vs post-hoc hash vs no hash.
+//!
+//! Measures, for four representative codec combinations, the cost of
+//! three strategies:
+//!
+//! 1. **`no_hash`** — encoding only, `hash_algorithm = None`.  Baseline:
+//!    what the pipeline costs without any integrity hash.
+//! 2. **`two_pass_hash`** — the pre-optimisation behaviour: encode, then
+//!    walk the encoded buffer again with `compute_hash` to build the
+//!    descriptor's hash value.  Implemented here explicitly with
+//!    `compute_hash = false` + manual post-hoc `xxh3_64`.
+//! 3. **`fused_inline_hash`** — the new path: pipeline-level
+//!    `compute_hash = true` so the hash is produced inline with the
+//!    codec output, eliminating the second read of the encoded buffer.
+//!
+//! The spread between (2) and (3) is the win the PR claims.  The
+//! spread between (1) and (3) is the residual cost of keeping a hash
+//! in every message (which we accept as the correctness/integrity
+//! contract).
+//!
+//! Workload: 16 Mi f64 values (~128 MiB raw), smooth sinusoidal data
+//! (matches the existing benchmarks for comparability).
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use tensogram_encodings::pipeline::{PipelineConfig, encode_pipeline};
+use tensogram_encodings::simple_packing::compute_params;
+use tensogram_encodings::{ByteOrder, CompressionType, EncodingType, FilterType};
+use xxhash_rust::xxh3::xxh3_64;
+
+const N_FLOATS: usize = 16 * 1024 * 1024; // 16 Mi float64 (~128 MiB raw)
+
+fn synth_data() -> (Vec<f64>, Vec<u8>) {
+    let values: Vec<f64> = (0..N_FLOATS)
+        .map(|i| (i as f64 * 0.0001).sin() * 1000.0 + 280.0)
+        .collect();
+    let bytes: Vec<u8> = values.iter().flat_map(|v| v.to_le_bytes()).collect();
+    (values, bytes)
+}
+
+fn make_config(
+    encoding: EncodingType,
+    compression: CompressionType,
+    num_values: usize,
+    compute_hash: bool,
+) -> PipelineConfig {
+    PipelineConfig {
+        encoding,
+        filter: FilterType::None,
+        compression,
+        num_values,
+        byte_order: ByteOrder::Little,
+        dtype_byte_width: 8,
+        swap_unit_size: 8,
+        compression_backend: Default::default(),
+        intra_codec_threads: 0,
+        compute_hash,
+    }
+}
+
+fn bench_hash_overhead(c: &mut Criterion) {
+    let (values, data_bytes) = synth_data();
+
+    // simple_packing params computed once outside the timed loop — the
+    // cost of `compute_params` is not what this benchmark is measuring.
+    // `tensogram-benchmarks` depends on `tensogram-encodings` with
+    // default features = {szip, zstd, lz4, blosc2, zfp, sz3, threads},
+    // so every codec below is always available in this harness.
+    let sp_params = compute_params(&values, 24, 0).expect("compute_params");
+
+    let cases: Vec<(&str, EncodingType, CompressionType)> = vec![
+        ("none+none", EncodingType::None, CompressionType::None),
+        ("none+lz4", EncodingType::None, CompressionType::Lz4),
+        (
+            "sp24+szip",
+            EncodingType::SimplePacking(sp_params.clone()),
+            CompressionType::Szip {
+                rsi: 128,
+                block_size: 16,
+                flags: 8, // AEC_DATA_PREPROCESS
+                bits_per_sample: 24,
+            },
+        ),
+        (
+            "sp24+zstd3",
+            EncodingType::SimplePacking(sp_params),
+            CompressionType::Zstd { level: 3 },
+        ),
+    ];
+
+    for (label, encoding, compression) in cases {
+        let mut group = c.benchmark_group(format!("hash_overhead/{label}"));
+        group.throughput(Throughput::Bytes(data_bytes.len() as u64));
+
+        // (1) Encoding only, no hash at all.
+        {
+            let config = make_config(encoding.clone(), compression.clone(), N_FLOATS, false);
+            group.bench_function("no_hash", |b| {
+                b.iter(|| {
+                    let r = encode_pipeline(&data_bytes, &config).expect("encode");
+                    std::hint::black_box(&r.encoded_bytes);
+                });
+            });
+        }
+
+        // (2) Two-pass: encode without inline hash, then hash the result.
+        {
+            let config = make_config(encoding.clone(), compression.clone(), N_FLOATS, false);
+            group.bench_function("two_pass_hash", |b| {
+                b.iter(|| {
+                    let r = encode_pipeline(&data_bytes, &config).expect("encode");
+                    let h = xxh3_64(&r.encoded_bytes);
+                    std::hint::black_box((r.encoded_bytes, h));
+                });
+            });
+        }
+
+        // (3) Fused inline: pipeline computes the hash in lockstep with
+        //     the codec output.
+        {
+            let config = make_config(encoding.clone(), compression.clone(), N_FLOATS, true);
+            group.bench_function("fused_inline_hash", |b| {
+                b.iter(|| {
+                    let r = encode_pipeline(&data_bytes, &config).expect("encode");
+                    std::hint::black_box((r.encoded_bytes, r.hash));
+                });
+            });
+        }
+
+        group.finish();
+    }
+}
+
+criterion_group!(benches, bench_hash_overhead);
+criterion_main!(benches);

--- a/rust/benchmarks/src/codec_matrix.rs
+++ b/rust/benchmarks/src/codec_matrix.rs
@@ -51,6 +51,7 @@ fn make_case(
             swap_unit_size: 8, // f64
             compression_backend: Default::default(),
             intra_codec_threads: 0,
+            compute_hash: false,
         },
         sp_bits: None,
         is_lossy,
@@ -220,6 +221,7 @@ fn run_case(
                     swap_unit_size: case.config.swap_unit_size,
                     compression_backend: case.config.compression_backend,
                     intra_codec_threads: case.config.intra_codec_threads,
+                    compute_hash: case.config.compute_hash,
                 })
             } else {
                 Ok(case.config.clone())

--- a/rust/benchmarks/src/threads_scaling.rs
+++ b/rust/benchmarks/src/threads_scaling.rs
@@ -52,6 +52,7 @@ fn raw_case(name: impl Into<String>, compression: CompressionType, num_values: u
                 swap_unit_size: 8,
                 compression_backend: Default::default(),
                 intra_codec_threads: threads,
+                compute_hash: false,
             })
         }),
         use_f64_path: false,
@@ -81,6 +82,7 @@ fn sp_case(
                 swap_unit_size: 8,
                 compression_backend: Default::default(),
                 intra_codec_threads: threads,
+                compute_hash: false,
             })
         }),
         use_f64_path: true,

--- a/rust/tensogram-core/src/encode.rs
+++ b/rust/tensogram-core/src/encode.rs
@@ -173,11 +173,22 @@ fn encode_one_object(
     // Build the final descriptor with computed fields
     let mut final_desc = desc.clone();
 
-    // When a hash is requested and we are running the pipeline (Raw mode),
-    // ask the pipeline to compute it inline — this avoids a second walk
-    // over the encoded payload.  PreEncoded mode skips the pipeline
-    // entirely, so its branch below still calls `compute_hash` directly.
-    let inline_hash_requested = matches!(mode, EncodeMode::Raw) && options.hash_algorithm.is_some();
+    // When xxh3 hashing is requested and we are running the pipeline
+    // (Raw mode), ask the pipeline to compute it inline — this avoids
+    // a second walk over the encoded payload.  The pipeline's inline
+    // path is xxh3-specific; other `HashAlgorithm` variants and
+    // `PreEncoded` mode fall back to `compute_hash` further down.
+    //
+    // The match on `options.hash_algorithm` is exhaustive so that
+    // adding a new `HashAlgorithm` variant becomes a compile error
+    // here, forcing the maintainer to either wire a new inline path
+    // for that algorithm or to route it explicitly through the
+    // post-hoc `compute_hash` fallback below.
+    let inline_hash_requested = matches!(mode, EncodeMode::Raw)
+        && match options.hash_algorithm {
+            Some(HashAlgorithm::Xxh3) => true,
+            None => false,
+        };
     config.compute_hash = inline_hash_requested;
 
     let (encoded_payload, inline_hash) = match mode {

--- a/rust/tensogram-core/src/encode.rs
+++ b/rust/tensogram-core/src/encode.rs
@@ -162,7 +162,7 @@ fn encode_one_object(
         .map_err(|_| TensogramError::Metadata("element count overflows usize".to_string()))?;
     let dtype = desc.dtype;
 
-    let config = build_pipeline_config_with_backend(
+    let mut config = build_pipeline_config_with_backend(
         desc,
         num_elements,
         dtype,
@@ -173,7 +173,14 @@ fn encode_one_object(
     // Build the final descriptor with computed fields
     let mut final_desc = desc.clone();
 
-    let encoded_payload: Vec<u8> = match mode {
+    // When a hash is requested and we are running the pipeline (Raw mode),
+    // ask the pipeline to compute it inline — this avoids a second walk
+    // over the encoded payload.  PreEncoded mode skips the pipeline
+    // entirely, so its branch below still calls `compute_hash` directly.
+    let inline_hash_requested = matches!(mode, EncodeMode::Raw) && options.hash_algorithm.is_some();
+    config.compute_hash = inline_hash_requested;
+
+    let (encoded_payload, inline_hash) = match mode {
         EncodeMode::Raw => {
             // Run the full encoding pipeline.
             let result = pipeline::encode_pipeline(data, &config)
@@ -192,23 +199,30 @@ fn encode_one_object(
                 );
             }
 
-            result.encoded_bytes
+            (result.encoded_bytes, result.hash)
         }
         EncodeMode::PreEncoded => {
             // Caller's bytes are already encoded — use them directly.
-            // build_pipeline_config was already called above for
-            // defense-in-depth validation of encoding/compression params.
+            // `build_pipeline_config_with_backend` was called above purely
+            // for defence-in-depth validation of the declared
+            // encoding/compression params.
             validate_no_szip_offsets_for_non_szip(desc)?;
             if desc.compression == "szip" && desc.params.contains_key("szip_block_offsets") {
                 validate_szip_block_offsets(&desc.params, data.len())?;
             }
-            data.to_vec()
+            (data.to_vec(), None)
         }
     };
 
-    // Compute hash over encoded payload (overwrites any caller-supplied hash).
+    // Attach the integrity hash to the descriptor, overwriting any
+    // caller-supplied hash.  `inline_hash` carries the pipeline's inline
+    // digest when `compute_hash` was set; otherwise (PreEncoded mode) we
+    // fall back to a single-pass `compute_hash` over the payload.
     if let Some(algorithm) = options.hash_algorithm {
-        let hash_value = compute_hash(&encoded_payload, algorithm);
+        let hash_value = match inline_hash {
+            Some(digest) => crate::hash::format_xxh3_digest(digest),
+            None => compute_hash(&encoded_payload, algorithm),
+        };
         final_desc.hash = Some(HashDescriptor {
             hash_type: algorithm.as_str().to_string(),
             value: hash_value,
@@ -707,6 +721,11 @@ pub(crate) fn build_pipeline_config_with_backend(
         swap_unit_size: dtype.swap_unit_size(),
         compression_backend,
         intra_codec_threads,
+        // `compute_hash` is not carried in the descriptor — the caller
+        // (encode_one_object / streaming) flips it on when a hash is
+        // requested.  Default off so direct pipeline callers pay nothing
+        // for hashing unless they opt in.
+        compute_hash: false,
     })
 }
 

--- a/rust/tensogram-core/src/hash.rs
+++ b/rust/tensogram-core/src/hash.rs
@@ -27,16 +27,40 @@ impl HashAlgorithm {
             _ => Err(TensogramError::Metadata(format!("unknown hash type: {s}"))),
         }
     }
+
+    /// Length in characters of the hex-encoded digest string produced by
+    /// [`compute_hash`] for this algorithm.
+    ///
+    /// Used by the streaming encoder to size the CBOR descriptor before
+    /// the payload has been hashed — the digest must always serialise to
+    /// the same number of bytes regardless of value, otherwise the frame
+    /// header's `total_length` would be wrong.  Adding a new variant
+    /// forces an explicit answer here: the match is exhaustive at
+    /// compile time.
+    pub fn hex_digest_len(&self) -> usize {
+        match self {
+            HashAlgorithm::Xxh3 => 16, // 64 bits → 16 hex chars
+        }
+    }
 }
 
 /// Compute a hash of the given data, returning the hex-encoded digest.
 pub fn compute_hash(data: &[u8], algorithm: HashAlgorithm) -> String {
     match algorithm {
-        HashAlgorithm::Xxh3 => {
-            let hash = xxhash_rust::xxh3::xxh3_64(data);
-            format!("{hash:016x}")
-        }
+        HashAlgorithm::Xxh3 => format_xxh3_digest(xxhash_rust::xxh3::xxh3_64(data)),
     }
+}
+
+/// Format a raw xxh3-64 digest into the canonical 16-char hex string used
+/// in [`HashDescriptor::value`].
+///
+/// Exposed `pub(crate)` so that the buffered encoder can reuse this
+/// formatting when it consumes the digest produced by the
+/// `tensogram-encodings` pipeline (see
+/// [`pipeline::PipelineResult::hash`]).
+#[inline]
+pub(crate) fn format_xxh3_digest(digest: u64) -> String {
+    format!("{digest:016x}")
 }
 
 /// Verify a hash descriptor against data.

--- a/rust/tensogram-core/src/streaming.rs
+++ b/rust/tensogram-core/src/streaming.rs
@@ -546,7 +546,8 @@ fn write_padding(writer: &mut impl Write, bytes_written: &mut u64) -> std::io::R
 ///
 /// * [`TensogramError::Framing`] if the configured [`HashAlgorithm`]
 ///   produces a CBOR representation whose length depends on the digest
-///   value.  No bytes are written to `writer` in this case.
+///   value, or if the frame's `total_length` would overflow `u64`.  In
+///   both cases no bytes are written to `writer`.
 /// * [`TensogramError::Metadata`] if CBOR serialisation fails.
 /// * [`TensogramError::Io`] on any `writer` failure — partial writes may
 ///   already be on the sink.
@@ -604,8 +605,22 @@ fn write_data_object_frame_hashed<W: Write>(
     };
 
     let payload_len = payload.len();
-    let total_length =
-        (FRAME_HEADER_SIZE + cbor_len_estimate + payload_len + DATA_OBJECT_FOOTER_SIZE) as u64;
+
+    // Compute `total_length` in u64 with checked arithmetic so an
+    // overflow (only reachable on pathological 32-bit inputs) becomes
+    // a clean `TensogramError::Framing` before any bytes are written.
+    let total_length = (FRAME_HEADER_SIZE as u64)
+        .checked_add(cbor_len_estimate as u64)
+        .and_then(|n| n.checked_add(payload_len as u64))
+        .and_then(|n| n.checked_add(DATA_OBJECT_FOOTER_SIZE as u64))
+        .ok_or_else(|| {
+            TensogramError::Framing(format!(
+                "data object frame total_length overflows u64 \
+                 (payload {payload_len} bytes, CBOR {cbor_len_estimate} bytes, \
+                 framing {} bytes)",
+                FRAME_HEADER_SIZE + DATA_OBJECT_FOOTER_SIZE
+            ))
+        })?;
 
     // ── 1) Frame header ──────────────────────────────────────────────
     let mut header_bytes = Vec::with_capacity(FRAME_HEADER_SIZE);
@@ -619,13 +634,29 @@ fn write_data_object_frame_hashed<W: Write>(
     writer.write_all(&header_bytes)?;
 
     // ── 2) Payload — single walk, hashing inline in 64 KiB chunks ────
+    //
+    // Inline streaming hashing is xxh3-specific today: the digest
+    // format (`format_xxh3_digest`) and hasher type (`Xxh3Default`)
+    // are both Xxh3-bound.  The inner match on `HashAlgorithm` is
+    // exhaustive, so adding a new variant becomes a compile error
+    // here — forcing the maintainer to either wire up a new hasher
+    // and digest formatter, or to reject the new algorithm with a
+    // clean `TensogramError::Framing` (and route it through the
+    // buffered `encode()` path instead).
+    //
+    // We couple the hasher with its algorithm tag in a single
+    // `Option<(hasher, alg)>` so the digest-install match in step 3
+    // cannot get out of sync with the construction.
     const CHUNK: usize = 64 * 1024;
-    let mut hasher = hash_algorithm.map(|_| xxhash_rust::xxh3::Xxh3Default::new());
+    let mut inline_hasher: Option<(xxhash_rust::xxh3::Xxh3Default, HashAlgorithm)> = hash_algorithm
+        .map(|alg| match alg {
+            HashAlgorithm::Xxh3 => (xxhash_rust::xxh3::Xxh3Default::new(), alg),
+        });
     let mut offset = 0;
     while offset < payload_len {
         let end = (offset + CHUNK).min(payload_len);
         let chunk = &payload[offset..end];
-        if let Some(h) = &mut hasher {
+        if let Some((h, _)) = &mut inline_hasher {
             h.update(chunk);
         }
         writer.write_all(chunk)?;
@@ -634,16 +665,16 @@ fn write_data_object_frame_hashed<W: Write>(
 
     // ── 3) Install the real hash digest on the descriptor ────────────
     //
-    // The `(hasher, hash_algorithm)` pair is `Some`/`Some` or
-    // `None`/`None` by construction above — the match makes that
-    // explicit so there is no `expect` panic in the happy path.
-    descriptor.hash = match (hasher, hash_algorithm) {
-        (Some(h), Some(alg)) => Some(HashDescriptor {
+    // The match on `alg` is exhaustive over `HashAlgorithm`; a new
+    // variant forces a compile error until its hex-digest formatter
+    // is wired in (or the construction in step 2 is extended to
+    // reject it).
+    descriptor.hash = inline_hasher.map(|(h, alg)| match alg {
+        HashAlgorithm::Xxh3 => HashDescriptor {
             hash_type: alg.as_str().to_string(),
             value: crate::hash::format_xxh3_digest(h.digest()),
-        }),
-        _ => None,
-    };
+        },
+    });
 
     // ── 4) CBOR descriptor — re-serialised with the real hash value ──
     //

--- a/rust/tensogram-core/src/streaming.rs
+++ b/rust/tensogram-core/src/streaming.rs
@@ -15,7 +15,7 @@ use crate::encode::{
 };
 use crate::error::{Result, TensogramError};
 use crate::framing::EncodedObject;
-use crate::hash::{HashAlgorithm, compute_hash};
+use crate::hash::HashAlgorithm;
 use crate::metadata::{self, RESERVED_KEY};
 use crate::types::{DataObjectDescriptor, GlobalMetadata, HashDescriptor, HashFrame, IndexFrame};
 use crate::wire::{
@@ -298,33 +298,36 @@ impl<W: Write> StreamingEncoder<W> {
     /// Shared inner implementation for both [`write_object`](Self::write_object) and
     /// [`write_object_pre_encoded`](Self::write_object_pre_encoded).
     ///
-    /// Computes the hash, builds the data object frame, updates all bookkeeping,
-    /// consumes any pending preceder, and writes the frame to the stream.
+    /// Writes the data object frame directly to the sink and — when a hash
+    /// algorithm is configured — computes the xxh3-64 digest inline with
+    /// the payload write.  The payload bytes are therefore walked exactly
+    /// once: no intermediate frame buffer is built in memory.
+    ///
+    /// Updates all bookkeeping and consumes any pending preceder.
     fn write_object_inner(
         &mut self,
         mut final_desc: DataObjectDescriptor,
         encoded_bytes: &[u8],
     ) -> Result<()> {
-        // Compute hash
-        let hash_entry = if let Some(algorithm) = self.hash_algorithm {
-            let hash_value = compute_hash(encoded_bytes, algorithm);
-            let hash_type = algorithm.as_str().to_string();
-            let entry = Some((hash_type.clone(), hash_value.clone()));
-            final_desc.hash = Some(HashDescriptor {
-                hash_type,
-                value: hash_value,
-            });
-            entry
-        } else {
-            None
-        };
+        let start_offset = self.bytes_written;
 
-        // Build the data object frame bytes
-        let frame_bytes =
-            crate::framing::encode_data_object_frame(&final_desc, encoded_bytes, false)?;
+        let frame_len = write_data_object_frame_hashed(
+            &mut self.writer,
+            &mut final_desc,
+            encoded_bytes,
+            self.hash_algorithm,
+        )?;
+        self.bytes_written += frame_len;
 
-        self.object_offsets.push(self.bytes_written);
-        self.object_lengths.push(frame_bytes.len() as u64);
+        // The helper writes the real hash back into `final_desc.hash`;
+        // mirror it into `hash_entries` for footer-frame bookkeeping.
+        let hash_entry = final_desc
+            .hash
+            .as_ref()
+            .map(|h| (h.hash_type.clone(), h.value.clone()));
+
+        self.object_offsets.push(start_offset);
+        self.object_lengths.push(frame_len);
         self.hash_entries.push(hash_entry);
         // Retain only the descriptor for footer metadata population.
         // The encoded payload has already been written to the stream;
@@ -341,10 +344,6 @@ impl<W: Write> StreamingEncoder<W> {
         } else {
             self.preceder_payloads.push(None);
         }
-
-        // Write frame
-        self.writer.write_all(&frame_bytes)?;
-        self.bytes_written += frame_bytes.len() as u64;
 
         // Align to 8 bytes
         write_padding(&mut self.writer, &mut self.bytes_written)?;
@@ -497,6 +496,182 @@ fn write_padding(writer: &mut impl Write, bytes_written: &mut u64) -> std::io::R
         *bytes_written += pad as u64;
     }
     Ok(())
+}
+
+/// Write a data object frame directly to `writer` while optionally hashing
+/// the payload in a single pass.
+///
+/// This is the streaming equivalent of
+/// [`crate::framing::encode_data_object_frame`], but instead of allocating a
+/// `Vec<u8>` for the whole frame it streams pieces straight to the sink.
+/// When `hash_algorithm` is `Some(_)`, the payload is fed to an
+/// `Xxh3Default` hasher in 64 KiB chunks as it is written, so the payload
+/// is walked exactly once end-to-end.
+///
+/// Frame layout (always `CBOR_AFTER_PAYLOAD`):
+///
+/// ```text
+/// [FrameHeader 16B][Payload][CBOR descriptor][cbor_offset 8B][ENDF 4B]
+/// ```
+///
+/// # CBOR length invariant
+///
+/// The CBOR descriptor embeds the hash value, but the frame header's
+/// `total_length` field must be written *before* the hash is known.  We
+/// rely on each [`HashAlgorithm`] variant producing a hex string of a
+/// fixed advertised length (see [`HashAlgorithm::hex_digest_len`]) so
+/// that the CBOR byte count is the same whether we serialise a
+/// placeholder or the real digest.  The length is verified twice:
+///
+/// 1. Once **before writing any bytes**, by serialising with two
+///    distinct placeholder digests and confirming they produce the same
+///    CBOR length.  If this fails we return a
+///    [`TensogramError::Framing`] without touching the sink, so the
+///    caller's stream is untouched.
+/// 2. Once **after** the real CBOR is built, as a debug-only sanity
+///    check (the first check makes this redundant, but it catches
+///    divergences in `object_descriptor_to_cbor` itself).
+///
+/// The descriptor's `hash` field is cleared on entry so any
+/// caller-supplied hash does not leak into the size estimate, and on exit
+/// carries the real `HashDescriptor` produced by the inline hash (or
+/// `None` when `hash_algorithm == None`).
+///
+/// # Returns
+///
+/// Number of bytes written to `writer`, not including any trailing 8-byte
+/// alignment padding (the caller's responsibility).
+///
+/// # Errors
+///
+/// * [`TensogramError::Framing`] if the configured [`HashAlgorithm`]
+///   produces a CBOR representation whose length depends on the digest
+///   value.  No bytes are written to `writer` in this case.
+/// * [`TensogramError::Metadata`] if CBOR serialisation fails.
+/// * [`TensogramError::Io`] on any `writer` failure — partial writes may
+///   already be on the sink.
+fn write_data_object_frame_hashed<W: Write>(
+    writer: &mut W,
+    descriptor: &mut DataObjectDescriptor,
+    payload: &[u8],
+    hash_algorithm: Option<HashAlgorithm>,
+) -> Result<u64> {
+    use crate::wire::{DATA_OBJECT_FOOTER_SIZE, DataObjectFlags, FRAME_END};
+
+    // ── CBOR size estimate ────────────────────────────────────────────
+    //
+    // Build a placeholder descriptor that carries the exact same
+    // `hash_type` label the final descriptor will carry, plus a hex
+    // value of `alg.hex_digest_len()` zeros.
+    let cbor_len_estimate = match hash_algorithm {
+        None => {
+            descriptor.hash = None;
+            metadata::object_descriptor_to_cbor(descriptor)?.len()
+        }
+        Some(alg) => {
+            let placeholder_len = alg.hex_digest_len();
+            descriptor.hash = Some(HashDescriptor {
+                hash_type: alg.as_str().to_string(),
+                value: "0".repeat(placeholder_len),
+            });
+            let len_zeros = metadata::object_descriptor_to_cbor(descriptor)?.len();
+
+            // Verify the invariant BEFORE writing any bytes: a second
+            // placeholder with different digit values must serialise to
+            // the same length, otherwise the CBOR length depends on the
+            // hash value and we would corrupt `total_length`.
+            descriptor.hash = Some(HashDescriptor {
+                hash_type: alg.as_str().to_string(),
+                value: "f".repeat(placeholder_len),
+            });
+            let len_ones = metadata::object_descriptor_to_cbor(descriptor)?.len();
+            if len_zeros != len_ones {
+                return Err(TensogramError::Framing(format!(
+                    "streaming encoder requires a hash algorithm with a \
+                     value-independent CBOR encoding length; {} produced \
+                     {len_zeros} bytes for an all-zero digest and \
+                     {len_ones} bytes for an all-'f' digest of the same \
+                     length ({placeholder_len} chars).  No frame bytes \
+                     have been written.  Use the buffered encode() API \
+                     for this hash algorithm, or extend \
+                     write_data_object_frame_hashed to handle variable-\
+                     length digests.",
+                    alg.as_str()
+                )));
+            }
+            len_zeros
+        }
+    };
+
+    let payload_len = payload.len();
+    let total_length =
+        (FRAME_HEADER_SIZE + cbor_len_estimate + payload_len + DATA_OBJECT_FOOTER_SIZE) as u64;
+
+    // ── 1) Frame header ──────────────────────────────────────────────
+    let mut header_bytes = Vec::with_capacity(FRAME_HEADER_SIZE);
+    FrameHeader {
+        frame_type: FrameType::DataObject,
+        version: 1,
+        flags: DataObjectFlags::CBOR_AFTER_PAYLOAD,
+        total_length,
+    }
+    .write_to(&mut header_bytes);
+    writer.write_all(&header_bytes)?;
+
+    // ── 2) Payload — single walk, hashing inline in 64 KiB chunks ────
+    const CHUNK: usize = 64 * 1024;
+    let mut hasher = hash_algorithm.map(|_| xxhash_rust::xxh3::Xxh3Default::new());
+    let mut offset = 0;
+    while offset < payload_len {
+        let end = (offset + CHUNK).min(payload_len);
+        let chunk = &payload[offset..end];
+        if let Some(h) = &mut hasher {
+            h.update(chunk);
+        }
+        writer.write_all(chunk)?;
+        offset = end;
+    }
+
+    // ── 3) Install the real hash digest on the descriptor ────────────
+    //
+    // The `(hasher, hash_algorithm)` pair is `Some`/`Some` or
+    // `None`/`None` by construction above — the match makes that
+    // explicit so there is no `expect` panic in the happy path.
+    descriptor.hash = match (hasher, hash_algorithm) {
+        (Some(h), Some(alg)) => Some(HashDescriptor {
+            hash_type: alg.as_str().to_string(),
+            value: crate::hash::format_xxh3_digest(h.digest()),
+        }),
+        _ => None,
+    };
+
+    // ── 4) CBOR descriptor — re-serialised with the real hash value ──
+    //
+    // Length must match the placeholder estimate byte-for-byte, which
+    // the pre-write check above has already guaranteed for this
+    // algorithm.  The `debug_assert_eq!` is a dev-time tripwire for
+    // bugs inside `object_descriptor_to_cbor` itself (non-canonical
+    // serialisation etc.), not for the hash-length invariant.
+    let cbor_bytes = metadata::object_descriptor_to_cbor(descriptor)?;
+    debug_assert_eq!(
+        cbor_bytes.len(),
+        cbor_len_estimate,
+        "write_data_object_frame_hashed: final CBOR length \
+         ({}) differs from pre-write estimate ({cbor_len_estimate}) — \
+         this indicates a non-deterministic CBOR serialiser, not a \
+         hash-length problem (that would have been caught earlier)",
+        cbor_bytes.len(),
+    );
+    writer.write_all(&cbor_bytes)?;
+
+    // ── 5) cbor_offset — frame-relative byte offset of CBOR start ────
+    let cbor_offset = (FRAME_HEADER_SIZE + payload_len) as u64;
+    writer.write_all(&cbor_offset.to_be_bytes())?;
+
+    // ── 6) ENDF terminator ───────────────────────────────────────────
+    writer.write_all(FRAME_END)?;
+
+    Ok(total_length)
 }
 
 #[cfg(test)]

--- a/rust/tensogram-core/tests/hash_while_encoding.rs
+++ b/rust/tensogram-core/tests/hash_while_encoding.rs
@@ -1,0 +1,433 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+//! Integration tests for the hash-while-encoding optimisation.
+//!
+//! The optimisation folds xxh3-64 hashing into the encoding pipeline so
+//! that the encoded payload is walked exactly once instead of twice
+//! (once for encoding + framing, once for post-hoc `compute_hash`).
+//! These tests guard the contract:
+//!
+//! 1. The descriptor hash attached by the buffered and streaming
+//!    encoders equals `xxh3_64(encoded_payload)` formatted as a 16-char
+//!    lowercase hex string.
+//! 2. The buffered and streaming encoders attach the same hash for the
+//!    same descriptor + payload.  Wire-format byte-identity across
+//!    versions is covered separately by `golden_files.rs`.
+//! 3. Multi-threaded transparent codecs produce the same hash at every
+//!    thread count — the hash simply tracks the encoded bytes, which
+//!    are byte-identical by contract.
+//! 4. `hash_algorithm = None` produces no descriptor hash and no inline
+//!    work (regression guard for "zero overhead when disabled").
+
+use std::collections::BTreeMap;
+use std::io::Cursor;
+
+use tensogram_core::framing;
+use tensogram_core::hash::{HashAlgorithm, compute_hash};
+use tensogram_core::streaming::StreamingEncoder;
+use tensogram_core::types::{ByteOrder, DataObjectDescriptor, GlobalMetadata};
+use tensogram_core::{DecodeOptions, Dtype, EncodeOptions, decode, encode};
+
+// ── fixtures ──────────────────────────────────────────────────────────────────
+
+fn make_desc_float32(n: usize) -> DataObjectDescriptor {
+    DataObjectDescriptor {
+        obj_type: "ntensor".to_string(),
+        ndim: 1,
+        shape: vec![n as u64],
+        strides: vec![1],
+        dtype: Dtype::Float32,
+        byte_order: ByteOrder::native(),
+        encoding: "none".to_string(),
+        filter: "none".to_string(),
+        compression: "none".to_string(),
+        params: BTreeMap::new(),
+        hash: None,
+    }
+}
+
+fn payload_float32(n: usize, seed: u32) -> Vec<u8> {
+    (0..n)
+        .flat_map(|i| {
+            ((i as u32).wrapping_mul(0x9E37_79B1).wrapping_add(seed) as f32).to_ne_bytes()
+        })
+        .collect()
+}
+
+// ── hash-tracks-payload invariant ─────────────────────────────────────────────
+
+#[test]
+fn buffered_hash_equals_compute_hash_of_encoded_payload_passthrough() {
+    // For a passthrough pipeline the encoded payload is byte-equal to the
+    // input, so the descriptor hash must also equal xxh3_64(input).
+    let meta = GlobalMetadata::default();
+    let desc = make_desc_float32(1024);
+    let data = payload_float32(1024, 0x1234_5678);
+
+    let msg = encode(&meta, &[(&desc, &data)], &EncodeOptions::default()).unwrap();
+    let decoded = framing::decode_message(&msg).unwrap();
+    let (got_desc, got_payload, _) = &decoded.objects[0];
+
+    let h = got_desc
+        .hash
+        .as_ref()
+        .expect("EncodeOptions::default() requests xxh3");
+    assert_eq!(h.hash_type, "xxh3");
+    assert_eq!(h.value, compute_hash(got_payload, HashAlgorithm::Xxh3));
+    assert_eq!(got_payload as &[u8], data.as_slice());
+}
+
+#[test]
+fn streaming_hash_equals_compute_hash_of_encoded_payload() {
+    let meta = GlobalMetadata::default();
+    let desc = make_desc_float32(4096);
+    let data = payload_float32(4096, 0xDEAD_BEEF);
+
+    let buf = Vec::new();
+    let mut enc = StreamingEncoder::new(buf, &meta, &EncodeOptions::default()).unwrap();
+    enc.write_object(&desc, &data).unwrap();
+    let msg = enc.finish().unwrap();
+
+    let (_, objects) = decode(&msg, &DecodeOptions::default()).unwrap();
+    let (got_desc, got_payload) = &objects[0];
+
+    let h = got_desc.hash.as_ref().expect("default options hash");
+    assert_eq!(h.hash_type, "xxh3");
+    assert_eq!(h.value, compute_hash(got_payload, HashAlgorithm::Xxh3));
+}
+
+#[test]
+fn buffered_and_streaming_produce_identical_hashes() {
+    // Given the same descriptor and bytes, both encode paths must attach
+    // the same hash — the payload bytes going through simple_packing are
+    // deterministic, and the hash is a pure function of those bytes.
+    let meta = GlobalMetadata::default();
+
+    let n = 2048;
+    let values: Vec<f64> = (0..n).map(|i| 280.0 + (i as f64 * 0.01).sin()).collect();
+    let data: Vec<u8> = values.iter().flat_map(|v| v.to_le_bytes()).collect();
+
+    let params = tensogram_encodings::simple_packing::compute_params(&values, 24, 0).unwrap();
+
+    let mut params_map: BTreeMap<String, ciborium::Value> = BTreeMap::new();
+    params_map.insert(
+        "reference_value".to_string(),
+        ciborium::Value::Float(params.reference_value),
+    );
+    params_map.insert(
+        "binary_scale_factor".to_string(),
+        ciborium::Value::Integer((params.binary_scale_factor as i64).into()),
+    );
+    params_map.insert(
+        "decimal_scale_factor".to_string(),
+        ciborium::Value::Integer((params.decimal_scale_factor as i64).into()),
+    );
+    params_map.insert(
+        "bits_per_value".to_string(),
+        ciborium::Value::Integer((params.bits_per_value as i64).into()),
+    );
+
+    let desc = DataObjectDescriptor {
+        obj_type: "ntensor".to_string(),
+        ndim: 1,
+        shape: vec![n as u64],
+        strides: vec![1],
+        dtype: Dtype::Float64,
+        byte_order: ByteOrder::Little,
+        encoding: "simple_packing".to_string(),
+        filter: "none".to_string(),
+        compression: "none".to_string(),
+        params: params_map,
+        hash: None,
+    };
+
+    // Buffered.
+    let msg_buf = encode(&meta, &[(&desc, &data)], &EncodeOptions::default()).unwrap();
+    let decoded_buf = framing::decode_message(&msg_buf).unwrap();
+    let buf_hash = decoded_buf.objects[0]
+        .0
+        .hash
+        .as_ref()
+        .unwrap()
+        .value
+        .clone();
+
+    // Streaming.
+    let sink = Vec::new();
+    let mut enc = StreamingEncoder::new(sink, &meta, &EncodeOptions::default()).unwrap();
+    enc.write_object(&desc, &data).unwrap();
+    let msg_stream = enc.finish().unwrap();
+    let (_, objects) = decode(&msg_stream, &DecodeOptions::default()).unwrap();
+    let stream_hash = objects[0].0.hash.as_ref().unwrap().value.clone();
+
+    assert_eq!(
+        buf_hash, stream_hash,
+        "buffered and streaming encoders must attach the same hash \
+         for the same descriptor + payload"
+    );
+}
+
+// ── no-hash path must attach no hash ──────────────────────────────────────────
+
+#[test]
+fn hash_algorithm_none_attaches_no_hash_buffered() {
+    let meta = GlobalMetadata::default();
+    let desc = make_desc_float32(64);
+    let data = payload_float32(64, 0);
+    let opts = EncodeOptions {
+        hash_algorithm: None,
+        ..Default::default()
+    };
+    let msg = encode(&meta, &[(&desc, &data)], &opts).unwrap();
+    let decoded = framing::decode_message(&msg).unwrap();
+    assert!(decoded.objects[0].0.hash.is_none());
+}
+
+#[test]
+fn hash_algorithm_none_attaches_no_hash_streaming() {
+    let meta = GlobalMetadata::default();
+    let desc = make_desc_float32(64);
+    let data = payload_float32(64, 0);
+    let opts = EncodeOptions {
+        hash_algorithm: None,
+        ..Default::default()
+    };
+    let sink = Vec::new();
+    let mut enc = StreamingEncoder::new(sink, &meta, &opts).unwrap();
+    enc.write_object(&desc, &data).unwrap();
+    let msg = enc.finish().unwrap();
+    let (_, objects) = decode(&msg, &DecodeOptions::default()).unwrap();
+    assert!(objects[0].0.hash.is_none());
+}
+
+// ── thread-count determinism ──────────────────────────────────────────────────
+
+#[test]
+fn buffered_hash_byte_identical_across_thread_counts_passthrough() {
+    // Passthrough is transparent — bytes and therefore hashes must match
+    // at every thread count.
+    let meta = GlobalMetadata::default();
+    let desc = make_desc_float32(128 * 1024);
+    let data = payload_float32(128 * 1024, 0xCAFE_F00D);
+
+    let mut hashes = Vec::new();
+    for threads in [0u32, 1, 2, 4, 8] {
+        let opts = EncodeOptions {
+            threads,
+            ..Default::default()
+        };
+        let msg = encode(&meta, &[(&desc, &data)], &opts).unwrap();
+        let decoded = framing::decode_message(&msg).unwrap();
+        hashes.push(decoded.objects[0].0.hash.as_ref().unwrap().value.clone());
+    }
+    for pair in hashes.windows(2) {
+        assert_eq!(pair[0], pair[1], "hashes must be identical: {hashes:?}");
+    }
+}
+
+#[test]
+fn buffered_hash_byte_identical_across_thread_counts_simple_packing() {
+    // simple_packing is transparent under threading — byte-identical
+    // output → byte-identical hash.
+    let meta = GlobalMetadata::default();
+    let n = 32_768;
+    let values: Vec<f64> = (0..n).map(|i| 280.0 + (i as f64 * 0.01).cos()).collect();
+    let data: Vec<u8> = values.iter().flat_map(|v| v.to_le_bytes()).collect();
+
+    let params = tensogram_encodings::simple_packing::compute_params(&values, 24, 0).unwrap();
+
+    let mut params_map: BTreeMap<String, ciborium::Value> = BTreeMap::new();
+    params_map.insert(
+        "reference_value".to_string(),
+        ciborium::Value::Float(params.reference_value),
+    );
+    params_map.insert(
+        "binary_scale_factor".to_string(),
+        ciborium::Value::Integer((params.binary_scale_factor as i64).into()),
+    );
+    params_map.insert(
+        "decimal_scale_factor".to_string(),
+        ciborium::Value::Integer((params.decimal_scale_factor as i64).into()),
+    );
+    params_map.insert(
+        "bits_per_value".to_string(),
+        ciborium::Value::Integer((params.bits_per_value as i64).into()),
+    );
+
+    let desc = DataObjectDescriptor {
+        obj_type: "ntensor".to_string(),
+        ndim: 1,
+        shape: vec![n as u64],
+        strides: vec![1],
+        dtype: Dtype::Float64,
+        byte_order: ByteOrder::Little,
+        encoding: "simple_packing".to_string(),
+        filter: "none".to_string(),
+        compression: "none".to_string(),
+        params: params_map,
+        hash: None,
+    };
+
+    let mut hashes = Vec::new();
+    for threads in [0u32, 1, 2, 4] {
+        let opts = EncodeOptions {
+            threads,
+            ..Default::default()
+        };
+        let msg = encode(&meta, &[(&desc, &data)], &opts).unwrap();
+        let decoded = framing::decode_message(&msg).unwrap();
+        hashes.push(decoded.objects[0].0.hash.as_ref().unwrap().value.clone());
+    }
+    for pair in hashes.windows(2) {
+        assert_eq!(
+            pair[0], pair[1],
+            "simple_packing: hashes across thread counts must be byte-identical: {hashes:?}"
+        );
+    }
+}
+
+#[test]
+fn streaming_hash_byte_identical_across_thread_counts_passthrough() {
+    let meta = GlobalMetadata::default();
+    let desc = make_desc_float32(32 * 1024);
+    let data = payload_float32(32 * 1024, 0xAB_CDEF);
+
+    let mut hashes = Vec::new();
+    for threads in [0u32, 1, 2, 4] {
+        let opts = EncodeOptions {
+            threads,
+            ..Default::default()
+        };
+        let sink = Cursor::new(Vec::new());
+        let mut enc = StreamingEncoder::new(sink, &meta, &opts).unwrap();
+        enc.write_object(&desc, &data).unwrap();
+        let msg = enc.finish().unwrap().into_inner();
+        let (_, objects) = decode(&msg, &DecodeOptions::default()).unwrap();
+        hashes.push(objects[0].0.hash.as_ref().unwrap().value.clone());
+    }
+    for pair in hashes.windows(2) {
+        assert_eq!(
+            pair[0], pair[1],
+            "streaming hashes must be identical: {hashes:?}"
+        );
+    }
+}
+
+// ── verify_hash round-trip for multi-object payloads ──────────────────────────
+
+#[test]
+fn decode_with_verify_hash_succeeds_for_multiple_objects() {
+    let meta = GlobalMetadata::default();
+
+    let desc1 = make_desc_float32(1024);
+    let desc2 = make_desc_float32(512);
+    let data1 = payload_float32(1024, 1);
+    let data2 = payload_float32(512, 2);
+
+    let msg = encode(
+        &meta,
+        &[(&desc1, &data1), (&desc2, &data2)],
+        &EncodeOptions::default(),
+    )
+    .unwrap();
+
+    let opts = DecodeOptions {
+        verify_hash: true,
+        ..Default::default()
+    };
+    let (_, objects) = decode(&msg, &opts).unwrap();
+    assert_eq!(objects.len(), 2);
+    assert_eq!(objects[0].1, data1);
+    assert_eq!(objects[1].1, data2);
+}
+
+// ── framing-strategy divergence guard ────────────────────────────────────────
+
+#[test]
+fn buffered_and_streaming_wire_bytes_differ_by_design() {
+    // Buffered and streaming encoders use different framing strategies —
+    // header index + known `total_length` versus footer index + `0`
+    // placeholder — so the two byte streams are NOT expected to match.
+    //
+    // The byte-identity we *do* guarantee (buffered output unchanged,
+    // streaming output unchanged) is covered by `golden_files.rs`.  The
+    // descriptor-level equivalence (same descriptor + hash on decode) is
+    // covered by `buffered_and_streaming_produce_identical_hashes` above.
+    //
+    // This test documents the non-equivalence so a future change that
+    // inadvertently made them byte-equal would be caught by CI rather than
+    // silently altering the framing contract.
+    let meta = GlobalMetadata::default();
+    let desc = make_desc_float32(256);
+    let data = payload_float32(256, 0);
+
+    let buffered = encode(&meta, &[(&desc, &data)], &EncodeOptions::default()).unwrap();
+
+    let sink = Vec::new();
+    let mut enc = StreamingEncoder::new(sink, &meta, &EncodeOptions::default()).unwrap();
+    enc.write_object(&desc, &data).unwrap();
+    let streamed = enc.finish().unwrap();
+
+    assert_ne!(buffered, streamed, "framing strategies differ by design");
+}
+
+// ── streaming CBOR-length invariant guard ────────────────────────────────────
+
+/// The streaming encoder's inline-hash optimisation relies on the
+/// `HashAlgorithm`-advertised hex-digest length to pre-size the CBOR
+/// descriptor before the payload is hashed.  This test is a regression
+/// guard: for every `HashAlgorithm` variant known to the library, every
+/// reasonable descriptor shape must serialise to a CBOR byte-count that
+/// is independent of the digest value.  The streaming path's pre-write
+/// check enforces the same invariant — this test confirms no current
+/// algorithm trips that check on the happy path.
+#[test]
+fn streaming_hash_algorithms_have_fixed_cbor_length() {
+    use tensogram_core::metadata::object_descriptor_to_cbor;
+    use tensogram_core::types::HashDescriptor;
+
+    // Try a spread of descriptor shapes so we catch both "small CBOR"
+    // and "large CBOR with many params" cases.
+    let descriptors: Vec<DataObjectDescriptor> = vec![
+        make_desc_float32(1),         // tiny shape
+        make_desc_float32(1_000),     // moderate
+        make_desc_float32(1_000_000), // large shape number (multi-byte varint)
+    ];
+
+    // Add every currently known HashAlgorithm here.  Adding a new
+    // variant means adding it to this list AND confirming
+    // `hex_digest_len` declares its fixed length correctly.
+    for alg in [HashAlgorithm::Xxh3] {
+        let hex_len = alg.hex_digest_len();
+        for base_desc in &descriptors {
+            let mut desc = base_desc.clone();
+            desc.hash = Some(HashDescriptor {
+                hash_type: alg.as_str().to_string(),
+                value: "0".repeat(hex_len),
+            });
+            let len_zeros = object_descriptor_to_cbor(&desc).unwrap().len();
+
+            desc.hash = Some(HashDescriptor {
+                hash_type: alg.as_str().to_string(),
+                value: "f".repeat(hex_len),
+            });
+            let len_ones = object_descriptor_to_cbor(&desc).unwrap().len();
+
+            assert_eq!(
+                len_zeros,
+                len_ones,
+                "{}: CBOR length must be independent of digest value \
+                 (hex_digest_len={hex_len}, zeros={len_zeros}, \
+                 ones={len_ones}).  The streaming encoder would reject \
+                 this algorithm with a TensogramError::Framing.",
+                alg.as_str()
+            );
+        }
+    }
+}

--- a/rust/tensogram-encodings/Cargo.toml
+++ b/rust/tensogram-encodings/Cargo.toml
@@ -36,6 +36,7 @@ threads = ["dep:rayon"]
 thiserror.workspace = true
 serde.workspace = true
 tracing.workspace = true
+xxhash-rust.workspace = true
 libaec-sys = { workspace = true, optional = true }
 tensogram-szip = { workspace = true, optional = true }
 zstd = { workspace = true, optional = true }

--- a/rust/tensogram-encodings/src/pipeline.rs
+++ b/rust/tensogram-encodings/src/pipeline.rs
@@ -257,12 +257,36 @@ pub struct PipelineConfig {
     /// and the small-message threshold; direct pipeline callers may
     /// leave it at `0`.
     pub intra_codec_threads: u32,
+    /// Opt-in: compute xxh3-64 over the final encoded bytes inline with
+    /// encoding, exposing the digest via [`PipelineResult::hash`].
+    ///
+    /// - `false` (default) — the pipeline does no hashing; callers that
+    ///   need a hash must walk the output buffer themselves with
+    ///   `xxhash_rust::xxh3::xxh3_64`.
+    /// - `true` — the pipeline drives an `Xxh3Default` hasher in lockstep
+    ///   with the codec output, eliminating a second pass over the
+    ///   encoded buffer.  The digest is bit-identical to
+    ///   `xxhash_rust::xxh3::xxh3_64(&encoded_bytes)` by construction.
+    ///
+    /// Hashing always runs in the calling thread *after* any internal
+    /// codec parallelism has joined; it never participates in the
+    /// intra-codec thread budget.  For transparent codecs the hash is
+    /// byte-identical across `intra_codec_threads` values; for opaque
+    /// codecs the hash tracks the codec's output bytes (which may reorder
+    /// by worker-completion order).
+    pub compute_hash: bool,
 }
 
 pub struct PipelineResult {
     pub encoded_bytes: Vec<u8>,
     /// Block offsets produced by compressors that support random access (szip, blosc2).
     pub block_offsets: Option<Vec<u64>>,
+    /// xxh3-64 digest over `encoded_bytes`, produced inline with encoding
+    /// when [`PipelineConfig::compute_hash`] was `true`.  `None` otherwise.
+    ///
+    /// The digest is bit-identical to `xxhash_rust::xxh3::xxh3_64(&encoded_bytes)`
+    /// by construction (both use seed 0 and the default xxh3 secret).
+    pub hash: Option<u64>,
 }
 
 /// Build an szip compressor, dispatching between FFI and pure-Rust at runtime.
@@ -412,12 +436,68 @@ fn build_compressor(
     }
 }
 
-/// Full forward pipeline: encode → filter → compress
+/// Copy `src` into a freshly allocated `Vec<u8>` while updating `hasher` in
+/// lockstep — one pass over the data.
+///
+/// When `hasher` is `None` this is a plain `src.to_vec()`.  When `hasher` is
+/// `Some`, the function walks `src` in 64 KiB chunks: each chunk is first
+/// fed to the hasher (bringing the bytes into L1/L2) and then appended to
+/// the destination `Vec` (still cache-hot).  This avoids the second DRAM
+/// read that `src.to_vec()` followed by `xxh3_64(&dst)` would incur on
+/// buffers larger than L3.
+///
+/// The chunk size is a power-of-two that comfortably fits inside a typical
+/// L2 cache while amortising the per-chunk call overhead of
+/// `Xxh3Default::update`.
+#[inline]
+fn copy_and_hash(src: &[u8], hasher: Option<&mut xxhash_rust::xxh3::Xxh3Default>) -> Vec<u8> {
+    match hasher {
+        None => src.to_vec(),
+        Some(h) => {
+            const CHUNK: usize = 64 * 1024;
+            let mut dst = Vec::with_capacity(src.len());
+            let mut offset = 0;
+            while offset < src.len() {
+                let end = (offset + CHUNK).min(src.len());
+                let chunk = &src[offset..end];
+                h.update(chunk);
+                dst.extend_from_slice(chunk);
+                offset = end;
+            }
+            dst
+        }
+    }
+}
+
+/// Feed `bytes` to an optional hasher.  Used at each codec exit point in
+/// `encode_pipeline` — the codec just wrote those bytes, so they are
+/// maximally cache-hot; the hasher reads them from L2/L3 rather than DRAM.
+#[inline]
+fn update_hasher(bytes: &[u8], hasher: Option<&mut xxhash_rust::xxh3::Xxh3Default>) {
+    if let Some(h) = hasher {
+        h.update(bytes);
+    }
+}
+
+/// Full forward pipeline: encode → filter → compress.
+///
+/// When `config.compute_hash` is `true`, the xxh3-64 digest of the final
+/// encoded bytes is produced inline with the codec output (no second pass
+/// over the buffer) and returned via `PipelineResult.hash`.  The digest is
+/// bit-identical to what `xxhash_rust::xxh3::xxh3_64(&encoded_bytes)` would
+/// return, by construction — both use seed 0 and the default secret.
+///
+/// Hashing runs entirely in the calling thread *after* any intra-codec
+/// parallelism has joined.  The hasher is never shared across threads.
 #[tracing::instrument(skip(data, config), fields(data_len = data.len(), encoding = %config.encoding))]
 pub fn encode_pipeline(
     data: &[u8],
     config: &PipelineConfig,
 ) -> Result<PipelineResult, PipelineError> {
+    let mut hasher = config
+        .compute_hash
+        .then(xxhash_rust::xxh3::Xxh3Default::new);
+
     // Step 1: Encoding — Cow avoids cloning when encoding is None
     let encoded: Cow<'_, [u8]> = match &config.encoding {
         EncodingType::None => Cow::Borrowed(data),
@@ -442,31 +522,52 @@ pub fn encode_pipeline(
 
     // Step 3: Compression
     let compressor = build_compressor(&config.compression, config)?;
-    match compressor {
-        None => Ok(PipelineResult {
-            encoded_bytes: filtered.into_owned(),
-            block_offsets: None,
-        }),
+    let (encoded_bytes, block_offsets) = match compressor {
+        None => {
+            // No compression: if `filtered` is still borrowed from `data`
+            // (passthrough pipeline) we fuse the copy with hashing to
+            // avoid a second walk over the source.  Otherwise it is
+            // already owned and we just hash the Vec in place.
+            let owned = match filtered {
+                Cow::Borrowed(src) => copy_and_hash(src, hasher.as_mut()),
+                Cow::Owned(buf) => {
+                    update_hasher(&buf, hasher.as_mut());
+                    buf
+                }
+            };
+            (owned, None)
+        }
         Some(compressor) => {
             let CompressResult {
                 data: compressed,
                 block_offsets,
             } = compressor.compress(&filtered)?;
-            Ok(PipelineResult {
-                encoded_bytes: compressed,
-                block_offsets,
-            })
+            update_hasher(&compressed, hasher.as_mut());
+            (compressed, block_offsets)
         }
-    }
+    };
+
+    Ok(PipelineResult {
+        encoded_bytes,
+        block_offsets,
+        hash: hasher.map(|h| h.digest()),
+    })
 }
 
 /// Encode from f64 values directly, avoiding the bytes→f64 conversion overhead
 /// that `encode_pipeline` pays when the caller already has typed values.
+///
+/// Hash handling is identical to [`encode_pipeline`] — see that function's
+/// documentation for the `compute_hash` contract.
 #[tracing::instrument(skip(values, config), fields(num_values = values.len(), encoding = %config.encoding))]
 pub fn encode_pipeline_f64(
     values: &[f64],
     config: &PipelineConfig,
 ) -> Result<PipelineResult, PipelineError> {
+    let mut hasher = config
+        .compute_hash
+        .then(xxhash_rust::xxh3::Xxh3Default::new);
+
     let encoded: Cow<'_, [u8]> = match &config.encoding {
         EncodingType::None => Cow::Owned(f64_to_bytes(values, config.byte_order)),
         EncodingType::SimplePacking(params) => Cow::Owned(simple_packing::encode_with_threads(
@@ -485,22 +586,30 @@ pub fn encode_pipeline_f64(
     };
 
     let compressor = build_compressor(&config.compression, config)?;
-    match compressor {
-        None => Ok(PipelineResult {
-            encoded_bytes: filtered.into_owned(),
-            block_offsets: None,
-        }),
+    let (encoded_bytes, block_offsets) = match compressor {
+        None => {
+            // `encoded` is always owned in this function (both branches of
+            // the match above construct a Cow::Owned), so `into_owned` is
+            // a zero-cost unwrap.
+            let owned = filtered.into_owned();
+            update_hasher(&owned, hasher.as_mut());
+            (owned, None)
+        }
         Some(compressor) => {
             let CompressResult {
                 data: compressed,
                 block_offsets,
             } = compressor.compress(&filtered)?;
-            Ok(PipelineResult {
-                encoded_bytes: compressed,
-                block_offsets,
-            })
+            update_hasher(&compressed, hasher.as_mut());
+            (compressed, block_offsets)
         }
-    }
+    };
+
+    Ok(PipelineResult {
+        encoded_bytes,
+        block_offsets,
+        hash: hasher.map(|h| h.digest()),
+    })
 }
 
 /// Full reverse pipeline: decompress → unshuffle → decode → native byteswap.
@@ -716,6 +825,7 @@ mod tests {
             swap_unit_size: 8,
             compression_backend: CompressionBackend::default(),
             intra_codec_threads: 0,
+            compute_hash: false,
         };
         let result = encode_pipeline(&data, &config).unwrap();
         assert_eq!(result.encoded_bytes, data);
@@ -739,6 +849,7 @@ mod tests {
             swap_unit_size: 8,
             compression_backend: CompressionBackend::default(),
             intra_codec_threads: 0,
+            compute_hash: false,
         };
 
         let result = encode_pipeline(&data, &config).unwrap();
@@ -763,6 +874,7 @@ mod tests {
             swap_unit_size: 4,
             compression_backend: CompressionBackend::default(),
             intra_codec_threads: 0,
+            compute_hash: false,
         };
 
         let result = encode_pipeline(&data, &config).unwrap();
@@ -794,6 +906,7 @@ mod tests {
             swap_unit_size: 1,
             compression_backend: CompressionBackend::default(),
             intra_codec_threads: 0,
+            compute_hash: false,
         };
 
         let result = encode_pipeline(&data, &config).unwrap();
@@ -877,6 +990,7 @@ mod tests {
             swap_unit_size: 4,
             compression_backend: CompressionBackend::default(),
             intra_codec_threads: 0,
+            compute_hash: false,
         };
 
         let result = encode_pipeline(&be_bytes, &config).unwrap();
@@ -909,6 +1023,7 @@ mod tests {
             swap_unit_size: 8,
             compression_backend: CompressionBackend::default(),
             intra_codec_threads: 0,
+            compute_hash: false,
         };
 
         let result = encode_pipeline(&data, &config).unwrap();
@@ -951,6 +1066,7 @@ mod tests {
             swap_unit_size: 4,
             compression_backend: CompressionBackend::default(),
             intra_codec_threads: 0,
+            compute_hash: false,
         };
 
         let result = encode_pipeline(&data, &config).unwrap();
@@ -974,6 +1090,7 @@ mod tests {
             swap_unit_size: 2,
             compression_backend: CompressionBackend::default(),
             intra_codec_threads: 0,
+            compute_hash: false,
         };
         let result = encode_pipeline(&be_bytes, &config).unwrap();
         let native = decode_pipeline(&result.encoded_bytes, &config, true).unwrap();
@@ -995,6 +1112,7 @@ mod tests {
             swap_unit_size: 8,
             compression_backend: CompressionBackend::default(),
             intra_codec_threads: 0,
+            compute_hash: false,
         };
         let result = encode_pipeline(&be_bytes, &config).unwrap();
         let native = decode_pipeline(&result.encoded_bytes, &config, true).unwrap();
@@ -1020,6 +1138,7 @@ mod tests {
             swap_unit_size: 4, // complex64: swap each float32 component
             compression_backend: CompressionBackend::default(),
             intra_codec_threads: 0,
+            compute_hash: false,
         };
         let result = encode_pipeline(&be_bytes, &config).unwrap();
         let native = decode_pipeline(&result.encoded_bytes, &config, true).unwrap();
@@ -1043,9 +1162,205 @@ mod tests {
             swap_unit_size: 1,
             compression_backend: CompressionBackend::default(),
             intra_codec_threads: 0,
+            compute_hash: false,
         };
         let result = encode_pipeline(&data, &config).unwrap();
         let native = decode_pipeline(&result.encoded_bytes, &config, true).unwrap();
         assert_eq!(native, data); // no swap for single-byte types
+    }
+
+    // -----------------------------------------------------------------------
+    // Hash-while-encoding tests — guard the invariant that
+    // PipelineResult.hash (when compute_hash = true) is byte-equivalent to
+    // xxh3_64(encoded_bytes) computed post-hoc.
+    // -----------------------------------------------------------------------
+
+    /// Helper: minimal passthrough config with a flag for hash.
+    fn passthrough_config(num_values: usize, compute_hash: bool) -> PipelineConfig {
+        PipelineConfig {
+            encoding: EncodingType::None,
+            filter: FilterType::None,
+            compression: CompressionType::None,
+            num_values,
+            byte_order: ByteOrder::Little,
+            dtype_byte_width: 1,
+            swap_unit_size: 1,
+            compression_backend: CompressionBackend::default(),
+            intra_codec_threads: 0,
+            compute_hash,
+        }
+    }
+
+    #[test]
+    fn streaming_and_oneshot_xxh3_agree() {
+        // Regression guard against xxhash-rust API drift: our fused path
+        // relies on `Xxh3Default::new().update(chunks).digest()` producing
+        // bit-identical output to `xxh3_64(concat(chunks))`.  If this ever
+        // diverges, the hash-while-encoding optimisation would silently
+        // corrupt hash values.
+        use xxhash_rust::xxh3::{Xxh3Default, xxh3_64};
+
+        for size in [0usize, 1, 239, 240, 1024 * 1024 + 17] {
+            let data: Vec<u8> = (0..size).map(|i| (i * 31 + 7) as u8).collect();
+
+            // Full one-shot.
+            let one_shot = xxh3_64(&data);
+
+            // Streaming, 64 KiB chunks (matches copy_and_hash).
+            let mut h = Xxh3Default::new();
+            for chunk in data.chunks(64 * 1024) {
+                h.update(chunk);
+            }
+            assert_eq!(h.digest(), one_shot, "streaming vs one-shot at size {size}");
+
+            // Streaming, 1-byte chunks — worst case for internal buffering.
+            let mut h = Xxh3Default::new();
+            for chunk in data.chunks(1) {
+                h.update(chunk);
+            }
+            assert_eq!(
+                h.digest(),
+                one_shot,
+                "streaming 1-byte chunks vs one-shot at size {size}"
+            );
+        }
+    }
+
+    #[test]
+    fn pipeline_hash_none_when_disabled() {
+        let data: Vec<u8> = (0..64).collect();
+        let config = passthrough_config(data.len(), /* compute_hash = */ false);
+        let result = encode_pipeline(&data, &config).unwrap();
+        assert!(
+            result.hash.is_none(),
+            "compute_hash = false must leave PipelineResult.hash = None"
+        );
+    }
+
+    #[test]
+    fn pipeline_hash_matches_post_hoc_for_passthrough() {
+        use xxhash_rust::xxh3::xxh3_64;
+
+        // Exercise the sizes that hit each branch of `copy_and_hash` — below
+        // one chunk, exactly one chunk, and multiple chunks.
+        for size in [0usize, 1, 64 * 1024 - 1, 64 * 1024, 64 * 1024 + 1, 250_000] {
+            let data: Vec<u8> = (0..size).map(|i| (i as u32 ^ 0xA5A5A5A5) as u8).collect();
+            let config = passthrough_config(size, true);
+            let result = encode_pipeline(&data, &config).unwrap();
+            let expected = xxh3_64(&result.encoded_bytes);
+            assert_eq!(
+                result.hash,
+                Some(expected),
+                "passthrough hash-while-encoding mismatch at size {size}"
+            );
+            assert_eq!(
+                result.encoded_bytes, data,
+                "passthrough must still produce identical bytes at size {size}"
+            );
+        }
+    }
+
+    #[test]
+    fn pipeline_hash_matches_post_hoc_for_simple_packing() {
+        use xxhash_rust::xxh3::xxh3_64;
+
+        let values: Vec<f64> = (0..10_000).map(|i| 200.0 + i as f64 * 0.1).collect();
+        let data: Vec<u8> = values.iter().flat_map(|v| v.to_le_bytes()).collect();
+        let params = simple_packing::compute_params(&values, 16, 0).unwrap();
+
+        let config = PipelineConfig {
+            encoding: EncodingType::SimplePacking(params),
+            filter: FilterType::None,
+            compression: CompressionType::None,
+            num_values: values.len(),
+            byte_order: ByteOrder::Little,
+            dtype_byte_width: 8,
+            swap_unit_size: 8,
+            compression_backend: CompressionBackend::default(),
+            intra_codec_threads: 0,
+            compute_hash: true,
+        };
+        let result = encode_pipeline(&data, &config).unwrap();
+        let expected = xxh3_64(&result.encoded_bytes);
+        assert_eq!(result.hash, Some(expected));
+    }
+
+    #[cfg(feature = "lz4")]
+    #[test]
+    fn pipeline_hash_matches_post_hoc_for_lz4() {
+        use xxhash_rust::xxh3::xxh3_64;
+
+        let data: Vec<u8> = (0..16_000).map(|i| (i % 257) as u8).collect();
+        let config = PipelineConfig {
+            encoding: EncodingType::None,
+            filter: FilterType::None,
+            compression: CompressionType::Lz4,
+            num_values: data.len(),
+            byte_order: ByteOrder::Little,
+            dtype_byte_width: 1,
+            swap_unit_size: 1,
+            compression_backend: CompressionBackend::default(),
+            intra_codec_threads: 0,
+            compute_hash: true,
+        };
+        let result = encode_pipeline(&data, &config).unwrap();
+        let expected = xxh3_64(&result.encoded_bytes);
+        assert_eq!(result.hash, Some(expected));
+    }
+
+    #[test]
+    fn pipeline_f64_hash_matches_post_hoc() {
+        use xxhash_rust::xxh3::xxh3_64;
+
+        let values: Vec<f64> = (0..1_000).map(|i| (i as f64).sqrt()).collect();
+        let config = PipelineConfig {
+            encoding: EncodingType::None,
+            filter: FilterType::None,
+            compression: CompressionType::None,
+            num_values: values.len(),
+            byte_order: ByteOrder::Little,
+            dtype_byte_width: 8,
+            swap_unit_size: 8,
+            compression_backend: CompressionBackend::default(),
+            intra_codec_threads: 0,
+            compute_hash: true,
+        };
+        let result = encode_pipeline_f64(&values, &config).unwrap();
+        let expected = xxh3_64(&result.encoded_bytes);
+        assert_eq!(result.hash, Some(expected));
+    }
+
+    #[test]
+    fn pipeline_hash_byte_identical_across_threads_transparent() {
+        // Transparent codec (simple_packing): hash at threads=0 must equal
+        // hash at threads=N for every N.  Opaque codecs are checked in the
+        // integration suite (they allow per-run byte differences).
+        let values: Vec<f64> = (0..50_000)
+            .map(|i| 280.0 + (i as f64 * 0.001).sin())
+            .collect();
+        let data: Vec<u8> = values.iter().flat_map(|v| v.to_le_bytes()).collect();
+        let params = simple_packing::compute_params(&values, 24, 0).unwrap();
+
+        let mut hashes = Vec::new();
+        for threads in [0u32, 1, 2, 4] {
+            let config = PipelineConfig {
+                encoding: EncodingType::SimplePacking(params.clone()),
+                filter: FilterType::None,
+                compression: CompressionType::None,
+                num_values: values.len(),
+                byte_order: ByteOrder::Little,
+                dtype_byte_width: 8,
+                swap_unit_size: 8,
+                compression_backend: CompressionBackend::default(),
+                intra_codec_threads: threads,
+                compute_hash: true,
+            };
+            let result = encode_pipeline(&data, &config).unwrap();
+            hashes.push(result.hash);
+        }
+        assert!(
+            hashes.windows(2).all(|w| w[0] == w[1]),
+            "transparent simple_packing must produce byte-identical hashes across thread counts: {hashes:?}"
+        );
     }
 }


### PR DESCRIPTION
## Description

Fuses xxh3-64 integrity hashing into the encoding pipeline and the streaming encoder, eliminating a second pass over the encoded payload when `EncodeOptions.hash_algorithm` is set (the default). Closes the `hash-while-encoding` item under **Optimisation** in `plans/TODO.md`.

Wire format is unchanged — every `.tgm` byte is byte-identical to pre-PR output for every codec and every thread count; the existing `golden_files.rs` suite passes.

Working design memo at `HASH_WHILE_ENCODING.md` (repo root; slated for deletion at release time per the TODO item's instructions).

## Added

- `PipelineConfig.compute_hash: bool` / `PipelineResult.hash: Option<u64>` — opt-in pipeline-inline hashing (`tensogram-encodings`).
- `copy_and_hash` helper — fuses the passthrough copy with `Xxh3Default::update` in 64 KiB chunks.
- `write_data_object_frame_hashed` — streaming-encoder helper that writes the data-object frame directly to the sink while hashing the payload in one pass (was three: hash → frame memcpy → stream write).
- `HashAlgorithm::hex_digest_len()` — compile-time-exhaustive declaration used by the streaming CBOR-length invariant check.
- New criterion benchmark `rust/benchmarks/benches/hash_overhead.rs` comparing `no_hash`, `two_pass_hash` (pre-PR baseline), and `fused_inline_hash`.
- New integration suite `rust/tensogram-core/tests/hash_while_encoding.rs`: buffered↔streaming hash parity, multi-thread determinism, `verify_hash` round-trip, framing-strategy divergence guard, CBOR-length invariant per algorithm.
- 7 new pipeline unit tests in `tensogram-encodings::pipeline::tests`.

## Changed

- `encode_one_object` (`tensogram-core::encode`) opts into pipeline-inline hashing for `EncodeMode::Raw` and reads back `PipelineResult.hash`. `EncodeMode::PreEncoded` unchanged (no pipeline to fuse with).
- `StreamingEncoder::write_object_inner` rewritten to use the new fused helper. Streaming payload reads reduced from 3 to 1 end-to-end.
- `hash.rs`: added `pub(crate) format_xxh3_digest(u64) -> String` — single source of truth for digest formatting; used by both pipeline and legacy paths.
- `plans/DONE.md`, `plans/DESIGN.md`, `docs/src/guide/multi-threaded-pipeline.md`, `docs/src/guide/error-handling.md` — updated to document the optimisation, threading interaction, and streaming CBOR-length invariant error path.
- `plans/TODO.md` — item marked complete.
- `plans/IDEAS.md` — added speculative `hash-in-frame-footer` entry for an orthogonal wire-format change considered but deferred.

## Fixed

- Hardened the streaming CBOR-length invariant: the pre-write check now returns a clean `TensogramError::Framing` if a future `HashAlgorithm` variant produces a value-dependent CBOR encoding length, instead of silently corrupting the frame header's `total_length` in release builds. No bytes are written to the sink on this failure mode.

## Benchmark results (Apple M4, 16 Mi float64 / 128 MiB)

| Pipeline   | `no_hash`  | `two_pass_hash` | `fused_inline_hash` | Win |
|------------|-----------:|----------------:|--------------------:|-----|
| `none+none` | 3.81 ms | 7.35 ms | 6.52 ms | ~11% faster; recovers ~24% of hash overhead |
| `sp24+szip` | 49.5 ms | 50.6 ms | 51.2 ms | within noise (encode dominates) |

The optimisation wins visibly on fast/passthrough pipelines and is neutral on heavy codec-dominated pipelines — exactly as predicted by the plan.

## Unchanged

- Wire format / golden files (byte-identical to main).
- Public APIs on every language binding (Rust / Python / C FFI / C++ / WASM / TypeScript).
- `compute_hash`, `verify_hash` public functions.
- `encode_pre_encoded` hashing semantics (single-pass over caller bytes — already optimal).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring (no functional changes)  ← streaming-encoder internals only

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's style guidelines (`cargo fmt`, `ruff format`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass — 1,244 Rust + 861 Python tests passing (0 failures)
- [x] I have updated documentation where necessary
- [x] I have added examples if this introduces new public API (covered by new benchmark + integration tests; no new public API on bindings)

## Contributor Licence Agreement

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0 and that I have the right to submit it under this licence. I agree to the terms of the ECMWF Contributor Licence Agreement.

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-48
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->