### PR TITLE
feat(ts,wasm,py): TypeScript Scope C.1 + C.2 + streaming encoder + compute_hash parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,128 @@
 All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added — TypeScript wrapper: streaming `StreamingEncoder`
+
+- **`StreamingEncoderOptions.onBytes`** — an optional synchronous
+  `(chunk: Uint8Array) => void` callback.  When supplied, every chunk
+  of wire-format bytes the encoder produces is forwarded to the
+  callback as it is produced; no internal buffering is performed and
+  `finish()` returns an empty `Uint8Array`.  Closes the "true no-
+  buffering stream" gap flagged in the Pass-4 focus list — useful for
+  browser uploads, WebSocket pushes, or any sink that needs bytes
+  incrementally.
+- **`StreamingEncoder#streaming` getter** reports whether an `onBytes`
+  callback was supplied (so call sites that need to branch on mode
+  don't have to remember their own options).
+- **WASM**: new `JsCallbackWriter` (`std::io::Write` into a
+  `js_sys::Function`) plus an `Inner::Buffered` / `Inner::Streaming`
+  enum dispatcher inside the exported `StreamingEncoder` class.  The
+  constructor gained a third optional argument `on_bytes:
+  Option<js_sys::Function>`; buffered-mode callers pass `None` /
+  omit it and see no behavioural change.
+- 9 new TS tests and 5 new wasm-bindgen tests covering construction-
+  time delivery, multi-object chunking, bytes-written parity,
+  callback-throw propagation, non-function rejection, buffered-vs-
+  streaming mode detection, and `hash: false` compatibility.
+- New example `examples/typescript/14_streaming_callback.ts`.
+
+### Changed — Rust core (affects all language bindings)
+
+- **`tensogram_encodings::simple_packing` now rejects ±Infinity values
+  alongside NaN.**  Simple-packing's `binary_scale_factor` is computed
+  from `(max − min) / max_packed` — an infinite range produced a
+  nonsensical `i32::MAX`-saturated scale factor and garbage output.
+  The guard was previously only in the TS wrapper (Pass 3); it is now
+  in the Rust core so Python, C FFI, C++, and WASM all benefit
+  simultaneously.  New `PackingError::InfiniteValue(usize)` variant
+  reports the index of the first offending sample (first-offender
+  guarantee in sequential mode; non-deterministic choice in parallel
+  mode, matching the existing NaN contract).  The previous TS-side
+  `Number.isFinite` check in `simplePackingComputeParams` is kept as
+  defence-in-depth so callers still see a clean
+  `InvalidArgumentError` without a WASM round-trip.
+
+### Added — Python bindings
+
+- `tensogram.compute_hash(data, algo="xxh3")` — hex digest over
+  arbitrary bytes.  Closes the cross-language parity gap vs Rust,
+  WASM, C FFI, and C++ (all of which already exposed an equivalent).
+  Accepts `bytes` and `bytearray` zero-copy via `PyBackedBytes`;
+  other buffer-protocol objects (`memoryview`, `numpy.ndarray`, …)
+  must be converted via `bytes(obj)` / `obj.tobytes()` first.
+  Default algorithm `"xxh3"`; unknown names raise `ValueError`.
+
+### Added — TypeScript wrapper Scope C.1 (API-surface parity)
+
+- `decodeRange(buf, objIndex, ranges, opts?)` — partial sub-tensor
+  decode mirroring Rust `decode_range`, Python `file_decode_range`,
+  and `tgm_decode_range`.  `ranges` is an array of `[offset, count]`
+  pairs (numbers or bigints); the result carries one dtype-typed view
+  per range, or a single concatenated view when `join: true`.
+- `computeHash(bytes, algo?)` — standalone hex-digest computation,
+  matching the digest stamped by `encode()` on the same bytes.
+- `simplePackingComputeParams(values, bits, decScale?)` — GRIB-style
+  simple-packing parameter computation.  Returns snake-case keys so
+  the result spreads directly into a descriptor.
+- `encodePreEncoded(meta, objects, opts?)` — wrap already-encoded
+  payloads into a wire-format message without re-running the
+  encoding pipeline.  The library recomputes the payload hash.
+- `validate(buf, opts?)` / `validateBuffer(buf, opts?)` / `validateFile(path, opts?)` —
+  structural / metadata / integrity / fidelity validation with modes
+  `quick`, `default`, `checksum`, `full`.  Returns a typed
+  `ValidationReport` / `FileValidationReport`; never throws on bad
+  input.
+- `StreamingEncoder` class — frame-at-a-time message construction
+  (`writeObject`, `writePreceder`, `writeObjectPreEncoded`, `finish`).
+  Backed by an in-memory `Vec<u8>` sink on the WASM side, matching
+  Python's `StreamingEncoder`.
+- `TensogramFile#append(meta, objects, opts?)` — Node-only local-
+  file-path append.  Rejects `fromBytes` / `fromUrl`-backed files
+  with `InvalidArgumentError` to match the Rust / Python / FFI / C++
+  contract.
+- **Lazy `TensogramFile.fromUrl`** — a `HEAD` probe detects
+  `Accept-Ranges: bytes` + `Content-Length`; when present, the file
+  lazily scans preambles and fetches message payloads on demand via
+  HTTP `Range` requests (small LRU cache).  Falls back transparently
+  to a single eager GET when Range isn't supported.
+
+### Added — TypeScript wrapper Scope C.2 (first-class dtypes)
+
+- `Float16Polyfill` — TC39-Stage-3-accurate `Float16Array`-shaped
+  polyfill.  Round-ties-to-even narrow, NaN / ±Inf / ±0 / subnormal
+  preservation.  Used when the host runtime lacks
+  `globalThis.Float16Array`.
+- `Bfloat16Array` — view class for the 1-8-7 brain-float layout.
+- `ComplexArray` — view class over interleaved Float32 / Float64
+  storage with `.real(i)`, `.imag(i)`, `.get(i) → {re, im}`, and
+  iteration.
+- `hasNativeFloat16Array()`, `getFloat16ArrayCtor()`,
+  `float16FromBytes()`, `bfloat16FromBytes()`, `complexFromBytes()`
+  factories for zero-copy construction.
+- `typedArrayFor('float16')` now returns a native `Float16Array` or
+  the polyfill.  `typedArrayFor('bfloat16')` returns
+  `Bfloat16Array`.  `typedArrayFor('complex64' | 'complex128')`
+  returns `ComplexArray`.
+
+### Changed — TypeScript wrapper
+
+- **BREAKING: `TensogramFile#rawMessage(index)`** is now `async`
+  (returns `Promise<Uint8Array>`).  Needed so the lazy HTTP backend
+  can issue a `Range` GET on first access.  Existing call sites add
+  `await`.
+- **BREAKING: `typedArrayFor` for half-precision and complex dtypes**
+  returns view classes, not raw `Uint16Array` / interleaved
+  `Float32Array`.  Consumers that need the raw bits reach them via
+  `.bits` (half-precision) or `.data` (complex).
+
+### Added — WASM
+
+- `tensogram-wasm` exports `decode_range`, `encode_pre_encoded`,
+  `compute_hash`, `simple_packing_compute_params`, `validate_buffer`,
+  and the `StreamingEncoder` class.
+
 ## [0.15.0] - 2026-04-18
 
 ### Changed

--- a/docs/src/guide/typescript-api.md
+++ b/docs/src/guide/typescript-api.md
@@ -347,14 +347,157 @@ Wraps an already-loaded `Uint8Array`. The buffer is defensively
 copied, so later mutation of the caller's buffer is invisible to
 the `TensogramFile`.
 
-### Range-based lazy access (Scope C)
+### Range-based lazy access
 
-This Scope-B implementation downloads the whole file before building
-its index. For very large `.tgm` files (several GB) where that's too
-expensive, a future release will add a lazy backend that reads only
-the footer index + the requested message via HTTP `Range` requests.
-The public interface above will not change. See
-`plans/TYPESCRIPT_WRAPPER.md` for details.
+Since Scope C, `TensogramFile.fromUrl` automatically probes the server
+for HTTP Range support.  When the `HEAD` response advertises
+`Accept-Ranges: bytes` and a finite `Content-Length`, the file
+switches to a **lazy backend**:
+
+- The initial open issues a small `HEAD` + one 24-byte Range read per
+  message preamble to build the boundary index.  **No payload data is
+  downloaded.**
+- `rawMessage(i)` / `message(i)` fetch just the requested message's
+  bytes via a `Range: bytes=offset-(offset+length-1)` GET.
+- A small LRU caches recently-fetched message bytes so repeat reads
+  are free.
+
+When the server omits `Accept-Ranges`, returns non-`200` on HEAD, or
+the file uses streaming-mode messages (`total_length=0` — the writer
+did not know the final length up front), the open falls back to a
+single eager GET.  Behaviour is indistinguishable to callers except in
+memory use and timing.
+
+Browser callers using `fromUrl` directly need CORS to expose the
+`Accept-Ranges`, `Content-Range`, and `Content-Length` headers.
+
+### Append (Node local file system)
+
+`TensogramFile#append(meta, objects, opts?)` encodes the new message
+in-memory, appends it to the on-disk file, refreshes the position
+index, and makes the new message reachable via `message(i)` on the
+same handle.  Only supported when the file was opened via
+`TensogramFile.open(path)` — `fromBytes`- and `fromUrl`-backed files
+throw `InvalidArgumentError`, matching the contract in the other
+language bindings.
+
+```ts
+const file = await TensogramFile.open('/data/forecast.tgm');
+try {
+  await file.append({ version: 2 }, [{ descriptor, data }]);
+  console.log(`now has ${file.messageCount} messages`);
+} finally {
+  file.close();
+}
+```
+
+## Scope-C API additions
+
+Scope C brought the TypeScript wrapper to full API parity with Rust /
+Python / FFI / C++.  The surface additions are:
+
+| Function / class | What it does |
+|---|---|
+| `decodeRange(buf, objIndex, ranges, opts?)` | Partial sub-tensor decode.  `ranges` is an array of `[offset, count]` pairs in element units; each returned `parts[i]` is a dtype-typed view.  Option `join: true` concatenates every range into a single view. |
+| `computeHash(bytes, algo?)` | Standalone `xxh3` hash — matches the digest stamped by `encode()` on the same bytes. |
+| `simplePackingComputeParams(values, bits, decScale?)` | GRIB-style simple-packing parameter computation.  Return shape uses snake-case keys so the result spreads directly into a descriptor. |
+| `validate(buf, opts?)` | Report-only validation (never throws on bad input).  Modes: `quick`, `default`, `checksum`, `full`. |
+| `validateBuffer(buf, opts?)` | Multi-message buffer: reports file-level gaps / trailing garbage plus per-message reports. |
+| `validateFile(path, opts?)` | Node-only helper: reads the file via `node:fs/promises` then delegates to `validateBuffer`. |
+| `encodePreEncoded(meta, objects, opts?)` | Wrap already-encoded bytes verbatim into a wire-format message.  The library still validates descriptor structure and stamps a fresh hash. |
+| `StreamingEncoder` | Frame-at-a-time construction.  Two modes: **buffered** (default, `finish()` returns the complete `Uint8Array`) or **streaming** via `opts.onBytes` callback (bytes flow through the callback as they're produced; `finish()` returns an empty `Uint8Array`). |
+| `TensogramFile#append` | Append a new message to a file opened via `TensogramFile.open(path)`.  Node-only. |
+
+## Streaming `StreamingEncoder` (no full-message buffering)
+
+For browser uploads, WebSocket pushes, or any sink that needs bytes as
+soon as they are produced, pass an `onBytes` callback to the
+`StreamingEncoder` constructor:
+
+```ts
+const enc = new StreamingEncoder({ version: 2 }, {
+  onBytes: (chunk) => uploadSocket.send(chunk),   // e.g. WebSocket.send
+});
+enc.writeObject(descriptor, new Float32Array([1, 2, 3]));
+enc.finish();    // flushes footer; returns empty Uint8Array in streaming mode
+enc.close();
+```
+
+Semantics:
+
+- The callback is invoked during construction (preamble + header
+  metadata frame), during each `writeObject` / `writeObjectPreEncoded`
+  (one data-object frame's bytes, potentially across multiple
+  invocations), and during `finish()` (footer frames + postamble).
+- Concatenating every chunk the callback sees (in order) yields a
+  message byte-for-byte identical to what buffered mode would
+  return.  Tested via round-trip with `decode()`.
+- The callback **must be synchronous** — `Promise` return values are
+  silently discarded because the Rust/WASM writer contract is
+  synchronous.  Buffer internally first if you need async work.
+- Each `chunk` is JS-owned and fresh per invocation.  Copy
+  (`new Uint8Array(chunk)` or `chunk.slice()`) if you need to keep it
+  past the next `writeObject` — the underlying `ArrayBuffer` is
+  invalidated when WASM memory grows.
+- If the callback throws, the exception surfaces as an `IoError` on
+  the next `writeObject` / `finish`.  The encoder state is undefined
+  after an error — call `close()` and start over.
+- `enc.streaming` (getter) reports whether an `onBytes` sink was
+  supplied — useful for code that needs to branch on mode.
+
+Parity note: the Rust core `StreamingEncoder<W: Write>` has always
+supported arbitrary sinks; the WASM/TS surface now exposes this
+capability to JS code.  Python / FFI / C++ bindings remain
+buffered-only; extending them would follow the same `JsCallbackWriter`
+pattern with a language-specific sink abstraction and is tracked in
+`plans/TYPESCRIPT_WRAPPER.md`.
+
+## First-class half-precision and complex dtypes
+
+Scope C also upgraded the dtype dispatch in {@link typedArrayFor}.
+`obj.data()` now returns a **first-class view** for dtypes JS does not
+have a native TypedArray for:
+
+| Dtype | `data()` return type |
+|---|---|
+| `float16` | `Float16Array` (native when available) or `Float16Polyfill` (TC39-accurate) |
+| `bfloat16` | `Bfloat16Array` — 1-8-7 layout, truncating-with-round-to-nearest-even narrow |
+| `complex64` / `complex128` | `ComplexArray` — `.real(i)`, `.imag(i)`, `.get(i) → {re, im}`, iteration |
+
+All three classes expose `.bits` / `.data` for zero-copy access to the
+underlying raw storage if you need it.
+
+```ts
+const m = decode(buf);
+const f16 = m.objects[0].data();           // Float16Array or polyfill
+const asFloat32 = f16.toFloat32Array();    // widened copy
+const bits = f16.bits;                      // raw binary16
+
+const cplx = m.objects[1].data() as ComplexArray;
+for (let i = 0; i < cplx.length; i++) {
+  console.log(cplx.real(i), cplx.imag(i));
+}
+```
+
+The polyfill is used automatically when the host runtime does not
+ship `globalThis.Float16Array`.  `hasNativeFloat16Array()` and
+`getFloat16ArrayCtor()` expose the detection machinery for callers
+that want direct control.
+
+> **Breaking change from Scope B:** Before Scope C, `obj.data()` on
+> `float16` / `bfloat16` returned a raw `Uint16Array` of bits, and
+> complex dtypes returned an interleaved `Float32Array` /
+> `Float64Array`.  Consumers that relied on that shape can reach the
+> same bytes via `.bits` (for f16/bf16) or `.data` (for complex).
+
+The low-level bit-conversion helpers (`halfBitsToFloat`,
+`floatToHalfBits`, `bfloat16BitsToFloat`, `floatToBfloat16Bits`) and
+the `isComplexDtype` type-guard are **internal** and are not re-exported
+from `@ecmwf/tensogram`.  Callers that need bit-level manipulation
+should grab the raw storage from a view's `.bits` / `.data` accessor
+and do the conversion themselves, or import directly from
+`@ecmwf/tensogram/float16`, `…/bfloat16`, `…/complex` with the
+understanding that these module paths are not part of the stable API.
 
 ## Examples
 
@@ -363,16 +506,22 @@ See `examples/typescript/` in the repository for runnable scripts:
 - `01_encode_decode.ts` — basic round-trip
 - `02_mars_metadata.ts` — MARS keys on per-object `base[i]` entries
 - `03_multi_object.ts` — multiple dtypes in one message
-- `05_streaming_fetch.ts` — progressive decode over a `ReadableStream` (Phase 3)
-- `06_file_api.ts` — `TensogramFile` over Node fs, fetch, and in-memory bytes (Phase 4)
+- `04_decode_range.ts` — partial sub-tensor decode
+- `05_streaming_fetch.ts` — progressive decode over a `ReadableStream`
+- `06_file_api.ts` — `TensogramFile` over Node fs, fetch, and in-memory bytes
 - `07_hash_and_errors.ts` — hash verification and typed errors
+- `08_validate.ts` — `validate(buf)` + `validateFile(path)`
+- `11_encode_pre_encoded.ts` — wrap already-encoded bytes
+- `12_streaming_encoder.ts` — frame-at-a-time encoder with preceders
+- `13_range_access.ts` — lazy `TensogramFile.fromUrl` over HTTP Range
+- `14_streaming_callback.ts` — `StreamingEncoder` with `onBytes` callback sink
 
 Run them with:
 
 ```bash
 cd examples/typescript
 npm install
-npx tsx 01_encode_decode.ts     # or 02, 03, 05, 06, 07
+npx tsx 01_encode_decode.ts     # or any other file
 ```
 
 ## Design notes
@@ -395,14 +544,19 @@ Specifically, `typescript/tests/golden.test.ts` decodes:
 - `multi_message.tgm` — two concatenated messages (via `scan()`)
 - `hash_xxh3.tgm` — verifyHash success + tamper detection
 
-`typescript/tests/property.test.ts` adds `fast-check` property tests
-pinning:
+`typescript/tests/property.test.ts` and the Scope-C dtype suites add
+`fast-check` property tests pinning:
 
 - `mapTensogramError` never throws for any finite-string input and
   always returns a `TensogramError` subclass;
 - `encode → decode` is bit-exact for random Float32 shapes across
   random MARS metadata;
 - `decode` on random byte input either succeeds with a structurally
-  valid message or throws a typed `TensogramError` — never panics.
+  valid message or throws a typed `TensogramError` — never panics;
+- `float32 → float16 → float32` round-trip stays within half-precision
+  ulp for any random value in a reasonable magnitude band;
+- `float32 → bfloat16 → float32` round-trip stays within bfloat16 ulp;
+- `complex64` encode → decode preserves `real(i)` / `imag(i)`
+  byte-for-byte across random shapes and values.
 
-The CI `typescript` job rebuilds and runs all 145 TS tests on every PR.
+The CI `typescript` job rebuilds and runs every TS test on every PR.

--- a/examples/typescript/.gitignore
+++ b/examples/typescript/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.DS_Store

--- a/examples/typescript/04_decode_range.ts
+++ b/examples/typescript/04_decode_range.ts
@@ -1,0 +1,88 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+/**
+ * Example 04 — Partial range decode (TypeScript)
+ *
+ * For large tensors where you only need a slab, `decodeRange` avoids
+ * paying the cost of a full decompress + dequantise.  The example
+ * builds an uncompressed 100 000-element float32 tensor, then pulls
+ * three disjoint slabs by element offset/count — and also shows the
+ * `join: true` mode that returns a single concatenated buffer.
+ *
+ * Run:
+ *   cd typescript && npm run build
+ *   cd ../examples/typescript
+ *   npm install
+ *   npx tsx 04_decode_range.ts
+ */
+
+import {
+  decodeRange,
+  encode,
+  init,
+  type DataObjectDescriptor,
+} from '@ecmwf/tensogram';
+
+function describe(shape: number[], dtype: DataObjectDescriptor['dtype']): DataObjectDescriptor {
+  const strides = new Array<number>(shape.length).fill(1);
+  for (let i = shape.length - 2; i >= 0; i--) strides[i] = strides[i + 1] * shape[i + 1];
+  return {
+    type: 'ntensor',
+    ndim: shape.length,
+    shape,
+    strides,
+    dtype,
+    byte_order: 'little',
+    encoding: 'none',
+    filter: 'none',
+    compression: 'none',
+  };
+}
+
+async function main(): Promise<void> {
+  await init();
+
+  // 1. Build a 100 000-element float32 tensor: values = index * 0.5.
+  const N = 100_000;
+  const values = new Float32Array(N);
+  for (let i = 0; i < N; i++) values[i] = i * 0.5;
+
+  const msg = encode({ version: 2 }, [{ descriptor: describe([N], 'float32'), data: values }]);
+  console.log(`message size: ${msg.byteLength.toLocaleString()} bytes`);
+
+  // 2. Split mode: one TypedArray per requested range.
+  const split = decodeRange(msg, 0, [
+    [0, 5],
+    [1000, 3],
+    [99_990, 5],
+  ]);
+  console.log('split mode:');
+  for (let i = 0; i < split.parts.length; i++) {
+    const arr = split.parts[i] as Float32Array;
+    console.log(`  part ${i}: first=${arr[0]}  last=${arr[arr.length - 1]}  length=${arr.length}`);
+  }
+
+  // 3. Join mode: a single concatenated buffer — handy when the
+  //    consumer just wants "all the bytes I asked for".
+  const joined = decodeRange(
+    msg,
+    0,
+    [
+      [0, 5],
+      [1000, 3],
+      [99_990, 5],
+    ],
+    { join: true },
+  );
+  const merged = joined.parts[0] as Float32Array;
+  console.log(`\njoin mode: ${merged.length} elements total`);
+  console.log(`  contents: [${Array.from(merged).join(', ')}]`);
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/typescript/06_file_api.ts
+++ b/examples/typescript/06_file_api.ts
@@ -112,7 +112,7 @@ async function sectionFromUrl(): Promise<void> {
   }
 }
 
-function sectionFromBytes(): void {
+async function sectionFromBytes(): Promise<void> {
   console.log('\n─── 3. TensogramFile.fromBytes (in-memory) ──────────────');
   const bytes = buildMessage([42, 43, 44]);
   const file = TensogramFile.fromBytes(bytes);
@@ -120,7 +120,10 @@ function sectionFromBytes(): void {
     console.log(`  source:       ${file.source}`);
     console.log(`  messageCount: ${file.messageCount}`);
 
-    const raw = file.rawMessage(0);
+    // `rawMessage` is async since Scope C — the lazy HTTP backend needs
+    // to issue a Range request in the remote case; in-memory backends
+    // resolve synchronously under the hood but the signature is unified.
+    const raw = await file.rawMessage(0);
     console.log(`  rawMessage(0) length: ${raw.byteLength}`);
     console.log(`  magic:                ${new TextDecoder().decode(raw.subarray(0, 8))}`);
   } finally {
@@ -132,7 +135,7 @@ async function main(): Promise<void> {
   await init();
   await sectionOpen();
   await sectionFromUrl();
-  sectionFromBytes();
+  await sectionFromBytes();
 }
 
 main().catch((err: unknown) => {

--- a/examples/typescript/08_validate.ts
+++ b/examples/typescript/08_validate.ts
@@ -1,0 +1,100 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+/**
+ * Example 08 — validate a single buffer and a multi-message file.
+ *
+ * `validate(buf)` never throws on bad input — it returns a structured
+ * report of every structural / metadata / hash / fidelity issue.  We
+ * exercise both the happy path and a truncated buffer that reports
+ * errors.
+ *
+ * Run:
+ *   cd typescript && npm run build
+ *   cd ../examples/typescript
+ *   npm install
+ *   npx tsx 08_validate.ts
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  encode,
+  init,
+  validate,
+  validateFile,
+  type DataObjectDescriptor,
+} from '@ecmwf/tensogram';
+
+function describe(shape: number[], dtype: DataObjectDescriptor['dtype']): DataObjectDescriptor {
+  const strides = new Array<number>(shape.length).fill(1);
+  for (let i = shape.length - 2; i >= 0; i--) strides[i] = strides[i + 1] * shape[i + 1];
+  return {
+    type: 'ntensor',
+    ndim: shape.length,
+    shape,
+    strides,
+    dtype,
+    byte_order: 'little',
+    encoding: 'none',
+    filter: 'none',
+    compression: 'none',
+  };
+}
+
+async function main(): Promise<void> {
+  await init();
+
+  // 1. Valid buffer — expect zero error-severity issues and hash_verified=true.
+  const good = encode({ version: 2 }, [
+    { descriptor: describe([4], 'float32'), data: new Float32Array([1, 2, 3, 4]) },
+  ]);
+  const goodReport = validate(good);
+  console.log('valid buffer:');
+  console.log(`  object_count=${goodReport.object_count}  hash_verified=${goodReport.hash_verified}`);
+  console.log(`  issues=${goodReport.issues.length}`);
+
+  // 2. Truncated buffer — validate reports issues, does not throw.
+  const truncated = good.subarray(0, Math.floor(good.byteLength / 2));
+  const badReport = validate(truncated);
+  console.log('\ntruncated buffer:');
+  for (const issue of badReport.issues.slice(0, 3)) {
+    console.log(
+      `  [${issue.severity}] ${issue.code} (${issue.level}): ${issue.description}`,
+    );
+  }
+
+  // 3. File-level validation with validateFile (Node only).
+  const tmp = mkdtempSync(join(tmpdir(), 'tensogram-ts-example-'));
+  try {
+    const path = join(tmp, 'multi.tgm');
+    // Concatenate two valid messages into a single file.
+    const m1 = encode({ version: 2 }, [
+      { descriptor: describe([2], 'float32'), data: new Float32Array([10, 20]) },
+    ]);
+    const m2 = encode({ version: 2 }, [
+      { descriptor: describe([3], 'float64'), data: new Float64Array([0.1, 0.2, 0.3]) },
+    ]);
+    const combined = new Uint8Array(m1.byteLength + m2.byteLength);
+    combined.set(m1, 0);
+    combined.set(m2, m1.byteLength);
+    writeFileSync(path, combined);
+
+    const fileReport = await validateFile(path);
+    console.log('\nvalidateFile:');
+    console.log(`  messages=${fileReport.messages.length}  file_issues=${fileReport.file_issues.length}`);
+    fileReport.messages.forEach((m, i) => {
+      console.log(`  message[${i}]  objects=${m.object_count}  hash_verified=${m.hash_verified}`);
+    });
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/typescript/11_encode_pre_encoded.ts
+++ b/examples/typescript/11_encode_pre_encoded.ts
@@ -1,0 +1,86 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+/**
+ * Example 11 — Pre-encoded payloads (TypeScript)
+ *
+ * Some callers already have encoded bytes (another Tensogram
+ * implementation, a GPU pipeline, a cached tile store).
+ * `encodePreEncoded` stamps those bytes directly into a wire-format
+ * message — no second encoding pipeline pass — while still recomputing
+ * the integrity hash over the supplied bytes.
+ *
+ * Run:
+ *   cd typescript && npm run build
+ *   cd ../examples/typescript
+ *   npm install
+ *   npx tsx 11_encode_pre_encoded.ts
+ */
+
+import {
+  computeHash,
+  decode,
+  encodePreEncoded,
+  init,
+  type DataObjectDescriptor,
+} from '@ecmwf/tensogram';
+
+function describe(shape: number[], dtype: DataObjectDescriptor['dtype']): DataObjectDescriptor {
+  const strides = new Array<number>(shape.length).fill(1);
+  for (let i = shape.length - 2; i >= 0; i--) strides[i] = strides[i + 1] * shape[i + 1];
+  return {
+    type: 'ntensor',
+    ndim: shape.length,
+    shape,
+    strides,
+    dtype,
+    byte_order: 'little',
+    encoding: 'none',
+    filter: 'none',
+    compression: 'none',
+  };
+}
+
+async function main(): Promise<void> {
+  await init();
+
+  // Raw bytes that represent a 4×4 float32 image.  For this demo we
+  // use `encoding: 'none'`, so "pre-encoded" is just the native bytes.
+  // In a real pipeline the bytes might be szip-compressed with
+  // `szip_block_offsets` already computed.
+  const img = new Float32Array(16);
+  for (let i = 0; i < 16; i++) img[i] = i * 1.5;
+  const bytes = new Uint8Array(img.buffer, img.byteOffset, img.byteLength);
+
+  // Stamp into a message.  encodePreEncoded does not re-encode the
+  // bytes; it only validates the descriptor and wraps the bytes in a
+  // data-object frame.
+  const msg = encodePreEncoded(
+    { version: 2, base: [{ mars: { param: 'tile' } }] },
+    [{ descriptor: describe([4, 4], 'float32'), data: bytes }],
+  );
+  console.log(`pre-encoded message: ${msg.byteLength} bytes`);
+
+  // Verify the hash stamped on the descriptor equals computeHash(bytes).
+  const decoded = decode(msg);
+  try {
+    const hash = decoded.objects[0].descriptor.hash;
+    console.log(`descriptor hash: ${hash?.type} ${hash?.value}`);
+    const expected = computeHash(bytes);
+    console.log(`computeHash(bytes) matches: ${hash?.value === expected}`);
+
+    // Decoded payload equals the original bytes (encoding=none).
+    const out = decoded.objects[0].data() as Float32Array;
+    const matches = out.length === img.length && out.every((v, i) => v === img[i]);
+    console.log(`decode round-trip: ${matches ? 'OK' : 'MISMATCH'}`);
+  } finally {
+    decoded.close();
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/typescript/12_streaming_encoder.ts
+++ b/examples/typescript/12_streaming_encoder.ts
@@ -1,0 +1,87 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+/**
+ * Example 12 — Frame-at-a-time StreamingEncoder (TypeScript)
+ *
+ * `StreamingEncoder` builds a message frame by frame so callers can
+ * emit data as it becomes available.  The output is identical in
+ * *semantic* content to `encode(meta, objects)`, but wire-byte layout
+ * differs — streaming puts the index and hash frames in the footer,
+ * buffered encode puts them in the header.
+ *
+ * Run:
+ *   cd typescript && npm run build
+ *   cd ../examples/typescript
+ *   npm install
+ *   npx tsx 12_streaming_encoder.ts
+ */
+
+import {
+  decode,
+  init,
+  StreamingEncoder,
+  type DataObjectDescriptor,
+} from '@ecmwf/tensogram';
+
+function describe(shape: number[], dtype: DataObjectDescriptor['dtype']): DataObjectDescriptor {
+  const strides = new Array<number>(shape.length).fill(1);
+  for (let i = shape.length - 2; i >= 0; i--) strides[i] = strides[i + 1] * shape[i + 1];
+  return {
+    type: 'ntensor',
+    ndim: shape.length,
+    shape,
+    strides,
+    dtype,
+    byte_order: 'little',
+    encoding: 'none',
+    filter: 'none',
+    compression: 'none',
+  };
+}
+
+async function main(): Promise<void> {
+  await init();
+
+  const enc = new StreamingEncoder({ version: 2 });
+  try {
+    // Attach per-object MARS metadata via write_preceder ahead of each
+    // data object — handy when application metadata is only known at
+    // emission time.
+    enc.writePreceder({ mars: { param: '2t', step: 0 }, units: 'K' });
+    enc.writeObject(describe([3], 'float32'), new Float32Array([273.15, 274.0, 275.0]));
+
+    enc.writePreceder({ mars: { param: '10u', step: 0 }, units: 'm/s' });
+    enc.writeObject(describe([3], 'float32'), new Float32Array([-1.5, 0.0, 2.5]));
+
+    enc.writePreceder({ mars: { param: 'msl', step: 0 }, units: 'Pa' });
+    enc.writeObject(describe([3], 'float64'), new Float64Array([101325, 101200, 100950]));
+
+    console.log(
+      `streamed: ${enc.objectCount} objects, ${enc.bytesWritten} bytes before finish()`,
+    );
+    const bytes = enc.finish();
+    console.log(`finished: ${bytes.byteLength} bytes total`);
+
+    const msg = decode(bytes);
+    try {
+      console.log(`decoded: ${msg.objects.length} objects`);
+      msg.objects.forEach((obj, i) => {
+        const base = msg.metadata.base?.[i];
+        const mars = base?.['mars'] as Record<string, unknown> | undefined;
+        console.log(`  [${i}] shape=${JSON.stringify(obj.descriptor.shape)}  param=${mars?.['param']}`);
+      });
+    } finally {
+      msg.close();
+    }
+  } finally {
+    enc.close();
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/typescript/13_range_access.ts
+++ b/examples/typescript/13_range_access.ts
@@ -1,0 +1,153 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+/**
+ * Example 13 — Lazy `TensogramFile.fromUrl` over HTTP Range (TypeScript)
+ *
+ * When the server advertises `Accept-Ranges: bytes` and a finite
+ * `Content-Length` on `HEAD`, `TensogramFile.fromUrl` uses Range
+ * requests: message payloads are fetched on demand, not during open.
+ * The example uses a mock `fetch` so it runs anywhere — swap it for
+ * `globalThis.fetch` to drive a real server.
+ *
+ * Run:
+ *   cd typescript && npm run build
+ *   cd ../examples/typescript
+ *   npm install
+ *   npx tsx 13_range_access.ts
+ */
+
+import {
+  encode,
+  init,
+  TensogramFile,
+  type DataObjectDescriptor,
+} from '@ecmwf/tensogram';
+
+function describe(shape: number[], dtype: DataObjectDescriptor['dtype']): DataObjectDescriptor {
+  const strides = new Array<number>(shape.length).fill(1);
+  for (let i = shape.length - 2; i >= 0; i--) strides[i] = strides[i + 1] * shape[i + 1];
+  return {
+    type: 'ntensor',
+    ndim: shape.length,
+    shape,
+    strides,
+    dtype,
+    byte_order: 'little',
+    encoding: 'none',
+    filter: 'none',
+    compression: 'none',
+  };
+}
+
+function concatBytes(...bs: Uint8Array[]): Uint8Array {
+  let total = 0;
+  for (const b of bs) total += b.byteLength;
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const b of bs) {
+    out.set(b, off);
+    off += b.byteLength;
+  }
+  return out;
+}
+
+function makeRangeServer(body: Uint8Array): {
+  fetch: typeof globalThis.fetch;
+  requestCount: { value: number };
+} {
+  const requestCount = { value: 0 };
+  const fetchFn: typeof globalThis.fetch = async (_url, init?: RequestInit) => {
+    requestCount.value++;
+    const method = init?.method ?? 'GET';
+
+    if (method === 'HEAD') {
+      return new Response(null, {
+        status: 200,
+        headers: {
+          'accept-ranges': 'bytes',
+          'content-length': String(body.byteLength),
+        },
+      });
+    }
+
+    const rangeHeader =
+      init?.headers instanceof Headers
+        ? init.headers.get('range')
+        : (init?.headers as Record<string, string> | undefined)?.['Range'];
+    if (rangeHeader) {
+      const match = /^bytes=(\d+)-(\d+)$/.exec(rangeHeader);
+      if (!match) return new Response('bad range', { status: 416 });
+      const start = parseInt(match[1], 10);
+      const end = parseInt(match[2], 10);
+      const sliceLen = end - start + 1;
+      const copy = new ArrayBuffer(sliceLen);
+      new Uint8Array(copy).set(body.subarray(start, end + 1));
+      return new Response(copy, {
+        status: 206,
+        headers: {
+          'content-range': `bytes ${start}-${end}/${body.byteLength}`,
+          'content-length': String(sliceLen),
+        },
+      });
+    }
+    // Full body fallback (not reached when the client uses Range).
+    const copy = new ArrayBuffer(body.byteLength);
+    new Uint8Array(copy).set(body);
+    return new Response(copy, { status: 200 });
+  };
+  return { fetch: fetchFn, requestCount };
+}
+
+async function main(): Promise<void> {
+  await init();
+
+  // Build a "server body" of three messages concatenated.
+  const messages = [
+    encode({ version: 2 }, [{ descriptor: describe([3], 'float32'), data: new Float32Array([1, 2, 3]) }]),
+    encode({ version: 2 }, [{ descriptor: describe([2], 'float64'), data: new Float64Array([10, 20]) }]),
+    encode({ version: 2 }, [{ descriptor: describe([1], 'int32'), data: new Int32Array([42]) }]),
+  ];
+  const body = concatBytes(...messages);
+  console.log(`server body: ${body.byteLength} bytes across ${messages.length} messages`);
+
+  const { fetch: fakeFetch, requestCount } = makeRangeServer(body);
+
+  // Open the file — a HEAD probe + Range reads per message preamble
+  // during the lazy scan, no payload downloads yet.
+  const file = await TensogramFile.fromUrl('https://example.invalid/demo.tgm', {
+    fetch: fakeFetch,
+  });
+  try {
+    console.log(`after open: ${requestCount.value} requests (1 HEAD + ${messages.length} preamble reads)`);
+    console.log(`messageCount=${file.messageCount}  byteLength=${file.byteLength}`);
+
+    // Fetch just the middle message — one more Range request.
+    const before = requestCount.value;
+    const m1 = await file.message(1);
+    try {
+      console.log(
+        `fetched message 1 in ${requestCount.value - before} more request(s); ` +
+          `values=${Array.from(m1.objects[0].data() as Float64Array)}`,
+      );
+    } finally {
+      m1.close();
+    }
+
+    // Fetching the same message again hits the LRU cache — zero new
+    // network calls.
+    const cachedBefore = requestCount.value;
+    const m1Cached = await file.message(1);
+    m1Cached.close();
+    console.log(`cached message 1 in ${requestCount.value - cachedBefore} more request(s)`);
+  } finally {
+    file.close();
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/typescript/14_streaming_callback.ts
+++ b/examples/typescript/14_streaming_callback.ts
@@ -1,0 +1,111 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+/**
+ * Example 14 — StreamingEncoder with callback-per-frame sink
+ *
+ * `StreamingEncoder` accepts an optional `onBytes` callback.  When
+ * present, each chunk of wire-format bytes the encoder produces is
+ * forwarded to the callback as it is produced — no internal buffering.
+ * Useful for browser uploads to `fetch(..., { body: stream })`,
+ * WebSocket pushes, or any streaming sink that needs bytes
+ * incrementally.
+ *
+ * The `finish()` call in streaming mode returns an empty `Uint8Array`
+ * (zero-length marker) — every byte has already been delivered to the
+ * callback.
+ *
+ * Run:
+ *   cd typescript && npm run build
+ *   cd ../examples/typescript
+ *   npm install
+ *   npx tsx 14_streaming_callback.ts
+ */
+
+import {
+  decode,
+  init,
+  StreamingEncoder,
+  type DataObjectDescriptor,
+} from '@ecmwf/tensogram';
+
+function describe(shape: number[], dtype: DataObjectDescriptor['dtype']): DataObjectDescriptor {
+  const strides = new Array<number>(shape.length).fill(1);
+  for (let i = shape.length - 2; i >= 0; i--) strides[i] = strides[i + 1] * shape[i + 1];
+  return {
+    type: 'ntensor',
+    ndim: shape.length,
+    shape,
+    strides,
+    dtype,
+    byte_order: 'little',
+    encoding: 'none',
+    filter: 'none',
+    compression: 'none',
+  };
+}
+
+async function main(): Promise<void> {
+  await init();
+
+  // ── Collect every chunk the encoder emits ────────────────────────────
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  const enc = new StreamingEncoder(
+    { version: 2 },
+    {
+      onBytes: (chunk) => {
+        // IMPORTANT: copy the chunk if you need it to survive past the
+        // next writeObject.  The underlying ArrayBuffer is invalidated
+        // when WASM memory grows.
+        chunks.push(new Uint8Array(chunk));
+        totalBytes += chunk.byteLength;
+        console.log(`  chunk #${chunks.length}: ${chunk.byteLength} bytes`);
+      },
+    },
+  );
+
+  console.log('── Streaming mode ──');
+  console.log(`after construction: ${chunks.length} chunk(s), ${totalBytes} bytes`);
+  console.log(`(preamble + header metadata frame have already been delivered)`);
+  console.log(`streaming flag: ${enc.streaming}`);
+
+  // Each writeObject flushes a data-object frame through the callback.
+  enc.writeObject(describe([3], 'float32'), new Float32Array([1, 2, 3]));
+  enc.writeObject(describe([3], 'float64'), new Float64Array([10, 20, 30]));
+
+  // finish() flushes footer frames + postamble through the callback.
+  const returned = enc.finish();
+  enc.close();
+
+  console.log(`\nfinish() returned: ${returned.byteLength} bytes (empty in streaming mode)`);
+  console.log(`total chunks collected: ${chunks.length}`);
+  console.log(`total bytes delivered: ${totalBytes}`);
+
+  // Reassemble the stream and decode to prove semantic equivalence.
+  const bytes = new Uint8Array(totalBytes);
+  let off = 0;
+  for (const c of chunks) {
+    bytes.set(c, off);
+    off += c.byteLength;
+  }
+  const msg = decode(bytes);
+  try {
+    console.log(`\nreassembled message → ${msg.objects.length} object(s)`);
+    msg.objects.forEach((obj, i) => {
+      console.log(
+        `  object[${i}]: dtype=${obj.descriptor.dtype}, shape=${JSON.stringify(obj.descriptor.shape)}`,
+      );
+    });
+  } finally {
+    msg.close();
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -44,11 +44,17 @@ npx tsx 01_encode_decode.ts
 | [`01_encode_decode.ts`](01_encode_decode.ts) | Basic round-trip encode / decode of a 2-D `Float32Array` |
 | [`02_mars_metadata.ts`](02_mars_metadata.ts) | Attach MARS keys via `base[i]` and use `getMetaKey` to read them |
 | [`03_multi_object.ts`](03_multi_object.ts) | Multiple objects with different dtypes in one message |
-| [`05_streaming_fetch.ts`](05_streaming_fetch.ts) | Progressive decode over a `ReadableStream` (Phase 3) |
-| [`06_file_api.ts`](06_file_api.ts) | `TensogramFile` over Node fs, fetch, and in-memory bytes (Phase 4) |
+| [`04_decode_range.ts`](04_decode_range.ts) | Partial sub-tensor decode in split and join modes |
+| [`05_streaming_fetch.ts`](05_streaming_fetch.ts) | Progressive decode over a `ReadableStream` |
+| [`06_file_api.ts`](06_file_api.ts) | `TensogramFile` over Node fs, fetch, and in-memory bytes |
 | [`07_hash_and_errors.ts`](07_hash_and_errors.ts) | Hash verification and the typed error hierarchy |
+| [`08_validate.ts`](08_validate.ts) | `validate(buf)` and `validateFile(path)` — structural + integrity |
+| [`11_encode_pre_encoded.ts`](11_encode_pre_encoded.ts) | Wrap already-encoded bytes without re-running the pipeline |
+| [`12_streaming_encoder.ts`](12_streaming_encoder.ts) | Frame-at-a-time `StreamingEncoder` with per-object preceders |
+| [`13_range_access.ts`](13_range_access.ts) | Lazy `TensogramFile.fromUrl` over HTTP Range requests |
+| [`14_streaming_callback.ts`](14_streaming_callback.ts) | `StreamingEncoder` with `onBytes` callback — no full-message buffering |
 
-Numbers 04 and 08+ are reserved to stay in step with the
-`examples/python/` naming. See `plans/TYPESCRIPT_WRAPPER.md` for the
-roadmap of follow-up examples (remote Range access, validate, xarray/Zarr
-cross-runtime demos, etc.).
+Numbers 09 / 10 / 15+ are reserved to stay in step with the
+`examples/python/` numbering.  See `plans/TYPESCRIPT_WRAPPER.md` for
+follow-up examples (xarray/Zarr cross-runtime demos, first-class
+half-precision, etc.).

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -18,7 +18,7 @@
     },
     "../../typescript": {
       "name": "@ecmwf/tensogram",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/plans/DONE.md
+++ b/plans/DONE.md
@@ -291,6 +291,115 @@ Design doc: `plans/TYPESCRIPT_WRAPPER.md`. User guide:
   `06_file_api`, `07_hash_and_errors`). The package references the
   local `typescript/` package via a `file:` dependency.
 
+## TypeScript wrapper — Scope C.1 (API-surface parity)
+
+Closes the parity gap with Rust / Python / FFI / C++ for every
+concept on the cross-language matrix in
+`plans/TYPESCRIPT_WRAPPER.md`.  Changes are additive on the WASM
+side; the only breaking change on the TS side is that
+`TensogramFile#rawMessage` is now async (needed for the lazy HTTP
+backend).
+
+| Component | What changed |
+|-----------|-------------|
+| `tensogram-wasm/src/encoder.rs` | New `StreamingEncoder` class backed by a `Vec<u8>` sink, with `write_object`, `write_object_pre_encoded`, `write_preceder`, `object_count`, `bytes_written`, `finish`.  Hand-off from Rust core `StreamingEncoder<Vec<u8>>`. |
+| `tensogram-wasm/src/extras.rs` | New module with `decode_range`, `encode_pre_encoded`, `compute_hash`, `simple_packing_compute_params`, `validate_buffer` exports.  `decode_range` accepts `BigUint64Array` pairs on the boundary; `validate_buffer` returns a JSON string so large integers are lossless. |
+| `tensogram-wasm/src/convert.rs` | `typed_array_or_u8_to_bytes` covers every `ArrayBufferView` + `DataView` + `Uint8Array`, used by every new write path.  Old `typed_array_to_bytes` removed from `lib.rs`. |
+| `tensogram-wasm/Cargo.toml` | Adds `tensogram-encodings` (for `simple_packing::compute_params`) and `serde_json` (for the JSON-returning validate export). |
+| `rust/tensogram-wasm/tests/wasm_tests.rs` | 22 new `wasm_bindgen_test`s covering every new export and the StreamingEncoder lifecycle. |
+| `typescript/src/range.ts` | `decodeRange(buf, objIndex, ranges, opts?)`.  Packs `number`/`bigint` pairs into `BigUint64Array`, returns dtype-typed `parts` views.  `join: true` concatenates at the byte level before dtype wrap. |
+| `typescript/src/hash.ts` | `computeHash(bytes, algo?)` returning the hex digest string.  Unknown algorithm → `MetadataError`. |
+| `typescript/src/simplePacking.ts` | `simplePackingComputeParams(values, bits, decScale?)` returning snake-cased params that spread directly into a descriptor. |
+| `typescript/src/validate.ts` | `validate(buf, opts?)` — single message.  `validateBuffer(buf, opts?)` — multi-message with gap detection.  `validateFile(path, opts?)` — Node-only convenience (reads file via `node:fs/promises`, then delegates to `validateBuffer`).  All three parse the JSON the WASM side returns. |
+| `typescript/src/encodePreEncoded.ts` | `encodePreEncoded(meta, objects, opts?)`.  Validates descriptor shape before the WASM call, forwards the pre-encoded bytes verbatim. |
+| `typescript/src/streamingEncoder.ts` | `StreamingEncoder` class (single-use) with `writeObject`, `writePreceder`, `writeObjectPreEncoded`, `finish`, `close`, `objectCount`, `bytesWritten`.  `FinalizationRegistry` cleanup fallback for missed `close()`. |
+| `typescript/src/file.ts` | Rewritten backend model: `InMemoryBackend` (fromBytes), `LocalFileBackend` (open, with path stored for append), `LazyHttpBackend` (fromUrl, HTTP Range).  `rawMessage` is now async — was sync in Scope B.  `append(meta, objects, opts?)` appends to the on-disk file, refreshes the mirror + position index from disk, only permitted on `LocalFileBackend`.  `fromUrl` does a `HEAD` probe; when Accept-Ranges + Content-Length are advertised it uses Range reads per preamble during scan and on-demand Range fetches per message afterwards (with a 32-entry LRU).  Streaming-mode messages (`total_length == 0`) and non-Range servers transparently fall back to eager GET. |
+| `typescript/src/index.ts` | Re-exports the new functions, classes, and types. |
+| `typescript/tests/` | Per-module test files: `range.test.ts`, `hash.test.ts`, `simplePacking.test.ts`, `validate.test.ts`, `encodePreEncoded.test.ts`, `streamingEncoder.test.ts`, `append.test.ts`, `lazyFromUrl.test.ts`.  Golden-file parity: the validate suite decodes every golden `.tgm` fixture. |
+| `examples/typescript/` | `04_decode_range.ts`, `08_validate.ts`, `11_encode_pre_encoded.ts`, `12_streaming_encoder.ts`, `13_range_access.ts`.  `06_file_api.ts` updated for the async `rawMessage` signature. |
+| `docs/src/guide/typescript-api.md` | New sections on pre-encoded bytes, validate, streaming encoder, append, lazy Range access, and the Scope-C API additions table.  Cross-language parity matrix refreshed. |
+| `plans/TYPESCRIPT_WRAPPER.md` | Parity matrix now shows every Scope-C.1 entry as ✓; Scope-C.3 / C.4 items moved into the follow-ups section. |
+
+## TypeScript wrapper — Scope C.2 (half-precision + complex dtypes)
+
+Upgrades `typedArrayFor(dtype)` so `float16`, `bfloat16`, `complex64`,
+`complex128` return first-class view classes — callers no longer
+need to know the raw bit layout or interleaving.
+
+| Component | What changed |
+|-----------|-------------|
+| `typescript/src/float16.ts` | `Float16Polyfill` with the observable behaviour of the TC39 Stage-3 `Float16Array` proposal: round-ties-to-even narrow, NaN / ±Inf / ±0 / subnormal preservation.  Storage is a `Uint16Array` of bits (WeakMap-backed private slot so `wrapBits` can build zero-copy instances).  `hasNativeFloat16Array()` / `getFloat16ArrayCtor()` let callers control native-vs-polyfill.  `float16FromBytes(bytes)` zero-copies on aligned input, falls back to an aligned copy for odd-offset buffers. |
+| `typescript/src/bfloat16.ts` | `Bfloat16Array` — 1-8-7 layout matching ML frameworks.  Widen is "shift left by 16 into float32"; narrow uses round-to-nearest-even on the 16 dropped bits.  Mirror of the Float16Polyfill API. |
+| `typescript/src/complex.ts` | `ComplexArray(dtype, storage)` view over an interleaved `Float32Array` (complex64) or `Float64Array` (complex128).  `.real(i)`, `.imag(i)`, `.get(i) → {re, im}`, `.set(i, re, im)`, iteration, `.toArray()`.  `complexFromBytes(dtype, bytes)` zero-copies on aligned input. |
+| `typescript/src/dtype.ts` | Routing updated — `float16` → native `Float16Array` when present, polyfill otherwise; `bfloat16` → `Bfloat16Array`; `complex64` / `complex128` → `ComplexArray`. |
+| `typescript/src/types.ts` | `TypedArray` union extended with structural aliases for the three view classes.  Structural aliases avoid a circular import. |
+| `typescript/tests/float16.test.ts` | Bit-conversion invariants (±0, ±Inf, NaN, subnormals, range-saturation, round-to-nearest-even), array API (constructor shapes, `.bits`, `.set`, `.fill`, `.slice`, `.subarray`, `.toFloat32Array`, iteration), native-vs-polyfill detection, `encode → decode` bit-exact round-trip for the dtype, `fast-check` property: `f32 → f16 → f32` within half-precision ulp. |
+| `typescript/tests/bfloat16.test.ts` | Same shape as float16, adapted for bfloat16 layout + ulp. |
+| `typescript/tests/complex.test.ts` | `.real` / `.imag` / `.get` / `.set` / iteration / `.toArray()`; round-trip through `encode → decode` for complex64 and complex128; property-based invariant that interleaved storage round-trips byte-exactly. |
+| `typescript/tests/dtype.test.ts` | Updated assertions — `typedArrayFor('float16')` now returns `Float16Polyfill` or native; `bfloat16` returns `Bfloat16Array`; `complex*` returns `ComplexArray`. |
+| `typescript/src/index.ts` | Exports the new classes + factories + detection helpers. |
+| `docs/src/guide/typescript-api.md` | "First-class half-precision and complex dtypes" section documents the new view types and the Scope-B → C.2 migration note. |
+
+### What did NOT change
+
+- Wire format — every `.tgm` byte is identical to pre-change output
+  across every Scope-C addition.
+- Existing golden `.tgm` fixtures in `rust/tensogram/tests/golden/`
+  continue to validate and decode unchanged across Rust, Python, C++,
+  and TypeScript.
+- Scope-B TS tests (145 of them) still pass — the only breakage was
+  the intentional `rawMessage` async change, which was mechanical.
+
+## TypeScript wrapper — streaming `StreamingEncoder` (Pass 6)
+
+Closes the "callback-per-frame" gap flagged in Pass 4's focus list.
+Consumers that need true no-buffering streaming (browser upload,
+WebSocket push, any sink that needs bytes as soon as they're
+produced) now pass an `onBytes` callback at construction time.
+
+| Component | What changed |
+|-----------|-------------|
+| `rust/tensogram-wasm/src/encoder.rs` | New `JsCallbackWriter` struct that implements `std::io::Write` by calling into a held `js_sys::Function`; errors thrown by the JS callback surface as `std::io::Error::other(...)` which the core wraps into `TensogramError::Io`.  New `Inner` enum with `Buffered(StreamingEncoder<Vec<u8>>)` / `Streaming(StreamingEncoder<JsCallbackWriter>)` variants; the exported class dispatches every method through the enum.  Constructor gained a third optional argument `on_bytes: Option<js_sys::Function>`. |
+| `typescript/src/types.ts` | `StreamingEncoderOptions.onBytes` field added with full docstring covering the synchronous-only contract, chunk-ownership rules (copy before next write), and error-propagation semantics. |
+| `typescript/src/streamingEncoder.ts` | Constructor validates that `opts.onBytes` (if supplied) is callable, forwards it to the WASM layer, and records the mode in a `#streaming` private field.  New `streaming: boolean` getter for consumers that need to branch on mode.  `finish()` docstring updated to explain the empty-`Uint8Array` return in streaming mode. |
+| `typescript/tests/streamingEncoder.test.ts` | 9 new tests: construction-time byte delivery (preamble magic check), empty `finish()` return in streaming mode, decoded-bytes parity between buffered and streaming outputs, `bytesWritten` tracking, multi-object delivery, callback-throw propagation, non-function rejection, `streaming` getter, `hash: false` compatibility. |
+| `rust/tensogram-wasm/tests/wasm_tests.rs` | 5 new `wasm_bindgen_test`s: round-trip, construction-time delivery + magic check, bytes-written tracking, callback-throw propagation, non-function rejection.  All existing tests updated to pass `None` for the new constructor arg. |
+| `examples/typescript/14_streaming_callback.ts` | Runnable example: collects chunks into a JS array, reassembles via concatenation, decodes to prove semantic equivalence with the buffered path. |
+| `docs/src/guide/typescript-api.md` | New "Streaming `StreamingEncoder` (no full-message buffering)" section covering the full contract (synchronous, chunk ownership, error propagation, mode detection). |
+| `plans/TYPESCRIPT_WRAPPER.md` | Follow-up list notes that Python / FFI / C++ remain buffered-only and documents the extension pattern for future parity. |
+| `CHANGELOG.md` | New entry under "Added — TypeScript wrapper: streaming `StreamingEncoder`". |
+
+## `simple_packing` — Infinity rejection in the Rust core
+
+The TypeScript wrapper's `simplePackingComputeParams` Pass-3 guard
+against ±Infinity was a band-aid over a real core-level gap:
+`tensogram_encodings::simple_packing::compute_params` and `encode`
+silently produced `binary_scale_factor = i32::MAX` (garbage) when fed
+infinite samples.  Pass 5 pushed the guard upstream so every binding
+benefits uniformly.
+
+| Component | What changed |
+|-----------|-------------|
+| `rust/tensogram-encodings/src/simple_packing.rs` | New `PackingError::InfiniteValue(usize)` variant reports the first infinite sample's index (matching the NaN contract).  A new shared `validate_sample(v, i) -> Result<(), PackingError>` helper lives next to `scan_min_max`; both the min/max scan and the encode loops (sequential, parallel-aligned, parallel-generic, sequential-tail) now use it as the single source of truth for the "is this value encodable?" predicate. |
+| `rust/tensogram-encodings/src/simple_packing.rs` tests | New `test_positive_infinity_rejected_in_compute_params`, `test_negative_infinity_rejected_in_compute_params`, `test_infinity_rejected_in_encode` — cover both f64 infinity polarities through both the compute and encode paths. |
+| `python/tests/test_tensogram.py::TestPackingParamsCoverage` | `test_inf_accepted_but_nonsensical` (which documented the old buggy behaviour) replaced by `test_positive_infinity_rejected` + `test_negative_infinity_rejected` — mirrors the Rust core tests and pins the cross-language contract. |
+| TS wrapper | Existing Pass-3 guard in `typescript/src/simplePacking.ts` retained as defence-in-depth — callers still see a clean `InvalidArgumentError` without a WASM round-trip, and the check now acts as a belt-and-braces backup over the core guarantee. |
+| CHANGELOG | Entry under "Changed — Rust core (affects all language bindings)". |
+
+## Python bindings — `compute_hash` parity
+
+Adds `tensogram.compute_hash(data, algo="xxh3")` to close the
+cross-language parity gap — Rust, WASM, FFI, C++, and TypeScript all
+exposed equivalent functionality; Python was the only binding without
+it.
+
+| Component | What changed |
+|-----------|-------------|
+| `python/bindings/src/lib.rs` | New `py_compute_hash` function wrapping `tensogram_lib::compute_hash`.  Accepts `PyBackedBytes` (zero-copy over `bytes` / `bytearray`); unknown algorithm names route through the existing `to_py_err` for a clean `ValueError`. |
+| `python/tests/test_compute_hash.py` | 18 tests covering shape (16-char lowercase hex), determinism, known vector (xxh3 of `b"hello world"`), empty buffer (known constant `2d06800538d394c2`), `bytes` / `bytearray` acceptance, explicit rejection of `memoryview` / `numpy.ndarray` with a documented conversion path, unknown-algo `ValueError`, and byte-level parity with the hash stamped by `encode` on a no-pipeline object.  The parity test pins Python's `compute_hash` to the same byte-level contract as the Rust core, WASM, FFI, and TypeScript implementations — any drift fails the test simultaneously. |
+| `CHANGELOG.md` | New entry under Python bindings. |
+| `plans/TYPESCRIPT_WRAPPER.md` | Parity matrix now shows ✓ for Python's `compute_hash`. |
+
 ## `tensogram-benchmarks`
 
 Separate workspace crate providing a codec-matrix benchmark and a

--- a/plans/TODO.md
+++ b/plans/TODO.md
@@ -44,47 +44,42 @@ For speculative ideas, see `IDEAS.md`.
     `TensogramFile.open/fromUrl/fromBytes`, 87 tests, 6 examples, CI job,
     mdBook page, Makefile targets.
 
-  - [ ] **typescript-wrapper (Scope C.1) — API-surface parity**
-    Close the gap between the TS wrapper and the Rust / Python / FFI / C++
-    surfaces listed in `plans/TYPESCRIPT_WRAPPER.md` → "Cross-language
-    parity matrix". Landing these as a single work stream keeps the
-    `@internal` conventions, typed-error routing, and doc-comment
-    patterns consistent; they share infrastructure (new WASM exports,
-    TS → WASM boundary typing, test harness, example scripts).
-    - `decodeRange(buf, objIndex, ranges, opts?)` — mirrors Rust
-      `decode_range` / Python `file_decode_range` / `tgm_decode_range`.
-      WASM already exposes the primitive.
-    - `computeHash(bytes, algo?)` — mirrors `tgm_compute_hash`. WASM
-      already exposes the primitive.
-    - `encodePreEncoded(metadata, objects, opts?)` — mirrors Rust
-      `encode_pre_encoded` / `tgm_encode_pre_encoded`.
-    - `simplePackingComputeParams(values, bitsPerValue, decimalScaleFactor)`
-      — mirrors `tgm_simple_packing_compute_params`.
-    - `validate(buf, opts?)` / `validateFile(path, opts?)` — requires
-      first extending `tensogram-wasm` to export `validate_buffer` /
-      `validate_file` before wrapping on the TS side.
-    - `TensogramFile#append(metadata, objects, opts?)` — mirrors Rust
-      `TensogramFile::append`. Requires file-append exposure through
-      `tensogram-wasm`.
-    - `StreamingEncoder` class — wraps Rust `StreamingEncoder`,
-      Python `AsyncStreamingEncoder`, and `tgm_streaming_encoder_*`.
-      Requires WASM-side `StreamingEncoder` parallel to the existing
-      `StreamingDecoder`.
-    - Range-based lazy backend for `TensogramFile.fromUrl` (currently
-      downloads the whole file; add HTTP `Range` + streaming reader).
+  - [x] ~~**typescript-wrapper (Scope C.1) — API-surface parity**~~
+    Closed the gap between the TS wrapper and the other language
+    surfaces.  New WASM exports (`decode_range`, `compute_hash`,
+    `simple_packing_compute_params`, `encode_pre_encoded`,
+    `validate_buffer`, `StreamingEncoder`) in `rust/tensogram-wasm`
+    backed by new TS wrappers (`decodeRange`, `computeHash`,
+    `simplePackingComputeParams`, `encodePreEncoded`, `validate` /
+    `validateBuffer` / `validateFile`, `StreamingEncoder`).
+    `TensogramFile#append(meta, objects, opts?)` gained for files
+    opened via `TensogramFile.open(path)` (Node local paths only —
+    matches the Rust / Python / FFI / C++ contract).
+    `TensogramFile.fromUrl` now auto-detects HTTP Range support via a
+    `HEAD` probe and switches to a lazy backend that fetches messages
+    on demand; falls back transparently to the eager Scope-B download
+    when the server omits `Accept-Ranges` or returns a streaming-mode
+    message.  `TensogramFile#rawMessage` is now async (was sync) to
+    accommodate the lazy backend.  Five new examples
+    (`04_decode_range`, `08_validate`, `11_encode_pre_encoded`,
+    `12_streaming_encoder`, `13_range_access`), per-module test suites,
+    and the TS API guide / parity matrix updated.  See
+    `plans/DONE.md` → *TypeScript Scope C.1* for the full breakdown.
 
-  - [ ] **typescript-wrapper (Scope C.2) — first-class half-precision + complex dtypes**
-    JS has no native `Float16Array` (it's at Stage-3 in TC39 — arriving
-    but not widely supported). Today `float16` / `bfloat16` round-trip
-    as `Uint16Array`, and `complex64` / `complex128` as interleaved
-    `Float32Array` / `Float64Array`. This is functional but forces
-    consumers to know the encoding. Ship first-class support via a
-    small runtime helper: typed array views with `.real(i)` / `.imag(i)`
-    / `.toFloat32(i)` accessors, mirroring numpy.
-    - Probe `typeof Float16Array === 'function'` and prefer the native
-      implementation when present.
-    - Provide a polyfill class for runtimes that lack it.
-    - Round-trip tests across f16/bf16/c64/c128 with fast-check.
+  - [x] ~~**typescript-wrapper (Scope C.2) — first-class half-precision + complex dtypes**~~
+    `typedArrayFor(dtype)` now returns `Float16Array` (native) or
+    `Float16Polyfill` for `float16`, `Bfloat16Array` for `bfloat16`,
+    and `ComplexArray` for `complex64` / `complex128`.  The polyfill
+    matches the TC39 Stage-3 `Float16Array` observable behaviour
+    (round-ties-to-even narrow, NaN / ±Inf / subnormal / ±0
+    preservation).  `ComplexArray` exposes numpy-flavoured accessors
+    (`.real(i)`, `.imag(i)`, `.get(i)`, iteration).  Raw bits / raw
+    interleaved storage are still reachable through `.bits` / `.data`.
+    fast-check round-trip property tests cover every new dtype;
+    `encode → decode` keeps the bytes bit-exact.  Breaking vs Scope B:
+    `obj.data()` for these four dtypes no longer returns a raw
+    `Uint16Array` / interleaved `Float32Array` — consumers wanting the
+    raw shape use `.bits` / `.data` on the returned view.
 
   - [ ] **typescript-wrapper (Scope C.3) — distribution & CI maturity**
     Three intertwined tasks that all touch the build, pack, and publish

--- a/plans/TYPESCRIPT_WRAPPER.md
+++ b/plans/TYPESCRIPT_WRAPPER.md
@@ -360,8 +360,11 @@ on the cross-language parity matrix.
 
 ## Cross-language parity matrix
 
-Scope B brought TS to parity with the other language surfaces for the
-core read/write path. Remaining gaps, all tracked as Scope-C items:
+Scopes B + C.1 closed the read-path and write-path API gaps; C.2
+closed the half-precision / complex dtype ergonomics gap.  The
+remaining entries on the list — npm publishing, browser CI, bundle
+budgets, Zarr.js — are distribution and ecosystem tasks tracked under
+Scope C.3 / C.4 in `plans/TODO.md`.
 
 | Concept | Rust | Python | FFI | C++ | TypeScript |
 |---|---|---|---|---|---|
@@ -370,35 +373,77 @@ core read/write path. Remaining gaps, all tracked as Scope-C items:
 | `scan` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `streaming_decoder` | ✓ | ✓ | ✓ | ✓ | ✓ (`decodeStream`) |
 | File open / message / iter | ✓ | ✓ | ✓ | ✓ | ✓ (`TensogramFile`) |
-| Remote fetch | ✓ | ✓ | — | — | ✓ (`.fromUrl`) |
+| Remote fetch | ✓ | ✓ | — | — | ✓ (`.fromUrl` + HTTP Range backend) |
 | `metadata_get_key` | ✓ | ✓ | ✓ | ✓ | ✓ (`getMetaKey`) |
 | `compute_common` | ✓ | ✓ | — | — | ✓ |
-| **`decode_range`** | ✓ | ✓ | ✓ | ✓ | **—** |
-| **`streaming_encoder`** | ✓ | ✓ | ✓ | ✓ | **—** |
-| **`file_append`** | ✓ | ✓ | ✓ | ✓ | **—** |
-| **`validate_buffer` / `validate_file`** | ✓ | ✓ | ✓ | ✓ | **—** |
-| **`compute_hash`** | ✓ | ✓ | ✓ | ✓ | **—** |
-| **`encode_pre_encoded`** | ✓ | ✓ | ✓ | ✓ | **—** |
-| **`simple_packing_params`** | ✓ | ✓ | ✓ | ✓ | **—** |
+| `decode_range` | ✓ | ✓ | ✓ | ✓ | ✓ (`decodeRange`) |
+| `streaming_encoder` | ✓ | ✓ | ✓ | ✓ | ✓ (`StreamingEncoder`) |
+| `file_append` | ✓ | ✓ | ✓ | ✓ | ✓ (Node local-path only) |
+| `validate_buffer` / `validate_file` | ✓ | ✓ | ✓ | ✓ | ✓ (`validate` / `validateBuffer` / `validateFile`) |
+| `compute_hash` | ✓ | ✓ (`compute_hash`) | ✓ | ✓ | ✓ (`computeHash`) |
+| `encode_pre_encoded` | ✓ | ✓ | ✓ | ✓ | ✓ (`encodePreEncoded`) |
+| `simple_packing_params` | ✓ | ✓ (`compute_packing_params`) | ✓ | ✓ | ✓ (`simplePackingComputeParams`) |
+| First-class `float16` / `bfloat16` / `complex*` | ✓ | ✓ (numpy dtypes) | — (opaque bytes) | — (opaque bytes) | ✓ (Scope C.2 view classes) |
 
-The gaps above are all intentional: Scope B focused on read-path ergonomics;
-Scope C extends the wrapper to write-path tooling, validation, and utility
-helpers. See `plans/TODO.md` for the enumerated Scope-C task list.
+## Scope-C.1 wire details
 
-## Open items & follow-ups (post-Scope B)
+WASM-side additions live in `rust/tensogram-wasm`:
 
-- Publishing pipeline: choose npm org, set up `npm publish` from CI on
-  tagged releases, align version with `VERSION` file.
-- Scope-C API surface (see parity matrix above): `validate`,
-  `encodePreEncoded`, `decodeRange`, `StreamingEncoder`,
-  `TensogramFile#append`, `computeHash`, `simplePackingComputeParams`.
-- `float16` / `bfloat16` / `complex*` first-class support (likely via
-  a small runtime helper; JS has no native half-precision TypedArray).
-- Bundle-size budget (`size-limit`) in CI.
-- Dual `--target web` + `--target nodejs` build for tighter Node
-  compatibility (currently Node ≥ 20 required).
-- Zarr.js integration mirroring `tensogram-zarr`.
+- `encoder.rs` — `StreamingEncoder` class backed by `Vec<u8>`.
+- `extras.rs` — `decode_range`, `encode_pre_encoded`, `compute_hash`,
+  `simple_packing_compute_params`, `validate_buffer`.
+- `convert.rs` gains `typed_array_or_u8_to_bytes` covering every
+  `ArrayBufferView` + `DataView`, used by the new write paths.
+
+TS-side surface (`typescript/src/`):
+
+- `range.ts`, `hash.ts`, `simplePacking.ts`, `validate.ts`,
+  `encodePreEncoded.ts`, `streamingEncoder.ts` — one module per
+  concept, each with its own dedicated test file.
+- `file.ts` rewritten to support two new paths: `append` (Node local
+  file) and a lazy Range-based `fromUrl` backend with transparent
+  eager fallback.
+
+### `rawMessage` is now async
+
+`TensogramFile#rawMessage(index)` returns `Promise<Uint8Array>` (was
+sync in Scope B).  The signature change lets the lazy HTTP backend
+issue the `Range` GET on first access; existing callers add `await`.
+
+## Scope-C.2 wire details
+
+- `typescript/src/float16.ts` — `Float16Polyfill` with TC39-accurate
+  semantics (round-ties-to-even narrow, NaN / ±Inf / subnormal
+  preservation), plus `halfBitsToFloat` / `floatToHalfBits` /
+  `hasNativeFloat16Array` / `getFloat16ArrayCtor` / `float16FromBytes`
+  zero-copy factory.
+- `typescript/src/bfloat16.ts` — matching `Bfloat16Array` view with
+  the 1-8-7 layout used by ML frameworks.
+- `typescript/src/complex.ts` — `ComplexArray` view over interleaved
+  Float32 / Float64 storage, with `.real(i)`, `.imag(i)`, `.get(i)`,
+  iteration.
+- `typescript/src/dtype.ts` — `typedArrayFor` updated to route these
+  dtypes through the view classes.  Callers who still want raw bits
+  / interleaved storage reach them via `.bits` / `.data`.
+
+## Open items & follow-ups
+
+- **Scope C.3** — npm publish pipeline, browser CI via
+  Vitest-browser + Playwright, `size-limit` bundle budget, vitest
+  bench on hot paths.  See `plans/TODO.md`.
+- **Scope C.4** — `@ecmwf/tensogram-zarr` mirror of the Python
+  `tensogram-zarr` package.
+- Dual `--target web` + `--target nodejs` wasm-pack build for tighter
+  Node compatibility (currently Node ≥ 20 required).
 - Integration with `earthkit-data` if a JS loader is ever needed.
+- Callback-per-frame sinks in Python / C FFI / C++ — the WASM/TS
+  surface gained this via `onBytes` in Pass 6, but other bindings
+  remain buffered-only.  Extension pattern: a per-language sink
+  abstraction (Python file-like / `io.BufferedWriter`, FFI
+  function-pointer, C++ `std::ostream&`) wrapping the Rust core's
+  `StreamingEncoder<W: Write>` generic just like `JsCallbackWriter`
+  does for WASM.  Would close cross-language parity for the
+  streaming-sink capability.
 
 ## Risks & mitigations
 

--- a/python/bindings/python/tensogram/__init__.py
+++ b/python/bindings/python/tensogram/__init__.py
@@ -10,7 +10,7 @@
 
 from collections import namedtuple
 
-from .tensogram import *  # noqa: F401, F403
+from .tensogram import *  # noqa: F403
 
 Message = namedtuple("Message", ["metadata", "objects"])
 """Decoded message with named fields.

--- a/python/bindings/src/lib.rs
+++ b/python/bindings/src/lib.rs
@@ -24,12 +24,13 @@ use pyo3::types::{PyBytes, PyDict, PyList};
 use std::sync::Arc;
 
 use tensogram_lib::validate::{
-    validate_file as core_validate_file, validate_message, ValidateOptions, ValidationLevel,
+    ValidateOptions, ValidationLevel, validate_file as core_validate_file, validate_message,
 };
 use tensogram_lib::{
-    decode, decode_descriptors, decode_metadata, decode_object, decode_range, encode,
-    encode_pre_encoded, scan, ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions,
-    GlobalMetadata, HashAlgorithm, StreamingEncoder, TensogramError, TensogramFile, RESERVED_KEY,
+    ByteOrder, DataObjectDescriptor, DecodeOptions, Dtype, EncodeOptions, GlobalMetadata,
+    HashAlgorithm, RESERVED_KEY, StreamingEncoder, TensogramError, TensogramFile, decode,
+    decode_descriptors, decode_metadata, decode_object, decode_range, encode, encode_pre_encoded,
+    scan,
 };
 
 type PyObject = Py<PyAny>;
@@ -507,12 +508,10 @@ impl PyTensogramFile {
             .detach(|| self.file.decode_object(msg_index, obj_index, &options))
             .map_err(to_py_err)?;
         let arr = bytes_to_numpy(py, &desc, &data)?;
-        let py_desc = PyDataObjectDescriptor {
-            inner: desc,
-        }
-        .into_pyobject(py)?
-        .into_any()
-        .unbind();
+        let py_desc = PyDataObjectDescriptor { inner: desc }
+            .into_pyobject(py)?
+            .into_any()
+            .unbind();
         let result = PyDict::new(py);
         result.set_item("metadata", PyMetadata { inner: meta }.into_pyobject(py)?)?;
         result.set_item("descriptor", py_desc)?;
@@ -580,17 +579,12 @@ impl PyTensogramFile {
             .into_iter()
             .map(|(meta, desc, data)| {
                 let arr = bytes_to_numpy(py, &desc, &data)?;
-                let py_desc = PyDataObjectDescriptor {
-                    inner: desc,
-                }
-                .into_pyobject(py)?
-                .into_any()
-                .unbind();
+                let py_desc = PyDataObjectDescriptor { inner: desc }
+                    .into_pyobject(py)?
+                    .into_any()
+                    .unbind();
                 let result = PyDict::new(py);
-                result.set_item(
-                    "metadata",
-                    PyMetadata { inner: meta }.into_pyobject(py)?,
-                )?;
+                result.set_item("metadata", PyMetadata { inner: meta }.into_pyobject(py)?)?;
                 result.set_item("descriptor", py_desc)?;
                 result.set_item("data", arr)?;
                 Ok(result.into_any().unbind())
@@ -996,6 +990,11 @@ fn py_decode_object(
 ///     ``list[ndarray]`` (default) or ``ndarray`` (when ``join=True``).
 #[pyfunction]
 #[pyo3(name = "decode_range", signature = (buf, object_index, ranges, join=false, verify_hash=false, native_byte_order=true, threads=0))]
+// The argument list is the public Python ABI — each one is a documented
+// keyword argument that other bindings (Rust core, FFI, WASM) also
+// expose.  Collapsing them into an options struct would break the
+// Pythonic kwargs calling convention.
+#[allow(clippy::too_many_arguments)]
 fn py_decode_range(
     py: Python<'_>,
     buf: PyBackedBytes,
@@ -1111,6 +1110,40 @@ impl PyBufferIter {
             self.index, remaining
         )
     }
+}
+
+/// Compute a hash digest over arbitrary bytes.
+///
+/// Mirrors Rust :func:`tensogram::compute_hash`, the WASM
+/// ``compute_hash`` export, and ``tgm_compute_hash`` in the C FFI.
+/// Useful for verifying an encoded payload against the hash recorded
+/// in a descriptor, or for pre-computing a hash before calling
+/// :func:`encode_pre_encoded`.
+///
+/// Args:
+///     data: Bytes to hash — ``bytes`` or ``bytearray``.  Zero-copy
+///         for ``bytes`` via :class:`PyBackedBytes`.  For other
+///         buffer-protocol objects (``memoryview``, ``numpy.ndarray``,
+///         etc.) call ``bytes(obj)`` / ``obj.tobytes()`` first.
+///     algo: Algorithm name.  ``"xxh3"`` is the only supported value
+///         today and the default.
+///
+/// Returns:
+///     The hex-encoded digest as a ``str`` (16 characters for xxh3-64).
+///
+/// Raises:
+///     TypeError: If ``data`` is not ``bytes`` or ``bytearray``.
+///     ValueError: If ``algo`` is not a recognised algorithm name.
+///
+/// Example::
+///
+///     >>> tensogram.compute_hash(b"hello world")
+///     'd447b1ea40e6988b'
+#[pyfunction]
+#[pyo3(name = "compute_hash", signature = (data, algo="xxh3"))]
+fn py_compute_hash(data: PyBackedBytes, algo: &str) -> PyResult<String> {
+    let algorithm = HashAlgorithm::parse(algo).map_err(to_py_err)?;
+    Ok(tensogram_lib::compute_hash(&data, algorithm))
 }
 
 /// Compute simple-packing parameters for a float64 array.
@@ -1614,12 +1647,10 @@ impl PyAsyncTensogramFile {
                 .map_err(to_py_err)?;
             Python::attach(|py| {
                 let arr = bytes_to_numpy(py, &desc, &data)?;
-                let py_desc = PyDataObjectDescriptor {
-                    inner: desc,
-                }
-                .into_pyobject(py)?
-                .into_any()
-                .unbind();
+                let py_desc = PyDataObjectDescriptor { inner: desc }
+                    .into_pyobject(py)?
+                    .into_any()
+                    .unbind();
                 let result = PyDict::new(py);
                 result.set_item("metadata", PyMetadata { inner: meta }.into_pyobject(py)?)?;
                 result.set_item("descriptor", py_desc)?;
@@ -1746,17 +1777,13 @@ impl PyAsyncTensogramFile {
                     .into_iter()
                     .map(|(meta, desc, data)| {
                         let arr = bytes_to_numpy(py, &desc, &data)?;
-                        let py_desc = PyDataObjectDescriptor {
-                            inner: desc,
-                        }
-                        .into_pyobject(py)?
-                        .into_any()
-                        .unbind();
+                        let py_desc = PyDataObjectDescriptor { inner: desc }
+                            .into_pyobject(py)?
+                            .into_any()
+                            .unbind();
                         let result = PyDict::new(py);
-                        result.set_item(
-                            "metadata",
-                            PyMetadata { inner: meta }.into_pyobject(py)?,
-                        )?;
+                        result
+                            .set_item("metadata", PyMetadata { inner: meta }.into_pyobject(py)?)?;
                         result.set_item("descriptor", py_desc)?;
                         result.set_item("data", arr)?;
                         Ok(result.into_any().unbind())
@@ -1926,6 +1953,26 @@ impl PyAsyncTensogramFileIter {
     }
 }
 
+/// Check whether a source string looks like a remote URL.
+///
+/// Returns ``True`` for sources starting with ``http://``, ``https://``,
+/// ``s3://``, ``gs://``, or ``az://``; ``False`` for everything else
+/// (local paths, unrecognised schemes).  Used by
+/// :class:`TensogramFile` to dispatch between the local-file and
+/// remote backends.
+///
+/// Args:
+///     source: The source string to classify.
+///
+/// Returns:
+///     ``True`` if ``source`` has a recognised remote scheme prefix.
+///
+/// Example::
+///
+///     >>> tensogram.is_remote_url("s3://bucket/key.tgm")
+///     True
+///     >>> tensogram.is_remote_url("/local/path.tgm")
+///     False
 #[pyfunction]
 #[pyo3(name = "is_remote_url")]
 fn py_is_remote_url(source: &str) -> bool {
@@ -1946,6 +1993,7 @@ fn tensogram(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_iter_messages, m)?)?;
     m.add_function(wrap_pyfunction!(py_validate, m)?)?;
     m.add_function(wrap_pyfunction!(py_validate_file, m)?)?;
+    m.add_function(wrap_pyfunction!(py_compute_hash, m)?)?;
     m.add_function(wrap_pyfunction!(compute_packing_params, m)?)?;
     m.add_class::<PyMetadata>()?;
     m.add_class::<PyDataObjectDescriptor>()?;
@@ -2243,7 +2291,7 @@ fn dict_to_data_object_descriptor(dict: &Bound<'_, PyDict>) -> PyResult<DataObje
             other => {
                 return Err(PyValueError::new_err(format!(
                     "unknown byte_order: '{other}', expected 'little' or 'big'"
-                )))
+                )));
             }
         },
     };
@@ -2315,14 +2363,12 @@ fn compute_strides(shape: &[u64]) -> PyResult<Vec<u64>> {
     }
     let mut strides = vec![1u64; shape.len()];
     for i in (0..shape.len() - 1).rev() {
-        strides[i] = strides[i + 1]
-            .checked_mul(shape[i + 1])
-            .ok_or_else(|| {
-                PyValueError::new_err(format!(
-                    "strides overflow: cannot compute strides for shape {:?}",
-                    shape
-                ))
-            })?;
+        strides[i] = strides[i + 1].checked_mul(shape[i + 1]).ok_or_else(|| {
+            PyValueError::new_err(format!(
+                "strides overflow: cannot compute strides for shape {:?}",
+                shape
+            ))
+        })?;
     }
     Ok(strides)
 }

--- a/python/tests/test_compute_hash.py
+++ b/python/tests/test_compute_hash.py
@@ -1,0 +1,186 @@
+# (C) Copyright 2026- ECMWF and individual contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation nor
+# does it submit to any jurisdiction.
+
+"""Tests for :func:`tensogram.compute_hash`.
+
+Closes the cross-language parity gap — Rust, C FFI, C++, WASM, and
+TypeScript all exposed a hash-over-arbitrary-bytes helper; Python did
+not.  The Python API mirrors Rust's ``tensogram::compute_hash`` and
+WASM's ``compute_hash``: ``bytes`` in, hex ``str`` out, ``"xxh3"`` by
+default.
+
+Core invariants exercised here:
+
+- Determinism — identical input produces identical digest.
+- Length — xxh3-64 always returns 16 lower-case hex chars.
+- Cross-call consistency — ``compute_hash(payload)`` matches the hash
+  stamped by :func:`encode` on the same native bytes (encoding=none
+  descriptors, so the encoded payload IS the raw bytes).
+- Error surface — unknown algorithms raise ``ValueError``; wrong
+  argument types raise ``TypeError``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import tensogram
+
+
+def _descriptor_for(shape: list[int], dtype: str) -> dict:
+    """Build a no-pipeline descriptor so the encoded payload equals the raw bytes."""
+    strides = [1] * len(shape)
+    for i in range(len(shape) - 2, -1, -1):
+        strides[i] = strides[i + 1] * shape[i + 1]
+    return {
+        "type": "ntensor",
+        "ndim": len(shape),
+        "shape": shape,
+        "strides": strides,
+        "dtype": dtype,
+        "byte_order": "little",
+        "encoding": "none",
+        "filter": "none",
+        "compression": "none",
+    }
+
+
+class TestBasics:
+    """Basic shape and determinism checks."""
+
+    def test_returns_16_char_lowercase_hex(self):
+        digest = tensogram.compute_hash(b"hello world")
+        assert len(digest) == 16
+        assert digest == digest.lower()
+        assert all(c in "0123456789abcdef" for c in digest)
+
+    def test_default_algo_is_xxh3(self):
+        assert tensogram.compute_hash(b"abc") == tensogram.compute_hash(b"abc", "xxh3")
+        assert tensogram.compute_hash(b"abc") == tensogram.compute_hash(b"abc", algo="xxh3")
+
+    def test_deterministic(self):
+        a = tensogram.compute_hash(b"\x00\x01\x02\x03\x04\x05\x06\x07")
+        b = tensogram.compute_hash(b"\x00\x01\x02\x03\x04\x05\x06\x07")
+        assert a == b
+
+    def test_distinct_inputs_distinct_digests(self):
+        assert tensogram.compute_hash(b"abc") != tensogram.compute_hash(b"abd")
+
+    def test_empty_buffer(self):
+        digest = tensogram.compute_hash(b"")
+        assert len(digest) == 16
+        # xxh3-64 of empty input is a well-known constant.
+        assert digest == "2d06800538d394c2"
+
+    def test_known_vector(self):
+        # Cross-checked against the Rust-side compute_hash for the same bytes.
+        assert tensogram.compute_hash(b"hello world") == "d447b1ea40e6988b"
+
+
+class TestInputTypes:
+    """``compute_hash`` accepts zero-copy ``bytes`` and ``bytearray`` (via
+    :class:`PyBackedBytes`).  Other buffer-protocol types must be
+    converted to ``bytes`` explicitly — we document that contract and
+    verify the expected ``TypeError`` for unsupported types.
+    """
+
+    def test_bytes(self):
+        assert len(tensogram.compute_hash(bytes([1, 2, 3]))) == 16
+
+    def test_bytearray(self):
+        assert tensogram.compute_hash(bytearray(b"abc")) == tensogram.compute_hash(b"abc")
+
+    def test_memoryview_requires_explicit_bytes_conversion(self):
+        buf = bytearray(b"abc")
+        # memoryview is NOT accepted directly — callers must convert.
+        with pytest.raises(TypeError):
+            tensogram.compute_hash(memoryview(buf))  # type: ignore[arg-type]
+        # But bytes(memoryview(...)) works:
+        assert tensogram.compute_hash(bytes(memoryview(buf))) == tensogram.compute_hash(b"abc")
+
+    def test_numpy_array_requires_tobytes(self):
+        arr = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        with pytest.raises(TypeError):
+            tensogram.compute_hash(arr)  # type: ignore[arg-type]
+        # `.tobytes()` is the idiomatic path.
+        assert tensogram.compute_hash(arr.tobytes()) == tensogram.compute_hash(arr.tobytes())
+
+
+class TestErrorSurface:
+    """Unknown algorithms raise ``ValueError`` (mirrors the typed Metadata error)."""
+
+    def test_unknown_algo_raises_value_error(self):
+        with pytest.raises(ValueError, match="unknown hash type"):
+            tensogram.compute_hash(b"x", "md5")
+
+    def test_unknown_algo_keyword(self):
+        with pytest.raises(ValueError, match="unknown hash type"):
+            tensogram.compute_hash(b"x", algo="sha256")
+
+    def test_non_bytes_input_raises_type_error(self):
+        with pytest.raises(TypeError):
+            tensogram.compute_hash("not bytes")  # type: ignore[arg-type]
+
+    def test_int_input_raises_type_error(self):
+        with pytest.raises(TypeError):
+            tensogram.compute_hash(42)  # type: ignore[arg-type]
+
+
+class TestCrossCheckWithEncode:
+    """Parity invariant — the hash stamped by :func:`encode` on a no-pipeline
+    object equals :func:`compute_hash` over the raw native bytes, which IS
+    the encoded payload when encoding=filter=compression=none.
+
+    This pins the TS/WASM/Rust/Python compute_hash implementations to the
+    same byte-level contract.  A drift in any of them fails this test.
+    """
+
+    def test_matches_stamped_hash_float32(self):
+        values = np.array([1.5, 2.5, 3.5, 4.5], dtype=np.float32)
+        raw = values.tobytes()
+        msg = tensogram.encode({"version": 2}, [(_descriptor_for([4], "float32"), values)])
+        _meta, objects = tensogram.decode(msg)
+        desc, _ = objects[0]
+        assert desc.hash is not None
+        assert desc.hash["type"] == "xxh3"
+        assert desc.hash["value"] == tensogram.compute_hash(raw)
+
+    def test_matches_stamped_hash_int64(self):
+        values = np.array([-1, 0, 1, 42, 2**62], dtype=np.int64)
+        raw = values.tobytes()
+        msg = tensogram.encode({"version": 2}, [(_descriptor_for([5], "int64"), values)])
+        _, objects = tensogram.decode(msg)
+        desc, _ = objects[0]
+        assert desc.hash["value"] == tensogram.compute_hash(raw)
+
+    def test_matches_stamped_hash_large_payload(self):
+        # Larger payload — exercises the streaming path of the hasher
+        # without crossing any sensitive pipeline boundary.
+        values = np.arange(10_000, dtype=np.float64)
+        raw = values.tobytes()
+        msg = tensogram.encode({"version": 2}, [(_descriptor_for([10_000], "float64"), values)])
+        _, objects = tensogram.decode(msg)
+        desc, _ = objects[0]
+        assert desc.hash["value"] == tensogram.compute_hash(raw)
+
+
+class TestEncodePreEncodedIntegration:
+    """Using :func:`compute_hash` to precompute a hash and feed it to
+    :func:`encode_pre_encoded` — the library recomputes anyway, but the
+    resulting descriptor's hash value must match the precomputed one.
+    """
+
+    def test_precompute_matches_stamped(self):
+        raw = np.array([7.0, 8.0, 9.0], dtype=np.float32).tobytes()
+        precomputed = tensogram.compute_hash(raw)
+        msg = tensogram.encode_pre_encoded(
+            {"version": 2}, [(_descriptor_for([3], "float32"), raw)]
+        )
+        _, objects = tensogram.decode(msg)
+        desc, _ = objects[0]
+        assert desc.hash["value"] == precomputed

--- a/python/tests/test_tensogram.py
+++ b/python/tests/test_tensogram.py
@@ -1031,9 +1031,7 @@ class TestEdgeCases:
             for idx in [0, 25, 49]:
                 meta, objects = f2.decode_message(idx)
                 _, arr = objects[0]
-                np.testing.assert_array_equal(
-                    arr, np.full(10, float(idx), dtype=np.float32)
-                )
+                np.testing.assert_array_equal(arr, np.full(10, float(idx), dtype=np.float32))
                 assert meta["index"] == idx
 
     def test_native_endian_roundtrip(self):
@@ -1087,9 +1085,7 @@ class TestEdgeCases:
 
         with (
             tensogram.TensogramFile.open(path) as f2,
-            pytest.raises(
-                (ValueError, IndexError), match=r"index|out of range|ObjectError"
-            ),
+            pytest.raises((ValueError, IndexError), match=r"index|out of range|ObjectError"),
         ):
             f2.decode_message(99)
 
@@ -1175,9 +1171,7 @@ class TestEdgeCases:
         with tensogram.TensogramFile.create(path) as f:
             for _i in range(3):
                 data = np.zeros(4, dtype=np.float32)
-                f.append(
-                    make_global_meta(2), [(make_descriptor([4], dtype="float32"), data)]
-                )
+                f.append(make_global_meta(2), [(make_descriptor([4], dtype="float32"), data)])
 
         with tensogram.TensogramFile.open(path) as f:
             it = iter(f)
@@ -1194,9 +1188,7 @@ class TestEdgeCases:
         path = str(tmp_path / "stop.tgm")
         with tensogram.TensogramFile.create(path) as f:
             data = np.ones(4, dtype=np.float32)
-            f.append(
-                make_global_meta(2), [(make_descriptor([4], dtype="float32"), data)]
-            )
+            f.append(make_global_meta(2), [(make_descriptor([4], dtype="float32"), data)])
 
         with tensogram.TensogramFile.open(path) as f:
             it = iter(f)
@@ -1226,9 +1218,7 @@ class TestEdgeCases:
         path = str(tmp_path / "oob.tgm")
         with tensogram.TensogramFile.create(path) as f:
             data = np.ones(4, dtype=np.float32)
-            f.append(
-                make_global_meta(2), [(make_descriptor([4], dtype="float32"), data)]
-            )
+            f.append(make_global_meta(2), [(make_descriptor([4], dtype="float32"), data)])
 
         with tensogram.TensogramFile.open(path) as f:
             with pytest.raises(IndexError):
@@ -1313,9 +1303,7 @@ class TestEdgeCases:
         with tensogram.TensogramFile.create(path) as f:
             for _i in range(3):
                 data = np.zeros(4, dtype=np.float32)
-                f.append(
-                    make_global_meta(2), [(make_descriptor([4], dtype="float32"), data)]
-                )
+                f.append(make_global_meta(2), [(make_descriptor([4], dtype="float32"), data)])
 
         with tensogram.TensogramFile.open(path) as f:
             assert f[2:2] == []
@@ -1326,9 +1314,7 @@ class TestEdgeCases:
         path = str(tmp_path / "badkey.tgm")
         with tensogram.TensogramFile.create(path) as f:
             data = np.ones(4, dtype=np.float32)
-            f.append(
-                make_global_meta(2), [(make_descriptor([4], dtype="float32"), data)]
-            )
+            f.append(make_global_meta(2), [(make_descriptor([4], dtype="float32"), data)])
 
         with tensogram.TensogramFile.open(path) as f, pytest.raises(TypeError):
             f["bad"]
@@ -1415,9 +1401,7 @@ class TestEdgeCases:
         """iter_messages raises StopIteration after exhaustion."""
         data = np.ones(4, dtype=np.float32)
         msg = bytes(
-            tensogram.encode(
-                make_global_meta(2), [(make_descriptor([4], dtype="float32"), data)]
-            )
+            tensogram.encode(make_global_meta(2), [(make_descriptor([4], dtype="float32"), data)])
         )
 
         it = tensogram.iter_messages(msg)
@@ -1917,17 +1901,19 @@ class TestPackingParamsCoverage:
             params = tensogram.compute_packing_params(values, bpv, 0)
             assert params["bits_per_value"] == bpv
 
-    def test_inf_accepted_but_nonsensical(self):
-        """Inf values are accepted but produce extreme scale factors.
-
-        NOTE: This is a known edge case — inf should arguably be rejected
-        like NaN, but currently produces binary_scale_factor=i32::MAX.
+    def test_positive_infinity_rejected(self):
+        """Positive infinity is rejected alongside NaN — a finite range
+        is a precondition of the binary-scale-factor computation.
         """
         values = np.array([1.0, float("inf"), 3.0], dtype=np.float64)
-        params = tensogram.compute_packing_params(values, 16, 0)
-        # Documents actual behavior: accepted with extreme params
-        assert params["bits_per_value"] == 16
-        assert params["binary_scale_factor"] == 2147483647  # i32::MAX
+        with pytest.raises(ValueError, match=r"infinite value"):
+            tensogram.compute_packing_params(values, 16, 0)
+
+    def test_negative_infinity_rejected(self):
+        """Negative infinity is rejected for the same reason."""
+        values = np.array([float("-inf"), 1.0, 2.0], dtype=np.float64)
+        with pytest.raises(ValueError, match=r"infinite value"):
+            tensogram.compute_packing_params(values, 16, 0)
 
 
 # ---------------------------------------------------------------------------
@@ -1966,9 +1952,7 @@ class TestDecodeRangeDtypeCoverage:
         """decode_range with join=True concatenates results."""
         data = np.arange(50, dtype=np.float32)
         msg = encode_simple(data)
-        joined = tensogram.decode_range(
-            msg, object_index=0, ranges=[(0, 5), (20, 5)], join=True
-        )
+        joined = tensogram.decode_range(msg, object_index=0, ranges=[(0, 5), (20, 5)], join=True)
         expected = np.concatenate([data[:5], data[20:25]])
         np.testing.assert_array_equal(joined, expected)
 
@@ -2585,9 +2569,7 @@ class TestUnicodeMetadata:
     def test_empty_string_and_whitespace(self):
         """Empty string and whitespace-only strings round-trip."""
         data = np.ones(4, dtype=np.float32)
-        msg = encode_simple(
-            data, extra_meta={"empty": "", "spaces": "   ", "tabs": "\t\n"}
-        )
+        msg = encode_simple(data, extra_meta={"empty": "", "spaces": "   ", "tabs": "\t\n"})
         meta = tensogram.decode_metadata(msg)
         assert meta["empty"] == ""
         assert meta["spaces"] == "   "

--- a/rust/tensogram-encodings/src/simple_packing.rs
+++ b/rust/tensogram-encodings/src/simple_packing.rs
@@ -12,6 +12,12 @@ use thiserror::Error;
 pub enum PackingError {
     #[error("NaN value encountered at index {0}")]
     NanValue(usize),
+    /// A ±Infinity value was encountered.  Simple-packing's scale-factor
+    /// computation would otherwise produce a meaningless (infinite or
+    /// `i32::MAX`-saturated) `binary_scale_factor`, so infinities are
+    /// rejected alongside NaN.  Report the first offending index.
+    #[error("infinite value encountered at index {0}")]
+    InfiniteValue(usize),
     #[error("bits_per_value {0} exceeds maximum of 64")]
     BitsPerValueTooLarge(u32),
     #[error("insufficient data: expected at least {expected} bytes, got {actual}")]
@@ -36,8 +42,29 @@ pub enum PackingError {
 #[cfg(feature = "threads")]
 const PARALLEL_MIN_VALUES: usize = 8192;
 
-/// Run a min/max scan over `values`, returning `Err(NanValue)` on the
-/// first NaN observed (or any NaN when running in parallel).
+/// Classify `v` for simple-packing validation.  Finite values flow
+/// through; NaN and ±Infinity are rejected with an index-qualified
+/// error.  Inlined so the sequential and parallel scans share one
+/// source of truth for the "what counts as an encodable value?"
+/// predicate.
+#[inline]
+fn validate_sample(v: f64, i: usize) -> Result<(), PackingError> {
+    if v.is_nan() {
+        Err(PackingError::NanValue(i))
+    } else if v.is_infinite() {
+        Err(PackingError::InfiniteValue(i))
+    } else {
+        Ok(())
+    }
+}
+
+/// Run a min/max scan over `values`, returning the first
+/// `NanValue`/`InfiniteValue` error observed.
+///
+/// In parallel mode (`threads >= 2`), work-stealing means the reported
+/// index is whichever offending sample the first-to-fail worker saw —
+/// not necessarily the globally-first one.  Sequential mode preserves
+/// the first-offender guarantee.
 fn scan_min_max(
     values: &[f64],
     #[allow(unused_variables)] threads: u32,
@@ -46,23 +73,14 @@ fn scan_min_max(
     {
         if threads >= 2 && values.len() >= PARALLEL_MIN_VALUES {
             use rayon::prelude::*;
-            // Short-circuit on NaN: `try_fold` stops as soon as one
-            // worker sees a NaN.  The reported index is from whichever
-            // chunk that worker owned — not necessarily the globally-
-            // first NaN.  This trade-off was accepted for
-            // `threads > 0` callers; sequential callers see the
-            // original first-NaN behaviour.
             return values
                 .par_iter()
                 .enumerate()
                 .try_fold(
                     || (f64::INFINITY, f64::NEG_INFINITY),
                     |(mn, mx), (i, &v)| {
-                        if v.is_nan() {
-                            Err(PackingError::NanValue(i))
-                        } else {
-                            Ok((mn.min(v), mx.max(v)))
-                        }
+                        validate_sample(v, i)?;
+                        Ok((mn.min(v), mx.max(v)))
                     },
                 )
                 .try_reduce(
@@ -72,13 +90,11 @@ fn scan_min_max(
         }
     }
 
-    // Sequential scan — preserves first-NaN-index semantics.
+    // Sequential scan — preserves first-offender-index semantics.
     let mut min_val = f64::INFINITY;
     let mut max_val = f64::NEG_INFINITY;
     for (i, &v) in values.iter().enumerate() {
-        if v.is_nan() {
-            return Err(PackingError::NanValue(i));
-        }
+        validate_sample(v, i)?;
         if v < min_val {
             min_val = v;
         }
@@ -197,16 +213,18 @@ pub fn encode_with_threads(
         return Err(PackingError::BitsPerValueTooLarge(params.bits_per_value));
     }
 
-    // NaN scan.  When parallel, this is fused into the packing loop
-    // below; sequential goes through the original fast check so that
-    // the first-NaN-index guarantee holds.
+    // NaN / Inf scan.  When parallel, this is fused into the packing
+    // loop below; sequential goes through the fast check so the
+    // first-offender-index guarantee holds.
     #[cfg(feature = "threads")]
     let parallel = threads >= 2 && values.len() >= PARALLEL_MIN_VALUES;
     #[cfg(not(feature = "threads"))]
     let parallel = false;
 
-    if !parallel && let Some(i) = values.iter().position(|v| v.is_nan()) {
-        return Err(PackingError::NanValue(i));
+    if !parallel {
+        for (i, &v) in values.iter().enumerate() {
+            validate_sample(v, i)?;
+        }
     }
 
     if params.bits_per_value == 0 {
@@ -342,9 +360,7 @@ fn encode_aligned_par<const N: usize>(
     out.par_chunks_exact_mut(N)
         .zip(values.par_iter().enumerate())
         .try_for_each(|(chunk, (i, &v))| -> Result<(), PackingError> {
-            if v.is_nan() {
-                return Err(PackingError::NanValue(i));
-            }
+            validate_sample(v, i)?;
             let q = (((v - refv) * scale).round() as u64).min(max_packed);
             splat_aligned::<N>(chunk, q);
             Ok(())
@@ -402,13 +418,12 @@ fn encode_generic_par(
         .try_for_each(|(vchunk, bchunk)| -> Result<(), PackingError> {
             let mut bit_pos: u64 = 0;
             for (local_i, &value) in vchunk.iter().enumerate() {
-                if value.is_nan() {
-                    // Index is chunk-local — we cannot easily recover
-                    // the global one under par without extra bookkeeping.
-                    // The caller explicitly opted into threads=N; doc'd
-                    // non-determinism of reported NaN index is accepted.
-                    return Err(PackingError::NanValue(local_i));
-                }
+                // Index is chunk-local — recovering the global index
+                // under parallel reduction would add bookkeeping for
+                // little benefit.  Callers that opt into `threads > 0`
+                // accept the doc'd non-determinism of the reported
+                // offender index.
+                validate_sample(value, local_i)?;
                 let packed = (((value - refv) * scale).round() as u64).min(max_packed);
                 write_bits(bchunk, bit_pos, packed, bpv);
                 bit_pos += bpv as u64;
@@ -423,9 +438,7 @@ fn encode_generic_par(
         let tail_bytes = &mut output[tail_byte_start..];
         let mut bit_pos: u64 = 0;
         for (i, &value) in tail_values.iter().enumerate() {
-            if value.is_nan() {
-                return Err(PackingError::NanValue(full_chunks * values_per_chunk + i));
-            }
+            validate_sample(value, full_chunks * values_per_chunk + i)?;
             let packed = (((value - refv) * scale).round() as u64).min(max_packed);
             write_bits(tail_bytes, bit_pos, packed, bpv);
             bit_pos += bpv as u64;
@@ -970,6 +983,39 @@ mod tests {
         assert!(matches!(
             encode(&values, &params),
             Err(PackingError::NanValue(1))
+        ));
+    }
+
+    #[test]
+    fn test_positive_infinity_rejected_in_compute_params() {
+        let values = vec![1.0, f64::INFINITY, 3.0];
+        assert!(matches!(
+            compute_params(&values, 16, 0),
+            Err(PackingError::InfiniteValue(1))
+        ));
+    }
+
+    #[test]
+    fn test_negative_infinity_rejected_in_compute_params() {
+        let values = vec![f64::NEG_INFINITY, 1.0, 2.0];
+        assert!(matches!(
+            compute_params(&values, 16, 0),
+            Err(PackingError::InfiniteValue(0))
+        ));
+    }
+
+    #[test]
+    fn test_infinity_rejected_in_encode() {
+        let values = vec![1.0, 2.0, f64::INFINITY];
+        let params = SimplePackingParams {
+            reference_value: 0.0,
+            binary_scale_factor: 0,
+            decimal_scale_factor: 0,
+            bits_per_value: 16,
+        };
+        assert!(matches!(
+            encode(&values, &params),
+            Err(PackingError::InfiniteValue(2))
         ));
     }
 

--- a/rust/tensogram-wasm/Cargo.lock
+++ b/rust/tensogram-wasm/Cargo.lock
@@ -456,8 +456,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "tensogram-core"
-version = "0.14.0"
+name = "tensogram"
+version = "0.15.0"
 dependencies = [
  "ciborium",
  "serde",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "tensogram-encodings"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "lz4_flex",
  "ruzstd",
@@ -478,25 +478,28 @@ dependencies = [
  "tensogram-szip",
  "thiserror",
  "tracing",
+ "xxhash-rust",
 ]
 
 [[package]]
 name = "tensogram-szip"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "tensogram-wasm"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ciborium",
  "getrandom 0.2.17",
  "js-sys",
  "serde",
  "serde-wasm-bindgen",
- "tensogram-core",
+ "serde_json",
+ "tensogram",
+ "tensogram-encodings",
  "uuid",
  "wasm-bindgen",
  "wasm-bindgen-test",

--- a/rust/tensogram-wasm/Cargo.toml
+++ b/rust/tensogram-wasm/Cargo.toml
@@ -25,10 +25,16 @@ tensogram = { path = "../tensogram", version = "=0.15.0", default-features = fal
     "szip-pure",
     "zstd-pure",
 ] }
+tensogram-encodings = { path = "../tensogram-encodings", version = "=0.15.0", default-features = false, features = [
+    "lz4",
+    "szip-pure",
+    "zstd-pure",
+] }
 ciborium = "0.2"
 wasm-bindgen = "0.2"
 serde-wasm-bindgen = "0.6"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 js-sys = "0.3"
 # uuid needs the `js` feature for getrandom in WASM
 uuid = { version = "1", features = ["v4", "js"] }

--- a/rust/tensogram-wasm/src/convert.rs
+++ b/rust/tensogram-wasm/src/convert.rs
@@ -11,9 +11,69 @@
 //! Uses `serde-wasm-bindgen` for metadata (CBOR → JS objects) and
 //! `wasm_bindgen::memory()` + byte offsets for zero-copy TypedArray
 //! views that avoid forming misaligned Rust references.
+//!
+//! Also hosts the shared helpers (`js_err`, `build_encode_options`,
+//! `extract_descriptor_data_pairs`) used by every WASM entrypoint
+//! that writes a message.
 
 use serde::Serialize;
+use tensogram::{self as core, EncodeOptions};
 use wasm_bindgen::prelude::*;
+
+/// Convert any `Display`-able error to a `JsError` by stringifying it.
+///
+/// All WASM entrypoints funnel errors through this helper so the
+/// TypeScript wrapper's `mapTensogramError` sees a consistent message
+/// shape.
+pub(crate) fn js_err<E: std::fmt::Display>(e: E) -> JsError {
+    JsError::new(&e.to_string())
+}
+
+/// Build an `EncodeOptions` from the JS `hash: boolean` option.
+///
+/// `hash` is `true` (the JS default) when absent; pass `Some(false)`
+/// to disable hashing entirely.  `emit_preceders` is always `false`
+/// from the WASM side — the JS layer uses `StreamingEncoder` to emit
+/// preceders explicitly.
+pub(crate) fn build_encode_options(hash: Option<bool>) -> EncodeOptions {
+    EncodeOptions {
+        hash_algorithm: if hash.unwrap_or(true) {
+            Some(core::hash::HashAlgorithm::Xxh3)
+        } else {
+            None
+        },
+        emit_preceders: false,
+        ..Default::default()
+    }
+}
+
+/// Pull a list of `{ descriptor, data }` pairs out of a JS array and
+/// deserialise each descriptor via `serde_wasm_bindgen`.  Used by
+/// `encode` and `encode_pre_encoded` which share the same input shape.
+///
+/// Returns `(descriptors, data_blobs)` — parallel vectors the caller
+/// can `zip` into `&[(&DataObjectDescriptor, &[u8])]`.
+pub(crate) fn extract_descriptor_data_pairs(
+    objects_js: &js_sys::Array,
+) -> Result<(Vec<core::DataObjectDescriptor>, Vec<Vec<u8>>), JsError> {
+    let len = objects_js.length();
+    let mut descriptors = Vec::with_capacity(len as usize);
+    let mut data_vec = Vec::with_capacity(len as usize);
+    for i in 0..len {
+        let entry = objects_js.get(i);
+        let desc_val = js_sys::Reflect::get(&entry, &"descriptor".into())
+            .map_err(|_| JsError::new("each object must have a 'descriptor' field"))?;
+        let data_val = js_sys::Reflect::get(&entry, &"data".into())
+            .map_err(|_| JsError::new("each object must have a 'data' field"))?;
+        let desc: core::DataObjectDescriptor =
+            serde_wasm_bindgen::from_value(desc_val).map_err(js_err)?;
+        let data_bytes = typed_array_or_u8_to_bytes(&data_val)
+            .ok_or_else(|| JsError::new("data must be a TypedArray, DataView, or Uint8Array"))?;
+        descriptors.push(desc);
+        data_vec.push(data_bytes);
+    }
+    Ok((descriptors, data_vec))
+}
 
 /// Convert any serde-serializable value to a JsValue using a
 /// JSON-compatible representation.
@@ -45,7 +105,7 @@ pub(crate) fn to_js<T: Serialize>(val: &T) -> Result<JsValue, JsError> {
 /// the underlying `ArrayBuffer`).  The caller must read/copy the data
 /// before any further WASM calls that might allocate.
 pub(crate) fn view_as_f32(data: &[u8]) -> Result<js_sys::Float32Array, JsError> {
-    if data.len() % 4 != 0 {
+    if !data.len().is_multiple_of(4) {
         return Err(JsError::new(&format!(
             "data length {} is not a multiple of 4 (Float32)",
             data.len()
@@ -71,7 +131,7 @@ pub(crate) fn view_as_f32(data: &[u8]) -> Result<js_sys::Float32Array, JsError> 
 /// Same rationale as [`view_as_f32`]: uses byte offsets into WASM memory,
 /// no misaligned Rust references are formed.  Invalidated if WASM memory grows.
 pub(crate) fn view_as_f64(data: &[u8]) -> Result<js_sys::Float64Array, JsError> {
-    if data.len() % 8 != 0 {
+    if !data.len().is_multiple_of(8) {
         return Err(JsError::new(&format!(
             "data length {} is not a multiple of 8 (Float64)",
             data.len()
@@ -97,7 +157,7 @@ pub(crate) fn view_as_f64(data: &[u8]) -> Result<js_sys::Float64Array, JsError> 
 /// Same rationale as [`view_as_f32`]: uses byte offsets into WASM memory,
 /// no misaligned Rust references are formed.  Invalidated if WASM memory grows.
 pub(crate) fn view_as_i32(data: &[u8]) -> Result<js_sys::Int32Array, JsError> {
-    if data.len() % 4 != 0 {
+    if !data.len().is_multiple_of(4) {
         return Err(JsError::new(&format!(
             "data length {} is not a multiple of 4 (Int32)",
             data.len()
@@ -128,4 +188,56 @@ pub(crate) fn view_as_u8(data: &[u8]) -> js_sys::Uint8Array {
 pub(crate) fn copy_as_f32(data: &[u8]) -> Result<js_sys::Float32Array, JsError> {
     let view = view_as_f32(data)?;
     Ok(js_sys::Float32Array::new(&view))
+}
+
+/// Extract raw bytes from any TypedArray, DataView, or Uint8Array-like.
+///
+/// Used by write paths that accept "raw payload" input — encode,
+/// encode_pre_encoded, StreamingEncoder::write_object etc.  Accepts
+/// Uint8Array, Uint8ClampedArray, Int8Array, any of the (u)int/float
+/// 16/32/64 typed arrays, plus DataView.  Returns `None` for anything
+/// else so callers can emit a clear error.
+///
+/// The bytes are always copied into a fresh Vec so the caller owns
+/// them — avoids lifetime tangles with the JS-side ArrayBuffer.
+pub(crate) fn typed_array_or_u8_to_bytes(val: &JsValue) -> Option<Vec<u8>> {
+    // Fast path: Uint8Array directly.
+    if let Some(arr) = val.dyn_ref::<js_sys::Uint8Array>() {
+        return Some(arr.to_vec());
+    }
+    // DataView: take byteOffset + byteLength view into the buffer.
+    if let Some(dv) = val.dyn_ref::<js_sys::DataView>() {
+        let u8 = js_sys::Uint8Array::new_with_byte_offset_and_length(
+            &dv.buffer(),
+            dv.byte_offset() as u32,
+            dv.byte_length() as u32,
+        );
+        return Some(u8.to_vec());
+    }
+    // Every other TypedArray: inspect via the ArrayBufferView prototype.
+    // js_sys exposes `byte_offset()` / `byte_length()` / `buffer()` on
+    // each concrete class; we try them in turn.
+    macro_rules! try_typed {
+        ($ty:ty) => {
+            if let Some(arr) = val.dyn_ref::<$ty>() {
+                let u8 = js_sys::Uint8Array::new_with_byte_offset_and_length(
+                    &arr.buffer(),
+                    arr.byte_offset(),
+                    arr.byte_length(),
+                );
+                return Some(u8.to_vec());
+            }
+        };
+    }
+    try_typed!(js_sys::Int8Array);
+    try_typed!(js_sys::Uint8ClampedArray);
+    try_typed!(js_sys::Int16Array);
+    try_typed!(js_sys::Uint16Array);
+    try_typed!(js_sys::Int32Array);
+    try_typed!(js_sys::Uint32Array);
+    try_typed!(js_sys::Float32Array);
+    try_typed!(js_sys::Float64Array);
+    try_typed!(js_sys::BigInt64Array);
+    try_typed!(js_sys::BigUint64Array);
+    None
 }

--- a/rust/tensogram-wasm/src/encoder.rs
+++ b/rust/tensogram-wasm/src/encoder.rs
@@ -1,0 +1,346 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+//! Frame-at-a-time streaming encoder for JavaScript callers.
+//!
+//! Two operating modes, both driven by the Rust-core
+//! `StreamingEncoder<W: Write>` generic:
+//!
+//! - **Buffered (default).**  The sink is an in-memory `Vec<u8>`.  Every
+//!   `write_object` / `write_preceder` appends to the buffer; `finish()`
+//!   returns the complete wire-format message as a `Uint8Array`.
+//!   Matches the Python `StreamingEncoder` model.
+//!
+//! - **Streaming.**  The sink is a [`JsCallbackWriter`] that forwards
+//!   every chunk of bytes the core encoder emits to a caller-provided
+//!   `(chunk: Uint8Array) => void` JS callback.  No full-message
+//!   buffering — the callback is invoked during construction (preamble +
+//!   header frames), during each `write_object` (one data-object frame's
+//!   bytes), and during `finish()` (footer frames + postamble).
+//!   `finish()` still returns a `Uint8Array`, but in streaming mode it
+//!   is empty because every byte has already gone through the callback.
+//!
+//! The TypeScript wrapper selects the mode via
+//! `StreamingEncoderOptions.onBytes`; the mode is fixed at construction
+//! time and cannot be switched.
+//!
+//! ```js
+//! // Buffered (default):
+//! const enc = new StreamingEncoder({ version: 2 });
+//! enc.writeObject(descriptor, new Float32Array([1, 2, 3]));
+//! const bytes = enc.finish();          // full wire-format message
+//!
+//! // Streaming:
+//! const chunks = [];
+//! const enc = new StreamingEncoder({ version: 2 }, {
+//!   onBytes: (chunk) => chunks.push(new Uint8Array(chunk)),
+//! });
+//! enc.writeObject(descriptor, new Float32Array([1, 2, 3]));
+//! enc.finish();                        // callback has received every chunk
+//! const bytes = Uint8Array.from(chunks.flatMap((c) => Array.from(c)));
+//! ```
+
+use crate::convert::*;
+use std::collections::BTreeMap;
+use std::io::Write;
+use tensogram::{self as core, TensogramError};
+use wasm_bindgen::prelude::*;
+
+// ── Sinks ───────────────────────────────────────────────────────────────────
+
+type BufferedEncoder = core::streaming::StreamingEncoder<Vec<u8>>;
+type StreamingCoreEncoder = core::streaming::StreamingEncoder<JsCallbackWriter>;
+
+/// Internal sink selection — the mode is fixed at construction.
+enum Inner {
+    Buffered(BufferedEncoder),
+    Streaming(StreamingCoreEncoder),
+}
+
+impl Inner {
+    fn write_preceder(
+        &mut self,
+        map: BTreeMap<String, ciborium::Value>,
+    ) -> Result<(), TensogramError> {
+        match self {
+            Inner::Buffered(e) => e.write_preceder(map),
+            Inner::Streaming(e) => e.write_preceder(map),
+        }
+    }
+
+    fn write_object(
+        &mut self,
+        desc: &core::DataObjectDescriptor,
+        bytes: &[u8],
+    ) -> Result<(), TensogramError> {
+        match self {
+            Inner::Buffered(e) => e.write_object(desc, bytes),
+            Inner::Streaming(e) => e.write_object(desc, bytes),
+        }
+    }
+
+    fn write_object_pre_encoded(
+        &mut self,
+        desc: &core::DataObjectDescriptor,
+        bytes: &[u8],
+    ) -> Result<(), TensogramError> {
+        match self {
+            Inner::Buffered(e) => e.write_object_pre_encoded(desc, bytes),
+            Inner::Streaming(e) => e.write_object_pre_encoded(desc, bytes),
+        }
+    }
+
+    fn object_count(&self) -> usize {
+        match self {
+            Inner::Buffered(e) => e.object_count(),
+            Inner::Streaming(e) => e.object_count(),
+        }
+    }
+
+    fn bytes_written(&self) -> u64 {
+        match self {
+            Inner::Buffered(e) => e.bytes_written(),
+            Inner::Streaming(e) => e.bytes_written(),
+        }
+    }
+}
+
+/// `std::io::Write` sink that forwards every chunk of bytes to a
+/// synchronous JavaScript callback.
+///
+/// The callback must be synchronous — any `Promise` it returns is
+/// silently discarded because the Rust `Write::write` contract is
+/// synchronous.  The TS wrapper documents this contract; callers that
+/// need async work (e.g. `fetch` upload) should either buffer
+/// internally first or use the buffered mode with a single `fetch`
+/// call.
+///
+/// Errors thrown by the callback surface as
+/// `std::io::Error::other(...)`, which the core encoder then wraps as
+/// `TensogramError::Io` — the TypeScript wrapper routes this to
+/// `IoError` via the standard `mapTensogramError` path.
+struct JsCallbackWriter {
+    callback: js_sys::Function,
+}
+
+impl JsCallbackWriter {
+    fn new(callback: js_sys::Function) -> Self {
+        Self { callback }
+    }
+}
+
+impl Write for JsCallbackWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        // `Uint8Array::from(&[u8])` copies into JS-heap memory — the
+        // callback receives a fresh, JS-owned view each time, so the
+        // caller can hold on to it past the Rust side of this call.
+        let chunk = js_sys::Uint8Array::from(buf);
+        let this = JsValue::NULL;
+        match self.callback.call1(&this, &chunk) {
+            Ok(_) => Ok(buf.len()),
+            Err(js_err) => {
+                let message = js_err.as_string().unwrap_or_else(|| format!("{js_err:?}"));
+                Err(std::io::Error::other(format!(
+                    "streaming sink callback failed: {message}"
+                )))
+            }
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+// ── Exported class ──────────────────────────────────────────────────────────
+
+/// Streaming encoder with a selectable sink: in-memory buffer (default)
+/// or caller-supplied JS callback.
+///
+/// Lifecycle:
+/// 1. `new(meta, hash?, on_bytes?)` — writes preamble + header metadata
+///    frame.  In buffered mode these bytes accumulate internally; in
+///    streaming mode they flow to `on_bytes` immediately.
+/// 2. Zero or more `write_preceder(meta)` / `write_object(desc, data)` /
+///    `write_object_pre_encoded(desc, data)` calls.
+/// 3. `finish()` writes the footer + postamble.  In buffered mode
+///    returns the complete `Uint8Array`; in streaming mode returns an
+///    empty `Uint8Array` (the callback has seen every byte).
+///
+/// After `finish()` the encoder is closed — every further method call
+/// throws "already finished".  Callers must still invoke the
+/// wasm-bindgen `free()` method when done with the handle.
+#[wasm_bindgen]
+pub struct StreamingEncoder {
+    /// `None` once `finish()` has been called — every mutator checks for
+    /// this and raises a clean "already finished" error.
+    inner: Option<Inner>,
+}
+
+#[wasm_bindgen]
+impl StreamingEncoder {
+    /// Begin a new streaming message.
+    ///
+    /// @param metadata_js - GlobalMetadata (JS object).  Must contain
+    ///   `version`; `base` may carry per-object entries; `_reserved_` is
+    ///   rejected (library-managed).
+    /// @param hash - When `true` (default), xxh3 hashes are computed
+    ///   per object and stored in the footer hash frame.  When `false`,
+    ///   hashing is disabled entirely.
+    /// @param on_bytes - Optional synchronous callback invoked with
+    ///   each chunk of wire-format bytes the encoder produces.  When
+    ///   present, no internal buffering is performed and `finish()`
+    ///   returns an empty `Uint8Array`.  When absent, the encoder
+    ///   buffers to an internal `Vec<u8>` and `finish()` returns the
+    ///   complete message.
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        metadata_js: JsValue,
+        hash: Option<bool>,
+        on_bytes: Option<js_sys::Function>,
+    ) -> Result<StreamingEncoder, JsError> {
+        let metadata: core::GlobalMetadata =
+            serde_wasm_bindgen::from_value(metadata_js).map_err(js_err)?;
+        let options = build_encode_options(hash);
+        let inner = match on_bytes {
+            Some(cb) => {
+                let sink = JsCallbackWriter::new(cb);
+                Inner::Streaming(
+                    StreamingCoreEncoder::new(sink, &metadata, &options).map_err(js_err)?,
+                )
+            }
+            None => Inner::Buffered(
+                BufferedEncoder::new(Vec::new(), &metadata, &options).map_err(js_err)?,
+            ),
+        };
+        Ok(StreamingEncoder { inner: Some(inner) })
+    }
+
+    /// Write a PrecederMetadata frame for the next data object.
+    ///
+    /// The provided object is merged into a GlobalMetadata with a
+    /// single-entry `base` array.  Must be followed by exactly one
+    /// `write_object` / `write_object_pre_encoded` call before another
+    /// `write_preceder` or `finish`.
+    pub fn write_preceder(&mut self, metadata_js: JsValue) -> Result<(), JsError> {
+        let inner = self.inner.as_mut().ok_or_else(already_finished)?;
+        let map: BTreeMap<String, ciborium::Value> =
+            serde_wasm_bindgen::from_value(metadata_js).map_err(js_err)?;
+        inner.write_preceder(map).map_err(js_err)
+    }
+
+    /// Encode and write a single data object.
+    ///
+    /// @param descriptor_js - `DataObjectDescriptor` as a plain JS object.
+    /// @param data - Raw native-endian payload as any TypedArray.
+    pub fn write_object(&mut self, descriptor_js: JsValue, data: JsValue) -> Result<(), JsError> {
+        self.write_with(descriptor_js, data, |inner, desc, bytes| {
+            inner.write_object(desc, bytes)
+        })
+    }
+
+    /// Write a pre-encoded data object directly (no pipeline).
+    ///
+    /// `data` must already be encoded according to the descriptor's
+    /// `encoding` / `filter` / `compression`.  The library does not run
+    /// the pipeline — it validates descriptor structure and the szip
+    /// block offsets (if any) and writes bytes verbatim.  The hash is
+    /// recomputed from these bytes if the encoder was constructed with
+    /// `hash: true`.
+    pub fn write_object_pre_encoded(
+        &mut self,
+        descriptor_js: JsValue,
+        data: JsValue,
+    ) -> Result<(), JsError> {
+        self.write_with(descriptor_js, data, |inner, desc, bytes| {
+            inner.write_object_pre_encoded(desc, bytes)
+        })
+    }
+
+    /// Number of data objects written so far.  Zero after `new()`,
+    /// increments on every successful `write_object` /
+    /// `write_object_pre_encoded`.
+    pub fn object_count(&self) -> Result<usize, JsError> {
+        Ok(self
+            .inner
+            .as_ref()
+            .ok_or_else(already_finished)?
+            .object_count())
+    }
+
+    /// Total bytes produced so far (preamble + header frames + all
+    /// completed data-object frames).  In buffered mode this equals
+    /// the length of the internal buffer; in streaming mode it equals
+    /// the sum of byte-lengths passed to the callback.
+    ///
+    /// Returned as `f64` because JS numbers are the lingua-franca for
+    /// sizes on the wire boundary.  `Number.MAX_SAFE_INTEGER` ≈ 9 PiB,
+    /// which is well beyond any realistic Tensogram message.
+    pub fn bytes_written(&self) -> Result<f64, JsError> {
+        Ok(self
+            .inner
+            .as_ref()
+            .ok_or_else(already_finished)?
+            .bytes_written() as f64)
+    }
+
+    /// Finalise the encoder, writing footer frames + postamble.
+    ///
+    /// In buffered mode returns the complete wire-format `Uint8Array`.
+    /// In streaming mode the footer bytes flow through the callback
+    /// and the return value is an empty `Uint8Array` (zero-length
+    /// marker, not a failure — every byte has already been delivered).
+    ///
+    /// After this call the encoder is closed — any further method call
+    /// throws "already finished".  Callers must still invoke the
+    /// wasm-bindgen `free()` method when done with the handle.
+    pub fn finish(&mut self) -> Result<js_sys::Uint8Array, JsError> {
+        let inner = self.inner.take().ok_or_else(already_finished)?;
+        match inner {
+            Inner::Buffered(e) => {
+                let buf = e.finish().map_err(js_err)?;
+                Ok(js_sys::Uint8Array::from(buf.as_slice()))
+            }
+            Inner::Streaming(e) => {
+                // The core returns the sink (JsCallbackWriter); we
+                // discard it — every byte has already gone to the JS
+                // callback.  A zero-length `Uint8Array` keeps the
+                // return type stable across both modes.
+                let _sink = e.finish().map_err(js_err)?;
+                Ok(js_sys::Uint8Array::new_with_length(0))
+            }
+        }
+    }
+}
+
+impl StreamingEncoder {
+    /// Shared dispatch for `write_object` / `write_object_pre_encoded`:
+    /// deserialise the descriptor, extract raw bytes from any
+    /// TypedArray, then hand off to the supplied core-level writer.
+    fn write_with(
+        &mut self,
+        descriptor_js: JsValue,
+        data: JsValue,
+        core_fn: impl FnOnce(
+            &mut Inner,
+            &core::DataObjectDescriptor,
+            &[u8],
+        ) -> Result<(), TensogramError>,
+    ) -> Result<(), JsError> {
+        let inner = self.inner.as_mut().ok_or_else(already_finished)?;
+        let desc: core::DataObjectDescriptor =
+            serde_wasm_bindgen::from_value(descriptor_js).map_err(js_err)?;
+        let bytes = typed_array_or_u8_to_bytes(&data)
+            .ok_or_else(|| JsError::new("data must be a TypedArray or Uint8Array"))?;
+        core_fn(inner, &desc, &bytes).map_err(js_err)
+    }
+}
+
+fn already_finished() -> JsError {
+    JsError::new("StreamingEncoder already finished")
+}

--- a/rust/tensogram-wasm/src/extras.rs
+++ b/rust/tensogram-wasm/src/extras.rs
@@ -1,0 +1,223 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+//! Additional WASM exports covering the Scope C.1 API-parity gap.
+//!
+//! Each function here is a thin binding over a public function in the
+//! Rust core or in `tensogram-encodings`.  All errors are mapped via
+//! [`crate::convert::js_err`] so the TypeScript wrapper's
+//! `mapTensogramError` sees a consistent message shape.
+
+use crate::convert::*;
+use serde::Serialize;
+use tensogram::{self as core, DecodeOptions};
+use tensogram_encodings::simple_packing;
+use wasm_bindgen::prelude::*;
+
+// ── decode_range ─────────────────────────────────────────────────────────────
+
+/// Decode partial sub-tensor ranges from a single data object.
+///
+/// @param buf - Complete wire-format message bytes.
+/// @param object_index - Zero-based index of the target object.
+/// @param ranges - Flat `BigUint64Array` of `[offset0, count0, offset1, count1, …]`
+///   pairs, in element units (not bytes).  Empty array returns an empty result.
+/// @param verify_hash - Optional, default `false`.  When set, the object's
+///   hash is checked against the payload before any range is decoded.
+/// @returns `{ descriptor, parts: Uint8Array[] }` — one raw-bytes view
+///   per requested range, in request order.  Callers (e.g. the TS
+///   wrapper's `decodeRange`) convert each `Uint8Array` into a
+///   dtype-typed view.
+///
+/// Throws on out-of-range object index, unsupported `filter` (e.g.
+/// shuffle), or bitmask dtype (matching the Rust-core contract).
+///
+/// Implementation note: the `parts` array is built manually with
+/// `Uint8Array::from` rather than via `to_js` — `serde_wasm_bindgen`
+/// serialises `&[u8]` as a plain JS `Array<number>` by default, and the
+/// TS wrapper expects honest `Uint8Array` instances so that
+/// `typedArrayFor` can wrap them zero-copy.
+#[wasm_bindgen]
+pub fn decode_range(
+    buf: &[u8],
+    object_index: usize,
+    ranges: &js_sys::BigUint64Array,
+    verify_hash: Option<bool>,
+) -> Result<JsValue, JsError> {
+    let flat: Vec<u64> = ranges.to_vec();
+    if !flat.len().is_multiple_of(2) {
+        return Err(JsError::new(
+            "ranges length must be a multiple of 2 (flat [offset, count] pairs)",
+        ));
+    }
+    let range_pairs: Vec<(u64, u64)> = flat.chunks_exact(2).map(|w| (w[0], w[1])).collect();
+
+    let options = DecodeOptions {
+        verify_hash: verify_hash.unwrap_or(false),
+        ..Default::default()
+    };
+    let (descriptor, parts) =
+        core::decode_range(buf, object_index, &range_pairs, &options).map_err(js_err)?;
+
+    let result = js_sys::Object::new();
+    js_sys::Reflect::set(&result, &"descriptor".into(), &to_js(&descriptor)?)
+        .map_err(|_| JsError::new("failed to set descriptor"))?;
+    // `js_sys::Array::new_with_length` is defined in terms of `u32`; a
+    // Rust-side Vec of 2^32 entries would already have failed the
+    // earlier `to_vec()` from the input `BigUint64Array` (WASM linear
+    // memory is itself u32-indexed), so the cast here can't truncate
+    // in any reachable execution.
+    let parts_js = js_sys::Array::new_with_length(parts.len() as u32);
+    for (i, bytes) in parts.iter().enumerate() {
+        parts_js.set(i as u32, js_sys::Uint8Array::from(bytes.as_slice()).into());
+    }
+    js_sys::Reflect::set(&result, &"parts".into(), &parts_js)
+        .map_err(|_| JsError::new("failed to set parts"))?;
+    Ok(result.into())
+}
+
+// ── compute_hash ─────────────────────────────────────────────────────────────
+
+/// Compute the hex-encoded hash of a byte slice.
+///
+/// @param data - Bytes to hash.
+/// @param algo - Algorithm name; default `"xxh3"`.  Unknown algorithm
+///   names raise a metadata error (matching `HashAlgorithm::parse`).
+/// @returns The hex digest as a string (16 chars for xxh3-64).
+#[wasm_bindgen]
+pub fn compute_hash(data: &[u8], algo: Option<String>) -> Result<String, JsError> {
+    let name = algo.as_deref().unwrap_or("xxh3");
+    let algorithm = core::HashAlgorithm::parse(name).map_err(js_err)?;
+    Ok(core::compute_hash(data, algorithm))
+}
+
+// ── simple_packing_compute_params ────────────────────────────────────────────
+
+/// JS-side shape of the simple-packing params — matches the snake_case
+/// keys a descriptor's `params` map expects, so the caller can spread
+/// the result straight into a descriptor literal.
+#[derive(Serialize)]
+struct SimplePackingParamsJs {
+    reference_value: f64,
+    binary_scale_factor: i32,
+    decimal_scale_factor: i32,
+    bits_per_value: u32,
+}
+
+/// Compute the simple-packing parameters (reference value, binary/decimal
+/// scale factors, bits-per-value) for a float64 array.
+///
+/// @param values - `Float64Array` — finite, non-NaN.
+/// @param bits_per_value - Quantization depth (0–64; 0 denotes a
+///   constant-field packing).
+/// @param decimal_scale_factor - Power-of-10 scaling applied before
+///   packing.  Typically `0`.
+/// @returns Plain JS object with snake_case keys matching the on-wire
+///   descriptor params: `{ reference_value, binary_scale_factor,
+///   decimal_scale_factor, bits_per_value }`.  Spread into a descriptor
+///   to apply: `{ ...computed, encoding: "simple_packing", …}`.
+#[wasm_bindgen]
+pub fn simple_packing_compute_params(
+    values: &[f64],
+    bits_per_value: u32,
+    decimal_scale_factor: i32,
+) -> Result<JsValue, JsError> {
+    let params = simple_packing::compute_params(values, bits_per_value, decimal_scale_factor)
+        .map_err(|e| JsError::new(&format!("encoding error: {e}")))?;
+    to_js(&SimplePackingParamsJs {
+        reference_value: params.reference_value,
+        binary_scale_factor: params.binary_scale_factor,
+        decimal_scale_factor: params.decimal_scale_factor,
+        bits_per_value: params.bits_per_value,
+    })
+}
+
+// ── encode_pre_encoded ───────────────────────────────────────────────────────
+
+/// Encode a complete Tensogram message from pre-encoded data objects.
+///
+/// Like [`crate::encode`], but each object's bytes are assumed already
+/// encoded by the caller (according to its descriptor's pipeline) and
+/// are written verbatim.  The library validates descriptor structure and
+/// any `szip_block_offsets` it finds but never runs the encoding
+/// pipeline.  The hash is always recomputed from the caller's bytes.
+///
+/// @param metadata_js - GlobalMetadata (JS object, `version: 2` required).
+/// @param objects_js - Array of `{descriptor, data}`; each `data` must
+///   be a `Uint8Array` (opaque pre-encoded bytes).
+/// @param hash - Whether to stamp an xxh3 hash.  Default `true`.
+/// @returns Full wire-format message as `Uint8Array`.
+#[wasm_bindgen]
+pub fn encode_pre_encoded(
+    metadata_js: JsValue,
+    objects_js: js_sys::Array,
+    hash: Option<bool>,
+) -> Result<js_sys::Uint8Array, JsError> {
+    let metadata: core::GlobalMetadata =
+        serde_wasm_bindgen::from_value(metadata_js).map_err(js_err)?;
+    let (descriptors, data_vec) = extract_descriptor_data_pairs(&objects_js)?;
+    let pairs: Vec<(&core::DataObjectDescriptor, &[u8])> = descriptors
+        .iter()
+        .zip(data_vec.iter())
+        .map(|(d, v)| (d, v.as_slice()))
+        .collect();
+    let encoded =
+        core::encode_pre_encoded(&metadata, &pairs, &build_encode_options(hash)).map_err(js_err)?;
+    Ok(js_sys::Uint8Array::from(encoded.as_slice()))
+}
+
+// ── validate_buffer ──────────────────────────────────────────────────────────
+
+/// Validate a single Tensogram message buffer.  Returns a JSON string
+/// matching the structure emitted by `tensogram::validate::ValidationReport`:
+/// `{ issues: [...], object_count: N, hash_verified: bool }`.
+///
+/// The TypeScript wrapper parses this JSON once and exposes a typed
+/// `ValidationReport`.  Keeping the bridge as a JSON string avoids
+/// lossy conversion of large integers and keeps the WASM surface
+/// language-neutral (it already matches the FFI contract).
+///
+/// @param buf - The wire-format bytes of a single message (not a file).
+/// @param level - One of `"quick"` / `"default"` / `"checksum"` / `"full"`.
+///   `None` defaults to `"default"`.
+/// @param check_canonical - When true, adds RFC 8949 §4.2 canonical
+///   CBOR key-ordering checks.
+#[wasm_bindgen]
+pub fn validate_buffer(
+    buf: &[u8],
+    level: Option<String>,
+    check_canonical: bool,
+) -> Result<String, JsError> {
+    let options = parse_validate_options(level.as_deref(), check_canonical)?;
+    let report = core::validate::validate_message(buf, &options);
+    serde_json::to_string(&report).map_err(|e| JsError::new(&format!("encoding error: {e}")))
+}
+
+fn parse_validate_options(
+    level: Option<&str>,
+    check_canonical: bool,
+) -> Result<core::validate::ValidateOptions, JsError> {
+    use core::validate::{ValidateOptions, ValidationLevel};
+
+    let (max_level, checksum_only) = match level.unwrap_or("default") {
+        "quick" => (ValidationLevel::Structure, false),
+        "default" => (ValidationLevel::Integrity, false),
+        "checksum" => (ValidationLevel::Integrity, true),
+        "full" => (ValidationLevel::Fidelity, false),
+        other => {
+            return Err(JsError::new(&format!(
+                "unknown validation level '{other}', expected one of: quick, default, checksum, full",
+            )));
+        }
+    };
+    Ok(ValidateOptions {
+        max_level,
+        check_canonical,
+        checksum_only,
+    })
+}

--- a/rust/tensogram-wasm/src/lib.rs
+++ b/rust/tensogram-wasm/src/lib.rs
@@ -8,8 +8,10 @@
 
 //! WebAssembly bindings for the Tensogram N-tensor message format.
 //!
-//! Provides encode, decode, scan, and streaming decode functions
-//! accessible from JavaScript/TypeScript via wasm-bindgen.
+//! Provides encode, decode, scan, streaming decode, range decode, hash,
+//! validation, pre-encoded encode, `simple_packing` params, and a
+//! frame-at-a-time `StreamingEncoder` — accessible from JavaScript /
+//! TypeScript via `wasm-bindgen`.
 //!
 //! Tensor payloads are returned as zero-copy TypedArray views into
 //! WASM linear memory for 60fps visualisation performance.
@@ -20,10 +22,12 @@
 //! Attempts to decode blosc2/zfp/sz3 compressed data will return an error.
 
 mod convert;
+mod encoder;
+mod extras;
 mod streaming;
 
 use convert::*;
-use tensogram::{self as core, DecodeOptions, EncodeOptions};
+use tensogram::{self as core, DecodeOptions};
 use wasm_bindgen::prelude::*;
 
 // ── Decode API ───────────────────────────────────────────────────────────────
@@ -104,54 +108,16 @@ pub fn encode(
     objects_js: js_sys::Array,
     hash: Option<bool>,
 ) -> Result<js_sys::Uint8Array, JsError> {
-    use core::hash::HashAlgorithm;
-    use core::types::{DataObjectDescriptor, GlobalMetadata};
-
-    let metadata: GlobalMetadata =
-        serde_wasm_bindgen::from_value(metadata_js).map_err(|e| JsError::new(&e.to_string()))?;
-
-    let mut descriptors = Vec::new();
-    let mut data_vec: Vec<Vec<u8>> = Vec::new();
-
-    for i in 0..objects_js.length() {
-        let obj = objects_js.get(i);
-        let desc_val = js_sys::Reflect::get(&obj, &"descriptor".into())
-            .map_err(|_| JsError::new("each object must have a 'descriptor' field"))?;
-        let data_val = js_sys::Reflect::get(&obj, &"data".into())
-            .map_err(|_| JsError::new("each object must have a 'data' field"))?;
-
-        let desc: DataObjectDescriptor =
-            serde_wasm_bindgen::from_value(desc_val).map_err(|e| JsError::new(&e.to_string()))?;
-
-        // Accept any TypedArray — view the underlying ArrayBuffer as raw bytes.
-        let data_bytes = typed_array_to_bytes(&data_val).ok_or_else(|| {
-            JsError::new(
-                "data must be a TypedArray (Uint8Array, Float32Array, Float64Array, or Int32Array)",
-            )
-        })?;
-
-        descriptors.push(desc);
-        data_vec.push(data_bytes);
-    }
-
-    let options = EncodeOptions {
-        hash_algorithm: if hash.unwrap_or(true) {
-            Some(HashAlgorithm::Xxh3)
-        } else {
-            None
-        },
-        emit_preceders: false,
-        ..Default::default()
-    };
-
+    let metadata: core::GlobalMetadata =
+        serde_wasm_bindgen::from_value(metadata_js).map_err(js_err)?;
+    let (descriptors, data_vec) = extract_descriptor_data_pairs(&objects_js)?;
     let pairs: Vec<(&core::DataObjectDescriptor, &[u8])> = descriptors
         .iter()
         .zip(data_vec.iter())
         .map(|(d, v)| (d, v.as_slice()))
         .collect();
-    let encoded = core::encode(&metadata, &pairs, &options).map_err(js_err)?;
-
-    // Return a JS-owned copy.  We must not use view_as_u8 here because
+    let encoded = core::encode(&metadata, &pairs, &build_encode_options(hash)).map_err(js_err)?;
+    // Return a JS-owned copy.  We must not use `view_as_u8` here because
     // `encoded` is a local Vec that will be dropped when this function
     // returns — a view into it would be a dangling pointer.
     Ok(js_sys::Uint8Array::from(encoded.as_slice()))
@@ -252,50 +218,12 @@ impl DecodedMessage {
 
 pub use streaming::StreamingDecoder;
 
-// ── Internal helpers ─────────────────────────────────────────────────────────
+// ── StreamingEncoder re-export ───────────────────────────────────────────────
 
-fn js_err(e: core::TensogramError) -> JsError {
-    JsError::new(&e.to_string())
-}
+pub use encoder::StreamingEncoder;
 
-/// Extract raw bytes from any supported TypedArray by viewing its ArrayBuffer.
-///
-/// Correctly respects `byteOffset` and `byteLength` so that subarrays /
-/// views only yield the intended region (no data leak from the underlying
-/// ArrayBuffer).
-///
-/// Returns `None` if `val` is not a recognised TypedArray type.
-fn typed_array_to_bytes(val: &JsValue) -> Option<Vec<u8>> {
-    if let Some(arr) = val.dyn_ref::<js_sys::Uint8Array>() {
-        Some(arr.to_vec())
-    } else if let Some(arr) = val.dyn_ref::<js_sys::Float32Array>() {
-        Some(
-            js_sys::Uint8Array::new_with_byte_offset_and_length(
-                &arr.buffer(),
-                arr.byte_offset(),
-                arr.byte_length(),
-            )
-            .to_vec(),
-        )
-    } else if let Some(arr) = val.dyn_ref::<js_sys::Float64Array>() {
-        Some(
-            js_sys::Uint8Array::new_with_byte_offset_and_length(
-                &arr.buffer(),
-                arr.byte_offset(),
-                arr.byte_length(),
-            )
-            .to_vec(),
-        )
-    } else if let Some(arr) = val.dyn_ref::<js_sys::Int32Array>() {
-        Some(
-            js_sys::Uint8Array::new_with_byte_offset_and_length(
-                &arr.buffer(),
-                arr.byte_offset(),
-                arr.byte_length(),
-            )
-            .to_vec(),
-        )
-    } else {
-        None
-    }
-}
+// ── Scope-C exports (decode_range, compute_hash, validate, …) ───────────────
+
+pub use extras::{
+    compute_hash, decode_range, encode_pre_encoded, simple_packing_compute_params, validate_buffer,
+};

--- a/rust/tensogram-wasm/src/streaming.rs
+++ b/rust/tensogram-wasm/src/streaming.rs
@@ -68,6 +68,12 @@ pub struct StreamingDecoder {
     max_buffer: usize,
 }
 
+impl Default for StreamingDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[wasm_bindgen]
 impl StreamingDecoder {
     /// Create a new streaming decoder.

--- a/rust/tensogram-wasm/tests/wasm_tests.rs
+++ b/rust/tensogram-wasm/tests/wasm_tests.rs
@@ -36,7 +36,7 @@
 use std::collections::BTreeMap;
 use tensogram::dtype::Dtype;
 use tensogram::types::{ByteOrder, DataObjectDescriptor, GlobalMetadata};
-use wasm_bindgen::prelude::*;
+use wasm_bindgen::closure::Closure;
 use wasm_bindgen_test::*;
 
 // Szip flag constants (matching libaec.h / tensogram_szip::params exactly).
@@ -260,7 +260,9 @@ fn round_trip_f32_no_compression() {
 #[wasm_bindgen_test]
 fn round_trip_f64_no_compression() {
     let desc = make_descriptor(vec![4], Dtype::Float64);
-    let values = [3.14159f64, 2.71828, 1.41421, 0.0];
+    // Arbitrary test values — chosen to avoid matching any named
+    // mathematical constant (clippy::approx_constant).
+    let values = [3.5f64, 2.2, 1.1, 0.0];
     let payload = f64_payload(&values);
     let msg = encode_native_no_hash(&default_metadata(), &[(&desc, &payload)]);
 
@@ -635,7 +637,9 @@ fn zero_copy_f32_view_values_correct() {
 #[wasm_bindgen_test]
 fn zero_copy_f64_view_values_correct() {
     let desc = make_descriptor(vec![3], Dtype::Float64);
-    let values = [3.14f64, 2.718, 1.414];
+    // Arbitrary test values — not named mathematical constants
+    // (clippy::approx_constant).
+    let values = [3.5f64, 2.2, 1.4];
     let payload = f64_payload(&values);
     let msg = encode_native_no_hash(&default_metadata(), &[(&desc, &payload)]);
 
@@ -643,9 +647,9 @@ fn zero_copy_f64_view_values_correct() {
     let view = decoded.object_data_f64(0).unwrap();
 
     assert_eq!(view.length(), 3);
-    assert_eq!(view.get_index(0), 3.14);
-    assert_eq!(view.get_index(1), 2.718);
-    assert_eq!(view.get_index(2), 1.414);
+    assert_eq!(view.get_index(0), 3.5);
+    assert_eq!(view.get_index(1), 2.2);
+    assert_eq!(view.get_index(2), 1.4);
 }
 
 #[wasm_bindgen_test]
@@ -1726,7 +1730,7 @@ fn metadata_deep_nested_mars_keys() {
         ..Default::default()
     };
     let desc = make_descriptor(vec![10], Dtype::Float32);
-    let payload = f32_payload(&vec![0.0f32; 10]);
+    let payload = f32_payload(&[0.0f32; 10]);
     let msg = encode_native_no_hash(&meta, &[(&desc, &payload)]);
 
     // Just verify it decodes without error — metadata fidelity
@@ -2408,4 +2412,477 @@ fn compressed_data_i32_view_correct() {
     assert_eq!(view.length(), 4);
     assert_eq!(view.get_index(0), -10);
     assert_eq!(view.get_index(3), 20);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 16. SCOPE-C EXPORTS — decode_range / compute_hash / simple_packing_params /
+//     encode_pre_encoded / validate_buffer / StreamingEncoder
+// ═══════════════════════════════════════════════════════════════════════════════
+
+use js_sys::{Array, BigUint64Array, Uint8Array};
+use wasm_bindgen::JsCast;
+
+fn flatten_ranges(ranges: &[(u64, u64)]) -> BigUint64Array {
+    let flat: Vec<u64> = ranges.iter().flat_map(|(a, b)| [*a, *b]).collect();
+    let out = BigUint64Array::new_with_length(flat.len() as u32);
+    for (i, v) in flat.iter().enumerate() {
+        out.set_index(i as u32, *v);
+    }
+    out
+}
+
+// -- decode_range -----------------------------------------------------------
+
+#[wasm_bindgen_test]
+fn decode_range_single_range_uncompressed() {
+    let desc = make_descriptor(vec![16], Dtype::Float32);
+    let values: Vec<f32> = (0..16).map(|i| i as f32).collect();
+    let payload = f32_payload(&values);
+    let msg = encode_native_no_hash(&default_metadata(), &[(&desc, &payload)]);
+
+    // Elements 4..8 (count = 4) — byte range [16, 32).
+    let ranges = flatten_ranges(&[(4, 4)]);
+    let result = tensogram_wasm::decode_range(&msg, 0, &ranges, None).unwrap();
+    let parts = js_sys::Reflect::get(&result, &"parts".into()).unwrap();
+    let parts_arr = Array::from(&parts);
+    assert_eq!(parts_arr.length(), 1);
+
+    let part = parts_arr.get(0);
+    let u8 = part.dyn_into::<Uint8Array>().unwrap();
+    assert_eq!(u8.length(), 16); // 4 × f32 = 16 bytes
+    let bytes = u8.to_vec();
+    assert_eq!(bytes, &payload[16..32]);
+}
+
+#[wasm_bindgen_test]
+fn decode_range_multiple_ranges() {
+    let desc = make_descriptor(vec![32], Dtype::Float32);
+    let values: Vec<f32> = (0..32).map(|i| i as f32).collect();
+    let payload = f32_payload(&values);
+    let msg = encode_native_no_hash(&default_metadata(), &[(&desc, &payload)]);
+
+    // Two disjoint ranges: [0..4] and [20..24].
+    let ranges = flatten_ranges(&[(0, 4), (20, 4)]);
+    let result = tensogram_wasm::decode_range(&msg, 0, &ranges, None).unwrap();
+    let parts = js_sys::Reflect::get(&result, &"parts".into()).unwrap();
+    let parts_arr = Array::from(&parts);
+    assert_eq!(parts_arr.length(), 2);
+
+    let p0 = parts_arr.get(0).dyn_into::<Uint8Array>().unwrap().to_vec();
+    let p1 = parts_arr.get(1).dyn_into::<Uint8Array>().unwrap().to_vec();
+    assert_eq!(p0, &payload[0..16]);
+    assert_eq!(p1, &payload[80..96]);
+}
+
+#[wasm_bindgen_test]
+fn decode_range_empty_ranges_returns_empty_parts() {
+    let desc = make_descriptor(vec![4], Dtype::Float32);
+    let msg = encode_native_no_hash(
+        &default_metadata(),
+        &[(&desc, &f32_payload(&[1.0, 2.0, 3.0, 4.0]))],
+    );
+    let ranges = flatten_ranges(&[]);
+    let result = tensogram_wasm::decode_range(&msg, 0, &ranges, None).unwrap();
+    let parts = js_sys::Reflect::get(&result, &"parts".into()).unwrap();
+    assert_eq!(Array::from(&parts).length(), 0);
+}
+
+#[wasm_bindgen_test]
+fn decode_range_odd_length_rejected() {
+    let desc = make_descriptor(vec![4], Dtype::Float32);
+    let msg = encode_native_no_hash(
+        &default_metadata(),
+        &[(&desc, &f32_payload(&[1.0, 2.0, 3.0, 4.0]))],
+    );
+    // Odd number of u64 values — not valid [off, count] pairs.
+    let odd = BigUint64Array::new_with_length(3);
+    odd.set_index(0, 0);
+    odd.set_index(1, 2);
+    odd.set_index(2, 4);
+    assert!(tensogram_wasm::decode_range(&msg, 0, &odd, None).is_err());
+}
+
+#[wasm_bindgen_test]
+fn decode_range_filter_shuffle_rejected() {
+    use std::collections::BTreeMap as Map;
+    let mut params = Map::new();
+    params.insert(
+        "shuffle_element_size".to_string(),
+        ciborium::Value::Integer(4i64.into()),
+    );
+    let desc = DataObjectDescriptor {
+        filter: "shuffle".to_string(),
+        params,
+        ..make_descriptor(vec![4], Dtype::Float32)
+    };
+    let msg = encode_native_no_hash(
+        &default_metadata(),
+        &[(&desc, &f32_payload(&[1.0, 2.0, 3.0, 4.0]))],
+    );
+    let ranges = flatten_ranges(&[(0, 2)]);
+    let res = tensogram_wasm::decode_range(&msg, 0, &ranges, None);
+    assert!(res.is_err(), "filter=shuffle should reject decode_range");
+}
+
+// -- compute_hash -----------------------------------------------------------
+
+#[wasm_bindgen_test]
+fn compute_hash_xxh3_default() {
+    let data = b"hello world";
+    let hex = tensogram_wasm::compute_hash(data, None).unwrap();
+    assert_eq!(hex.len(), 16);
+    // Same bytes produce the same hash.
+    let again = tensogram_wasm::compute_hash(data, None).unwrap();
+    assert_eq!(hex, again);
+}
+
+#[wasm_bindgen_test]
+fn compute_hash_explicit_xxh3() {
+    let hex = tensogram_wasm::compute_hash(b"test", Some("xxh3".to_string())).unwrap();
+    assert_eq!(hex.len(), 16);
+}
+
+#[wasm_bindgen_test]
+fn compute_hash_empty_buffer() {
+    let hex = tensogram_wasm::compute_hash(&[], None).unwrap();
+    assert_eq!(hex.len(), 16);
+}
+
+#[wasm_bindgen_test]
+fn compute_hash_unknown_algo_errors() {
+    let res = tensogram_wasm::compute_hash(b"x", Some("sha256".to_string()));
+    assert!(res.is_err());
+}
+
+#[wasm_bindgen_test]
+fn compute_hash_matches_descriptor_hash() {
+    // The hash in the descriptor is computed over the encoded payload.
+    // For encoding=none,filter=none,compression=none the encoded payload
+    // is the raw native bytes, so the hashes must match.
+    let desc = make_descriptor(vec![4], Dtype::Float32);
+    let payload = f32_payload(&[1.0, 2.0, 3.0, 4.0]);
+    let msg = encode_native(&default_metadata(), &[(&desc, &payload)]); // with hash
+    let decoded = tensogram_wasm::decode(&msg, None).unwrap();
+    let desc_js = decoded.object_descriptor(0).unwrap();
+    let hash_val = js_sys::Reflect::get(&desc_js, &"hash".into()).unwrap();
+    let value_val = js_sys::Reflect::get(&hash_val, &"value".into()).unwrap();
+    let expected = value_val.as_string().unwrap();
+
+    let computed = tensogram_wasm::compute_hash(&payload, None).unwrap();
+    assert_eq!(computed, expected);
+}
+
+// -- simple_packing_compute_params -----------------------------------------
+
+#[wasm_bindgen_test]
+fn simple_packing_compute_params_basic() {
+    let values = [200.0f64, 210.0, 220.0, 230.0, 240.0];
+    let result = tensogram_wasm::simple_packing_compute_params(&values, 16, 0).unwrap();
+    let obj = js_sys::Object::from(result);
+    let ref_v = js_sys::Reflect::get(&obj, &"reference_value".into())
+        .unwrap()
+        .as_f64()
+        .unwrap();
+    let bpv = js_sys::Reflect::get(&obj, &"bits_per_value".into())
+        .unwrap()
+        .as_f64()
+        .unwrap();
+    assert_eq!(ref_v, 200.0);
+    assert_eq!(bpv, 16.0);
+}
+
+#[wasm_bindgen_test]
+fn simple_packing_compute_params_nan_rejected() {
+    let values = [1.0f64, f64::NAN, 3.0];
+    assert!(tensogram_wasm::simple_packing_compute_params(&values, 16, 0).is_err());
+}
+
+#[wasm_bindgen_test]
+fn simple_packing_compute_params_zero_bits() {
+    // bits=0 → constant-field packing, reference = first value
+    let values = [42.0f64, 42.0, 42.0];
+    let result = tensogram_wasm::simple_packing_compute_params(&values, 0, 0).unwrap();
+    let bpv = js_sys::Reflect::get(&result, &"bits_per_value".into())
+        .unwrap()
+        .as_f64()
+        .unwrap();
+    assert_eq!(bpv, 0.0);
+}
+
+// -- encode_pre_encoded -----------------------------------------------------
+
+#[wasm_bindgen_test]
+fn encode_pre_encoded_round_trip_uncompressed() {
+    // A pre-encoded object with encoding=filter=compression=none is just
+    // the raw bytes — the simplest round-trip.
+    let desc = make_descriptor(vec![4], Dtype::Float32);
+    let payload = f32_payload(&[10.0, 20.0, 30.0, 40.0]);
+
+    let meta_js = serde_wasm_bindgen::to_value(&default_metadata()).unwrap();
+    let objects = Array::new();
+    let entry = js_sys::Object::new();
+    let desc_js = serde_wasm_bindgen::to_value(&desc).unwrap();
+    js_sys::Reflect::set(&entry, &"descriptor".into(), &desc_js).unwrap();
+    js_sys::Reflect::set(
+        &entry,
+        &"data".into(),
+        &Uint8Array::from(payload.as_slice()).into(),
+    )
+    .unwrap();
+    objects.push(&entry);
+
+    let msg = tensogram_wasm::encode_pre_encoded(meta_js, objects, Some(true)).unwrap();
+    let msg_bytes = msg.to_vec();
+    let decoded = tensogram_wasm::decode(&msg_bytes, None).unwrap();
+    assert_eq!(decoded.object_count(), 1);
+    let data: Vec<u8> = decoded.object_data_u8(0).unwrap().to_vec();
+    assert_eq!(data, payload);
+}
+
+// -- validate_buffer --------------------------------------------------------
+
+#[wasm_bindgen_test]
+fn validate_buffer_valid_message() {
+    let desc = make_descriptor(vec![4], Dtype::Float32);
+    let payload = f32_payload(&[1.0, 2.0, 3.0, 4.0]);
+    let msg = encode_native(&default_metadata(), &[(&desc, &payload)]);
+
+    let json = tensogram_wasm::validate_buffer(&msg, None, false).unwrap();
+    assert!(json.contains("\"object_count\":1"));
+    assert!(json.contains("\"hash_verified\":true"));
+}
+
+#[wasm_bindgen_test]
+fn validate_buffer_truncated_message_reports_issues() {
+    let desc = make_descriptor(vec![4], Dtype::Float32);
+    let msg = encode_native(
+        &default_metadata(),
+        &[(&desc, &f32_payload(&[1.0, 2.0, 3.0, 4.0]))],
+    );
+    let truncated = &msg[..msg.len() / 2];
+    let json = tensogram_wasm::validate_buffer(truncated, None, false).unwrap();
+    // Should report issues rather than throwing.
+    assert!(json.contains("\"issues\""));
+}
+
+#[wasm_bindgen_test]
+fn validate_buffer_full_mode_scans_nan() {
+    // A finite, non-NaN payload passes full-mode validation.
+    let desc = make_descriptor(vec![4], Dtype::Float64);
+    let msg = encode_native(
+        &default_metadata(),
+        &[(&desc, &f64_payload(&[1.0, 2.0, 3.0, 4.0]))],
+    );
+    let json = tensogram_wasm::validate_buffer(&msg, Some("full".to_string()), false).unwrap();
+    assert!(json.contains("\"hash_verified\":true"));
+}
+
+#[wasm_bindgen_test]
+fn validate_buffer_unknown_level_errors() {
+    let msg = encode_native(
+        &default_metadata(),
+        &[(
+            &make_descriptor(vec![1], Dtype::Float32),
+            &f32_payload(&[1.0]),
+        )],
+    );
+    assert!(tensogram_wasm::validate_buffer(&msg, Some("bogus".to_string()), false).is_err());
+}
+
+// -- StreamingEncoder --------------------------------------------------------
+
+#[wasm_bindgen_test]
+fn streaming_encoder_single_object_round_trip() {
+    let meta_js = serde_wasm_bindgen::to_value(&default_metadata()).unwrap();
+    let mut enc = tensogram_wasm::StreamingEncoder::new(meta_js, Some(true), None).unwrap();
+    assert_eq!(enc.object_count().unwrap(), 0);
+
+    let desc = make_descriptor(vec![3], Dtype::Float32);
+    let desc_js = serde_wasm_bindgen::to_value(&desc).unwrap();
+    let payload = f32_payload(&[1.0, 2.0, 3.0]);
+    enc.write_object(desc_js, Uint8Array::from(payload.as_slice()).into())
+        .unwrap();
+    assert_eq!(enc.object_count().unwrap(), 1);
+
+    let bytes = enc.finish().unwrap();
+    let msg_vec = bytes.to_vec();
+    let decoded = tensogram_wasm::decode(&msg_vec, None).unwrap();
+    assert_eq!(decoded.object_count(), 1);
+    let got: Vec<u8> = decoded.object_data_u8(0).unwrap().to_vec();
+    assert_eq!(got, payload);
+}
+
+#[wasm_bindgen_test]
+fn streaming_encoder_finish_closes_handle() {
+    let meta_js = serde_wasm_bindgen::to_value(&default_metadata()).unwrap();
+    let mut enc = tensogram_wasm::StreamingEncoder::new(meta_js, Some(false), None).unwrap();
+    let _ = enc.finish().unwrap();
+    // Further access raises an error rather than panicking.
+    let meta_js2 = serde_wasm_bindgen::to_value(&default_metadata()).unwrap();
+    let desc_js = serde_wasm_bindgen::to_value(&make_descriptor(vec![1], Dtype::Float32)).unwrap();
+    // Re-using the closed encoder via write_object should fail.
+    assert!(
+        enc.write_object(desc_js, Uint8Array::from([0u8; 4].as_slice()).into())
+            .is_err()
+    );
+    // And constructing a brand-new encoder still works.
+    let mut enc2 = tensogram_wasm::StreamingEncoder::new(meta_js2, None, None).unwrap();
+    assert_eq!(enc2.object_count().unwrap(), 0);
+    let _ = enc2.finish().unwrap();
+}
+
+#[wasm_bindgen_test]
+fn streaming_encoder_preceder_merges_into_base() {
+    use std::collections::BTreeMap as Map;
+    let meta_js = serde_wasm_bindgen::to_value(&default_metadata()).unwrap();
+    let mut enc = tensogram_wasm::StreamingEncoder::new(meta_js, Some(false), None).unwrap();
+
+    let mut prec: Map<String, ciborium::Value> = Map::new();
+    prec.insert("units".to_string(), ciborium::Value::Text("K".to_string()));
+    let prec_js = serde_wasm_bindgen::to_value(&prec).unwrap();
+    enc.write_preceder(prec_js).unwrap();
+
+    let desc_js = serde_wasm_bindgen::to_value(&make_descriptor(vec![2], Dtype::Float32)).unwrap();
+    let payload = f32_payload(&[273.15, 274.0]);
+    enc.write_object(desc_js, Uint8Array::from(payload.as_slice()).into())
+        .unwrap();
+
+    let bytes = enc.finish().unwrap().to_vec();
+    let decoded = tensogram_wasm::decode(&bytes, None).unwrap();
+    assert_eq!(decoded.object_count(), 1);
+    let meta = decoded.metadata().unwrap();
+    assert!(meta.is_object());
+}
+
+#[wasm_bindgen_test]
+fn streaming_encoder_consecutive_preceders_rejected() {
+    let meta_js = serde_wasm_bindgen::to_value(&default_metadata()).unwrap();
+    let mut enc = tensogram_wasm::StreamingEncoder::new(meta_js, None, None).unwrap();
+    let empty_js = serde_wasm_bindgen::to_value(&serde_json::json!({})).unwrap();
+    enc.write_preceder(empty_js.clone()).unwrap();
+    assert!(enc.write_preceder(empty_js).is_err());
+}
+
+// ─── Streaming-callback mode (Pass 6) ────────────────────────────────────────
+
+/// Helper: build a JS function that pushes each chunk into a
+/// JS-side `Array`.  Returns the `(callback, chunks_array)` pair so
+/// the test body can inspect what the encoder emitted.
+fn make_collector() -> (js_sys::Function, js_sys::Array) {
+    let chunks = js_sys::Array::new();
+    let chunks_ref = chunks.clone();
+    let closure =
+        Closure::<dyn FnMut(js_sys::Uint8Array)>::new(move |chunk: js_sys::Uint8Array| {
+            // The callback receives a *borrowed* JS-heap view into the
+            // bytes the encoder emitted for this frame.  We copy it into
+            // a freshly owned `Uint8Array` so later encoder writes cannot
+            // mutate what the collector has remembered.
+            let owned = js_sys::Uint8Array::new_with_length(chunk.length());
+            owned.set(&chunk, 0);
+            chunks_ref.push(&owned.into());
+        });
+    let cb: js_sys::Function = closure.into_js_value().unchecked_into();
+    (cb, chunks)
+}
+
+/// Concatenate every `Uint8Array` chunk the collector saw into a
+/// single contiguous byte buffer.
+fn flatten_chunks(chunks: &js_sys::Array) -> Vec<u8> {
+    let mut out = Vec::new();
+    for i in 0..chunks.length() {
+        let u8: js_sys::Uint8Array = chunks.get(i).unchecked_into();
+        let mut buf = vec![0u8; u8.length() as usize];
+        u8.copy_to(&mut buf);
+        out.extend_from_slice(&buf);
+    }
+    out
+}
+
+#[wasm_bindgen_test]
+fn streaming_encoder_callback_mode_round_trip() {
+    // Streaming mode must produce the same wire bytes as buffered mode
+    // for the same input — the callback just chunks the delivery.
+    let (cb, chunks) = make_collector();
+    let meta_js = serde_wasm_bindgen::to_value(&default_metadata()).unwrap();
+    let mut enc = tensogram_wasm::StreamingEncoder::new(meta_js, Some(true), Some(cb)).unwrap();
+
+    let desc = make_descriptor(vec![3], Dtype::Float32);
+    let desc_js = serde_wasm_bindgen::to_value(&desc).unwrap();
+    let payload = f32_payload(&[1.5, 2.5, 3.5]);
+    enc.write_object(desc_js, Uint8Array::from(payload.as_slice()).into())
+        .unwrap();
+
+    // `finish()` in streaming mode returns an empty Uint8Array — every
+    // byte flowed through the callback.
+    let final_bytes = enc.finish().unwrap();
+    assert_eq!(final_bytes.length(), 0);
+
+    let streamed = flatten_chunks(&chunks);
+    let decoded = tensogram_wasm::decode(&streamed, None).unwrap();
+    assert_eq!(decoded.object_count(), 1);
+    let got: Vec<u8> = decoded.object_data_u8(0).unwrap().to_vec();
+    assert_eq!(got, payload);
+}
+
+#[wasm_bindgen_test]
+fn streaming_encoder_callback_invoked_during_construction() {
+    // The preamble + header metadata frame are written during
+    // construction, so the callback must have seen bytes before the
+    // first user call.
+    let (cb, chunks) = make_collector();
+    let meta_js = serde_wasm_bindgen::to_value(&default_metadata()).unwrap();
+    let _enc = tensogram_wasm::StreamingEncoder::new(meta_js, Some(false), Some(cb)).unwrap();
+    assert!(chunks.length() > 0);
+    // And the first bytes emitted must start with the Tensogram magic.
+    let first: js_sys::Uint8Array = chunks.get(0).unchecked_into();
+    let mut magic = [0u8; 8];
+    first.slice(0, 8).copy_to(&mut magic);
+    assert_eq!(&magic, b"TENSOGRM");
+}
+
+#[wasm_bindgen_test]
+fn streaming_encoder_bytes_written_tracks_callback_bytes() {
+    // `bytes_written` must report the total across every chunk sent,
+    // not zero (which would be the buffered interpretation of "nothing
+    // in the internal buffer").
+    let (cb, _) = make_collector();
+    let meta_js = serde_wasm_bindgen::to_value(&default_metadata()).unwrap();
+    let mut enc = tensogram_wasm::StreamingEncoder::new(meta_js, Some(false), Some(cb)).unwrap();
+
+    let before = enc.bytes_written().unwrap();
+    assert!(before > 0.0); // preamble + header already emitted
+
+    let desc_js = serde_wasm_bindgen::to_value(&make_descriptor(vec![4], Dtype::Float32)).unwrap();
+    enc.write_object(desc_js, Uint8Array::from([0u8; 16].as_slice()).into())
+        .unwrap();
+    let after = enc.bytes_written().unwrap();
+    assert!(after > before);
+}
+
+#[wasm_bindgen_test]
+fn streaming_encoder_callback_error_propagates() {
+    // A callback that throws must cause the encoder to surface an
+    // error rather than silently drop the exception.  We construct
+    // with a callback that raises synchronously — the preamble +
+    // header-metadata write happens inside `new()`, so the Err comes
+    // out of the constructor itself.
+    let bad_cb = js_sys::Function::new_no_args("throw new Error('sink failed');");
+    let meta_js = serde_wasm_bindgen::to_value(&default_metadata()).unwrap();
+    let result = tensogram_wasm::StreamingEncoder::new(meta_js, Some(false), Some(bad_cb));
+    assert!(result.is_err(), "throwing callback must propagate as error");
+}
+
+#[wasm_bindgen_test]
+fn streaming_encoder_rejects_non_function_callback() {
+    // wasm-bindgen's `Option<js_sys::Function>` conversion rejects
+    // non-callable inputs with a TypeError before our code runs — we
+    // document and test that a number does not reach the sink.
+    let meta_js = serde_wasm_bindgen::to_value(&default_metadata()).unwrap();
+    // Passing `None` is the well-formed "buffered" path, so we only
+    // need to assert that the streaming variant builds cleanly with a
+    // real function.  Non-function inputs are rejected at the wasm-
+    // bindgen conversion layer — covered by the TS-side test.
+    let cb = js_sys::Function::new_no_args("");
+    let enc = tensogram_wasm::StreamingEncoder::new(meta_js, None, Some(cb));
+    assert!(enc.is_ok());
 }

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ecmwf/tensogram",
-  "version": "0.12.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ecmwf/tensogram",
-      "version": "0.12.0",
+      "version": "0.15.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/typescript/src/bfloat16.ts
+++ b/typescript/src/bfloat16.ts
@@ -1,0 +1,211 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+/**
+ * `Bfloat16Array` — brain-float-16, the 8-bit-exponent / 7-bit-mantissa
+ * floating-point format popular in ML frameworks.
+ *
+ * Bit layout: `sign:1 | exp:8 | mantissa:7` — identical to `float32`'s
+ * top 16 bits.  This makes conversion close to a byte copy: widening
+ * is "shift left by 16", narrowing is "take the top 16 bits (with
+ * round-to-nearest-even) of the float32 representation".
+ *
+ * The API surface matches {@link Float16Polyfill}: array-like
+ * accessors, iteration, `.bits`, `.toFloat32Array()`.  There is no
+ * native JS `Bfloat16Array` today; this class is always used.
+ */
+
+const _f32_scratch = new Float32Array(1);
+const _u32_scratch = new Uint32Array(_f32_scratch.buffer);
+
+/**
+ * Widen a bfloat16 bit pattern to a `number`.
+ *
+ * @internal — not re-exported from the package barrel.
+ */
+export function bfloat16BitsToFloat(bits: number): number {
+  _u32_scratch[0] = (bits & 0xffff) << 16;
+  return _f32_scratch[0];
+}
+
+/**
+ * Narrow a `number` to a bfloat16 bit pattern.  Uses round-to-nearest-
+ * even on the 16 discarded float32 mantissa bits.  NaN propagates with
+ * the sign / quiet bit preserved; ±Inf saturates.
+ *
+ * @internal — not re-exported from the package barrel.
+ */
+export function floatToBfloat16Bits(value: number): number {
+  _f32_scratch[0] = value;
+  const x = _u32_scratch[0];
+  const high = x >>> 16;
+
+  // NaN: force mantissa ≠ 0 in the 7 retained bits, preserve sign.
+  const exp = (x >>> 23) & 0xff;
+  const mantissa = x & 0x7fffff;
+  if (exp === 0xff) {
+    if (mantissa === 0) return high; // ±Inf
+    // Keep the sign bit + all-ones exponent, and guarantee at least
+    // one set mantissa bit.  Preserving the original high-mantissa
+    // bits is good enough for nearly-transparent NaN propagation.
+    return (high | 0x40) & 0xffff;
+  }
+
+  // Round-to-nearest-even on the dropped bits.
+  const dropped = x & 0xffff;
+  const halfway = 0x8000;
+  const lsb = high & 1;
+  if (dropped > halfway || (dropped === halfway && lsb === 1)) {
+    const rounded = (high + 1) & 0xffff;
+    // Propagate exponent overflow into ±Inf.
+    if (((rounded >>> 7) & 0xff) === 0xff && (rounded & 0x7f) !== 0) {
+      return (rounded & 0x8000) | 0x7f80; // saturate to ±Inf
+    }
+    return rounded;
+  }
+  return high;
+}
+
+const STORAGE = new WeakMap<object, Uint16Array>();
+
+/** Brain-float-16 array.  API-compatible with {@link Float16Polyfill}. */
+export class Bfloat16Array {
+  readonly BYTES_PER_ELEMENT = 2 as const;
+
+  constructor(
+    a?: number | ArrayLike<number> | Iterable<number> | ArrayBufferLike,
+    b?: number,
+    c?: number,
+  ) {
+    let bits: Uint16Array;
+    if (a === undefined) {
+      bits = new Uint16Array(0);
+    } else if (typeof a === 'number') {
+      bits = new Uint16Array(a);
+    } else if (
+      a instanceof ArrayBuffer ||
+      (typeof SharedArrayBuffer !== 'undefined' && a instanceof SharedArrayBuffer)
+    ) {
+      bits = new Uint16Array(a as ArrayBufferLike, b, c);
+    } else if (ArrayBuffer.isView(a)) {
+      const src = a as unknown as ArrayLike<number>;
+      bits = new Uint16Array(src.length);
+      for (let i = 0; i < src.length; i++) bits[i] = floatToBfloat16Bits(src[i]);
+    } else {
+      const arr = Array.from(a as Iterable<number>);
+      bits = new Uint16Array(arr.length);
+      for (let i = 0; i < arr.length; i++) bits[i] = floatToBfloat16Bits(arr[i]);
+    }
+    STORAGE.set(this, bits);
+  }
+
+  // STORAGE is populated by the constructor (or `wrapBits`) before
+  // the instance is exposed — the non-null assertion documents this
+  // total invariant without a redundant runtime check.
+  private get _bits(): Uint16Array {
+    return STORAGE.get(this)!;
+  }
+
+  get length(): number {
+    return this._bits.length;
+  }
+  get byteLength(): number {
+    return this._bits.byteLength;
+  }
+  get byteOffset(): number {
+    return this._bits.byteOffset;
+  }
+  get buffer(): ArrayBufferLike {
+    return this._bits.buffer;
+  }
+  /** Raw bfloat16 bit patterns, zero-copy. */
+  get bits(): Uint16Array {
+    return this._bits;
+  }
+
+  at(index: number): number | undefined {
+    const b = this._bits;
+    if (index < 0) index += b.length;
+    if (index < 0 || index >= b.length) return undefined;
+    return bfloat16BitsToFloat(b[index]);
+  }
+
+  get(index: number): number {
+    const b = this._bits;
+    if (!Number.isInteger(index) || index < 0 || index >= b.length) return NaN;
+    return bfloat16BitsToFloat(b[index]);
+  }
+
+  set(source: ArrayLike<number> | Bfloat16Array, offset = 0): void {
+    const b = this._bits;
+    if (source instanceof Bfloat16Array) {
+      b.set(source.bits, offset);
+      return;
+    }
+    const arr = source as ArrayLike<number>;
+    for (let i = 0; i < arr.length; i++) b[offset + i] = floatToBfloat16Bits(arr[i]);
+  }
+
+  fill(value: number, start?: number, end?: number): this {
+    this._bits.fill(floatToBfloat16Bits(value), start, end);
+    return this;
+  }
+
+  slice(start?: number, end?: number): Bfloat16Array {
+    return wrapBits(this._bits.slice(start, end));
+  }
+
+  subarray(start?: number, end?: number): Bfloat16Array {
+    return wrapBits(this._bits.subarray(start, end));
+  }
+
+  toArray(): number[] {
+    const b = this._bits;
+    const out = new Array<number>(b.length);
+    for (let i = 0; i < b.length; i++) out[i] = bfloat16BitsToFloat(b[i]);
+    return out;
+  }
+
+  toFloat32Array(): Float32Array {
+    const b = this._bits;
+    const out = new Float32Array(b.length);
+    for (let i = 0; i < b.length; i++) out[i] = bfloat16BitsToFloat(b[i]);
+    return out;
+  }
+
+  *[Symbol.iterator](): IterableIterator<number> {
+    const b = this._bits;
+    for (let i = 0; i < b.length; i++) yield bfloat16BitsToFloat(b[i]);
+  }
+}
+
+function wrapBits(bits: Uint16Array): Bfloat16Array {
+  const inst = Object.create(Bfloat16Array.prototype) as Bfloat16Array;
+  STORAGE.set(inst, bits);
+  return inst;
+}
+
+/**
+ * Build a `Bfloat16Array` from raw binary bytes (2 bytes per element).
+ *
+ * @throws {RangeError} when `bytes.byteLength` is not a multiple of 2.
+ */
+export function bfloat16FromBytes(bytes: Uint8Array): Bfloat16Array {
+  if (!Number.isInteger(bytes.byteLength / 2)) {
+    throw new RangeError(
+      `bfloat16FromBytes: byte length ${bytes.byteLength} is not a multiple of 2`,
+    );
+  }
+  const aligned = bytes.byteOffset % 2 === 0 ? bytes : new Uint8Array(bytes);
+  const u16 = new Uint16Array(
+    aligned.buffer,
+    aligned.byteOffset,
+    aligned.byteLength / 2,
+  );
+  return wrapBits(u16);
+}

--- a/typescript/src/complex.ts
+++ b/typescript/src/complex.ts
@@ -1,0 +1,180 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+/**
+ * `ComplexArray` — typed view over interleaved complex payloads.
+ *
+ * Matches the Tensogram wire contract: `complex64` stores two float32
+ * components per element `[re₀, im₀, re₁, im₁, …]`, `complex128` stores
+ * two float64 components.  This class exposes `numpy`-flavoured
+ * accessors so callers don't have to remember the interleaving:
+ *
+ * ```ts
+ * const cplx = complexFromBytes('complex64', bytes);
+ * for (let i = 0; i < cplx.length; i++) {
+ *   const { re, im } = cplx.get(i);
+ *   // …
+ * }
+ * ```
+ *
+ * Accessors return primitives (`number`) — there is no `Complex` value
+ * type.  That avoids the per-access allocation `cplx.get(i)` would
+ * otherwise cost, and mirrors how ML frameworks and `numpy` expose
+ * complex dtypes at the array boundary.
+ */
+
+import type { Dtype } from './types.js';
+
+/** Which complex dtype a view covers.  The element-storage type flows from here. */
+export type ComplexDtype = 'complex64' | 'complex128';
+
+/** Underlying storage: `Float32Array` for complex64, `Float64Array` for complex128. */
+export type ComplexStorage = Float32Array | Float64Array;
+
+/** A single `{ re, im }` pair returned by {@link ComplexArray.get}. */
+export interface ComplexPair {
+  re: number;
+  im: number;
+}
+
+/**
+ * Read-only iteration over interleaved complex pairs.
+ *
+ * Instances are lightweight — a class-level wrapper around an existing
+ * `Float32Array` / `Float64Array`.  Zero-copy when built via
+ * {@link complexFromBytes} on an aligned `Uint8Array`.
+ */
+export class ComplexArray {
+  readonly dtype: ComplexDtype;
+  readonly #storage: ComplexStorage;
+
+  /**
+   * @param dtype   - Which complex variant this view represents.
+   * @param storage - Interleaved `[re, im, re, im, …]` storage.  Length
+   *                  must be even.
+   */
+  constructor(dtype: ComplexDtype, storage: ComplexStorage) {
+    if (dtype !== 'complex64' && dtype !== 'complex128') {
+      throw new TypeError(
+        `ComplexArray: unknown complex dtype "${String(dtype)}"; expected "complex64" or "complex128"`,
+      );
+    }
+    if (dtype === 'complex64' && !(storage instanceof Float32Array)) {
+      throw new TypeError('ComplexArray: complex64 requires a Float32Array storage');
+    }
+    if (dtype === 'complex128' && !(storage instanceof Float64Array)) {
+      throw new TypeError('ComplexArray: complex128 requires a Float64Array storage');
+    }
+    if (storage.length % 2 !== 0) {
+      throw new RangeError(
+        `ComplexArray: storage length ${storage.length} must be even (interleaved re/im pairs)`,
+      );
+    }
+    this.dtype = dtype;
+    this.#storage = storage;
+  }
+
+  /** Number of complex pairs stored. */
+  get length(): number {
+    return this.#storage.length / 2;
+  }
+
+  /** Raw interleaved storage, zero-copy. */
+  get data(): ComplexStorage {
+    return this.#storage;
+  }
+
+  /**
+   * Real component of the `i`-th complex value.  Out-of-range reads
+   * return `NaN`, matching {@link Float16Polyfill.get}.
+   */
+  real(i: number): number {
+    return this.#inRange(i) ? this.#storage[2 * i] : NaN;
+  }
+
+  /** Imaginary component of the `i`-th complex value. */
+  imag(i: number): number {
+    return this.#inRange(i) ? this.#storage[2 * i + 1] : NaN;
+  }
+
+  /**
+   * Both components as a fresh `{ re, im }` pair.  Does a single
+   * bounds check rather than the two `real()` + `imag()` would cost.
+   */
+  get(i: number): ComplexPair {
+    if (!this.#inRange(i)) return { re: NaN, im: NaN };
+    return { re: this.#storage[2 * i], im: this.#storage[2 * i + 1] };
+  }
+
+  /**
+   * Write a single complex pair.  Must lie within range — attempting to
+   * set an out-of-range index throws, since silently dropping writes
+   * would defy the normal TypedArray contract.
+   */
+  set(i: number, re: number, im: number): void {
+    if (!this.#inRange(i)) {
+      throw new RangeError(
+        `ComplexArray.set: index ${i} out of range [0, ${this.length})`,
+      );
+    }
+    this.#storage[2 * i] = re;
+    this.#storage[2 * i + 1] = im;
+  }
+
+  #inRange(i: number): boolean {
+    return Number.isInteger(i) && i >= 0 && i < this.length;
+  }
+
+  /** Iterate over all pairs — yields `{ re, im }` per element. */
+  *[Symbol.iterator](): IterableIterator<ComplexPair> {
+    for (let i = 0; i < this.length; i++) yield this.get(i);
+  }
+
+  /** Returns a copy: `[[re0, im0], [re1, im1], …]`. */
+  toArray(): Array<[number, number]> {
+    const out = new Array<[number, number]>(this.length);
+    for (let i = 0; i < this.length; i++) out[i] = [this.real(i), this.imag(i)];
+    return out;
+  }
+}
+
+/**
+ * Build a `ComplexArray` over raw interleaved bytes.  Zero-copy when
+ * the input is scalar-aligned; allocates an aligned copy when it isn't.
+ *
+ * @throws {RangeError} when `bytes.byteLength` is not a multiple of
+ *   `2 * scalar_bytes` — a complex element is one `re` + one `im`
+ *   scalar, so a residual byte means a truncated payload.  `complex64`
+ *   requires multiples of 8; `complex128` requires multiples of 16.
+ */
+export function complexFromBytes(dtype: ComplexDtype, bytes: Uint8Array): ComplexArray {
+  const scalarBytes = dtype === 'complex64' ? 4 : 8;
+  const pairBytes = 2 * scalarBytes;
+  if (!Number.isInteger(bytes.byteLength / pairBytes)) {
+    throw new RangeError(
+      `complexFromBytes: byte length ${bytes.byteLength} is not a multiple of ${pairBytes} (${dtype} pair size)`,
+    );
+  }
+  const aligned = bytes.byteOffset % scalarBytes === 0 ? bytes : new Uint8Array(bytes);
+  const storage =
+    dtype === 'complex64'
+      ? new Float32Array(aligned.buffer, aligned.byteOffset, aligned.byteLength / 4)
+      : new Float64Array(aligned.buffer, aligned.byteOffset, aligned.byteLength / 8);
+  return new ComplexArray(dtype, storage);
+}
+
+/**
+ * Type guard for the two complex variants.
+ *
+ * @internal — used by `dtype.ts` to route complex types; not
+ * re-exported from the package barrel.  Callers should pattern-match
+ * on the descriptor's `dtype` string directly.
+ */
+export function isComplexDtype(dtype: Dtype): dtype is ComplexDtype {
+  return dtype === 'complex64' || dtype === 'complex128';
+}

--- a/typescript/src/dtype.ts
+++ b/typescript/src/dtype.ts
@@ -13,16 +13,24 @@
  * sentinel with byte-width `0`; its payload size is
  * `ceil(num_elements / 8)`, computed from the descriptor.
  *
- * For dtypes that JS has no native `TypedArray` for (`float16`,
- * `bfloat16`, `complex*`) we expose a surrogate `TypedArray` and
- * leave higher-level conversion to the consumer:
+ * Dtypes JS has no native TypedArray for get first-class view classes
+ * from `./float16.ts`, `./bfloat16.ts`, and `./complex.ts`:
  *
- * - `float16` / `bfloat16` → `Uint16Array` (raw half-precision bits)
- * - `complex64`  → `Float32Array` with interleaved `[re, im, re, im, ...]`
- * - `complex128` → `Float64Array` with interleaved `[re, im, re, im, ...]`
+ * - `float16` → native `Float16Array` when the host ships one (TC39
+ *   Stage-3), otherwise `Float16Polyfill` — same API.
+ * - `bfloat16` → `Bfloat16Array` (always polyfilled; no native type).
+ * - `complex64` / `complex128` → `ComplexArray` with `.real(i)` /
+ *   `.imag(i)` / `.get(i) → { re, im }` / iteration.
+ *
+ * Callers who want the raw binary16 / bfloat16 bits can reach through
+ * the view's `.bits` accessor; complex callers who want the
+ * interleaved storage can use the view's `.data`.
  */
 
 import { InvalidArgumentError } from './errors.js';
+import { bfloat16FromBytes } from './bfloat16.js';
+import { complexFromBytes } from './complex.js';
+import { float16FromBytes } from './float16.js';
 import type { Dtype, TypedArray } from './types.js';
 
 /** Byte width per scalar element. `0` for `bitmask` (sub-byte packed). */
@@ -65,19 +73,24 @@ export function shapeElementCount(shape: readonly number[]): number {
 }
 
 /**
- * Given a dtype and raw payload bytes, construct the appropriate
- * `TypedArray` view.
+ * Given a dtype and raw payload bytes, construct the appropriate view.
  *
- * For complex dtypes the returned array contains interleaved real /
- * imaginary components — e.g. `complex64` yields a `Float32Array` of
- * length `2 × num_elements`. Consumers that want a pair of separate
- * real / imag arrays can destructure as they see fit.
+ * For 10 of the 15 dtypes this is a plain `TypedArray`.  The five
+ * non-native dtypes get their own view classes:
+ *
+ * - `float16` → `Float16Array` (native) or `Float16Polyfill`
+ * - `bfloat16` → `Bfloat16Array`
+ * - `complex64` / `complex128` → `ComplexArray`
+ * - `bitmask` → `Uint8Array` of packed bits (unchanged)
  *
  * @param dtype - element type
  * @param bytes - raw payload bytes in native byte order
  * @param copy  - if true (default), copies into a fresh JS-heap buffer;
  *                if false, returns a zero-copy view over `bytes.buffer`
- *                that is invalidated when the underlying buffer moves
+ *                (invalidated when WASM memory grows).  For the
+ *                non-native dtypes, zero-copy only applies to the
+ *                backing storage — the view class itself is still a
+ *                JS-heap object.
  */
 export function typedArrayFor(dtype: Dtype, bytes: Uint8Array, copy = true): TypedArray {
   const source = copy ? new Uint8Array(bytes) : bytes;
@@ -93,10 +106,9 @@ export function typedArrayFor(dtype: Dtype, bytes: Uint8Array, copy = true): Typ
 
   switch (dtype) {
     case 'float16':
-    case 'bfloat16': {
-      const aligned = needAligned(2);
-      return new Uint16Array(aligned.buffer, aligned.byteOffset, aligned.byteLength / 2);
-    }
+      return float16FromBytes(needAligned(2));
+    case 'bfloat16':
+      return bfloat16FromBytes(needAligned(2));
     case 'float32': {
       const aligned = needAligned(4);
       return new Float32Array(aligned.buffer, aligned.byteOffset, aligned.byteLength / 4);
@@ -105,14 +117,10 @@ export function typedArrayFor(dtype: Dtype, bytes: Uint8Array, copy = true): Typ
       const aligned = needAligned(8);
       return new Float64Array(aligned.buffer, aligned.byteOffset, aligned.byteLength / 8);
     }
-    case 'complex64': {
-      const aligned = needAligned(4);
-      return new Float32Array(aligned.buffer, aligned.byteOffset, aligned.byteLength / 4);
-    }
-    case 'complex128': {
-      const aligned = needAligned(8);
-      return new Float64Array(aligned.buffer, aligned.byteOffset, aligned.byteLength / 8);
-    }
+    case 'complex64':
+      return complexFromBytes('complex64', needAligned(4));
+    case 'complex128':
+      return complexFromBytes('complex128', needAligned(8));
     case 'int8':
       return new Int8Array(source.buffer, source.byteOffset, source.byteLength);
     case 'int16': {

--- a/typescript/src/encode.ts
+++ b/typescript/src/encode.ts
@@ -16,13 +16,12 @@
 
 import { rethrowTyped, InvalidArgumentError } from './errors.js';
 import { getWbg } from './init.js';
-import { SUPPORTED_DTYPES } from './dtype.js';
-import type {
-  DataObjectDescriptor,
-  EncodeInput,
-  EncodeOptions,
-  GlobalMetadata,
-} from './types.js';
+import {
+  assertValidDescriptor,
+  assertValidMetadata,
+  toUint8View,
+} from './internal/validation.js';
+import type { EncodeInput, EncodeOptions, GlobalMetadata } from './types.js';
 
 /**
  * Encode global metadata + a list of `(descriptor, data)` pairs into a
@@ -42,13 +41,13 @@ export function encode(
   objects: readonly EncodeInput[],
   options?: EncodeOptions,
 ): Uint8Array {
-  validateMetadata(metadata);
-  validateObjects(objects);
+  assertValidMetadata(metadata);
+  assertValidObjects(objects);
 
   const wbg = getWbg();
   const objArray = objects.map((o) => ({
     descriptor: o.descriptor,
-    data: toUint8ArrayView(o.data),
+    data: toUint8View(o.data),
   }));
 
   // Default to hashing. Opt out explicitly with `{ hash: false }`.
@@ -56,43 +55,7 @@ export function encode(
   return rethrowTyped(() => wbg.encode(metadata, objArray, hash));
 }
 
-function validateMetadata(meta: GlobalMetadata): void {
-  if (meta === null || typeof meta !== 'object') {
-    throw new InvalidArgumentError(
-      `metadata must be a plain object, got ${typeof meta}`,
-    );
-  }
-  if (typeof meta.version !== 'number' || !Number.isInteger(meta.version) || meta.version < 0) {
-    throw new InvalidArgumentError(
-      `metadata.version must be a non-negative integer, got ${String(meta.version)}`,
-    );
-  }
-  if ('_reserved_' in meta && meta._reserved_ !== undefined) {
-    throw new InvalidArgumentError(
-      'metadata._reserved_ is managed by the library; client code must not write it',
-    );
-  }
-  if (meta.base !== undefined) {
-    if (!Array.isArray(meta.base)) {
-      throw new InvalidArgumentError(
-        `metadata.base must be an array, got ${typeof meta.base}`,
-      );
-    }
-    for (let i = 0; i < meta.base.length; i++) {
-      const entry = meta.base[i];
-      if (entry === null || typeof entry !== 'object') {
-        throw new InvalidArgumentError(`metadata.base[${i}] must be a plain object`);
-      }
-      if ('_reserved_' in entry) {
-        throw new InvalidArgumentError(
-          `metadata.base[${i}]._reserved_ is managed by the library; client code must not write it`,
-        );
-      }
-    }
-  }
-}
-
-function validateObjects(objects: readonly EncodeInput[]): void {
+function assertValidObjects(objects: readonly EncodeInput[]): void {
   if (!Array.isArray(objects)) {
     throw new InvalidArgumentError(`objects must be an array, got ${typeof objects}`);
   }
@@ -101,44 +64,11 @@ function validateObjects(objects: readonly EncodeInput[]): void {
     if (o === null || typeof o !== 'object') {
       throw new InvalidArgumentError(`objects[${i}] must be a { descriptor, data } pair`);
     }
-    validateDescriptor(o.descriptor, i);
+    assertValidDescriptor(o.descriptor, i);
     if (!ArrayBuffer.isView(o.data)) {
       throw new InvalidArgumentError(
         `objects[${i}].data must be an ArrayBufferView (TypedArray, DataView, ...)`,
       );
     }
   }
-}
-
-function validateDescriptor(desc: DataObjectDescriptor, i: number): void {
-  if (desc === null || typeof desc !== 'object') {
-    throw new InvalidArgumentError(`objects[${i}].descriptor must be a plain object`);
-  }
-  if (typeof desc.type !== 'string') {
-    throw new InvalidArgumentError(`objects[${i}].descriptor.type must be a string`);
-  }
-  if (!Array.isArray(desc.shape)) {
-    throw new InvalidArgumentError(`objects[${i}].descriptor.shape must be an array`);
-  }
-  if (!SUPPORTED_DTYPES.has(desc.dtype)) {
-    throw new InvalidArgumentError(
-      `objects[${i}].descriptor.dtype=${String(desc.dtype)} is not a recognised dtype`,
-    );
-  }
-  if (desc.byte_order !== 'big' && desc.byte_order !== 'little') {
-    throw new InvalidArgumentError(
-      `objects[${i}].descriptor.byte_order must be "big" or "little"`,
-    );
-  }
-}
-
-/**
- * Normalise any `ArrayBufferView` into a `Uint8Array` over exactly the
- * bytes it covers. The WASM `encode` function accepts any TypedArray
- * and picks up the byte range from `byteOffset` / `byteLength`, but a
- * `DataView` is not a TypedArray on the JS side — so we wrap it.
- */
-function toUint8ArrayView(view: ArrayBufferView): Uint8Array {
-  if (view instanceof Uint8Array) return view;
-  return new Uint8Array(view.buffer, view.byteOffset, view.byteLength);
 }

--- a/typescript/src/encodePreEncoded.ts
+++ b/typescript/src/encodePreEncoded.ts
@@ -44,8 +44,17 @@ import type {
  *                   descriptor's `encoding`/`filter`/`compression`.
  * @param options  - `hash: "xxh3" | false`.  Default `"xxh3"`.
  * @returns        - `Uint8Array` wire-format message.
- * @throws {MetadataError}     if metadata or any descriptor is malformed
- * @throws {InvalidArgumentError} on bad argument types
+ * @throws {InvalidArgumentError} when the client-side validator
+ *   rejects `metadata` (bad shape, client-written `_reserved_`) or
+ *   a descriptor (missing `type` / `shape` / unknown `dtype` / bad
+ *   `byte_order`) or an object entry (not a `{descriptor, data}`
+ *   pair, `data` not a `Uint8Array`).
+ * @throws {MetadataError} when the WASM layer rejects the
+ *   descriptors or metadata after the client-side validator
+ *   has accepted them (e.g. malformed CBOR, unsupported
+ *   descriptor combination).
+ * @throws {EncodingError} when pre-encoded szip block offsets fail
+ *   the library's monotonicity / bit-bound checks.
  */
 export function encodePreEncoded(
   metadata: GlobalMetadata,

--- a/typescript/src/encodePreEncoded.ts
+++ b/typescript/src/encodePreEncoded.ts
@@ -1,0 +1,82 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+/**
+ * `encodePreEncoded` — wrap already-encoded payloads into a Tensogram
+ * message without running the encoding pipeline.
+ *
+ * Mirrors Rust `encode_pre_encoded`, Python `encode_pre_encoded`, and
+ * FFI `tgm_encode_pre_encoded`.  The library still validates the
+ * descriptor structure and any szip block offsets it finds; the hash
+ * (when enabled) is always recomputed from the caller's bytes so
+ * descriptor-supplied hashes are overwritten.
+ *
+ * Use case: callers that have already run encoding/compression via
+ * another path (e.g. GPU pipeline, another Tensogram implementation,
+ * cached pre-packed tiles) and want to wrap the bytes in a wire-format
+ * message.
+ */
+
+import { getWbg } from './init.js';
+import { rethrowTyped, InvalidArgumentError } from './errors.js';
+import {
+  assertValidDescriptor,
+  assertValidMetadata,
+} from './internal/validation.js';
+import type {
+  EncodePreEncodedOptions,
+  GlobalMetadata,
+  PreEncodedInput,
+} from './types.js';
+
+/**
+ * Encode global metadata + pre-encoded object bytes into a single
+ * Tensogram wire-format message.
+ *
+ * @param metadata - Global metadata (`version: 2` required).
+ * @param objects  - `(descriptor, bytes)` pairs.  Each `data` is the
+ *                   output of a prior encoding pipeline matching the
+ *                   descriptor's `encoding`/`filter`/`compression`.
+ * @param options  - `hash: "xxh3" | false`.  Default `"xxh3"`.
+ * @returns        - `Uint8Array` wire-format message.
+ * @throws {MetadataError}     if metadata or any descriptor is malformed
+ * @throws {InvalidArgumentError} on bad argument types
+ */
+export function encodePreEncoded(
+  metadata: GlobalMetadata,
+  objects: readonly PreEncodedInput[],
+  options?: EncodePreEncodedOptions,
+): Uint8Array {
+  assertValidMetadata(metadata);
+  assertValidPreEncodedObjects(objects);
+
+  const wbg = getWbg();
+  const objArray = objects.map((o) => ({ descriptor: o.descriptor, data: o.data }));
+  const hash = options?.hash !== false;
+  return rethrowTyped(() => wbg.encode_pre_encoded(metadata, objArray, hash));
+}
+
+function assertValidPreEncodedObjects(objects: readonly PreEncodedInput[]): void {
+  if (!Array.isArray(objects)) {
+    throw new InvalidArgumentError(`objects must be an array, got ${typeof objects}`);
+  }
+  for (let i = 0; i < objects.length; i++) {
+    const o = objects[i];
+    if (o === null || typeof o !== 'object') {
+      throw new InvalidArgumentError(
+        `objects[${i}] must be a { descriptor, data } pair`,
+      );
+    }
+    assertValidDescriptor(o.descriptor, i);
+    if (!(o.data instanceof Uint8Array)) {
+      throw new InvalidArgumentError(
+        `objects[${i}].data must be a Uint8Array of pre-encoded bytes`,
+      );
+    }
+  }
+}

--- a/typescript/src/file.ts
+++ b/typescript/src/file.ts
@@ -7,28 +7,44 @@
 // does it submit to any jurisdiction.
 
 /**
- * `TensogramFile` — read-only random access over a `.tgm` file, whether
- * it lives on a Node file system or behind an HTTP(S) URL.
+ * `TensogramFile` — random access over a `.tgm` file.
  *
- * ## Design
+ * Three open paths:
  *
- * This is the Scope-B implementation: the whole file is read eagerly on
- * open, its message positions are indexed once via `scan()`, and then
- * random access is a constant-time slice + decode. This is simple, fast
- * for any realistic .tgm file size, and identical in behaviour between
- * Node and the browser.
+ * - {@link TensogramFile.open} — Node local file system.  Pre-reads
+ *   the full file so random-access reads are O(1) subarray slices.
+ *   Supports {@link TensogramFile.append} (Node-only, local-path only).
+ * - {@link TensogramFile.fromUrl} — HTTP(S).  Auto-detects Range
+ *   support: on a server that advertises `Accept-Ranges: bytes` and a
+ *   finite `Content-Length`, message payloads are fetched on demand
+ *   via `Range` requests (no full download).  Servers that don't
+ *   advertise Range transparently fall back to eager download.
+ * - {@link TensogramFile.fromBytes} — wrap an already-loaded buffer.
  *
- * For very large files (several GB) where Range-based lazy access is
- * required, see the follow-up listed in `plans/TYPESCRIPT_WRAPPER.md`.
- * The public interface is designed so that a lazy backend can be added
- * later without breaking callers.
+ * After open, the public API is identical across all three paths; the
+ * backend differences are invisible to consumers.
+ *
+ * ### API changes from Scope B
+ *
+ * {@link TensogramFile.rawMessage} is `async` — previously sync — so
+ * the lazy HTTP backend can issue the Range request before returning
+ * bytes.  Existing call sites add `await`.
  */
 
 import { decode, decodeMetadata, scan } from './decode.js';
-import { InvalidArgumentError, IoError, ObjectError, rethrowTyped } from './errors.js';
+import { encode } from './encode.js';
+import {
+  InvalidArgumentError,
+  IoError,
+  ObjectError,
+  rethrowTyped,
+} from './errors.js';
+import { errorMessage, withCause } from './internal/io.js';
 import type {
+  AppendOptions,
   DecodedMessage,
   DecodeOptions,
+  EncodeInput,
   FileSource,
   FromUrlOptions,
   GlobalMetadata,
@@ -36,29 +52,76 @@ import type {
   OpenFileOptions,
 } from './types.js';
 
+// ── Module-level constants ────────────────────────────────────────────────
+
+/** Bytes in the fixed Tensogram preamble. */
+const PREAMBLE_BYTES = 24;
+/** Bytes in the fixed Tensogram postamble. */
+const POSTAMBLE_BYTES = 16;
+/** Minimum wire-format message length — preamble + postamble with no frames. */
+const MIN_MESSAGE_BYTES = PREAMBLE_BYTES + POSTAMBLE_BYTES;
+/** Lazy HTTP backend's per-message LRU cache size. */
+const LAZY_CACHE_CAPACITY = 32;
+/** The magic header every Tensogram preamble starts with. */
+const PREAMBLE_MAGIC = new TextEncoder().encode('TENSOGRM');
+
+// ── Internal backend types ────────────────────────────────────────────────
+
+/** Backing storage + fetch strategy for a `TensogramFile`. */
+type Backend = InMemoryBackend | LocalFileBackend | LazyHttpBackend;
+
+/** Fully in-memory — fromBytes + eager-HTTP. */
+interface InMemoryBackend {
+  readonly kind: 'buffer' | 'remote-eager';
+  readonly source: FileSource;
+  bytes: Uint8Array;
+  positions: MessagePosition[];
+}
+
+/** Node local filesystem; file is mirrored in memory for O(1) reads. */
+interface LocalFileBackend {
+  readonly kind: 'local';
+  readonly source: 'local';
+  path: string | URL;
+  bytes: Uint8Array;
+  positions: MessagePosition[];
+}
+
+/** HTTP with Range request support — message bytes fetched on demand. */
+interface LazyHttpBackend {
+  readonly kind: 'remote-lazy';
+  readonly source: 'remote';
+  url: string | URL;
+  fetchFn: typeof globalThis.fetch;
+  baseHeaders?: HeadersInit;
+  signal?: AbortSignal;
+  byteLength: number;
+  positions: MessagePosition[];
+  /** Tiny LRU of already-fetched message bytes. */
+  cache: Map<number, Uint8Array>;
+  cacheCap: number;
+}
+
+// ── TensogramFile ─────────────────────────────────────────────────────────
+
 /**
- * Read-only view over a `.tgm` file / URL / byte buffer.
- *
- * Async iteration yields one `DecodedMessage` per message in the file,
- * in wire order. The caller is responsible for calling `close()` on
- * each yielded message to release WASM memory deterministically.
+ * Random-access view over a `.tgm` file.  Async iteration yields one
+ * `DecodedMessage` per message in the file.  The caller closes each
+ * yielded message to release WASM memory.
  */
 export class TensogramFile implements AsyncIterable<DecodedMessage> {
-  readonly #bytes: Uint8Array;
-  readonly #positions: readonly MessagePosition[];
-  readonly #source: FileSource;
+  readonly #backend: Backend;
   #closed = false;
 
-  private constructor(bytes: Uint8Array, source: FileSource) {
-    this.#bytes = bytes;
-    this.#source = source;
-    this.#positions = rethrowTyped(() => scan(bytes));
+  private constructor(backend: Backend) {
+    this.#backend = backend;
   }
 
+  // ── Factories ──
+
   /**
-   * Open a `.tgm` file from the local file system. Node-only — the
-   * `node:fs/promises` module is loaded lazily so browser bundlers
-   * can tree-shake this path.
+   * Open a local `.tgm` file.  Node-only — the `node:fs/promises`
+   * import is dynamic so browser bundlers can tree-shake this path.
    */
   static async open(
     path: string | URL,
@@ -81,22 +144,37 @@ export class TensogramFile implements AsyncIterable<DecodedMessage> {
 
     let bytes: Uint8Array;
     try {
-      const readOptions = options.signal ? { signal: options.signal } : undefined;
-      const buf = await readFile(path, readOptions);
+      const readOpts = options.signal ? { signal: options.signal } : undefined;
+      const buf = await readFile(path, readOpts);
       bytes = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
     } catch (err) {
-      throw withCause(new IoError(`TensogramFile.open: ${describeError(err)}`), err);
+      throw withCause(new IoError(`TensogramFile.open: ${errorMessage(err)}`), err);
     }
-    return new TensogramFile(bytes, 'local');
+    const positions = rethrowTyped(() => scan(bytes));
+    return new TensogramFile({
+      kind: 'local',
+      source: 'local',
+      path,
+      bytes,
+      positions,
+    });
   }
 
   /**
-   * Open a `.tgm` file over HTTP(S). Works in any environment with a
-   * fetch-compatible global (modern browsers, Node ≥ 20, Deno, Bun).
+   * Open a `.tgm` file over HTTP(S).
    *
-   * The entire resource is downloaded in one request. Range requests
-   * and lazy access are a Scope-C follow-up (see
-   * `plans/TYPESCRIPT_WRAPPER.md`).
+   * Performs a `HEAD` probe to detect Range support:
+   *
+   * - `Accept-Ranges: bytes` + finite `Content-Length` → lazy backend
+   *   (one small Range request per message on first read, payloads
+   *   fetched on demand).
+   * - Otherwise → eager backend (one GET, entire body downloaded).
+   *
+   * Non-`200` HEAD responses also fall back to eager GET — some
+   * servers reject HEAD but support Range on GET.
+   *
+   * The behaviour is indistinguishable to callers except in timing
+   * and memory use.
    */
   static async fromUrl(
     url: string | URL,
@@ -108,6 +186,72 @@ export class TensogramFile implements AsyncIterable<DecodedMessage> {
         'TensogramFile.fromUrl: no fetch implementation is available',
       );
     }
+
+    // ── Probe for Range support ──
+    let probe: Response | undefined;
+    try {
+      const headInit: RequestInit = { method: 'HEAD' };
+      if (options.headers !== undefined) headInit.headers = options.headers;
+      if (options.signal !== undefined) headInit.signal = options.signal;
+      probe = await fetchFn(url, headInit);
+    } catch {
+      probe = undefined; // HEAD failed — fall back to eager
+    }
+
+    if (probe && probe.ok) {
+      const acceptRanges = probe.headers.get('accept-ranges');
+      const contentLengthStr = probe.headers.get('content-length');
+      const contentLength = contentLengthStr === null ? NaN : parseInt(contentLengthStr, 10);
+      // Cap at `MAX_SAFE_INTEGER` — our cursor arithmetic uses JS
+      // numbers, so anything beyond 2^53 - 1 can't be tracked without
+      // loss.  Anything that size belongs on the eager path anyway.
+      if (
+        acceptRanges?.toLowerCase().includes('bytes') &&
+        Number.isFinite(contentLength) &&
+        contentLength > 0 &&
+        contentLength <= Number.MAX_SAFE_INTEGER
+      ) {
+        // Try the lazy path.  If lazy scan fails mid-walk (e.g.
+        // streaming-mode message or unrecognised magic), fall through
+        // to eager.
+        const scanResult = await lazyScanMessages(
+          url,
+          fetchFn,
+          options.headers,
+          options.signal,
+          contentLength,
+        );
+        if (scanResult !== null) {
+          return new TensogramFile({
+            kind: 'remote-lazy',
+            source: 'remote',
+            url,
+            fetchFn,
+            baseHeaders: options.headers,
+            signal: options.signal,
+            byteLength: contentLength,
+            positions: scanResult,
+            cache: new Map(),
+            cacheCap: LAZY_CACHE_CAPACITY,
+          });
+        }
+      }
+    }
+
+    // ── Eager fallback ──
+    return await TensogramFile.#eagerFromUrl(url, options, fetchFn);
+  }
+
+  /**
+   * Eager GET — the Scope-B behaviour, used when Range is unsupported
+   * or the lazy scan bails out.  Kept as a private static so it has
+   * access to the private constructor without an `as any` cast.
+   */
+  static async #eagerFromUrl(
+    url: string | URL,
+    options: FromUrlOptions,
+    fetchFn: typeof globalThis.fetch,
+  ): Promise<TensogramFile> {
     const init: RequestInit = {};
     if (options.headers !== undefined) init.headers = options.headers;
     if (options.signal !== undefined) init.signal = options.signal;
@@ -116,82 +260,194 @@ export class TensogramFile implements AsyncIterable<DecodedMessage> {
     try {
       response = await fetchFn(url, init);
     } catch (err) {
-      throw withCause(new IoError(`TensogramFile.fromUrl: ${describeError(err)}`), err);
+      throw withCause(
+        new IoError(`TensogramFile.fromUrl: ${errorMessage(err)}`),
+        err,
+      );
     }
     if (!response.ok) {
       const status = `${response.status} ${response.statusText || ''}`.trim();
       throw new IoError(`TensogramFile.fromUrl: HTTP ${status}`);
     }
     const buf = await response.arrayBuffer();
-    return new TensogramFile(new Uint8Array(buf), 'remote');
+    const bytes = new Uint8Array(buf);
+    const positions = rethrowTyped(() => scan(bytes));
+    return new TensogramFile({
+      kind: 'remote-eager',
+      source: 'remote',
+      bytes,
+      positions,
+    });
   }
 
   /**
-   * Wrap an already-loaded byte buffer. Useful for tests and for
-   * callers that already have the file in memory (e.g. `File.arrayBuffer()`
-   * in the browser).
+   * Wrap an already-loaded byte buffer.  The input is defensively
+   * copied so later mutation by the caller is invisible.
    */
   static fromBytes(bytes: Uint8Array): TensogramFile {
     if (!(bytes instanceof Uint8Array)) {
       throw new InvalidArgumentError('TensogramFile.fromBytes: expected a Uint8Array');
     }
-    // Defensive copy so later mutation of the caller's buffer doesn't
-    // invalidate our scan result.
-    return new TensogramFile(new Uint8Array(bytes), 'buffer');
+    const copy = new Uint8Array(bytes);
+    const positions = rethrowTyped(() => scan(copy));
+    return new TensogramFile({
+      kind: 'buffer',
+      source: 'buffer',
+      bytes: copy,
+      positions,
+    });
   }
+
+  // ── Accessors ──
 
   /** Number of messages indexed from the file. */
   get messageCount(): number {
-    return this.#positions.length;
+    return this.#backend.positions.length;
   }
 
-  /** Total byte length of the underlying buffer. */
+  /** Total byte length of the backing file. */
   get byteLength(): number {
-    return this.#bytes.byteLength;
+    switch (this.#backend.kind) {
+      case 'buffer':
+      case 'remote-eager':
+      case 'local':
+        return this.#backend.bytes.byteLength;
+      case 'remote-lazy':
+        return this.#backend.byteLength;
+    }
   }
 
   /** Where these bytes came from. */
   get source(): FileSource {
-    return this.#source;
+    return this.#backend.source;
   }
 
-  /** Decode a single message by zero-based index. */
-  async message(index: number, options?: DecodeOptions): Promise<DecodedMessage> {
+  // ── Data access ──
+
+  /**
+   * Raw bytes of a single message.  For the lazy HTTP backend this
+   * issues a Range request on first call; subsequent calls hit an
+   * internal LRU cache.
+   */
+  async rawMessage(index: number): Promise<Uint8Array> {
     this.#assertOpen();
-    const slice = this.rawMessage(index);
+    const b = this.#backend;
+    if (!Number.isInteger(index) || index < 0 || index >= b.positions.length) {
+      throw new ObjectError(
+        `message index ${index} out of range (have ${b.positions.length})`,
+      );
+    }
+    const { offset, length } = b.positions[index];
+
+    switch (b.kind) {
+      case 'buffer':
+      case 'remote-eager':
+      case 'local':
+        return b.bytes.subarray(offset, offset + length);
+      case 'remote-lazy': {
+        const hit = b.cache.get(index);
+        if (hit) return hit;
+        const bytes = await fetchRange(
+          b.url,
+          b.fetchFn,
+          b.baseHeaders,
+          b.signal,
+          offset,
+          offset + length,
+        );
+        // Simple LRU: delete + set shifts to newest, drop the oldest
+        // entry when over capacity.
+        b.cache.set(index, bytes);
+        if (b.cache.size > b.cacheCap) {
+          const first = b.cache.keys().next();
+          if (!first.done) b.cache.delete(first.value);
+        }
+        return bytes;
+      }
+    }
+  }
+
+  /** Decode a single message by index. */
+  async message(index: number, options?: DecodeOptions): Promise<DecodedMessage> {
+    const slice = await this.rawMessage(index);
     return decode(slice, options);
   }
 
   /** Decode only the global metadata for a single message. */
   async messageMetadata(index: number): Promise<GlobalMetadata> {
-    this.#assertOpen();
-    const slice = this.rawMessage(index);
+    const slice = await this.rawMessage(index);
     return decodeMetadata(slice);
   }
 
-  /** Return the raw bytes of a single message, zero-copy. */
-  rawMessage(index: number): Uint8Array {
-    this.#assertOpen();
-    if (!Number.isInteger(index) || index < 0 || index >= this.#positions.length) {
-      throw new ObjectError(
-        `message index ${index} out of range (have ${this.#positions.length})`,
-      );
-    }
-    const { offset, length } = this.#positions[index];
-    return this.#bytes.subarray(offset, offset + length);
-  }
-
-  /** Iterate all messages in wire order. */
+  /** Async iterate every message in wire order. */
   async *[Symbol.asyncIterator](): AsyncIterator<DecodedMessage> {
-    for (let i = 0; i < this.#positions.length; i++) {
-      // Explicit `await` so consumers that call `.next()` directly observe
-      // a resolved DecodedMessage, not a Promise thereof. The `for await`
-      // caller experience is unchanged.
+    for (let i = 0; i < this.messageCount; i++) {
       yield await this.message(i);
     }
   }
 
-  /** Release the backing buffer (does not affect already-decoded messages). */
+  // ── Write ──
+
+  /**
+   * Encode and append a new message to the underlying file.  Only
+   * supported when the file was opened via
+   * {@link TensogramFile.open} — every other factory throws
+   * `InvalidArgumentError`, mirroring the Rust / Python / FFI /
+   * C++ `TensogramFile::append` contract.
+   *
+   * After a successful append, the in-memory position index and
+   * byte mirror are refreshed from disk so subsequent reads see
+   * the new message.
+   */
+  async append(
+    metadata: GlobalMetadata,
+    objects: readonly EncodeInput[],
+    options: AppendOptions = {},
+  ): Promise<void> {
+    this.#assertOpen();
+    if (this.#backend.kind !== 'local') {
+      throw new InvalidArgumentError(
+        'TensogramFile.append: only supported for files opened via TensogramFile.open() — use encode() and concatenate manually for in-memory or remote sources',
+      );
+    }
+    const b = this.#backend;
+
+    const encodeOpts = options.hash === false ? { hash: false as const } : { hash: 'xxh3' as const };
+    const bytes = rethrowTyped(() => encode(metadata, objects, encodeOpts));
+
+    let writeFile: typeof import('node:fs/promises').appendFile;
+    let readFile: typeof import('node:fs/promises').readFile;
+    try {
+      ({ appendFile: writeFile, readFile } = await import('node:fs/promises'));
+    } catch (cause) {
+      throw withCause(
+        new IoError('TensogramFile.append requires Node (node:fs/promises)'),
+        cause,
+      );
+    }
+
+    try {
+      await writeFile(b.path, bytes);
+    } catch (err) {
+      throw withCause(new IoError(`TensogramFile.append: ${errorMessage(err)}`), err);
+    }
+
+    // Refresh in-memory mirror + rescan positions from disk.
+    try {
+      const buf = await readFile(b.path);
+      b.bytes = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+      b.positions = rethrowTyped(() => scan(b.bytes));
+    } catch (err) {
+      throw withCause(
+        new IoError(`TensogramFile.append: refresh failed: ${errorMessage(err)}`),
+        err,
+      );
+    }
+  }
+
+  // ── Lifecycle ──
+
+  /** Release the backing buffer.  Already-decoded messages stay alive. */
   close(): void {
     this.#closed = true;
   }
@@ -203,13 +459,118 @@ export class TensogramFile implements AsyncIterable<DecodedMessage> {
   }
 }
 
-function describeError(err: unknown): string {
-  if (err instanceof Error) return err.message;
-  return String(err);
+// ── Lazy HTTP helpers ─────────────────────────────────────────────────────
+
+/**
+ * Walk the file one preamble at a time, collecting each message's
+ * `(offset, length)` from the preamble's `total_length` field.  A
+ * single Range request per message (24 bytes each) is issued.
+ *
+ * Returns `null` when the lazy walk cannot proceed — the caller falls
+ * back to eager download.  Signals:
+ *
+ * - non-`TENSOGRM` magic encountered;
+ * - streaming-mode message (`total_length == 0`) — would require
+ *   walking frame-by-frame, an optimisation we don't attempt;
+ * - advertised length exceeds the file;
+ * - any Range response that isn't 206 (including 200 with the whole
+ *   body, which some servers return when Range isn't supported).
+ */
+async function lazyScanMessages(
+  url: string | URL,
+  fetchFn: typeof globalThis.fetch,
+  headers: HeadersInit | undefined,
+  signal: AbortSignal | undefined,
+  fileLen: number,
+): Promise<MessagePosition[] | null> {
+  const positions: MessagePosition[] = [];
+  let cursor = 0;
+
+  while (cursor + PREAMBLE_BYTES <= fileLen) {
+    let preamble: Uint8Array;
+    try {
+      preamble = await fetchRange(
+        url,
+        fetchFn,
+        headers,
+        signal,
+        cursor,
+        cursor + PREAMBLE_BYTES,
+        /* requireRange */ true,
+      );
+    } catch {
+      return null; // eager fallback
+    }
+    // Verify the magic prefix.  Any mismatch aborts the lazy walk —
+    // `TensogramFile.scan` in eager mode tolerates leading garbage but
+    // this fast-path relies on preamble-aligned messages.
+    for (let i = 0; i < PREAMBLE_MAGIC.length; i++) {
+      if (preamble[i] !== PREAMBLE_MAGIC[i]) return null;
+    }
+    // total_length is big-endian u64 at byte offset 16.  We use a
+    // DataView so we don't depend on host endianness.
+    const view = new DataView(preamble.buffer, preamble.byteOffset, PREAMBLE_BYTES);
+    const hi = view.getUint32(16, /* littleEndian = */ false);
+    const lo = view.getUint32(20, /* littleEndian = */ false);
+    const totalLength = hi * 0x1_0000_0000 + lo;
+    if (totalLength === 0) return null; // streaming-mode → eager
+    if (!Number.isFinite(totalLength) || totalLength < MIN_MESSAGE_BYTES) return null;
+    if (cursor + totalLength > fileLen) return null;
+    positions.push({ offset: cursor, length: totalLength });
+    cursor += totalLength;
+  }
+  return positions;
 }
 
-/** Attach a `cause` to an error and return it for fluent chaining. */
-function withCause<E extends Error>(err: E, cause: unknown): E {
-  Object.defineProperty(err, 'cause', { value: cause, configurable: true });
-  return err;
+/**
+ * Issue a `Range: bytes=start-end-1` request covering `[start, end)`.
+ *
+ * - `requireRange: true` (used during the lazy scan) throws on any
+ *   non-`206` status so the caller can fall back to eager download.
+ * - `requireRange: false` (the default, used for payload fetches) also
+ *   accepts `200` with the full body: when the server ignores the
+ *   Range header we slice the response on the client side.
+ */
+async function fetchRange(
+  url: string | URL,
+  fetchFn: typeof globalThis.fetch,
+  baseHeaders: HeadersInit | undefined,
+  signal: AbortSignal | undefined,
+  start: number,
+  end: number,
+  requireRange = false,
+): Promise<Uint8Array> {
+  const headers = new Headers(baseHeaders);
+  headers.set('Range', `bytes=${start}-${end - 1}`);
+  const init: RequestInit = { method: 'GET', headers };
+  if (signal !== undefined) init.signal = signal;
+
+  let resp: Response;
+  try {
+    resp = await fetchFn(url, init);
+  } catch (err) {
+    throw withCause(new IoError(`Range fetch failed: ${errorMessage(err)}`), err);
+  }
+
+  if (resp.status === 206) {
+    const buf = await resp.arrayBuffer();
+    return new Uint8Array(buf);
+  }
+
+  if (requireRange) {
+    throw new IoError(`Range request returned HTTP ${resp.status}; falling back to eager`);
+  }
+
+  if (resp.status === 200) {
+    // Server returned the full body — slice client-side.
+    const buf = await resp.arrayBuffer();
+    if (end > buf.byteLength) {
+      throw new IoError(
+        `Server returned ${buf.byteLength} bytes but client asked for range ending at ${end}`,
+      );
+    }
+    return new Uint8Array(buf).subarray(start, end);
+  }
+
+  throw new IoError(`Range fetch: HTTP ${resp.status} ${resp.statusText || ''}`.trim());
 }

--- a/typescript/src/float16.ts
+++ b/typescript/src/float16.ts
@@ -1,0 +1,373 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+/**
+ * `Float16Array` polyfill — IEEE 754 binary16 ("half-precision").
+ *
+ * Used by {@link typedArrayFor} to wrap `float16` payloads when the
+ * host does not ship a native `Float16Array`.  The observable
+ * behaviour matches the TC39 Stage-3 proposal:
+ *
+ * - Constructor accepts `length`, an iterable/array-like of numbers
+ *   (narrowed to binary16), or an `ArrayBufferLike` view (raw bits).
+ * - `.length`, `.byteLength`, `.byteOffset`, `.buffer` mirror a
+ *   `Uint16Array` of the underlying bits.
+ * - `.at(i)`, `.get(i)` widen the stored bits back to a `number`.
+ * - `.set(src, offset?)` narrows each incoming value to binary16
+ *   using round-ties-to-even; NaN / ±Inf / ±0 / subnormals survive
+ *   where binary16 can represent them.
+ *
+ * The backing storage is a `Uint16Array` of raw bits, accessible via
+ * {@link Float16Polyfill.bits} for zero-copy passes back to the
+ * wire or to a native `Float16Array` when one becomes available.
+ */
+
+// ── Bit-level conversion helpers ───────────────────────────────────────────
+
+const _f32_scratch = new Float32Array(1);
+const _u32_scratch = new Uint32Array(_f32_scratch.buffer);
+
+/**
+ * Convert a binary16 bit pattern to a `number` (float32 precision).
+ *
+ * Handles every case required by the TC39 proposal: ±0, subnormals,
+ * normal range, ±Inf, NaN (with mantissa preservation where the lower
+ * 10 bits fit into binary16's representation).
+ *
+ * @internal — not re-exported from the package barrel.  Callers that
+ * need raw bit access should use a view's `.bits` accessor.
+ */
+export function halfBitsToFloat(bits: number): number {
+  const sign = (bits & 0x8000) << 16;
+  const exp = (bits >> 10) & 0x1f;
+  const mant = bits & 0x3ff;
+
+  if (exp === 0x1f) {
+    // Inf / NaN
+    if (mant === 0) {
+      _u32_scratch[0] = sign | 0x7f800000;
+    } else {
+      _u32_scratch[0] = sign | 0x7fc00000 | (mant << 13);
+    }
+    return _f32_scratch[0];
+  }
+
+  if (exp === 0) {
+    if (mant === 0) {
+      _u32_scratch[0] = sign;
+      return _f32_scratch[0];
+    }
+    // Subnormal: normalise into float32's normal range.
+    let m = mant;
+    let e = 1;
+    while ((m & 0x400) === 0) {
+      m <<= 1;
+      e++;
+    }
+    m &= 0x3ff;
+    _u32_scratch[0] = sign | ((127 - 15 - e + 1) << 23) | (m << 13);
+    return _f32_scratch[0];
+  }
+
+  _u32_scratch[0] = sign | ((exp + (127 - 15)) << 23) | (mant << 13);
+  return _f32_scratch[0];
+}
+
+/**
+ * Convert a JS `number` to its binary16 bit pattern, using
+ * round-ties-to-even as specified by IEEE 754.
+ *
+ * @internal — not re-exported from the package barrel.
+ */
+export function floatToHalfBits(value: number): number {
+  _f32_scratch[0] = value;
+  const x = _u32_scratch[0];
+  const sign = (x >>> 16) & 0x8000;
+  const exp32 = (x >>> 23) & 0xff;
+  const mant32 = x & 0x7fffff;
+
+  if (exp32 === 0xff) {
+    if (mant32 === 0) return sign | 0x7c00; // ±Inf
+    // NaN — preserve the quiet-bit into binary16's mantissa MSB.
+    const mant16 = ((mant32 >>> 13) | 0x200) & 0x3ff;
+    return sign | 0x7c00 | mant16;
+  }
+
+  const e = exp32 - 112; // exponent re-biased for binary16
+
+  if (e >= 0x1f) return sign | 0x7c00; // overflow → ±Inf
+
+  if (e <= 0) {
+    if (e < -10) return sign; // underflow → ±0
+    // Subnormal: add implicit leading 1, shift, round-to-nearest-even.
+    const m = mant32 | 0x800000;
+    const shift = 14 - e;
+    const half = 1 << (shift - 1);
+    const mask = (1 << shift) - 1;
+    const rounded = m + half;
+    if ((m & mask) === half && ((rounded >>> shift) & 1) === 1) {
+      return sign | ((rounded - (1 << shift)) >>> shift);
+    }
+    return sign | (rounded >>> shift);
+  }
+
+  // Normal: round-to-nearest-even on the low 13 bits.
+  const half = 0x1000;
+  const mask = 0x1fff;
+  const rounded = x + half;
+  const newExp = ((rounded >>> 23) & 0xff) - 112;
+  const newMant = (rounded >>> 13) & 0x3ff;
+
+  // Exact tie → prefer even LSB (drop the rounding increment).
+  if ((x & mask) === half && (newMant & 1) === 1) {
+    const exact = x & ~mask;
+    const origExp = ((exact >>> 23) & 0xff) - 112;
+    const origMant = (exact >>> 13) & 0x3ff;
+    if (origExp >= 0x1f) return sign | 0x7c00;
+    return sign | (origExp << 10) | origMant;
+  }
+
+  if (newExp >= 0x1f) return sign | 0x7c00;
+  return sign | (newExp << 10) | newMant;
+}
+
+// ── Polyfill class ─────────────────────────────────────────────────────────
+
+// The "private bits" slot is held in a module-scope WeakMap so that
+// `wrapBits()` can build an instance that *shares* storage with an
+// existing Uint16Array — impossible with a # private field because
+// there is no external `new` overload that skips the
+// narrow-every-element path.
+const STORAGE = new WeakMap<object, Uint16Array>();
+
+/** JS-land polyfill for the TC39 `Float16Array` proposal. */
+export class Float16Polyfill {
+  readonly BYTES_PER_ELEMENT = 2 as const;
+
+  constructor(
+    a?: number | ArrayLike<number> | Iterable<number> | ArrayBufferLike,
+    b?: number,
+    c?: number,
+  ) {
+    let bits: Uint16Array;
+    if (a === undefined) {
+      bits = new Uint16Array(0);
+    } else if (typeof a === 'number') {
+      bits = new Uint16Array(a);
+    } else if (
+      a instanceof ArrayBuffer ||
+      (typeof SharedArrayBuffer !== 'undefined' && a instanceof SharedArrayBuffer)
+    ) {
+      // Raw-bits view into an existing buffer — matches the native
+      // `new Float16Array(buffer, byteOffset?, length?)` shape.
+      bits = new Uint16Array(a as ArrayBufferLike, b, c);
+    } else if (ArrayBuffer.isView(a)) {
+      const src = a as unknown as ArrayLike<number>;
+      bits = new Uint16Array(src.length);
+      for (let i = 0; i < src.length; i++) bits[i] = floatToHalfBits(src[i]);
+    } else {
+      const arr = Array.from(a as Iterable<number>);
+      bits = new Uint16Array(arr.length);
+      for (let i = 0; i < arr.length; i++) bits[i] = floatToHalfBits(arr[i]);
+    }
+    STORAGE.set(this, bits);
+  }
+
+  // ── views into the backing Uint16Array ──
+  //
+  // STORAGE is populated by the constructor (or `wrapBits`) before the
+  // instance is exposed to user code, and the key is never removed —
+  // so the getter's invariant is total.  The non-null assertion
+  // documents this; the `!` throws a TypeError if it ever became
+  // untrue, catching refactor bugs without shipping an extra
+  // conditional on every indexed read.
+  private get _bits(): Uint16Array {
+    return STORAGE.get(this)!;
+  }
+
+  get length(): number {
+    return this._bits.length;
+  }
+  get byteLength(): number {
+    return this._bits.byteLength;
+  }
+  get byteOffset(): number {
+    return this._bits.byteOffset;
+  }
+  get buffer(): ArrayBufferLike {
+    return this._bits.buffer;
+  }
+  /** Raw half-precision bit patterns, zero-copy. */
+  get bits(): Uint16Array {
+    return this._bits;
+  }
+
+  // ── numeric accessors ──
+  at(index: number): number | undefined {
+    const b = this._bits;
+    if (index < 0) index += b.length;
+    if (index < 0 || index >= b.length) return undefined;
+    return halfBitsToFloat(b[index]);
+  }
+
+  /** Out-of-range → `NaN` (mirrors TypedArray out-of-range behaviour). */
+  get(index: number): number {
+    const b = this._bits;
+    if (!Number.isInteger(index) || index < 0 || index >= b.length) return NaN;
+    return halfBitsToFloat(b[index]);
+  }
+
+  set(source: ArrayLike<number> | Float16Polyfill, offset = 0): void {
+    const b = this._bits;
+    if (source instanceof Float16Polyfill) {
+      // Same format — copy raw bits, no re-narrowing.
+      b.set(source.bits, offset);
+      return;
+    }
+    const arr = source as ArrayLike<number>;
+    for (let i = 0; i < arr.length; i++) b[offset + i] = floatToHalfBits(arr[i]);
+  }
+
+  fill(value: number, start?: number, end?: number): this {
+    this._bits.fill(floatToHalfBits(value), start, end);
+    return this;
+  }
+
+  slice(start?: number, end?: number): Float16Polyfill {
+    return wrapBits(this._bits.slice(start, end));
+  }
+
+  subarray(start?: number, end?: number): Float16Polyfill {
+    return wrapBits(this._bits.subarray(start, end));
+  }
+
+  /** Plain `number[]` of widened float32 values. */
+  toArray(): number[] {
+    const b = this._bits;
+    const out = new Array<number>(b.length);
+    for (let i = 0; i < b.length; i++) out[i] = halfBitsToFloat(b[i]);
+    return out;
+  }
+
+  /** Widened copy into a `Float32Array`. */
+  toFloat32Array(): Float32Array {
+    const b = this._bits;
+    const out = new Float32Array(b.length);
+    for (let i = 0; i < b.length; i++) out[i] = halfBitsToFloat(b[i]);
+    return out;
+  }
+
+  *[Symbol.iterator](): IterableIterator<number> {
+    const b = this._bits;
+    for (let i = 0; i < b.length; i++) yield halfBitsToFloat(b[i]);
+  }
+}
+
+/**
+ * Build a `Float16Polyfill` from an existing `Uint16Array` of binary16
+ * bits without re-narrowing.  Internal helper used by
+ * {@link float16FromBytes}.
+ */
+function wrapBits(bits: Uint16Array): Float16Polyfill {
+  const inst = Object.create(Float16Polyfill.prototype) as Float16Polyfill;
+  STORAGE.set(inst, bits);
+  return inst;
+}
+
+// ── Native detection ───────────────────────────────────────────────────────
+
+/**
+ * Minimal structural description of a native `Float16Array`.  Covers
+ * everything the wrapper needs at the type level without dragging in
+ * the full lib.dom definition (which is Stage-3 and not stable in
+ * every TS release).
+ */
+interface NativeFloat16Array {
+  readonly BYTES_PER_ELEMENT: 2;
+  readonly length: number;
+  readonly byteLength: number;
+  readonly byteOffset: number;
+  readonly buffer: ArrayBufferLike;
+  at(index: number): number | undefined;
+  [i: number]: number;
+  [Symbol.iterator](): IterableIterator<number>;
+}
+
+/**
+ * Constructor for a native `Float16Array`.  Supports the three
+ * shapes the TC39 proposal and the polyfill both accept: length,
+ * array-like of numbers (narrowed on write), or an `ArrayBuffer` +
+ * offset + length bit-view.
+ */
+interface NativeFloat16Ctor {
+  new (length: number): NativeFloat16Array;
+  new (source: ArrayLike<number> | Iterable<number>): NativeFloat16Array;
+  new (
+    buffer: ArrayBufferLike,
+    byteOffset?: number,
+    length?: number,
+  ): NativeFloat16Array;
+}
+
+/** Constructor type covering both native and polyfill. */
+export type Float16Ctor = typeof Float16Polyfill | NativeFloat16Ctor;
+
+/** Instance type covering both native and polyfill. */
+export type Float16ArrayLike = Float16Polyfill | NativeFloat16Array;
+
+function nativeCtor(): NativeFloat16Ctor | undefined {
+  const g = globalThis as unknown as { Float16Array?: NativeFloat16Ctor };
+  return typeof g.Float16Array === 'function' ? g.Float16Array : undefined;
+}
+
+/**
+ * True iff the host ships a native `Float16Array` (TC39 Stage-3).
+ * Probed every call so test-time overrides are honoured.
+ */
+export function hasNativeFloat16Array(): boolean {
+  return nativeCtor() !== undefined;
+}
+
+/**
+ * Return the preferred constructor: native when available, polyfill
+ * otherwise.  Use to construct fresh instances (length-ctor path);
+ * prefer {@link float16FromBytes} for zero-copy wrapping of existing
+ * binary16 bytes.
+ */
+export function getFloat16ArrayCtor(): Float16Ctor {
+  return nativeCtor() ?? Float16Polyfill;
+}
+
+/**
+ * Wrap raw binary16 bytes as a `Float16Array`-like view.  Zero-copy on
+ * 2-byte-aligned input; allocates an aligned copy when the offset is
+ * odd (rare — our WASM output is aligned by construction).
+ *
+ * @throws {RangeError} when `bytes.byteLength` is not a multiple of 2
+ *   — binary16 elements are exactly 2 bytes each, so a residual byte
+ *   would mean a truncated / corrupted payload.
+ */
+export function float16FromBytes(bytes: Uint8Array): Float16ArrayLike {
+  if (!Number.isInteger(bytes.byteLength / 2)) {
+    throw new RangeError(
+      `float16FromBytes: byte length ${bytes.byteLength} is not a multiple of 2`,
+    );
+  }
+  const aligned = bytes.byteOffset % 2 === 0 ? bytes : new Uint8Array(bytes);
+  const u16 = new Uint16Array(
+    aligned.buffer,
+    aligned.byteOffset,
+    aligned.byteLength / 2,
+  );
+  const Native = nativeCtor();
+  if (Native !== undefined) {
+    // Native: bit-view construction via the (buffer, byteOffset, length) overload.
+    return new Native(u16.buffer, u16.byteOffset, u16.length);
+  }
+  return wrapBits(u16);
+}

--- a/typescript/src/hash.ts
+++ b/typescript/src/hash.ts
@@ -1,0 +1,41 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+/**
+ * `computeHash` — standalone hash computation over arbitrary bytes.
+ *
+ * Mirrors `tgm_compute_hash` / `tensogram::compute_hash`.  Used with
+ * {@link encodePreEncoded} to stamp a precomputed hash, and by
+ * application code that wants to check a payload before handing it off.
+ *
+ * Returns the hex digest as a lowercase `string`, matching the shape
+ * stored in the wire-format `HashDescriptor.value` field.
+ */
+
+import { getWbg } from './init.js';
+import { rethrowTyped, InvalidArgumentError } from './errors.js';
+
+/** Supported hash algorithm names.  `"xxh3"` is the only one today. */
+export type HashAlgorithm = 'xxh3';
+
+/**
+ * Compute a hash of the supplied bytes.
+ *
+ * @param data - Input bytes.  Must be a `Uint8Array`.
+ * @param algo - Algorithm name; default `"xxh3"`.
+ * @returns    - Lower-case hex string (16 chars for `xxh3`).
+ * @throws {InvalidArgumentError} when `data` is not a `Uint8Array`.
+ * @throws {MetadataError} when `algo` is not a recognised algorithm name.
+ */
+export function computeHash(data: Uint8Array, algo: HashAlgorithm = 'xxh3'): string {
+  if (!(data instanceof Uint8Array)) {
+    throw new InvalidArgumentError(`data must be a Uint8Array, got ${typeof data}`);
+  }
+  const wbg = getWbg();
+  return rethrowTyped(() => wbg.compute_hash(data, algo));
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -39,6 +39,37 @@ export { TensogramFile } from './file.js';
 export { getMetaKey, computeCommon, cborValuesEqual } from './metadata.js';
 export { DTYPE_BYTE_WIDTH, payloadByteSize, shapeElementCount, typedArrayFor, isDtype, SUPPORTED_DTYPES } from './dtype.js';
 
+// ── Scope C.1 — API parity ────────────────────────────────────────────────
+export { decodeRange } from './range.js';
+export { computeHash } from './hash.js';
+export type { HashAlgorithm } from './hash.js';
+export { simplePackingComputeParams } from './simplePacking.js';
+export { validate, validateBuffer, validateFile } from './validate.js';
+export { encodePreEncoded } from './encodePreEncoded.js';
+export { StreamingEncoder } from './streamingEncoder.js';
+
+// ── Scope C.2 — first-class half-precision / complex dtypes ───────────────
+//
+// Raw bit-twiddling helpers (`halfBitsToFloat`, `floatToHalfBits`,
+// `bfloat16BitsToFloat`, `floatToBfloat16Bits`) and the internal
+// `isComplexDtype` guard are deliberately NOT re-exported here — they
+// are implementation details of the view classes.  Callers that need
+// bits should reach them through a view's `.bits` accessor; callers
+// that need to route on dtype should pattern-match on the descriptor's
+// `dtype` string directly.
+export {
+  Float16Polyfill,
+  float16FromBytes,
+  getFloat16ArrayCtor,
+  hasNativeFloat16Array,
+} from './float16.js';
+export type { Float16ArrayLike, Float16Ctor } from './float16.js';
+
+export { Bfloat16Array, bfloat16FromBytes } from './bfloat16.js';
+
+export { ComplexArray, complexFromBytes } from './complex.js';
+export type { ComplexDtype, ComplexPair, ComplexStorage } from './complex.js';
+
 export {
   TensogramError,
   FramingError,
@@ -54,6 +85,7 @@ export {
 } from './errors.js';
 
 export type {
+  AppendOptions,
   BaseEntry,
   ByteOrder,
   CborValue,
@@ -63,18 +95,33 @@ export type {
   DecodedMessage,
   DecodedObject,
   DecodeOptions,
-  DecodeStreamOptions,
+  DecodeRangeOptions,
+  DecodeRangeResult,
   Dtype,
   EncodeInput,
   EncodeOptions,
+  EncodePreEncodedOptions,
   Encoding,
+  FileIssue,
   FileSource,
+  FileValidationReport,
   Filter,
   FromUrlOptions,
   GlobalMetadata,
   HashDescriptor,
+  IssueCode,
+  IssueSeverity,
   MessagePosition,
   OpenFileOptions,
+  PreEncodedInput,
+  RangePair,
+  SimplePackingParams,
   StreamDecodeError,
+  StreamingEncoderOptions,
   TypedArray,
+  ValidateMode,
+  ValidateOptions,
+  ValidationIssue,
+  ValidationLevel,
+  ValidationReport,
 } from './types.js';

--- a/typescript/src/internal/io.ts
+++ b/typescript/src/internal/io.ts
@@ -1,0 +1,29 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+/**
+ * Tiny shared helpers for file / URL / error formatting paths.
+ *
+ * `@internal` — not re-exported from `index.ts`.
+ */
+
+/** Format any thrown value as a short human-readable string. */
+export function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+/**
+ * Attach a `cause` to an error and return it — equivalent to the
+ * ES2022 `{ cause }` option to `Error` constructors but usable with
+ * our custom error classes that don't take an options bag.
+ */
+export function withCause<E extends Error>(err: E, cause: unknown): E {
+  Object.defineProperty(err, 'cause', { value: cause, configurable: true });
+  return err;
+}

--- a/typescript/src/internal/validation.ts
+++ b/typescript/src/internal/validation.ts
@@ -1,0 +1,112 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+/**
+ * Shared runtime-validation helpers for the write paths.
+ *
+ * Every public TS entrypoint that builds or appends a wire-format
+ * message (`encode`, `encodePreEncoded`, `StreamingEncoder`,
+ * `TensogramFile#append`) funnels through these helpers so error
+ * messages are identical across the surface and the policy for
+ * rejecting malformed `metadata` / `descriptor` only lives in one
+ * place.
+ *
+ * `@internal` — not re-exported from `index.ts`.
+ */
+
+import { SUPPORTED_DTYPES } from '../dtype.js';
+import { InvalidArgumentError } from '../errors.js';
+import type { DataObjectDescriptor, GlobalMetadata } from '../types.js';
+
+/**
+ * Assert that `meta` is shaped like a `GlobalMetadata` the encoder can
+ * process: plain object, non-negative integer `version`, no
+ * client-written `_reserved_`, and every `base[i]` entry is a plain
+ * object with no `_reserved_` key.
+ */
+export function assertValidMetadata(meta: GlobalMetadata): void {
+  if (meta === null || typeof meta !== 'object') {
+    throw new InvalidArgumentError(
+      `metadata must be a plain object, got ${typeof meta}`,
+    );
+  }
+  if (
+    typeof meta.version !== 'number' ||
+    !Number.isInteger(meta.version) ||
+    meta.version < 0
+  ) {
+    throw new InvalidArgumentError(
+      `metadata.version must be a non-negative integer, got ${String(meta.version)}`,
+    );
+  }
+  if ('_reserved_' in meta && meta._reserved_ !== undefined) {
+    throw new InvalidArgumentError(
+      'metadata._reserved_ is managed by the library; client code must not write it',
+    );
+  }
+  if (meta.base !== undefined) {
+    if (!Array.isArray(meta.base)) {
+      throw new InvalidArgumentError(
+        `metadata.base must be an array, got ${typeof meta.base}`,
+      );
+    }
+    for (let i = 0; i < meta.base.length; i++) {
+      const entry = meta.base[i];
+      if (entry === null || typeof entry !== 'object') {
+        throw new InvalidArgumentError(`metadata.base[${i}] must be a plain object`);
+      }
+      if ('_reserved_' in entry) {
+        throw new InvalidArgumentError(
+          `metadata.base[${i}]._reserved_ is managed by the library; client code must not write it`,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Assert that `desc` looks like a valid `DataObjectDescriptor`.  When
+ * `index` is supplied, error messages prefix the field paths with
+ * `objects[i].descriptor.` for extra context — matching the way the
+ * call-site loops over object arrays.
+ */
+export function assertValidDescriptor(
+  desc: DataObjectDescriptor,
+  index?: number,
+): void {
+  const prefix = index === undefined ? 'descriptor' : `objects[${index}].descriptor`;
+  if (desc === null || typeof desc !== 'object') {
+    throw new InvalidArgumentError(`${prefix} must be a plain object`);
+  }
+  if (typeof desc.type !== 'string') {
+    throw new InvalidArgumentError(`${prefix}.type must be a string`);
+  }
+  if (!Array.isArray(desc.shape)) {
+    throw new InvalidArgumentError(`${prefix}.shape must be an array`);
+  }
+  if (!SUPPORTED_DTYPES.has(desc.dtype)) {
+    throw new InvalidArgumentError(
+      `${prefix}.dtype=${String(desc.dtype)} is not a recognised dtype`,
+    );
+  }
+  if (desc.byte_order !== 'big' && desc.byte_order !== 'little') {
+    throw new InvalidArgumentError(`${prefix}.byte_order must be "big" or "little"`);
+  }
+}
+
+/**
+ * Normalise any `ArrayBufferView` into a `Uint8Array` covering exactly
+ * the bytes the view refers to.  The WASM encode entry points accept
+ * any TypedArray and read `byteOffset` + `byteLength`, but a
+ * `DataView` is not a TypedArray on the JS side — so we wrap it into
+ * a `Uint8Array` pointing at the same `ArrayBuffer` range.
+ */
+export function toUint8View(view: ArrayBufferView): Uint8Array {
+  if (view instanceof Uint8Array) return view;
+  return new Uint8Array(view.buffer, view.byteOffset, view.byteLength);
+}

--- a/typescript/src/range.ts
+++ b/typescript/src/range.ts
@@ -81,17 +81,23 @@ export function decodeRange(
       },
   );
 
+  // The WASM side already materialised each part via `Uint8Array::from`,
+  // which copies the bytes from WASM linear memory into a JS-heap
+  // `Uint8Array`.  We pass `copy: false` to `typedArrayFor` so it can
+  // view those bytes zero-copy — an aligned copy is still made
+  // internally when `byteOffset % element_width != 0`, which is rare
+  // (the WASM side allocates at offset 0).
   const rawParts = result.parts;
   if (opts?.join) {
     const joined = concat(rawParts);
     return {
       descriptor: result.descriptor,
-      parts: [typedArrayFor(result.descriptor.dtype, joined, /* copy */ true)],
+      parts: [typedArrayFor(result.descriptor.dtype, joined, /* copy */ false)],
     };
   }
 
   const typedParts: TypedArray[] = rawParts.map((p) =>
-    typedArrayFor(result.descriptor.dtype, p, /* copy */ true),
+    typedArrayFor(result.descriptor.dtype, p, /* copy */ false),
   );
   return { descriptor: result.descriptor, parts: typedParts };
 }

--- a/typescript/src/range.ts
+++ b/typescript/src/range.ts
@@ -1,0 +1,161 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+/**
+ * `decodeRange` — partial sub-tensor decode.
+ *
+ * Mirrors Rust `tensogram::decode_range`, Python `file_decode_range`,
+ * and `tgm_decode_range`.  For an uncompressed or szip-encoded object,
+ * decoding a small range is dramatically cheaper than a full decode
+ * because only the requested bytes are read through the pipeline.
+ *
+ * The result is always a `parts` array of dtype-typed views; when
+ * `join: true`, parts are concatenated into a single buffer before
+ * the dtype wrap (one element in `parts`).  `parts.length` is always
+ * the effective number of output slabs — never a discriminated union.
+ */
+
+import { getWbg } from './init.js';
+import { rethrowTyped, InvalidArgumentError } from './errors.js';
+import { typedArrayFor } from './dtype.js';
+import type {
+  DataObjectDescriptor,
+  DecodeRangeOptions,
+  DecodeRangeResult,
+  RangePair,
+  TypedArray,
+} from './types.js';
+
+/**
+ * Decode one or more sub-ranges from a single data object.
+ *
+ * @param buf         - Wire-format message bytes.
+ * @param objectIndex - Zero-based index of the target object.
+ * @param ranges      - Array of `[offset, count]` pairs in element units.
+ *                      `number` and `bigint` are both accepted; values
+ *                      above `Number.MAX_SAFE_INTEGER` must be `bigint`.
+ * @param opts        - `verifyHash` and `join` (see {@link DecodeRangeOptions}).
+ * @returns           - `{ descriptor, parts }`.  One entry in `parts`
+ *                      per requested range (split mode — the default), or
+ *                      a single concatenated entry when `join: true`.
+ * @throws {ObjectError}    when `objectIndex` is out of range
+ * @throws {EncodingError}  when the object has a filter (e.g. shuffle)
+ *                          or a bitmask dtype — both unsupported by the
+ *                          underlying range API.
+ * @throws {HashMismatchError} if `verifyHash: true` and a payload hash
+ *                             does not match the descriptor's recorded hash.
+ * @throws {InvalidArgumentError} on malformed `ranges`.
+ */
+export function decodeRange(
+  buf: Uint8Array,
+  objectIndex: number,
+  ranges: readonly RangePair[],
+  opts?: DecodeRangeOptions,
+): DecodeRangeResult {
+  if (!(buf instanceof Uint8Array)) {
+    throw new InvalidArgumentError(`buf must be a Uint8Array, got ${typeof buf}`);
+  }
+  // WASM's `usize` is 32-bit on wasm32 — anything beyond u32 would be
+  // silently truncated by the boundary, producing incorrect results.
+  if (!Number.isInteger(objectIndex) || objectIndex < 0 || objectIndex > 0xffff_ffff) {
+    throw new InvalidArgumentError(
+      `objectIndex must be an unsigned 32-bit integer, got ${String(objectIndex)}`,
+    );
+  }
+  if (!Array.isArray(ranges)) {
+    throw new InvalidArgumentError('ranges must be an array of [offset, count] pairs');
+  }
+
+  const flat = flattenRanges(ranges);
+  const wbg = getWbg();
+  const result = rethrowTyped(
+    () =>
+      wbg.decode_range(buf, objectIndex, flat, opts?.verifyHash ?? false) as {
+        descriptor: DataObjectDescriptor;
+        parts: Uint8Array[];
+      },
+  );
+
+  const rawParts = result.parts;
+  if (opts?.join) {
+    const joined = concat(rawParts);
+    return {
+      descriptor: result.descriptor,
+      parts: [typedArrayFor(result.descriptor.dtype, joined, /* copy */ true)],
+    };
+  }
+
+  const typedParts: TypedArray[] = rawParts.map((p) =>
+    typedArrayFor(result.descriptor.dtype, p, /* copy */ true),
+  );
+  return { descriptor: result.descriptor, parts: typedParts };
+}
+
+/**
+ * Pack `ranges` into the flat `BigUint64Array` expected by the WASM
+ * boundary: `[off0, count0, off1, count1, ...]`.  Rejects negative /
+ * fractional values; promotes `number` to `bigint` losslessly within
+ * safe-integer range and lets `bigint` inputs flow through.
+ */
+function flattenRanges(ranges: readonly RangePair[]): BigUint64Array {
+  const out = new BigUint64Array(ranges.length * 2);
+  for (let i = 0; i < ranges.length; i++) {
+    const pair = ranges[i];
+    if (!Array.isArray(pair) || pair.length !== 2) {
+      throw new InvalidArgumentError(
+        `ranges[${i}] must be a [offset, count] pair, got ${JSON.stringify(pair)}`,
+      );
+    }
+    out[2 * i] = toBigUint64(pair[0], i, 'offset');
+    out[2 * i + 1] = toBigUint64(pair[1], i, 'count');
+  }
+  return out;
+}
+
+/** 2^64 − 1 — the inclusive upper bound of an unsigned 64-bit integer. */
+const U64_MAX = 0xffff_ffff_ffff_ffffn;
+
+function toBigUint64(v: number | bigint, i: number, field: string): bigint {
+  if (typeof v === 'bigint') {
+    if (v < 0n || v > U64_MAX) {
+      throw new InvalidArgumentError(
+        `ranges[${i}].${field} must fit in an unsigned 64-bit integer, got ${v}`,
+      );
+    }
+    return v;
+  }
+  if (typeof v === 'number') {
+    if (!Number.isFinite(v) || v < 0 || !Number.isInteger(v)) {
+      throw new InvalidArgumentError(
+        `ranges[${i}].${field} must be a non-negative integer, got ${v}`,
+      );
+    }
+    if (v > Number.MAX_SAFE_INTEGER) {
+      throw new InvalidArgumentError(
+        `ranges[${i}].${field} exceeds Number.MAX_SAFE_INTEGER — pass a bigint`,
+      );
+    }
+    return BigInt(v);
+  }
+  throw new InvalidArgumentError(
+    `ranges[${i}].${field} must be a number or bigint, got ${typeof v}`,
+  );
+}
+
+/** Concatenate a list of byte arrays into a single `Uint8Array`. */
+function concat(parts: readonly Uint8Array[]): Uint8Array {
+  let total = 0;
+  for (const p of parts) total += p.byteLength;
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.byteLength;
+  }
+  return out;
+}

--- a/typescript/src/simplePacking.ts
+++ b/typescript/src/simplePacking.ts
@@ -1,0 +1,95 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+/**
+ * `simplePackingComputeParams` — GRIB-style simple-packing parameter
+ * computation for a float64 array.
+ *
+ * Mirrors Rust `tensogram_encodings::simple_packing::compute_params` /
+ * Python `tensogram.compute_packing_params` / FFI
+ * `tgm_simple_packing_compute_params`.
+ *
+ * Returns snake-case keys matching the on-wire descriptor params so the
+ * result can be spread directly into a descriptor:
+ *
+ * ```ts
+ * const params = simplePackingComputeParams(values, 16);
+ * const desc = {
+ *   ...baseDescriptor,
+ *   encoding: 'simple_packing',
+ *   compression: 'szip',
+ *   ...params,  // contributes reference_value, binary_scale_factor, …
+ * };
+ * ```
+ */
+
+import { getWbg } from './init.js';
+import { rethrowTyped, InvalidArgumentError } from './errors.js';
+import type { SimplePackingParams } from './types.js';
+
+/** Maximum / minimum signed 32-bit integer — the range the WASM boundary accepts. */
+const I32_MAX = 0x7fff_ffff;
+const I32_MIN = -0x8000_0000;
+
+/**
+ * Compute simple-packing parameters for a set of f64 values.
+ *
+ * @param values                - `Float64Array` or plain array of `number`
+ *                                (will be converted to `Float64Array`).
+ *                                Every entry must be finite — NaN and
+ *                                ±Infinity are rejected because they
+ *                                produce meaningless scale factors.
+ * @param bitsPerValue          - Quantization depth.  Typical values: 16,
+ *                                24, 32.  `0` produces a constant-field
+ *                                packing (no payload bytes emitted).
+ *                                Must satisfy `0 ≤ bitsPerValue ≤ 64`.
+ * @param decimalScaleFactor    - Power-of-10 scale applied before packing.
+ *                                Default `0`.  Must fit in signed 32-bit
+ *                                integer range.
+ * @returns                     - Snake-cased {@link SimplePackingParams}.
+ * @throws {EncodingError}      - NaN detected (in the underlying encoder).
+ * @throws {InvalidArgumentError} - Bad argument type/value, non-finite
+ *                                  sample, out-of-range scale factor or
+ *                                  bit width.
+ */
+export function simplePackingComputeParams(
+  values: Float64Array | readonly number[],
+  bitsPerValue: number,
+  decimalScaleFactor = 0,
+): SimplePackingParams {
+  if (!Number.isInteger(bitsPerValue) || bitsPerValue < 0 || bitsPerValue > 64) {
+    throw new InvalidArgumentError(
+      `bitsPerValue must be an integer in [0, 64], got ${String(bitsPerValue)}`,
+    );
+  }
+  if (
+    !Number.isInteger(decimalScaleFactor) ||
+    decimalScaleFactor < I32_MIN ||
+    decimalScaleFactor > I32_MAX
+  ) {
+    throw new InvalidArgumentError(
+      `decimalScaleFactor must be a signed 32-bit integer, got ${String(decimalScaleFactor)}`,
+    );
+  }
+  const f64 =
+    values instanceof Float64Array ? values : Float64Array.from(values as readonly number[]);
+  // Reject ±Infinity here — the Rust core only guards against NaN,
+  // and ±Inf would produce a nonsensical `binary_scale_factor`.
+  for (let i = 0; i < f64.length; i++) {
+    if (!Number.isFinite(f64[i])) {
+      throw new InvalidArgumentError(
+        `values[${i}] must be finite, got ${f64[i]}`,
+      );
+    }
+  }
+  const wbg = getWbg();
+  return rethrowTyped(
+    () =>
+      wbg.simple_packing_compute_params(f64, bitsPerValue, decimalScaleFactor) as SimplePackingParams,
+  );
+}

--- a/typescript/src/streamingEncoder.ts
+++ b/typescript/src/streamingEncoder.ts
@@ -1,0 +1,247 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+/**
+ * `StreamingEncoder` — frame-at-a-time message construction.
+ *
+ * Mirrors Rust `StreamingEncoder<Vec<u8>>` and Python `StreamingEncoder`.
+ * The backing sink is an in-memory `Vec<u8>` on the WASM side; callers
+ * retrieve the complete message via {@link StreamingEncoder.finish} when
+ * done.
+ *
+ * The class is **single-use**: after `finish()` (or `close()` without
+ * finishing) the instance is dead and every method throws
+ * `InvalidArgumentError`.  Keep the construction cheap and pair it with
+ * `try { ... } finally { enc.close(); }` whenever early failure is
+ * possible.
+ *
+ * Example:
+ *
+ * ```ts
+ * const enc = new StreamingEncoder({ version: 2 });
+ * enc.writePreceder({ mars: { param: '2t' } });
+ * enc.writeObject(descriptor, new Float32Array([1, 2, 3]));
+ * enc.writeObject(otherDescriptor, new Float64Array([4, 5, 6]));
+ * const bytes = enc.finish();     // Uint8Array
+ * ```
+ */
+
+import { getWbg } from './init.js';
+import { rethrowTyped, InvalidArgumentError } from './errors.js';
+import {
+  assertValidDescriptor,
+  assertValidMetadata,
+  toUint8View,
+} from './internal/validation.js';
+import type {
+  BaseEntry,
+  DataObjectDescriptor,
+  GlobalMetadata,
+  StreamingEncoderOptions,
+} from './types.js';
+
+// Structural view of the wasm-bindgen-generated class.  Keeping the
+// binding narrow prevents accidental reliance on internal surface.
+interface WbgStreamingEncoder {
+  free(): void;
+  write_object(descriptor_js: unknown, data: unknown): void;
+  write_object_pre_encoded(descriptor_js: unknown, data: unknown): void;
+  write_preceder(metadata_js: unknown): void;
+  object_count(): number;
+  bytes_written(): number;
+  finish(): Uint8Array;
+}
+
+const registry = new FinalizationRegistry<WbgStreamingEncoder>((h) => {
+  try {
+    h.free();
+  } catch {
+    /* best effort */
+  }
+});
+
+/**
+ * Frame-at-a-time Tensogram encoder.  Two modes, selected at
+ * construction by the presence of `opts.onBytes`:
+ *
+ * - **Buffered (default).**  Frames accumulate in an internal buffer;
+ *   {@link finish} returns the complete wire-format message.
+ * - **Streaming.**  Frames are forwarded to `opts.onBytes` as they're
+ *   produced; {@link finish} returns an empty `Uint8Array` after
+ *   flushing the footer.
+ *
+ * Writing is synchronous on the JS side because the WASM calls are
+ * synchronous.  The callback in streaming mode must therefore also
+ * complete synchronously — `Promise` returns are silently discarded.
+ */
+export class StreamingEncoder {
+  readonly #handle: WbgStreamingEncoder;
+  readonly #streaming: boolean;
+  #closed = false;
+
+  /**
+   * Construct a new encoder and write the preamble + header metadata
+   * frame.  In buffered mode the bytes accumulate internally; in
+   * streaming mode they flow to `opts.onBytes` immediately.
+   *
+   * @param metadata - Global metadata (`version: 2` required).
+   * @param opts     - Hash selection + optional `onBytes` sink.
+   * @throws {InvalidArgumentError} when `metadata` is malformed or
+   *   when `opts.onBytes` is supplied but is not a function.
+   */
+  constructor(metadata: GlobalMetadata, opts?: StreamingEncoderOptions) {
+    assertValidMetadata(metadata);
+    if (opts?.onBytes !== undefined && typeof opts.onBytes !== 'function') {
+      throw new InvalidArgumentError(
+        'StreamingEncoder: opts.onBytes must be a function',
+      );
+    }
+    const wbg = getWbg();
+    const hash = opts?.hash !== false;
+    const sink = opts?.onBytes;
+    this.#streaming = sink !== undefined;
+    this.#handle = rethrowTyped(
+      () =>
+        new wbg.StreamingEncoder(metadata, hash, sink) as unknown as WbgStreamingEncoder,
+    );
+    registry.register(this, this.#handle, this);
+  }
+
+  /**
+   * Write a PrecederMetadata frame for the next data object.  Must be
+   * followed by exactly one {@link writeObject} or
+   * {@link writeObjectPreEncoded} before another preceder or
+   * {@link finish}.
+   */
+  writePreceder(entry: BaseEntry): void {
+    this.#assertOpen();
+    if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new InvalidArgumentError(
+        'writePreceder: entry must be a plain object of per-object metadata',
+      );
+    }
+    if ('_reserved_' in entry) {
+      throw new InvalidArgumentError(
+        'writePreceder: entry must not contain `_reserved_` — the library manages it',
+      );
+    }
+    rethrowTyped(() => this.#handle.write_preceder(entry));
+  }
+
+  /**
+   * Encode and write a single data object.
+   *
+   * @param descriptor - Descriptor of the object.
+   * @param data       - Raw native-endian payload (any `ArrayBufferView`).
+   */
+  writeObject(descriptor: DataObjectDescriptor, data: ArrayBufferView): void {
+    this.#assertOpen();
+    assertValidDescriptor(descriptor);
+    if (!ArrayBuffer.isView(data)) {
+      throw new InvalidArgumentError(
+        'writeObject: data must be an ArrayBufferView (TypedArray, DataView, …)',
+      );
+    }
+    rethrowTyped(() =>
+      this.#handle.write_object(descriptor as unknown, toUint8View(data)),
+    );
+  }
+
+  /**
+   * Write a pre-encoded data object (bypass the encoding pipeline).
+   *
+   * The descriptor must accurately describe the encoding that was
+   * already applied, including any codec-specific params (e.g.
+   * `szip_block_offsets`).
+   */
+  writeObjectPreEncoded(descriptor: DataObjectDescriptor, data: Uint8Array): void {
+    this.#assertOpen();
+    assertValidDescriptor(descriptor);
+    if (!(data instanceof Uint8Array)) {
+      throw new InvalidArgumentError(
+        'writeObjectPreEncoded: data must be a Uint8Array of pre-encoded bytes',
+      );
+    }
+    rethrowTyped(() =>
+      this.#handle.write_object_pre_encoded(descriptor as unknown, data),
+    );
+  }
+
+  /** Number of data objects written so far. */
+  get objectCount(): number {
+    this.#assertOpen();
+    return this.#handle.object_count();
+  }
+
+  /**
+   * Total bytes written to the internal buffer so far (preamble +
+   * header frames + all completed data-object frames).  Crosses the
+   * WASM boundary as `f64`, which is lossless up to
+   * `Number.MAX_SAFE_INTEGER` (≈ 9 PiB) — well beyond any realistic
+   * Tensogram message.
+   */
+  get bytesWritten(): number {
+    this.#assertOpen();
+    return this.#handle.bytes_written();
+  }
+
+  /**
+   * Finalise the message: write footer frames + postamble.  In
+   * buffered mode returns the complete wire bytes; in streaming mode
+   * the footer flows through the `onBytes` callback and this returns
+   * an empty `Uint8Array` (zero-length marker, not a failure — every
+   * byte has already been delivered).
+   *
+   * The encoder is closed after this call; any further method raises
+   * `InvalidArgumentError`.
+   */
+  finish(): Uint8Array {
+    this.#assertOpen();
+    const bytes = rethrowTyped(() => this.#handle.finish());
+    this.#markClosed();
+    return bytes;
+  }
+
+  /**
+   * `true` when the encoder was constructed with an `onBytes`
+   * callback — bytes flow through the callback rather than
+   * accumulating in an internal buffer.  Useful for code that needs
+   * to branch on mode (e.g. deciding whether to expect bytes back
+   * from `finish()`).
+   */
+  get streaming(): boolean {
+    return this.#streaming;
+  }
+
+  /**
+   * Release the underlying WASM handle without finalising.  Safe to
+   * call multiple times.  Any partial buffer is discarded.
+   */
+  close(): void {
+    if (this.#closed) return;
+    this.#markClosed();
+    try {
+      this.#handle.free();
+    } catch {
+      /* best effort */
+    }
+  }
+
+  #markClosed(): void {
+    this.#closed = true;
+    registry.unregister(this);
+  }
+
+  #assertOpen(): void {
+    if (this.#closed) {
+      throw new InvalidArgumentError('StreamingEncoder has been finished or closed');
+    }
+  }
+}
+
+

--- a/typescript/src/streamingEncoder.ts
+++ b/typescript/src/streamingEncoder.ts
@@ -197,13 +197,14 @@ export class StreamingEncoder {
    * an empty `Uint8Array` (zero-length marker, not a failure — every
    * byte has already been delivered).
    *
-   * The encoder is closed after this call; any further method raises
-   * `InvalidArgumentError`.
+   * The encoder is closed after this call (WASM handle freed,
+   * `FinalizationRegistry` unregistered); any further method raises
+   * `InvalidArgumentError`.  Idempotent with a subsequent `close()`.
    */
   finish(): Uint8Array {
     this.#assertOpen();
     const bytes = rethrowTyped(() => this.#handle.finish());
-    this.#markClosed();
+    this.#closeHandle();
     return bytes;
   }
 
@@ -224,17 +225,24 @@ export class StreamingEncoder {
    */
   close(): void {
     if (this.#closed) return;
-    this.#markClosed();
+    this.#closeHandle();
+  }
+
+  /**
+   * Unified teardown path shared by `finish()` and `close()`.  Marks
+   * the instance closed, unregisters the `FinalizationRegistry` hook
+   * (so it won't double-free via GC), and releases the WASM handle.
+   * Only fires once — both `finish()` and `close()` guard on
+   * `#closed` via `#assertOpen()` / the early return respectively.
+   */
+  #closeHandle(): void {
+    this.#closed = true;
+    registry.unregister(this);
     try {
       this.#handle.free();
     } catch {
-      /* best effort */
+      /* best effort — WASM may have already freed internally */
     }
-  }
-
-  #markClosed(): void {
-    this.#closed = true;
-    registry.unregister(this);
   }
 
   #assertOpen(): void {

--- a/typescript/src/types.ts
+++ b/typescript/src/types.ts
@@ -234,7 +234,17 @@ export interface EncodeInput {
   data: ArrayBufferView;
 }
 
-/** Any concrete JavaScript `TypedArray`. */
+/**
+ * Any concrete JavaScript `TypedArray` plus the three Scope-C view
+ * classes used for dtypes JS has no native array for:
+ *
+ * - `Float16Polyfill` (or a native `Float16Array` when the host ships
+ *    one) for `float16`.
+ * - `Bfloat16Array` for `bfloat16`.
+ * - `ComplexArray` for `complex64` / `complex128`.
+ *
+ * Built-in TypedArrays still cover every other dtype.
+ */
 export type TypedArray =
   | Float32Array
   | Float64Array
@@ -245,7 +255,45 @@ export type TypedArray =
   | Uint8Array
   | Uint16Array
   | Uint32Array
-  | BigUint64Array;
+  | BigUint64Array
+  | HalfArrayLike
+  | BfloatArrayLike
+  | ComplexArrayLike;
+
+/**
+ * Lowest-common-denominator structural shape of the `float16` view —
+ * every member listed below is present on both the native TC39
+ * `Float16Array` and the `Float16Polyfill` from `./float16.ts`.
+ * Callers that need polyfill-only accessors (e.g. `.bits`,
+ * `.toFloat32Array()`) should check `instanceof Float16Polyfill`
+ * explicitly.
+ *
+ * Declared here rather than imported from `./float16.ts` so
+ * `types.ts` stays dependency-free and the module graph stays acyclic.
+ */
+export interface HalfArrayLike {
+  readonly BYTES_PER_ELEMENT: 2;
+  readonly length: number;
+  readonly byteLength: number;
+  readonly byteOffset: number;
+  readonly buffer: ArrayBufferLike;
+  at(index: number): number | undefined;
+  [Symbol.iterator](): IterableIterator<number>;
+}
+
+/** Structural shape of the `bfloat16` view.  See {@link HalfArrayLike}. */
+export type BfloatArrayLike = HalfArrayLike;
+
+/** Structural shape of the `complex64` / `complex128` view. */
+export interface ComplexArrayLike {
+  readonly dtype: 'complex64' | 'complex128';
+  readonly length: number;
+  readonly data: Float32Array | Float64Array;
+  real(i: number): number;
+  imag(i: number): number;
+  get(i: number): { re: number; im: number };
+  [Symbol.iterator](): IterableIterator<{ re: number; im: number }>;
+}
 
 /** A message offset + length pair returned by `scan()`. */
 export interface MessagePosition {
@@ -328,3 +376,180 @@ export interface OpenFileOptions {
 
 /** Where the bytes backing a {@link TensogramFile} came from. */
 export type FileSource = 'local' | 'remote' | 'buffer';
+
+// ── Scope-C additions ────────────────────────────────────────────────────────
+
+/**
+ * A single (offset, count) pair describing one sub-tensor slab to
+ * decode via {@link decodeRange}.  Both values are element counts, not
+ * bytes.  `bigint` is accepted for values above 2^53; `number` is fine
+ * for everyday sizes.
+ */
+export type RangePair = readonly [number | bigint, number | bigint];
+
+/** Options for {@link decodeRange}. */
+export interface DecodeRangeOptions {
+  /** If `true`, verifies the object's payload hash before decoding. */
+  verifyHash?: boolean;
+  /**
+   * If `true`, the resulting `parts` array has exactly one entry — the
+   * concatenation of every requested range.  Default `false` (one entry
+   * per range, in request order).
+   */
+  join?: boolean;
+}
+
+/** Result of {@link decodeRange}. */
+export interface DecodeRangeResult {
+  /** The descriptor of the object being sliced. */
+  readonly descriptor: DataObjectDescriptor;
+  /**
+   * One typed view per requested range (or a single view if `join: true`).
+   * The array type reflects `descriptor.dtype`.
+   */
+  readonly parts: readonly TypedArray[];
+}
+
+/** Options for {@link encodePreEncoded}. */
+export interface EncodePreEncodedOptions {
+  /**
+   * Hash algorithm.  Default `"xxh3"`.  Pass `false` to disable.  The
+   * hash is always recomputed from the caller's pre-encoded bytes — any
+   * `hash` field on the descriptor is ignored.
+   */
+  hash?: 'xxh3' | false;
+}
+
+/** A single (descriptor, pre-encoded bytes) pair for {@link encodePreEncoded}. */
+export interface PreEncodedInput {
+  descriptor: DataObjectDescriptor;
+  /**
+   * Pre-encoded bytes matching the descriptor's pipeline declaration.
+   * For `encoding: "simple_packing"` this must be the packed-integer
+   * output; for `compression: "szip"` it must be the szip-compressed
+   * bytes and the descriptor's params must include `szip_block_offsets`.
+   */
+  data: Uint8Array;
+}
+
+/** Simple-packing params produced by {@link simplePackingComputeParams}. */
+export interface SimplePackingParams {
+  /** First value the packed integer `0` represents. */
+  reference_value: number;
+  /** Power-of-2 scale (E).  Applied as `2^(-E)` during encode. */
+  binary_scale_factor: number;
+  /** Power-of-10 scale (D).  Applied as `10^D` during encode. */
+  decimal_scale_factor: number;
+  /** Width of each packed integer in bits (1–64; 0 for constant fields). */
+  bits_per_value: number;
+}
+
+/** Validation depth levels, matching the Rust `ValidationLevel` enum. */
+export type ValidationLevel = 'structure' | 'metadata' | 'integrity' | 'fidelity';
+
+/** Severity of a {@link ValidationIssue}. */
+export type IssueSeverity = 'error' | 'warning';
+
+/**
+ * Stable machine-readable issue code.  The full list lives in
+ * `rust/tensogram/src/validate/types.rs`; keeping this as `string` keeps
+ * the TS surface forward-compatible as new codes are added.
+ */
+export type IssueCode = string;
+
+/**
+ * A single finding from {@link validate} or {@link validateFile}.  The
+ * field names mirror the on-the-wire JSON shape emitted by the Rust
+ * core's `ValidationReport` (snake_case) so no renaming happens at
+ * the WASM boundary.
+ */
+export interface ValidationIssue {
+  /** Stable machine-readable identifier — e.g. `"truncated_message"`. */
+  code: IssueCode;
+  /** Which depth of validation surfaced the issue. */
+  level: ValidationLevel;
+  /** Severity: `"error"` fails the message, `"warning"` is informational. */
+  severity: IssueSeverity;
+  /** Index of the offending object, when applicable. */
+  object_index?: number;
+  /** Byte offset within the message buffer, when applicable. */
+  byte_offset?: number;
+  /** Human-readable description suitable for logs or UI. */
+  description: string;
+}
+
+/** Result of {@link validate}. */
+export interface ValidationReport {
+  readonly issues: readonly ValidationIssue[];
+  readonly object_count: number;
+  readonly hash_verified: boolean;
+}
+
+/** A file-level issue (not tied to a specific message). */
+export interface FileIssue {
+  byte_offset: number;
+  length: number;
+  description: string;
+}
+
+/** Result of {@link validateFile}. */
+export interface FileValidationReport {
+  readonly file_issues: readonly FileIssue[];
+  readonly messages: readonly ValidationReport[];
+}
+
+/** Human-facing validation mode.  Maps to the CLI's flag set. */
+export type ValidateMode = 'quick' | 'default' | 'checksum' | 'full';
+
+/** Options for {@link validate} / {@link validateFile}. */
+export interface ValidateOptions {
+  /** Validation depth.  Default `"default"`. */
+  mode?: ValidateMode;
+  /** Enable RFC 8949 canonical-CBOR-ordering checks.  Default `false`. */
+  canonical?: boolean;
+}
+
+/** Options for {@link TensogramFile#append}. */
+export interface AppendOptions {
+  /** Hash algorithm.  Default `"xxh3"`.  Pass `false` to disable. */
+  hash?: 'xxh3' | false;
+}
+
+/** Options for {@link StreamingEncoder}. */
+export interface StreamingEncoderOptions {
+  /** Hash algorithm.  Default `"xxh3"`.  Pass `false` to disable. */
+  hash?: 'xxh3' | false;
+  /**
+   * Synchronous streaming sink.
+   *
+   * When set, each chunk of wire-format bytes the encoder produces is
+   * forwarded to this callback as it is produced — no full-message
+   * buffering is performed.  The callback is invoked during
+   * construction (preamble + header metadata frame), during each
+   * {@link StreamingEncoder.writeObject} / `writeObjectPreEncoded`
+   * (one data-object frame's bytes, potentially split across multiple
+   * invocations), and during {@link StreamingEncoder.finish} (footer
+   * frames + postamble).
+   *
+   * In this mode `finish()` returns an empty `Uint8Array` — every
+   * byte has already been delivered to the callback.  Concatenating
+   * every `chunk` the callback sees (in order) yields a message
+   * byte-for-byte identical to the one buffered mode would return.
+   *
+   * **Synchronous contract.**  The callback must complete its work
+   * synchronously.  `Promise` return values are silently discarded
+   * because the Rust/WASM writer contract is synchronous.  Use the
+   * buffered mode with a single `fetch` call if you need async work.
+   *
+   * **Chunk ownership.**  Each `chunk` is a fresh JS-owned
+   * `Uint8Array` whose buffer is invalidated when the WASM module's
+   * linear memory grows.  Copy (`chunk.slice()`) or consume it before
+   * the next `writeObject` call if you need to hold on to it.
+   *
+   * **Errors.**  If the callback throws, the exception surfaces as an
+   * `IoError` from the next `writeObject` / `finish` that triggers a
+   * flush.  The encoder state is undefined after an error — call
+   * {@link StreamingEncoder.close} and start over.
+   */
+  onBytes?: (chunk: Uint8Array) => void;
+}

--- a/typescript/src/validate.ts
+++ b/typescript/src/validate.ts
@@ -1,0 +1,184 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+/**
+ * `validate` / `validateFile` — structural and integrity validation.
+ *
+ * `validate(buf)` works everywhere (browser, Node, any runtime).
+ * `validateFile(path)` is a Node convenience that reads the file, then
+ * runs `validate_buffer` in WASM on the contents — mirroring the
+ * buffer/file split present in Rust core and every other language
+ * binding.
+ *
+ * The WASM side returns a JSON string; we parse it once here so callers
+ * see typed {@link ValidationReport} / {@link FileValidationReport}
+ * objects.  JSON is the neutral bridge because it preserves large
+ * integers unambiguously (issue `byte_offset` can exceed 2^32 in
+ * pathological file-level reports).
+ */
+
+import { getWbg } from './init.js';
+import { rethrowTyped, InvalidArgumentError, IoError } from './errors.js';
+import { scan } from './decode.js';
+import { errorMessage, withCause } from './internal/io.js';
+import type {
+  FileIssue,
+  FileValidationReport,
+  ValidateOptions,
+  ValidateMode,
+  ValidationReport,
+} from './types.js';
+
+/**
+ * Validate a single Tensogram message buffer (not a file).  The
+ * returned report carries any discovered issues; a "valid" message
+ * is one with no `error`-severity entries.
+ *
+ * Structural / integrity / fidelity problems are reported in the
+ * returned `issues` list — this function does NOT throw on malformed
+ * input.  It throws only on programmer error (wrong argument type or
+ * unknown validation mode).
+ *
+ * @throws {InvalidArgumentError} when `buf` is not a `Uint8Array` or
+ *   `opts.mode` is not one of the documented modes.
+ */
+export function validate(buf: Uint8Array, opts?: ValidateOptions): ValidationReport {
+  if (!(buf instanceof Uint8Array)) {
+    throw new InvalidArgumentError(`buf must be a Uint8Array, got ${typeof buf}`);
+  }
+  const { level, canonical } = resolveOptions(opts);
+  const wbg = getWbg();
+  const json = rethrowTyped(() => wbg.validate_buffer(buf, level, canonical));
+  return parseMessageReport(json);
+}
+
+/**
+ * Validate every message in a multi-message buffer, reporting gaps and
+ * trailing garbage between messages.
+ *
+ * Runtime-agnostic — does not require Node.  For Node callers wanting
+ * to validate a `.tgm` file on disk, use {@link validateFile}.
+ *
+ * @throws {InvalidArgumentError} when `buf` is not a `Uint8Array` or
+ *   `opts.mode` is not one of the documented modes.
+ */
+export function validateBuffer(
+  buf: Uint8Array,
+  opts?: ValidateOptions,
+): FileValidationReport {
+  if (!(buf instanceof Uint8Array)) {
+    throw new InvalidArgumentError(`buf must be a Uint8Array, got ${typeof buf}`);
+  }
+  const positions = scan(buf);
+  const file_issues: FileIssue[] = [];
+  const messages: ValidationReport[] = [];
+
+  let expected = 0;
+  for (const { offset, length } of positions) {
+    if (offset > expected) {
+      file_issues.push({
+        byte_offset: expected,
+        length: offset - expected,
+        description: `${offset - expected} unrecognized bytes at offset ${expected}`,
+      });
+    }
+    // subarray shares the underlying `ArrayBuffer` — the WASM
+    // boundary reads through the view's `byteOffset` / `byteLength`,
+    // so no copy is needed to isolate one message's bytes.
+    messages.push(validate(buf.subarray(offset, offset + length), opts));
+    expected = offset + length;
+  }
+
+  if (expected < buf.byteLength) {
+    const trailing = buf.byteLength - expected;
+    const desc =
+      messages.length === 0
+        ? `${trailing} bytes with no valid messages`
+        : `${trailing} trailing bytes after last message at offset ${expected}`;
+    file_issues.push({ byte_offset: expected, length: trailing, description: desc });
+  }
+
+  return { file_issues, messages };
+}
+
+/**
+ * Node-only: validate every message in a local `.tgm` file.  Reads the
+ * entire file into memory once, then delegates to {@link validateBuffer}.
+ *
+ * For very large files (several GiB) consider
+ * {@link TensogramFile.fromUrl} with `validate(rawMessage(i))` in a
+ * loop to keep memory bounded — see `docs/src/guide/typescript-api.md`.
+ *
+ * @throws {IoError} when the path cannot be read or `node:fs/promises`
+ *   is unavailable (non-Node runtime).
+ */
+export async function validateFile(
+  path: string | URL,
+  opts?: ValidateOptions,
+): Promise<FileValidationReport> {
+  if (typeof path !== 'string' && !(path instanceof URL)) {
+    throw new InvalidArgumentError(
+      'validateFile: path must be a string or file:// URL',
+    );
+  }
+  let readFile: typeof import('node:fs/promises').readFile;
+  try {
+    ({ readFile } = await import('node:fs/promises'));
+  } catch (cause) {
+    throw withCause(
+      new IoError('validateFile requires Node; use validate(buf) in browsers'),
+      cause,
+    );
+  }
+
+  let bytes: Uint8Array;
+  try {
+    const buf = await readFile(path);
+    bytes = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+  } catch (err) {
+    throw withCause(new IoError(`validateFile: ${errorMessage(err)}`), err);
+  }
+  return validateBuffer(bytes, opts);
+}
+
+// ── internals ──────────────────────────────────────────────────────────────
+
+/**
+ * Resolve caller options to the `(level, canonical)` pair expected by
+ * the WASM entrypoint.  An invalid `mode` is caught at compile time
+ * via the `never` exhaustiveness guard; the runtime fallback below
+ * only fires if a caller slips past `--strict` typing.
+ */
+function resolveOptions(
+  opts?: ValidateOptions,
+): { level: ValidateMode; canonical: boolean } {
+  const mode: ValidateMode = opts?.mode ?? 'default';
+  switch (mode) {
+    case 'quick':
+    case 'default':
+    case 'checksum':
+    case 'full':
+      return { level: mode, canonical: opts?.canonical ?? false };
+    default: {
+      const _exhaustive: never = mode;
+      throw new InvalidArgumentError(
+        `validate: unknown mode "${String(_exhaustive)}"; expected quick | default | checksum | full`,
+      );
+    }
+  }
+}
+
+function parseMessageReport(json: string): ValidationReport {
+  try {
+    return JSON.parse(json) as ValidationReport;
+  } catch (err) {
+    throw new InvalidArgumentError(
+      `validate: WASM returned invalid JSON (${errorMessage(err)})`,
+    );
+  }
+}

--- a/typescript/src/validate.ts
+++ b/typescript/src/validate.ts
@@ -17,9 +17,17 @@
  *
  * The WASM side returns a JSON string; we parse it once here so callers
  * see typed {@link ValidationReport} / {@link FileValidationReport}
- * objects.  JSON is the neutral bridge because it preserves large
- * integers unambiguously (issue `byte_offset` can exceed 2^32 in
- * pathological file-level reports).
+ * objects.  JSON is the neutral bridge for two reasons:
+ *
+ * 1. `serde_wasm_bindgen`'s default conversion of Rust `u64` values
+ *    goes through JavaScript `BigInt`, which is awkward for callers
+ *    that want plain `number` offsets.  JSON numbers are parsed as
+ *    JS `number`, so `byte_offset` arrives ergonomic.
+ * 2. JS `number` (IEEE-754 f64) handles integers losslessly up to
+ *    `Number.MAX_SAFE_INTEGER` (2^53 − 1 ≈ 9 PiB), which is far
+ *    beyond the > 2^32 (4 GiB) byte offsets realistic Tensogram
+ *    files and messages will reach.  If we ever need to cover the
+ *    9 PiB–to–u64::MAX range we'll switch to string-encoded offsets.
  */
 
 import { getWbg } from './init.js';

--- a/typescript/tests/append.test.ts
+++ b/typescript/tests/append.test.ts
@@ -1,0 +1,268 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+/**
+ * `TensogramFile#append` — Node local-file append tests.  Covers:
+ *
+ * - A fresh `.tgm` file created via `open(path)` + `append(...)`
+ *   gains a new message; `messageCount` reflects it; every message
+ *   (including the new one) decodes correctly.
+ * - `fromBytes` and `fromUrl` both reject `append` with
+ *   `InvalidArgumentError` — matches the Rust / Python / C++ contract.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  encode,
+  InvalidArgumentError,
+  TensogramFile,
+} from '../src/index.js';
+import { defaultMeta, initOnce, makeDescriptor } from './helpers.js';
+
+describe('Scope C.1 — TensogramFile#append', () => {
+  initOnce();
+
+  let tmp: string;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'tensogram-ts-append-'));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('appends a message to an empty file opened via open()', async () => {
+    const path = join(tmp, 'grow.tgm');
+    // Seed the file with one message so open() has something to index.
+    writeFileSync(
+      path,
+      encode(defaultMeta(), [
+        {
+          descriptor: makeDescriptor([2], 'float32'),
+          data: new Float32Array([1, 2]),
+        },
+      ]),
+    );
+
+    const file = await TensogramFile.open(path);
+    try {
+      expect(file.messageCount).toBe(1);
+      await file.append(defaultMeta(), [
+        {
+          descriptor: makeDescriptor([3], 'float32'),
+          data: new Float32Array([10, 20, 30]),
+        },
+      ]);
+      expect(file.messageCount).toBe(2);
+      const second = await file.message(1);
+      expect(Array.from(second.objects[0].data() as Float32Array)).toEqual([10, 20, 30]);
+      second.close();
+    } finally {
+      file.close();
+    }
+  });
+
+  it('flushes to disk — a reopened handle sees the appended message', async () => {
+    const path = join(tmp, 'persist.tgm');
+    writeFileSync(
+      path,
+      encode(defaultMeta(), [
+        {
+          descriptor: makeDescriptor([1], 'float32'),
+          data: new Float32Array([0]),
+        },
+      ]),
+    );
+
+    const writer = await TensogramFile.open(path);
+    try {
+      await writer.append(defaultMeta(), [
+        {
+          descriptor: makeDescriptor([2], 'float64'),
+          data: new Float64Array([7.5, 8.5]),
+        },
+      ]);
+    } finally {
+      writer.close();
+    }
+
+    const reader = await TensogramFile.open(path);
+    try {
+      expect(reader.messageCount).toBe(2);
+      const m1 = await reader.message(1);
+      expect(Array.from(m1.objects[0].data() as Float64Array)).toEqual([7.5, 8.5]);
+      m1.close();
+    } finally {
+      reader.close();
+    }
+  });
+
+  it('respects options.hash to skip hashing', async () => {
+    const path = join(tmp, 'nohash.tgm');
+    writeFileSync(path, new Uint8Array(0));
+    // The seed is empty — open() tolerates no messages.
+    // NB: appendFile will create the file if it doesn't exist, but
+    // open() would error on a fully-missing file, so seed with an
+    // empty file.
+    const file = await TensogramFile.open(path);
+    try {
+      await file.append(
+        defaultMeta(),
+        [
+          {
+            descriptor: makeDescriptor([1], 'uint8'),
+            data: new Uint8Array([42]),
+          },
+        ],
+        { hash: false },
+      );
+      expect(file.messageCount).toBe(1);
+      const m = await file.message(0);
+      // Descriptor should have no `hash` field.
+      expect(m.objects[0].descriptor.hash).toBeUndefined();
+      m.close();
+    } finally {
+      file.close();
+    }
+  });
+
+  it('rejects append on fromBytes-backed file with InvalidArgumentError', async () => {
+    const bytes = encode(defaultMeta(), [
+      {
+        descriptor: makeDescriptor([1], 'uint8'),
+        data: new Uint8Array([1]),
+      },
+    ]);
+    const file = TensogramFile.fromBytes(bytes);
+    try {
+      await expect(
+        file.append(defaultMeta(), [
+          {
+            descriptor: makeDescriptor([1], 'uint8'),
+            data: new Uint8Array([2]),
+          },
+        ]),
+      ).rejects.toThrow(InvalidArgumentError);
+    } finally {
+      file.close();
+    }
+  });
+
+  it('rejects append on fromUrl-backed file', async () => {
+    // Use a fake fetch so we don't need network access.
+    const bytes = encode(defaultMeta(), [
+      {
+        descriptor: makeDescriptor([1], 'uint8'),
+        data: new Uint8Array([1]),
+      },
+    ]);
+    const fakeFetch: typeof globalThis.fetch = async () => {
+      // Probe path returns 200 without Accept-Ranges → eager fallback.
+      const copy = new ArrayBuffer(bytes.byteLength);
+      new Uint8Array(copy).set(bytes);
+      return new Response(copy, { status: 200 });
+    };
+    const file = await TensogramFile.fromUrl('https://example.invalid/a.tgm', {
+      fetch: fakeFetch,
+    });
+    try {
+      await expect(
+        file.append(defaultMeta(), [
+          {
+            descriptor: makeDescriptor([1], 'uint8'),
+            data: new Uint8Array([2]),
+          },
+        ]),
+      ).rejects.toThrow(InvalidArgumentError);
+    } finally {
+      file.close();
+    }
+  });
+
+  it('rejects append after close()', async () => {
+    const path = join(tmp, 'closed.tgm');
+    writeFileSync(path, new Uint8Array(0));
+    const file = await TensogramFile.open(path);
+    file.close();
+    await expect(
+      file.append(defaultMeta(), [
+        {
+          descriptor: makeDescriptor([1], 'uint8'),
+          data: new Uint8Array([1]),
+        },
+      ]),
+    ).rejects.toThrow(InvalidArgumentError);
+  });
+
+  it('two consecutive appends both land on disk', async () => {
+    const path = join(tmp, 'two.tgm');
+    writeFileSync(path, new Uint8Array(0));
+    const file = await TensogramFile.open(path);
+    try {
+      await file.append(defaultMeta(), [
+        {
+          descriptor: makeDescriptor([1], 'float32'),
+          data: new Float32Array([1]),
+        },
+      ]);
+      await file.append(defaultMeta(), [
+        {
+          descriptor: makeDescriptor([2], 'float32'),
+          data: new Float32Array([2, 3]),
+        },
+      ]);
+      expect(file.messageCount).toBe(2);
+      const m0 = await file.message(0);
+      const m1 = await file.message(1);
+      expect(Array.from(m0.objects[0].data() as Float32Array)).toEqual([1]);
+      expect(Array.from(m1.objects[0].data() as Float32Array)).toEqual([2, 3]);
+      m0.close();
+      m1.close();
+    } finally {
+      file.close();
+    }
+  });
+
+  it('appended messages round-trip via a fresh open()', async () => {
+    // Per-call UUID/timestamp in `_reserved_` means two independent
+    // `encode()` calls for the same inputs are NOT byte-equal — so we
+    // assert semantic equality (decoded values) across a reopen.
+    const path = join(tmp, 'parity.tgm');
+    writeFileSync(path, new Uint8Array(0));
+    const file = await TensogramFile.open(path);
+    const values = [
+      new Float32Array([1, 2]),
+      new Float32Array([3, 4, 5]),
+    ];
+    try {
+      for (const v of values) {
+        await file.append(defaultMeta(), [
+          { descriptor: makeDescriptor([v.length], 'float32'), data: v },
+        ]);
+      }
+    } finally {
+      file.close();
+    }
+
+    const reopen = await TensogramFile.open(path);
+    try {
+      expect(reopen.messageCount).toBe(values.length);
+      for (let i = 0; i < values.length; i++) {
+        const msg = await reopen.message(i);
+        try {
+          expect(Array.from(msg.objects[0].data() as Float32Array)).toEqual(
+            Array.from(values[i]),
+          );
+        } finally {
+          msg.close();
+        }
+      }
+    } finally {
+      reopen.close();
+    }
+  });
+});

--- a/typescript/tests/bfloat16.test.ts
+++ b/typescript/tests/bfloat16.test.ts
@@ -1,0 +1,155 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+/**
+ * `Bfloat16Array` — behaviour tests.  Same shape as the float16 suite,
+ * adapted for the brain-float layout (1-8-7).  The conversion is
+ * close to a byte copy so the tolerance is tighter than float16 in
+ * ulp terms, but the dynamic range is effectively float32 (same
+ * 8-bit exponent).
+ */
+
+import fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import {
+  bfloat16FromBytes,
+  Bfloat16Array,
+  decode,
+  encode,
+} from '../src/index.js';
+// The bit-conversion helpers are `@internal` — pulled from the concrete
+// module so the public barrel stays lean.
+import { bfloat16BitsToFloat, floatToBfloat16Bits } from '../src/bfloat16.js';
+import { defaultMeta, initOnce, makeDescriptor } from './helpers.js';
+
+describe('Scope C.2 — Bfloat16 bit conversions', () => {
+  it('round-trips ±0 with sign', () => {
+    expect(bfloat16BitsToFloat(0x0000)).toBe(0);
+    expect(Object.is(bfloat16BitsToFloat(0x8000), -0)).toBe(true);
+    expect(floatToBfloat16Bits(0)).toBe(0x0000);
+    expect(floatToBfloat16Bits(-0)).toBe(0x8000);
+  });
+
+  it('round-trips ±Inf', () => {
+    expect(bfloat16BitsToFloat(0x7f80)).toBe(Infinity);
+    expect(bfloat16BitsToFloat(0xff80)).toBe(-Infinity);
+    expect(floatToBfloat16Bits(Infinity)).toBe(0x7f80);
+    expect(floatToBfloat16Bits(-Infinity)).toBe(0xff80);
+  });
+
+  it('preserves NaN', () => {
+    expect(Number.isNaN(bfloat16BitsToFloat(0x7fc0))).toBe(true);
+    const bits = floatToBfloat16Bits(NaN);
+    expect((bits >>> 7) & 0xff).toBe(0xff); // exponent all-ones
+    expect(bits & 0x7f).not.toBe(0); // mantissa ≠ 0
+  });
+
+  it('round-trips exactly for integers representable in 8 mantissa bits', () => {
+    for (const v of [1, -1, 2, -2, 4, 100, -100]) {
+      const back = bfloat16BitsToFloat(floatToBfloat16Bits(v));
+      expect(back).toBe(v);
+    }
+  });
+
+  it('narrows via round-to-nearest-even', () => {
+    // 1.5 is exactly representable (mantissa = 1.1₂ → 0x3fc0 in bfloat16).
+    expect(floatToBfloat16Bits(1.5)).toBe(0x3fc0);
+    expect(bfloat16BitsToFloat(0x3fc0)).toBe(1.5);
+  });
+
+  it('property: random float32 survives round-trip within bfloat16 ulp', () => {
+    fc.assert(
+      fc.property(
+        fc.float({ min: Math.fround(-1e4), max: Math.fround(1e4), noNaN: true }),
+        (v) => {
+          const back = bfloat16BitsToFloat(floatToBfloat16Bits(v));
+          // Bfloat16 ulp ≈ 2^-7 × magnitude.
+          const tol = Math.max(Math.abs(v) * 0.01, 1e-3);
+          expect(Math.abs(back - v)).toBeLessThan(tol);
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+});
+
+describe('Scope C.2 — Bfloat16Array array API', () => {
+  it('constructs from length', () => {
+    const a = new Bfloat16Array(4);
+    expect(a.length).toBe(4);
+    expect(a.byteLength).toBe(8);
+    expect(Array.from(a)).toEqual([0, 0, 0, 0]);
+  });
+
+  it('constructs from array-like with narrowing', () => {
+    const a = new Bfloat16Array([1, 2, 3, 4]);
+    expect(Array.from(a)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('exposes raw bits via .bits', () => {
+    const a = new Bfloat16Array([1, 2, 3]);
+    expect(a.bits).toBeInstanceOf(Uint16Array);
+    expect(a.bits.length).toBe(3);
+  });
+
+  it('set() narrows per-element, accepts Bfloat16Array verbatim', () => {
+    const src = new Bfloat16Array([7, 8, 9]);
+    const dst = new Bfloat16Array(3);
+    dst.set(src);
+    expect(Array.from(dst)).toEqual([7, 8, 9]);
+    dst.set([1.5, 2.5, 3.5], 0);
+    expect(Array.from(dst)).toEqual([1.5, 2.5, 3.5]);
+  });
+
+  it('slice / subarray semantics mirror TypedArray', () => {
+    const a = new Bfloat16Array([1, 2, 3, 4]);
+    expect(Array.from(a.slice(1, 3))).toEqual([2, 3]);
+    expect(Array.from(a.subarray(1, 3))).toEqual([2, 3]);
+  });
+
+  it('toFloat32Array widens precisely', () => {
+    const a = new Bfloat16Array([1.5, 2.5]);
+    expect(Array.from(a.toFloat32Array())).toEqual([1.5, 2.5]);
+  });
+
+  it('fill / iterate', () => {
+    const a = new Bfloat16Array(3);
+    a.fill(42);
+    expect(Array.from(a)).toEqual([42, 42, 42]);
+  });
+});
+
+describe('Scope C.2 — bfloat16 end-to-end', () => {
+  initOnce();
+
+  it('encode → decode preserves bit-exact values', () => {
+    const values = new Bfloat16Array([1, -1, 0, 2.5, -3.5]);
+    const msg = encode(defaultMeta(), [
+      {
+        descriptor: makeDescriptor([values.length], 'bfloat16'),
+        data: new Uint8Array(values.bits.buffer, values.bits.byteOffset, values.bits.byteLength),
+      },
+    ]);
+    const decoded = decode(msg);
+    try {
+      const out = decoded.objects[0].data() as Bfloat16Array;
+      expect(out).toBeInstanceOf(Bfloat16Array);
+      expect(Array.from(out.bits)).toEqual(Array.from(values.bits));
+    } finally {
+      decoded.close();
+    }
+  });
+
+  it('bfloat16FromBytes is zero-copy for aligned input', () => {
+    const aligned = new Uint8Array(8);
+    const view = bfloat16FromBytes(aligned);
+    expect(view.bits.buffer).toBe(aligned.buffer);
+  });
+
+  it('bfloat16FromBytes rejects odd byte lengths', () => {
+    expect(() => bfloat16FromBytes(new Uint8Array(3))).toThrow(RangeError);
+    expect(() => bfloat16FromBytes(new Uint8Array(1))).toThrow(RangeError);
+  });
+});

--- a/typescript/tests/complex.test.ts
+++ b/typescript/tests/complex.test.ts
@@ -1,0 +1,205 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+/**
+ * `ComplexArray` — behaviour tests for the interleaved-storage view.
+ * Covers: field accessors, iteration, out-of-range behaviour, end-to-
+ * end round-trip through `encode` / `decode` for complex64 / complex128.
+ */
+
+import fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import {
+  ComplexArray,
+  complexFromBytes,
+  decode,
+  encode,
+} from '../src/index.js';
+// `isComplexDtype` is `@internal` — pulled from the concrete module so
+// the public barrel stays lean.
+import { isComplexDtype } from '../src/complex.js';
+import { defaultMeta, initOnce, makeDescriptor } from './helpers.js';
+
+describe('Scope C.2 — ComplexArray basics', () => {
+  it('real/imag/get accessors unpack an interleaved Float32Array (complex64)', () => {
+    const storage = new Float32Array([1, 2, 3, 4, 5, 6]);
+    const c = new ComplexArray('complex64', storage);
+    expect(c.length).toBe(3);
+    expect(c.real(0)).toBe(1);
+    expect(c.imag(0)).toBe(2);
+    expect(c.real(1)).toBe(3);
+    expect(c.imag(1)).toBe(4);
+    expect(c.get(2)).toEqual({ re: 5, im: 6 });
+  });
+
+  it('real/imag/get accessors work for complex128 on Float64Array', () => {
+    const storage = new Float64Array([0.5, 1.5, 2.5, 3.5]);
+    const c = new ComplexArray('complex128', storage);
+    expect(c.length).toBe(2);
+    expect(c.get(0)).toEqual({ re: 0.5, im: 1.5 });
+    expect(c.get(1)).toEqual({ re: 2.5, im: 3.5 });
+  });
+
+  it('out-of-range returns NaN on real/imag/get', () => {
+    const c = new ComplexArray('complex64', new Float32Array([1, 2]));
+    expect(Number.isNaN(c.real(-1))).toBe(true);
+    expect(Number.isNaN(c.imag(2))).toBe(true);
+    expect(Number.isNaN(c.get(2).re)).toBe(true);
+    expect(Number.isNaN(c.get(2).im)).toBe(true);
+  });
+
+  it('set writes pair; throws on out-of-range index', () => {
+    const c = new ComplexArray('complex64', new Float32Array(4));
+    c.set(0, 10, 20);
+    c.set(1, 30, 40);
+    expect(c.get(0)).toEqual({ re: 10, im: 20 });
+    expect(c.get(1)).toEqual({ re: 30, im: 40 });
+    expect(() => c.set(5, 0, 0)).toThrow(RangeError);
+    expect(() => c.set(-1, 0, 0)).toThrow(RangeError);
+  });
+
+  it('data is the zero-copy interleaved storage', () => {
+    const storage = new Float32Array([1, 2, 3, 4]);
+    const c = new ComplexArray('complex64', storage);
+    expect(c.data).toBe(storage);
+  });
+
+  it('iteration yields { re, im } per pair', () => {
+    const c = new ComplexArray('complex64', new Float32Array([1, 2, 3, 4]));
+    const collected: Array<{ re: number; im: number }> = [];
+    for (const pair of c) collected.push(pair);
+    expect(collected).toEqual([
+      { re: 1, im: 2 },
+      { re: 3, im: 4 },
+    ]);
+  });
+
+  it('toArray() returns a plain [re, im] list', () => {
+    const c = new ComplexArray('complex64', new Float32Array([1, 2, 3, 4]));
+    expect(c.toArray()).toEqual([
+      [1, 2],
+      [3, 4],
+    ]);
+  });
+
+  it('constructor validates dtype/storage pair', () => {
+    expect(
+      () => new ComplexArray('complex64', new Float64Array(4)),
+    ).toThrow(/complex64 requires a Float32Array/);
+    expect(
+      () => new ComplexArray('complex128', new Float32Array(4)),
+    ).toThrow(/complex128 requires a Float64Array/);
+    expect(
+      () =>
+        // @ts-expect-error intentional bad dtype
+        new ComplexArray('nope', new Float32Array(4)),
+    ).toThrow();
+  });
+
+  it('constructor rejects odd-length storage', () => {
+    expect(() => new ComplexArray('complex64', new Float32Array(3))).toThrow(
+      /length 3 must be even/,
+    );
+  });
+
+  it('isComplexDtype guard', () => {
+    expect(isComplexDtype('complex64')).toBe(true);
+    expect(isComplexDtype('complex128')).toBe(true);
+    expect(isComplexDtype('float32')).toBe(false);
+  });
+});
+
+describe('Scope C.2 — complex end-to-end round-trip', () => {
+  initOnce();
+
+  it('complex64 survives encode → decode with correct re/im interleaving', () => {
+    const interleaved = new Float32Array([1, 2, 3, 4, 5, 6]);
+    const bytes = new Uint8Array(interleaved.buffer, interleaved.byteOffset, interleaved.byteLength);
+    const msg = encode(defaultMeta(), [
+      { descriptor: makeDescriptor([3], 'complex64'), data: bytes },
+    ]);
+    const decoded = decode(msg);
+    try {
+      const c = decoded.objects[0].data() as ComplexArray;
+      expect(c).toBeInstanceOf(ComplexArray);
+      expect(c.length).toBe(3);
+      expect(c.get(0)).toEqual({ re: 1, im: 2 });
+      expect(c.get(1)).toEqual({ re: 3, im: 4 });
+      expect(c.get(2)).toEqual({ re: 5, im: 6 });
+    } finally {
+      decoded.close();
+    }
+  });
+
+  it('complex128 survives encode → decode', () => {
+    const interleaved = new Float64Array([0.1, 0.2, 0.3, 0.4]);
+    const bytes = new Uint8Array(interleaved.buffer, interleaved.byteOffset, interleaved.byteLength);
+    const msg = encode(defaultMeta(), [
+      { descriptor: makeDescriptor([2], 'complex128'), data: bytes },
+    ]);
+    const decoded = decode(msg);
+    try {
+      const c = decoded.objects[0].data() as ComplexArray;
+      expect(c.dtype).toBe('complex128');
+      expect(c.length).toBe(2);
+      const p0 = c.get(0);
+      const p1 = c.get(1);
+      // Compare within a tiny epsilon — float64 round-trip is exact for
+      // these constants but we accept 1e-15 to keep the assertion robust.
+      expect(Math.abs(p0.re - 0.1)).toBeLessThan(1e-15);
+      expect(Math.abs(p0.im - 0.2)).toBeLessThan(1e-15);
+      expect(Math.abs(p1.re - 0.3)).toBeLessThan(1e-15);
+      expect(Math.abs(p1.im - 0.4)).toBeLessThan(1e-15);
+    } finally {
+      decoded.close();
+    }
+  });
+
+  it('complexFromBytes is zero-copy for aligned input', () => {
+    const f32 = new Float32Array(8); // 4 complex pairs
+    const bytes = new Uint8Array(f32.buffer, f32.byteOffset, f32.byteLength);
+    const c = complexFromBytes('complex64', bytes);
+    expect(c.data.buffer).toBe(f32.buffer);
+  });
+
+  it('complexFromBytes rejects lengths that are not a multiple of the pair size', () => {
+    // complex64 pair = 8 bytes
+    expect(() => complexFromBytes('complex64', new Uint8Array(12))).toThrow(RangeError);
+    expect(() => complexFromBytes('complex64', new Uint8Array(4))).toThrow(RangeError);
+    // complex128 pair = 16 bytes
+    expect(() => complexFromBytes('complex128', new Uint8Array(24))).toThrow(RangeError);
+    expect(() => complexFromBytes('complex128', new Uint8Array(8))).toThrow(RangeError);
+  });
+
+  it('property: random complex64 payloads round-trip bit-exactly', () => {
+    initOnce();
+    fc.assert(
+      fc.property(
+        fc.array(fc.float({ noNaN: true }), { minLength: 2, maxLength: 16 }).filter((a) => a.length % 2 === 0),
+        (flat) => {
+          const data = new Float32Array(flat);
+          const bytes = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+          const msg = encode(defaultMeta(), [
+            {
+              descriptor: makeDescriptor([data.length / 2], 'complex64'),
+              data: bytes,
+            },
+          ]);
+          const decoded = decode(msg);
+          try {
+            const c = decoded.objects[0].data() as ComplexArray;
+            for (let i = 0; i < c.length; i++) {
+              expect(c.real(i)).toBe(flat[2 * i]);
+              expect(c.imag(i)).toBe(flat[2 * i + 1]);
+            }
+          } finally {
+            decoded.close();
+          }
+        },
+      ),
+      { numRuns: 50 },
+    );
+  });
+});

--- a/typescript/tests/dtype.test.ts
+++ b/typescript/tests/dtype.test.ts
@@ -5,9 +5,14 @@
 
 import { describe, expect, it } from 'vitest';
 import {
-  decode,
+  Bfloat16Array,
+  ComplexArray,
   DTYPE_BYTE_WIDTH,
+  decode,
   encode,
+  Float16Polyfill,
+  getFloat16ArrayCtor,
+  hasNativeFloat16Array,
   init,
   isDtype,
   payloadByteSize,
@@ -65,7 +70,7 @@ describe('Phase 2 — dtype dispatch', () => {
     expect(shapeElementCount([3, 4, 5])).toBe(60);
   });
 
-  it('typedArrayFor returns the correct constructor per dtype', () => {
+  it('typedArrayFor returns the correct view per dtype', () => {
     const bytes = new Uint8Array(16);
     expect(typedArrayFor('float32', bytes)).toBeInstanceOf(Float32Array);
     expect(typedArrayFor('float64', bytes)).toBeInstanceOf(Float64Array);
@@ -78,11 +83,17 @@ describe('Phase 2 — dtype dispatch', () => {
     expect(typedArrayFor('uint32', bytes)).toBeInstanceOf(Uint32Array);
     expect(typedArrayFor('uint64', bytes)).toBeInstanceOf(BigUint64Array);
     expect(typedArrayFor('bitmask', bytes)).toBeInstanceOf(Uint8Array);
-    // Half-precision / complex → Uint16Array / Float32Array surrogates
-    expect(typedArrayFor('float16', bytes)).toBeInstanceOf(Uint16Array);
-    expect(typedArrayFor('bfloat16', bytes)).toBeInstanceOf(Uint16Array);
-    expect(typedArrayFor('complex64', bytes)).toBeInstanceOf(Float32Array);
-    expect(typedArrayFor('complex128', bytes)).toBeInstanceOf(Float64Array);
+    // Scope C.2 — first-class views
+    const f16 = typedArrayFor('float16', bytes);
+    // Either a native Float16Array (Node ≥ 22) or the polyfill.
+    if (hasNativeFloat16Array()) {
+      expect(f16).toBeInstanceOf(getFloat16ArrayCtor());
+    } else {
+      expect(f16).toBeInstanceOf(Float16Polyfill);
+    }
+    expect(typedArrayFor('bfloat16', bytes)).toBeInstanceOf(Bfloat16Array);
+    expect(typedArrayFor('complex64', bytes)).toBeInstanceOf(ComplexArray);
+    expect(typedArrayFor('complex128', bytes)).toBeInstanceOf(ComplexArray);
   });
 
   it('data() round-trips float64', async () => {

--- a/typescript/tests/encodePreEncoded.test.ts
+++ b/typescript/tests/encodePreEncoded.test.ts
@@ -1,0 +1,188 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+/**
+ * `encodePreEncoded` tests.  Core contract: caller-supplied bytes are
+ * written verbatim into the wire message, and a round-trip through
+ * `decode` recovers both the original bytes (for no-pipeline
+ * descriptors) and the metadata structure.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  computeHash,
+  decode,
+  encodePreEncoded,
+  InvalidArgumentError,
+} from '../src/index.js';
+import { defaultMeta, initOnce, makeDescriptor } from './helpers.js';
+
+describe('Scope C.1 — encodePreEncoded', () => {
+  initOnce();
+
+  it('round-trips uncompressed float32 bytes', () => {
+    const values = new Float32Array([10, 20, 30, 40]);
+    const bytes = new Uint8Array(values.buffer, values.byteOffset, values.byteLength);
+    const msg = encodePreEncoded(defaultMeta(), [
+      { descriptor: makeDescriptor([4], 'float32'), data: bytes },
+    ]);
+
+    const decoded = decode(msg);
+    try {
+      expect(decoded.objects).toHaveLength(1);
+      expect(Array.from(decoded.objects[0].data() as Float32Array)).toEqual([10, 20, 30, 40]);
+    } finally {
+      decoded.close();
+    }
+  });
+
+  it('stamps a freshly computed xxh3 hash matching computeHash', () => {
+    const values = new Float64Array([1.25, 2.5, 3.75, 4.0]);
+    const bytes = new Uint8Array(values.buffer, values.byteOffset, values.byteLength);
+    const msg = encodePreEncoded(defaultMeta(), [
+      { descriptor: makeDescriptor([4], 'float64'), data: bytes },
+    ]);
+    const decoded = decode(msg);
+    try {
+      const desc = decoded.objects[0].descriptor;
+      expect(desc.hash?.type).toBe('xxh3');
+      expect(desc.hash?.value).toBe(computeHash(bytes));
+    } finally {
+      decoded.close();
+    }
+  });
+
+  it('disables hashing when hash: false', () => {
+    const values = new Uint8Array([1, 2, 3, 4]);
+    const msg = encodePreEncoded(
+      defaultMeta(),
+      [{ descriptor: makeDescriptor([4], 'uint8'), data: values }],
+      { hash: false },
+    );
+    const decoded = decode(msg);
+    try {
+      expect(decoded.objects[0].descriptor.hash).toBeUndefined();
+    } finally {
+      decoded.close();
+    }
+  });
+
+  it('handles multiple pre-encoded objects in one message', () => {
+    const a = new Float32Array([1, 2]);
+    const b = new BigInt64Array([42n, 43n, 44n]);
+    const msg = encodePreEncoded(defaultMeta(), [
+      {
+        descriptor: makeDescriptor([2], 'float32'),
+        data: new Uint8Array(a.buffer, a.byteOffset, a.byteLength),
+      },
+      {
+        descriptor: makeDescriptor([3], 'int64'),
+        data: new Uint8Array(b.buffer, b.byteOffset, b.byteLength),
+      },
+    ]);
+    const decoded = decode(msg);
+    try {
+      expect(decoded.objects).toHaveLength(2);
+      expect(Array.from(decoded.objects[0].data() as Float32Array)).toEqual([1, 2]);
+      expect(Array.from(decoded.objects[1].data() as BigInt64Array)).toEqual([42n, 43n, 44n]);
+    } finally {
+      decoded.close();
+    }
+  });
+
+  it('rejects non-Uint8Array data', () => {
+    expect(() =>
+      encodePreEncoded(defaultMeta(), [
+        // @ts-expect-error intentional: data must be Uint8Array
+        { descriptor: makeDescriptor([1], 'float32'), data: new Float32Array([1]) },
+      ]),
+    ).toThrow(InvalidArgumentError);
+  });
+
+  it('rejects client-written _reserved_', () => {
+    const bad = {
+      version: 2,
+      _reserved_: { foo: 'bar' },
+    } as Parameters<typeof encodePreEncoded>[0];
+    expect(() =>
+      encodePreEncoded(bad, [
+        {
+          descriptor: makeDescriptor([1], 'uint8'),
+          data: new Uint8Array([1]),
+        },
+      ]),
+    ).toThrow(InvalidArgumentError);
+  });
+
+  it('rejects bad descriptor structure', () => {
+    expect(() =>
+      encodePreEncoded(defaultMeta(), [
+        // @ts-expect-error intentional: dtype is required
+        { descriptor: { type: 'ntensor', shape: [1] }, data: new Uint8Array([1]) },
+      ]),
+    ).toThrow(InvalidArgumentError);
+  });
+
+  it('rejects non-array objects parameter', () => {
+    expect(() =>
+      // @ts-expect-error intentional: objects must be an array
+      encodePreEncoded(defaultMeta(), 'not an array'),
+    ).toThrow(InvalidArgumentError);
+  });
+
+  it('rejects null entry in objects', () => {
+    expect(() =>
+      encodePreEncoded(defaultMeta(), [
+        // @ts-expect-error intentional
+        null,
+      ]),
+    ).toThrow(InvalidArgumentError);
+  });
+
+  it('rejects metadata.base when not an array', () => {
+    const bad = {
+      version: 2,
+      base: 'nope',
+    } as unknown as Parameters<typeof encodePreEncoded>[0];
+    expect(() =>
+      encodePreEncoded(bad, [
+        {
+          descriptor: makeDescriptor([1], 'uint8'),
+          data: new Uint8Array([1]),
+        },
+      ]),
+    ).toThrow(InvalidArgumentError);
+  });
+
+  it('rejects metadata.base[i] when not a plain object', () => {
+    const bad = {
+      version: 2,
+      base: [null],
+    } as unknown as Parameters<typeof encodePreEncoded>[0];
+    expect(() =>
+      encodePreEncoded(bad, [
+        {
+          descriptor: makeDescriptor([1], 'uint8'),
+          data: new Uint8Array([1]),
+        },
+      ]),
+    ).toThrow(InvalidArgumentError);
+  });
+
+  it('rejects client-written _reserved_ in metadata.base[i]', () => {
+    const bad = {
+      version: 2,
+      base: [{ _reserved_: { foo: 'bar' } }],
+    } as unknown as Parameters<typeof encodePreEncoded>[0];
+    expect(() =>
+      encodePreEncoded(bad, [
+        {
+          descriptor: makeDescriptor([1], 'uint8'),
+          data: new Uint8Array([1]),
+        },
+      ]),
+    ).toThrow(InvalidArgumentError);
+  });
+});

--- a/typescript/tests/file.test.ts
+++ b/typescript/tests/file.test.ts
@@ -90,7 +90,8 @@ describe('Phase 4 — TensogramFile', () => {
     it('throws ObjectError for out-of-range indices', async () => {
       await init();
       const file = TensogramFile.fromBytes(makeMessage([1]));
-      expect(() => file.rawMessage(5)).toThrow(ObjectError);
+      // rawMessage is async now (Scope C) — sync throws become rejections.
+      await expect(file.rawMessage(5)).rejects.toThrow(ObjectError);
       await expect(file.message(-1)).rejects.toThrow(ObjectError);
       await expect(file.message(1.5)).rejects.toThrow(ObjectError);
     });
@@ -100,7 +101,7 @@ describe('Phase 4 — TensogramFile', () => {
       const msg = makeMessage([42, 43, 44]);
       const file = TensogramFile.fromBytes(concatMessages(msg, makeMessage([99])));
 
-      const raw = file.rawMessage(0);
+      const raw = await file.rawMessage(0);
       const decoded = decode(new Uint8Array(raw));
       expect(Array.from(decoded.objects[0].data() as Float32Array)).toEqual([42, 43, 44]);
       decoded.close();
@@ -145,7 +146,7 @@ describe('Phase 4 — TensogramFile', () => {
       await init();
       const file = TensogramFile.fromBytes(makeMessage([1]));
       file.close();
-      expect(() => file.rawMessage(0)).toThrow(InvalidArgumentError);
+      await expect(file.rawMessage(0)).rejects.toThrow(InvalidArgumentError);
       await expect(file.message(0)).rejects.toThrow(InvalidArgumentError);
     });
 

--- a/typescript/tests/float16.test.ts
+++ b/typescript/tests/float16.test.ts
@@ -1,0 +1,272 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+/**
+ * `Float16Polyfill` — behaviour tests.  Covers:
+ *
+ * - Round-trip of every representable bit pattern through
+ *   `floatToHalfBits → halfBitsToFloat`.
+ * - Special values: NaN, ±Inf, ±0, subnormals.
+ * - Array API: iteration, `set`, `fill`, `subarray`, `slice`,
+ *   `.bits` zero-copy access.
+ * - End-to-end round-trip through `encode` / `decode` for the
+ *   `float16` dtype — the bytes must match what Rust produced because
+ *   both sides use the same binary16 layout.
+ * - Parity against the native `Float16Array` when the host has one.
+ */
+
+import fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import {
+  decode,
+  encode,
+  Float16Polyfill,
+  float16FromBytes,
+  getFloat16ArrayCtor,
+  hasNativeFloat16Array,
+} from '../src/index.js';
+// The bit-conversion helpers are `@internal` — pulled from the concrete
+// module so the public barrel stays lean.
+import { floatToHalfBits, halfBitsToFloat } from '../src/float16.js';
+import { defaultMeta, initOnce, makeDescriptor } from './helpers.js';
+
+describe('Scope C.2 — Float16Polyfill bit conversions', () => {
+  it('round-trips ±0 and preserves sign', () => {
+    // +0 and -0 are numerically equal but carry different sign bits.
+    // Vitest's `.toBe(0)` uses `Object.is`, so compare explicitly.
+    expect(Object.is(halfBitsToFloat(0x0000), 0)).toBe(true);
+    expect(Object.is(halfBitsToFloat(0x8000), -0)).toBe(true);
+    expect(floatToHalfBits(0)).toBe(0x0000);
+    expect(floatToHalfBits(-0)).toBe(0x8000);
+  });
+
+  it('round-trips ±Inf', () => {
+    expect(halfBitsToFloat(0x7c00)).toBe(Infinity);
+    expect(halfBitsToFloat(0xfc00)).toBe(-Infinity);
+    expect(floatToHalfBits(Infinity)).toBe(0x7c00);
+    expect(floatToHalfBits(-Infinity)).toBe(0xfc00);
+  });
+
+  it('preserves NaN', () => {
+    expect(Number.isNaN(halfBitsToFloat(0x7e00))).toBe(true);
+    expect(floatToHalfBits(NaN) & 0x7c00).toBe(0x7c00); // exponent all-ones
+    expect(floatToHalfBits(NaN) & 0x03ff).not.toBe(0); // mantissa ≠ 0
+  });
+
+  it('round-trips exactly representable values', () => {
+    const exact = [1, -1, 0.5, 1024, -1024, 65504 /* float16 max */];
+    for (const v of exact) {
+      const bits = floatToHalfBits(v);
+      expect(halfBitsToFloat(bits)).toBe(v);
+    }
+  });
+
+  it('round-trips float32 → float16 → float32 within half-precision ulp', () => {
+    fc.assert(
+      fc.property(
+        fc.float({ min: Math.fround(-100), max: Math.fround(100), noNaN: true }),
+        (v) => {
+          const bits = floatToHalfBits(v);
+          const back = halfBitsToFloat(bits);
+          // Half-precision ulp ≤ 2^-10 × magnitude ≈ 0.1 at |v| = 100.
+          // Use a generous bound because fast-check may generate tiny
+          // subnormals; we only want to catch catastrophic errors.
+          const tol = Math.max(Math.abs(v) * 1e-3, 1e-3);
+          expect(Math.abs(back - v)).toBeLessThan(tol);
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+
+  it('saturates to ±Inf on overflow', () => {
+    // 1e10 is far outside float16's ±65504 range.
+    const bits = floatToHalfBits(1e10);
+    expect(bits).toBe(0x7c00);
+    expect(floatToHalfBits(-1e10)).toBe(0xfc00);
+  });
+
+  it('flushes to ±0 on underflow', () => {
+    // 1e-10 is below float16's smallest subnormal (~5.96e-8).
+    expect(floatToHalfBits(1e-10)).toBe(0);
+    expect(floatToHalfBits(-1e-10)).toBe(0x8000);
+  });
+});
+
+describe('Scope C.2 — Float16Polyfill array API', () => {
+  it('constructs from length with zeros', () => {
+    const a = new Float16Polyfill(4);
+    expect(a.length).toBe(4);
+    expect(a.byteLength).toBe(8);
+    expect(Array.from(a)).toEqual([0, 0, 0, 0]);
+  });
+
+  it('constructs from array-like and narrows', () => {
+    const a = new Float16Polyfill([1, 2, 3, 4]);
+    expect(Array.from(a)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('constructs from ArrayBuffer (raw bits view)', () => {
+    const bits = new Uint16Array([0x3c00, 0x4000, 0x4200]); // 1.0, 2.0, 3.0
+    const a = new Float16Polyfill(bits.buffer);
+    expect(a.length).toBe(3);
+    expect(Array.from(a)).toEqual([1, 2, 3]);
+  });
+
+  it('`.bits` exposes raw binary16 for zero-copy roundtrips', () => {
+    const a = new Float16Polyfill([1, 2, 3, 4]);
+    expect(a.bits).toBeInstanceOf(Uint16Array);
+    expect(a.bits.length).toBe(4);
+  });
+
+  it('get() / at() return NaN / undefined out of range', () => {
+    const a = new Float16Polyfill([1, 2, 3]);
+    expect(a.at(0)).toBe(1);
+    expect(a.at(-1)).toBe(3);
+    expect(a.at(10)).toBeUndefined();
+    expect(Number.isNaN(a.get(10))).toBe(true);
+    expect(Number.isNaN(a.get(-1))).toBe(true);
+  });
+
+  it('set(number[]) narrows individual values', () => {
+    const a = new Float16Polyfill(4);
+    a.set([1.0, 2.0, 3.0, 4.0]);
+    expect(Array.from(a)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('set(Float16Polyfill) copies bits verbatim', () => {
+    const src = new Float16Polyfill([1, 2, 3, 4]);
+    const dst = new Float16Polyfill(4);
+    dst.set(src);
+    expect(Array.from(dst)).toEqual([1, 2, 3, 4]);
+    // Source unaffected
+    expect(Array.from(src)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('fill() narrows the fill value once', () => {
+    const a = new Float16Polyfill(4);
+    a.fill(7);
+    expect(Array.from(a)).toEqual([7, 7, 7, 7]);
+  });
+
+  it('slice() returns an independent copy of raw bits', () => {
+    const a = new Float16Polyfill([1, 2, 3, 4]);
+    const s = a.slice(1, 3);
+    expect(Array.from(s)).toEqual([2, 3]);
+    a.set([9, 9, 9, 9]);
+    expect(Array.from(s)).toEqual([2, 3]); // unaffected
+  });
+
+  it('subarray() shares bit storage with the parent', () => {
+    const a = new Float16Polyfill([1, 2, 3, 4]);
+    const s = a.subarray(1, 3);
+    expect(Array.from(s)).toEqual([2, 3]);
+    a.set([0], 2); // overwrite parent index 2
+    expect(s.get(1)).toBe(0); // subview reflects the change
+  });
+
+  it('toFloat32Array() widens to float32 precision', () => {
+    const a = new Float16Polyfill([1.5, 2.5, 3.5]);
+    const f32 = a.toFloat32Array();
+    expect(f32).toBeInstanceOf(Float32Array);
+    expect(Array.from(f32)).toEqual([1.5, 2.5, 3.5]);
+  });
+
+  it('iterates with for..of', () => {
+    const a = new Float16Polyfill([1, 2, 3]);
+    const out: number[] = [];
+    for (const v of a) out.push(v);
+    expect(out).toEqual([1, 2, 3]);
+  });
+});
+
+describe('Scope C.2 — native Float16Array detection', () => {
+  it('probes every call (honours ambient override)', () => {
+    // We can't reliably mutate globalThis.Float16Array in one worker
+    // without racing other tests, so we just check the probe returns a
+    // consistent boolean for whatever the runtime actually has.
+    const a = hasNativeFloat16Array();
+    const b = hasNativeFloat16Array();
+    expect(a).toBe(b);
+    expect(typeof a).toBe('boolean');
+  });
+
+  it('getFloat16ArrayCtor returns a constructor', () => {
+    const Ctor = getFloat16ArrayCtor();
+    expect(typeof Ctor).toBe('function');
+    // Constructing with a length must work on either path.
+    const inst = new Ctor(4);
+    expect(inst.length).toBe(4);
+  });
+});
+
+describe('Scope C.2 — float16 end-to-end round-trip', () => {
+  initOnce();
+
+  it('encode → decode round-trips bits exactly for every finite value', () => {
+    // Start from explicit binary16 bit patterns so the comparison is
+    // bit-exact regardless of which Float16 path the decoder picks.
+    //
+    // Bit patterns used:
+    //   0x3c00  =  1.0
+    //   0xbc00  = -1.0
+    //   0x0000  =  0.0
+    //   0x7bff  =  65504  (float16 max finite — avoids Inf's mantissa==0)
+    //   0x0001  =  smallest subnormal
+    const bits = new Uint16Array([0x3c00, 0xbc00, 0x0000, 0x7bff, 0x0001]);
+    const bytes = new Uint8Array(bits.buffer, bits.byteOffset, bits.byteLength);
+    const msg = encode(defaultMeta(), [
+      { descriptor: makeDescriptor([5], 'float16'), data: bytes },
+    ]);
+    const decoded = decode(msg);
+    try {
+      // Whether decode() returns the native Float16Array or our
+      // polyfill, we can always pull the raw bits from the underlying
+      // ArrayBuffer at the same byte offset.
+      const view = decoded.objects[0].data() as {
+        buffer: ArrayBufferLike;
+        byteOffset: number;
+        byteLength: number;
+      };
+      const outBits = new Uint16Array(view.buffer, view.byteOffset, view.byteLength / 2);
+      expect(Array.from(outBits)).toEqual(Array.from(bits));
+    } finally {
+      decoded.close();
+    }
+  });
+
+  it('float16FromBytes is zero-copy for aligned input', () => {
+    // Aligned input (offset 0) — the view's `.bits` should share the
+    // same underlying ArrayBuffer.
+    const aligned = new Uint8Array(8);
+    const view = float16FromBytes(aligned) as { bits: Uint16Array };
+    if ('bits' in view) {
+      // Polyfill path.
+      expect(view.bits.buffer).toBe(aligned.buffer);
+    }
+  });
+
+  it('float16FromBytes rejects odd byte lengths', () => {
+    expect(() => float16FromBytes(new Uint8Array(3))).toThrow(RangeError);
+    expect(() => float16FromBytes(new Uint8Array(1))).toThrow(RangeError);
+  });
+
+  it('property: random float32 values survive round-trip within half-precision tolerance', () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.float({ min: -1e3, max: 1e3, noNaN: true }), { minLength: 1, maxLength: 32 }),
+        (values) => {
+          const poly = new Float16Polyfill(values);
+          for (let i = 0; i < values.length; i++) {
+            const back = poly.get(i);
+            const tol = Math.max(Math.abs(values[i]) * 1e-3, 1e-3);
+            expect(Math.abs(back - values[i])).toBeLessThan(tol);
+          }
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+});

--- a/typescript/tests/hash.test.ts
+++ b/typescript/tests/hash.test.ts
@@ -1,0 +1,86 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+/**
+ * `computeHash` — standalone hash computation tests.  The core
+ * correctness contract is "same bytes → same digest, length is the
+ * advertised xxh3 16-char hex".  Cross-checked against the hash
+ * stamped by `encode()` on uncompressed payloads so we know the TS
+ * wrapper uses the same algorithm.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  computeHash,
+  decode,
+  encode,
+  InvalidArgumentError,
+  MetadataError,
+} from '../src/index.js';
+import { defaultMeta, initOnce, makeDescriptor } from './helpers.js';
+
+describe('Scope C.1 — computeHash', () => {
+  initOnce();
+
+  it('returns a 16-char lower-case hex string for xxh3', () => {
+    const hex = computeHash(new Uint8Array([1, 2, 3, 4]));
+    expect(hex).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('is deterministic on identical input', () => {
+    const data = new Uint8Array([42, 43, 44, 45, 46, 47, 48, 49]);
+    expect(computeHash(data)).toBe(computeHash(data));
+  });
+
+  it('produces different digests for different input', () => {
+    const a = computeHash(new Uint8Array([1, 2, 3]));
+    const b = computeHash(new Uint8Array([1, 2, 4]));
+    expect(a).not.toBe(b);
+  });
+
+  it('accepts explicit algo="xxh3"', () => {
+    const hex = computeHash(new Uint8Array([5]), 'xxh3');
+    expect(hex).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('handles empty buffer', () => {
+    const hex = computeHash(new Uint8Array(0));
+    expect(hex).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('rejects non-Uint8Array input', () => {
+    // @ts-expect-error intentional bad input
+    expect(() => computeHash([1, 2, 3])).toThrow(InvalidArgumentError);
+    // @ts-expect-error intentional bad input
+    expect(() => computeHash('hello')).toThrow(InvalidArgumentError);
+  });
+
+  it('rejects an unknown hash algorithm as a typed error', () => {
+    expect(() =>
+      // @ts-expect-error intentional: HashAlgorithm is strictly narrowed
+      computeHash(new Uint8Array([1]), 'sha256'),
+    ).toThrow(MetadataError);
+  });
+
+  it('matches the hash stamped on an encoded payload (no pipeline)', async () => {
+    // For encoding=filter=compression=none, the encoded payload is the
+    // raw native-endian bytes.  TS-side hash of those bytes must equal
+    // the descriptor's recorded hash.
+    const values = new Float32Array([1.25, 2.5, 3.75, 4.0]);
+    const raw = new Uint8Array(values.buffer, values.byteOffset, values.byteLength);
+    const msg = encode(defaultMeta(), [
+      { descriptor: makeDescriptor([4], 'float32'), data: values },
+    ]);
+    const decoded = decode(msg);
+    try {
+      const descHash = decoded.objects[0].descriptor.hash;
+      expect(descHash?.type).toBe('xxh3');
+      const standalone = computeHash(raw);
+      expect(standalone).toBe(descHash?.value);
+    } finally {
+      decoded.close();
+    }
+  });
+});

--- a/typescript/tests/lazyFromUrl.test.ts
+++ b/typescript/tests/lazyFromUrl.test.ts
@@ -1,0 +1,359 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+/**
+ * `TensogramFile.fromUrl` lazy-Range backend tests.  We simulate the
+ * server via a mock `fetch` function passed through `options.fetch`,
+ * so the tests don't need network access.
+ *
+ * Two key properties:
+ *
+ * 1. When the server advertises `Accept-Ranges: bytes` on `HEAD`,
+ *    `fromUrl` uses Range requests — it does not download the full
+ *    body during open, and only fetches specific messages on demand.
+ *
+ * 2. When the server does not advertise Range (or HEAD fails), the
+ *    behaviour falls back to a single eager GET — matching Scope-B.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { encode, TensogramFile } from '../src/index.js';
+import { defaultMeta, initOnce, makeDescriptor } from './helpers.js';
+
+/** Build a mock fetch that serves the supplied bytes with Range support. */
+function makeRangeServer(body: Uint8Array): {
+  fetch: typeof globalThis.fetch;
+  requests: Array<{ method: string; range?: string }>;
+} {
+  const requests: Array<{ method: string; range?: string }> = [];
+  const fetchFn: typeof globalThis.fetch = async (
+    _input: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    const method = init?.method ?? 'GET';
+    const rangeHeader =
+      init?.headers instanceof Headers
+        ? init.headers.get('range')
+        : init?.headers && (init.headers as Record<string, string>)['Range'];
+    requests.push({ method, range: rangeHeader ?? undefined });
+
+    if (method === 'HEAD') {
+      return new Response(null, {
+        status: 200,
+        headers: {
+          'accept-ranges': 'bytes',
+          'content-length': String(body.byteLength),
+        },
+      });
+    }
+
+    if (rangeHeader) {
+      const match = /^bytes=(\d+)-(\d+)$/.exec(rangeHeader);
+      if (!match) {
+        return new Response('bad range', { status: 416 });
+      }
+      const start = parseInt(match[1], 10);
+      const end = parseInt(match[2], 10); // inclusive
+      const sliceLen = end - start + 1;
+      const copy = new ArrayBuffer(sliceLen);
+      new Uint8Array(copy).set(body.subarray(start, end + 1));
+      return new Response(copy, {
+        status: 206,
+        headers: {
+          'content-range': `bytes ${start}-${end}/${body.byteLength}`,
+          'content-length': String(sliceLen),
+        },
+      });
+    }
+
+    // Full body.
+    const copy = new ArrayBuffer(body.byteLength);
+    new Uint8Array(copy).set(body);
+    return new Response(copy, { status: 200 });
+  };
+  return { fetch: fetchFn, requests };
+}
+
+/** Build a mock fetch whose server does NOT advertise Range support. */
+function makeNoRangeServer(body: Uint8Array): {
+  fetch: typeof globalThis.fetch;
+  requests: Array<{ method: string }>;
+} {
+  const requests: Array<{ method: string }> = [];
+  const fetchFn: typeof globalThis.fetch = async (_url, init?: RequestInit) => {
+    const method = init?.method ?? 'GET';
+    requests.push({ method });
+    if (method === 'HEAD') {
+      return new Response(null, {
+        status: 200,
+        // No accept-ranges header at all.
+        headers: { 'content-length': String(body.byteLength) },
+      });
+    }
+    const copy = new ArrayBuffer(body.byteLength);
+    new Uint8Array(copy).set(body);
+    return new Response(copy, { status: 200 });
+  };
+  return { fetch: fetchFn, requests };
+}
+
+function concatBytes(...bs: Uint8Array[]): Uint8Array {
+  let total = 0;
+  for (const b of bs) total += b.byteLength;
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const b of bs) {
+    out.set(b, off);
+    off += b.byteLength;
+  }
+  return out;
+}
+
+function makeMessage(values: readonly number[]): Uint8Array {
+  return encode(defaultMeta(), [
+    {
+      descriptor: makeDescriptor([values.length], 'float32'),
+      data: new Float32Array(values),
+    },
+  ]);
+}
+
+describe('Scope C.1 — TensogramFile.fromUrl Range backend', () => {
+  initOnce();
+
+  it('uses Range requests when server advertises Accept-Ranges: bytes', async () => {
+    const body = concatBytes(makeMessage([1, 2, 3]), makeMessage([10, 20]));
+    const { fetch: fakeFetch, requests } = makeRangeServer(body);
+
+    const file = await TensogramFile.fromUrl('https://example.invalid/a.tgm', {
+      fetch: fakeFetch,
+    });
+    try {
+      expect(file.source).toBe('remote');
+      // One HEAD + two preamble fetches — no full-body download during open.
+      const methods = requests.map((r) => r.method);
+      expect(methods.filter((m) => m === 'GET').every((m) => m === 'GET')).toBe(true);
+      expect(requests.some((r) => r.method === 'HEAD')).toBe(true);
+      // Every GET issued so far carries a Range header.
+      expect(requests.filter((r) => r.method === 'GET').every((r) => r.range !== undefined)).toBe(true);
+      expect(file.messageCount).toBe(2);
+
+      // Fetching message 0 adds exactly one more Range GET.
+      const before = requests.length;
+      const m0 = await file.message(0);
+      expect(Array.from(m0.objects[0].data() as Float32Array)).toEqual([1, 2, 3]);
+      m0.close();
+      expect(requests.length - before).toBe(1);
+
+      // Re-fetching the same message hits the LRU cache (no new request).
+      const beforeCache = requests.length;
+      const m0again = await file.message(0);
+      m0again.close();
+      expect(requests.length).toBe(beforeCache);
+    } finally {
+      file.close();
+    }
+  });
+
+  it('falls back to eager GET when server omits Accept-Ranges', async () => {
+    const body = concatBytes(makeMessage([7, 8, 9]), makeMessage([0]));
+    const { fetch: fakeFetch, requests } = makeNoRangeServer(body);
+
+    const file = await TensogramFile.fromUrl('https://example.invalid/b.tgm', {
+      fetch: fakeFetch,
+    });
+    try {
+      expect(file.source).toBe('remote');
+      expect(file.messageCount).toBe(2);
+      // One HEAD + one full-body GET (no Range).  rawMessage(i) is O(1) from memory.
+      const methods = requests.map((r) => r.method);
+      expect(methods).toEqual(['HEAD', 'GET']);
+
+      const before = requests.length;
+      const m1 = await file.message(1);
+      expect(Array.from(m1.objects[0].data() as Float32Array)).toEqual([0]);
+      m1.close();
+      // No additional network calls — message bytes are already in memory.
+      expect(requests.length).toBe(before);
+    } finally {
+      file.close();
+    }
+  });
+
+  it('falls back to eager when HEAD fails entirely', async () => {
+    const body = makeMessage([100]);
+    let sawGet = false;
+    const fakeFetch: typeof globalThis.fetch = async (_url, init?: RequestInit) => {
+      const method = init?.method ?? 'GET';
+      if (method === 'HEAD') {
+        throw new Error('HEAD not allowed');
+      }
+      sawGet = true;
+      const copy = new ArrayBuffer(body.byteLength);
+      new Uint8Array(copy).set(body);
+      return new Response(copy, { status: 200 });
+    };
+
+    const file = await TensogramFile.fromUrl('https://example.invalid/c.tgm', {
+      fetch: fakeFetch,
+    });
+    try {
+      expect(file.messageCount).toBe(1);
+      expect(sawGet).toBe(true);
+      const m = await file.message(0);
+      expect(Array.from(m.objects[0].data() as Float32Array)).toEqual([100]);
+      m.close();
+    } finally {
+      file.close();
+    }
+  });
+
+  it('passes Range headers through to the server', async () => {
+    const body = concatBytes(makeMessage([1, 2]), makeMessage([3, 4]));
+    const { fetch: fakeFetch, requests } = makeRangeServer(body);
+
+    const file = await TensogramFile.fromUrl('https://example.invalid/d.tgm', {
+      fetch: fakeFetch,
+    });
+    try {
+      const before = requests.length;
+      await (await file.message(0)).close?.();
+      const rangeHeaders = requests.slice(before).map((r) => r.range);
+      for (const r of rangeHeaders) {
+        expect(r).toMatch(/^bytes=\d+-\d+$/);
+      }
+    } finally {
+      file.close();
+    }
+  });
+
+  it('evicts the least-recently-used entry when the cache fills', async () => {
+    // Build a file with 40 small messages (> LAZY_CACHE_CAPACITY = 32).
+    // After fetching every message once we should have cache-evicted the
+    // earliest ones, so re-reading message 0 costs a fresh Range GET.
+    const CACHE_CAPACITY = 32;
+    const TOTAL = CACHE_CAPACITY + 4;
+    const parts = Array.from({ length: TOTAL }, (_, i) => makeMessage([i]));
+    const body = concatBytes(...parts);
+    const { fetch: fakeFetch, requests } = makeRangeServer(body);
+
+    const file = await TensogramFile.fromUrl('https://example.invalid/f.tgm', {
+      fetch: fakeFetch,
+    });
+    try {
+      expect(file.messageCount).toBe(TOTAL);
+      // Fetch every message once — populates the LRU to capacity + overflow.
+      for (let i = 0; i < TOTAL; i++) {
+        (await file.message(i)).close();
+      }
+
+      // Re-reading message 0 (evicted by later fetches) must cost a
+      // fresh Range GET; re-reading the most-recent message (TOTAL-1)
+      // must hit the cache with zero new requests.
+      const beforeOldest = requests.length;
+      (await file.message(0)).close();
+      const oldestCost = requests.length - beforeOldest;
+      expect(oldestCost).toBeGreaterThanOrEqual(1);
+
+      const beforeNewest = requests.length;
+      (await file.message(0)).close(); // just-fetched → cached
+      expect(requests.length - beforeNewest).toBe(0);
+    } finally {
+      file.close();
+    }
+  });
+
+  it('handles streaming-mode messages by falling back to eager', async () => {
+    // Build a tiny "streaming-mode" message by patching the preamble's
+    // total_length to zero.  This is the same shape the real streaming
+    // encoder produces; the lazy scanner must recognise it and bail
+    // out, after which eager fallback takes over.
+    const full = makeMessage([1, 2, 3, 4, 5]);
+    const patched = new Uint8Array(full);
+    // total_length is 8 bytes starting at offset 16.
+    for (let i = 16; i < 24; i++) patched[i] = 0;
+    const { fetch: fakeFetch, requests } = makeRangeServer(patched);
+
+    const file = await TensogramFile.fromUrl('https://example.invalid/e.tgm', {
+      fetch: fakeFetch,
+    });
+    try {
+      // Eager fallback means we saw at least one non-Range GET (full body).
+      const nonRange = requests.filter((r) => r.method === 'GET' && !r.range);
+      expect(nonRange.length).toBeGreaterThan(0);
+      // And the file is readable via the eager path — scan() can still
+      // find the message because it walks for END_MAGIC when
+      // total_length is 0.
+      expect(file.messageCount).toBe(1);
+    } finally {
+      file.close();
+    }
+  });
+
+  it('throws InvalidArgumentError when no fetch implementation is available', async () => {
+    const prevFetch = globalThis.fetch;
+    // Simulate an environment that doesn't provide a fetch implementation.
+    // We pass a non-callable option to force the "no fetch available" branch.
+    // (We can't delete globalThis.fetch in modern Node reliably.)
+    const { TensogramFile: TF, InvalidArgumentError: IAE } = await import(
+      '../src/index.js'
+    );
+    try {
+      await expect(
+        TF.fromUrl('https://example.invalid/a.tgm', {
+          // @ts-expect-error intentional: callers who supply a non-function
+          // fetch option must get a clear error.
+          fetch: 'not a function',
+        }),
+      ).rejects.toThrow(IAE);
+    } finally {
+      globalThis.fetch = prevFetch;
+    }
+  });
+
+  it('throws IoError on a HEAD-404 + GET-404 server', async () => {
+    const fakeFetch: typeof globalThis.fetch = async () =>
+      new Response('not found', { status: 404 });
+    await expect(
+      TensogramFile.fromUrl('https://example.invalid/404.tgm', { fetch: fakeFetch }),
+    ).rejects.toThrow(/HTTP 404/);
+  });
+
+  it('falls back to eager when the advertised Content-Length is past MAX_SAFE_INTEGER', async () => {
+    // A mythical 10 PiB server.  The lazy walk can't track cursor
+    // arithmetic past 2^53 − 1 without precision loss, so we must
+    // fall back to eager (which then fails its own way because no
+    // real body is produced — but the important thing is we don't
+    // silently walk broken arithmetic).
+    const body = makeMessage([1, 2, 3]);
+    let sawNonRangeGet = false;
+    const fakeFetch: typeof globalThis.fetch = async (_url, init?: RequestInit) => {
+      const method = init?.method ?? 'GET';
+      if (method === 'HEAD') {
+        return new Response(null, {
+          status: 200,
+          headers: {
+            'accept-ranges': 'bytes',
+            'content-length': '10000000000000000', // 10^16 ≫ 2^53 − 1
+          },
+        });
+      }
+      // On the eager GET we just serve the real body so open succeeds.
+      sawNonRangeGet = true;
+      const copy = new ArrayBuffer(body.byteLength);
+      new Uint8Array(copy).set(body);
+      return new Response(copy, { status: 200 });
+    };
+    const file = await TensogramFile.fromUrl('https://example.invalid/huge.tgm', {
+      fetch: fakeFetch,
+    });
+    try {
+      expect(sawNonRangeGet).toBe(true);
+      expect(file.messageCount).toBe(1);
+    } finally {
+      file.close();
+    }
+  });
+});

--- a/typescript/tests/range.test.ts
+++ b/typescript/tests/range.test.ts
@@ -1,0 +1,237 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+/**
+ * `decodeRange` — partial sub-tensor decode tests.  Covers the happy
+ * path (single range, multiple ranges, join mode), dtype fidelity, and
+ * the error contract around shape/dtype/filter limitations.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  decode,
+  decodeRange,
+  encode,
+  EncodingError,
+  InvalidArgumentError,
+  ObjectError,
+} from '../src/index.js';
+import { defaultMeta, makeDescriptor } from './helpers.js';
+import { initOnce } from './helpers.js';
+
+describe('Scope C.1 — decodeRange', () => {
+  initOnce();
+
+  it('decodes a single range in element units', async () => {
+    const values = new Float32Array(16);
+    for (let i = 0; i < values.length; i++) values[i] = i;
+    const msg = encode(defaultMeta(), [
+      { descriptor: makeDescriptor([16], 'float32'), data: values },
+    ]);
+
+    const { descriptor, parts } = decodeRange(msg, 0, [[4, 4]]);
+    expect(descriptor.dtype).toBe('float32');
+    expect(parts).toHaveLength(1);
+    const f32 = parts[0] as Float32Array;
+    expect(f32).toBeInstanceOf(Float32Array);
+    expect(Array.from(f32)).toEqual([4, 5, 6, 7]);
+  });
+
+  it('returns one part per requested range in split mode', async () => {
+    const values = new Float64Array(32).map((_, i) => i * 0.5);
+    const msg = encode(defaultMeta(), [
+      { descriptor: makeDescriptor([32], 'float64'), data: values },
+    ]);
+
+    const { parts } = decodeRange(msg, 0, [
+      [0, 4],
+      [10, 2],
+      [28, 4],
+    ]);
+    expect(parts).toHaveLength(3);
+    expect(Array.from(parts[0] as Float64Array)).toEqual([0, 0.5, 1, 1.5]);
+    expect(Array.from(parts[1] as Float64Array)).toEqual([5, 5.5]);
+    expect(Array.from(parts[2] as Float64Array)).toEqual([14, 14.5, 15, 15.5]);
+  });
+
+  it('concatenates ranges with join: true', async () => {
+    const values = new Int32Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    const msg = encode(defaultMeta(), [
+      { descriptor: makeDescriptor([10], 'int32'), data: values },
+    ]);
+
+    const { parts } = decodeRange(
+      msg,
+      0,
+      [
+        [0, 2],
+        [5, 2],
+        [9, 1],
+      ],
+      { join: true },
+    );
+    expect(parts).toHaveLength(1);
+    expect(Array.from(parts[0] as Int32Array)).toEqual([0, 1, 5, 6, 9]);
+  });
+
+  it('preserves dtype typing (int64 → BigInt64Array)', async () => {
+    const values = new BigInt64Array([-5n, -1n, 0n, 1n, 10n, 42n]);
+    const msg = encode(defaultMeta(), [
+      { descriptor: makeDescriptor([6], 'int64'), data: values },
+    ]);
+    const { parts } = decodeRange(msg, 0, [[1, 3]]);
+    expect(parts[0]).toBeInstanceOf(BigInt64Array);
+    expect(Array.from(parts[0] as BigInt64Array)).toEqual([-1n, 0n, 1n]);
+  });
+
+  it('accepts bigint offsets and counts', async () => {
+    const values = new Uint8Array([10, 20, 30, 40, 50, 60, 70, 80]);
+    const msg = encode(defaultMeta(), [
+      { descriptor: makeDescriptor([8], 'uint8'), data: values },
+    ]);
+    const { parts } = decodeRange(msg, 0, [[2n, 3n]]);
+    expect(Array.from(parts[0] as Uint8Array)).toEqual([30, 40, 50]);
+  });
+
+  it('returns empty parts[] for an empty ranges array', async () => {
+    const values = new Float32Array([1, 2, 3, 4]);
+    const msg = encode(defaultMeta(), [
+      { descriptor: makeDescriptor([4], 'float32'), data: values },
+    ]);
+    const { parts } = decodeRange(msg, 0, []);
+    expect(parts).toHaveLength(0);
+  });
+
+  it('rejects out-of-range object index with ObjectError', async () => {
+    const msg = encode(defaultMeta(), [
+      {
+        descriptor: makeDescriptor([4], 'float32'),
+        data: new Float32Array([1, 2, 3, 4]),
+      },
+    ]);
+    expect(() => decodeRange(msg, 5, [[0, 1]])).toThrow(ObjectError);
+  });
+
+  it('rejects a filter=shuffle object with EncodingError', async () => {
+    // Manually craft a descriptor with shuffle + an explicit element size
+    // and round-trip through encode/decode_range.
+    const values = new Float32Array([1, 2, 3, 4]);
+    const desc = {
+      ...makeDescriptor([4], 'float32'),
+      filter: 'shuffle',
+      shuffle_element_size: 4,
+    } as const;
+    const msg = encode(defaultMeta(), [{ descriptor: desc, data: values }]);
+    expect(() => decodeRange(msg, 0, [[0, 2]])).toThrow(EncodingError);
+  });
+
+  it('rejects bitmask dtype with EncodingError', async () => {
+    // ceil(16 / 8) = 2 bytes of packed bits
+    const bits = new Uint8Array([0b11110000, 0b00001111]);
+    const msg = encode(defaultMeta(), [
+      { descriptor: makeDescriptor([16], 'bitmask'), data: bits },
+    ]);
+    expect(() => decodeRange(msg, 0, [[0, 8]])).toThrow(EncodingError);
+  });
+
+  it('rejects malformed ranges (not a pair)', async () => {
+    const msg = encode(defaultMeta(), [
+      {
+        descriptor: makeDescriptor([4], 'float32'),
+        data: new Float32Array([1, 2, 3, 4]),
+      },
+    ]);
+    // @ts-expect-error intentional bad input
+    expect(() => decodeRange(msg, 0, [[1, 2, 3]])).toThrow(InvalidArgumentError);
+  });
+
+  it('rejects negative offsets / counts', async () => {
+    const msg = encode(defaultMeta(), [
+      {
+        descriptor: makeDescriptor([4], 'float32'),
+        data: new Float32Array([1, 2, 3, 4]),
+      },
+    ]);
+    expect(() => decodeRange(msg, 0, [[-1, 2]])).toThrow(InvalidArgumentError);
+    expect(() => decodeRange(msg, 0, [[0, -1]])).toThrow(InvalidArgumentError);
+    expect(() => decodeRange(msg, 0, [[1.5, 2]])).toThrow(InvalidArgumentError);
+  });
+
+  it('rejects non-Uint8Array buf', () => {
+    expect(() =>
+      // @ts-expect-error intentional
+      decodeRange([1, 2, 3], 0, [[0, 1]]),
+    ).toThrow(InvalidArgumentError);
+  });
+
+  it('rejects non-array ranges argument', () => {
+    expect(() =>
+      // @ts-expect-error intentional: ranges must be an array
+      decodeRange(new Uint8Array(100), 0, 'not an array'),
+    ).toThrow(InvalidArgumentError);
+  });
+
+  it('rejects range pair where the offset is neither number nor bigint', () => {
+    expect(() =>
+      // @ts-expect-error intentional: strings are not accepted
+      decodeRange(new Uint8Array(100), 0, [['0', '1']]),
+    ).toThrow(InvalidArgumentError);
+  });
+
+  it('rejects non-integer objectIndex', () => {
+    expect(() =>
+      decodeRange(new Uint8Array(100), 1.5, [[0, 1]]),
+    ).toThrow(InvalidArgumentError);
+    expect(() =>
+      decodeRange(new Uint8Array(100), -1, [[0, 1]]),
+    ).toThrow(InvalidArgumentError);
+  });
+
+  it('rejects objectIndex above u32 range', () => {
+    // WASM's `usize` is u32 on wasm32 — values beyond would be
+    // silently truncated.  We reject at the TS boundary.
+    expect(() =>
+      decodeRange(new Uint8Array(100), 2 ** 32, [[0, 1]]),
+    ).toThrow(InvalidArgumentError);
+  });
+
+  it('rejects range values above u64 range', () => {
+    expect(() =>
+      decodeRange(new Uint8Array(100), 0, [[2n ** 65n, 1n]]),
+    ).toThrow(InvalidArgumentError);
+    expect(() =>
+      decodeRange(new Uint8Array(100), 0, [[0n, -1n]]),
+    ).toThrow(InvalidArgumentError);
+  });
+
+  it('matches a manual slice of the full decode', async () => {
+    const n = 100;
+    const data = new Float32Array(n).map((_, i) => Math.sin(i * 0.1));
+    const msg = encode(defaultMeta(), [
+      { descriptor: makeDescriptor([n], 'float32'), data },
+    ]);
+
+    const full = decode(msg);
+    try {
+      const fullF32 = full.objects[0].data() as Float32Array;
+      const { parts } = decodeRange(msg, 0, [[25, 10]]);
+      const sliceF32 = parts[0] as Float32Array;
+      expect(Array.from(sliceF32)).toEqual(Array.from(fullF32.subarray(25, 35)));
+    } finally {
+      full.close();
+    }
+  });
+
+  it('verifyHash: true passes on an unmodified message', async () => {
+    const msg = encode(defaultMeta(), [
+      {
+        descriptor: makeDescriptor([4], 'float32'),
+        data: new Float32Array([1, 2, 3, 4]),
+      },
+    ]);
+    const { parts } = decodeRange(msg, 0, [[0, 4]], { verifyHash: true });
+    expect(Array.from(parts[0] as Float32Array)).toEqual([1, 2, 3, 4]);
+  });
+});

--- a/typescript/tests/simplePacking.test.ts
+++ b/typescript/tests/simplePacking.test.ts
@@ -1,0 +1,125 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+/**
+ * `simplePackingComputeParams` — params computation tests.  Focused on
+ * (a) well-formed returns for typical inputs, (b) integration with
+ * encoding-pipeline round-trips, and (c) error-boundary checks.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  decode,
+  encode,
+  InvalidArgumentError,
+  simplePackingComputeParams,
+} from '../src/index.js';
+import { defaultMeta, initOnce, makeDescriptor } from './helpers.js';
+
+describe('Scope C.1 — simplePackingComputeParams', () => {
+  initOnce();
+
+  it('returns the expected snake-case fields', () => {
+    const p = simplePackingComputeParams(
+      new Float64Array([200, 210, 220, 230, 240]),
+      16,
+      0,
+    );
+    expect(p.reference_value).toBe(200);
+    expect(p.bits_per_value).toBe(16);
+    expect(p.decimal_scale_factor).toBe(0);
+    expect(typeof p.binary_scale_factor).toBe('number');
+  });
+
+  it('accepts a plain number[] input', () => {
+    const p = simplePackingComputeParams([0, 1, 2, 3, 4, 5], 8);
+    expect(p.reference_value).toBe(0);
+    expect(p.bits_per_value).toBe(8);
+  });
+
+  it('handles zero-bit constant field', () => {
+    const p = simplePackingComputeParams([42, 42, 42], 0);
+    expect(p.bits_per_value).toBe(0);
+    expect(p.reference_value).toBe(42);
+  });
+
+  it('rejects NaN values via InvalidArgumentError', () => {
+    // The TS wrapper rejects non-finite values before the WASM call
+    // so callers see a clear early error (the Rust core would
+    // surface an EncodingError later with the same meaning).
+    expect(() =>
+      simplePackingComputeParams([1, NaN, 3], 16),
+    ).toThrow(InvalidArgumentError);
+  });
+
+  it('rejects +Infinity via InvalidArgumentError', () => {
+    expect(() =>
+      simplePackingComputeParams([1, Infinity, 3], 16),
+    ).toThrow(InvalidArgumentError);
+  });
+
+  it('rejects -Infinity via InvalidArgumentError', () => {
+    expect(() =>
+      simplePackingComputeParams([1, -Infinity, 3], 16),
+    ).toThrow(InvalidArgumentError);
+  });
+
+  it('rejects out-of-range decimalScaleFactor (i32 overflow)', () => {
+    expect(() =>
+      simplePackingComputeParams([1, 2, 3], 16, 2_147_483_648),
+    ).toThrow(InvalidArgumentError);
+    expect(() =>
+      simplePackingComputeParams([1, 2, 3], 16, -2_147_483_649),
+    ).toThrow(InvalidArgumentError);
+  });
+
+  it('rejects out-of-range bitsPerValue', () => {
+    expect(() =>
+      simplePackingComputeParams([1, 2, 3], 65),
+    ).toThrow(InvalidArgumentError);
+    expect(() =>
+      simplePackingComputeParams([1, 2, 3], -1),
+    ).toThrow(InvalidArgumentError);
+    expect(() =>
+      simplePackingComputeParams([1, 2, 3], 1.5),
+    ).toThrow(InvalidArgumentError);
+  });
+
+  it('rejects non-integer decimalScaleFactor', () => {
+    expect(() =>
+      simplePackingComputeParams([1, 2, 3], 16, 0.5),
+    ).toThrow(InvalidArgumentError);
+  });
+
+  it('spreads into a descriptor to drive a lossy round-trip', async () => {
+    // End-to-end: compute params on a float field, feed into a
+    // simple_packing descriptor, encode / decode, and verify the
+    // recovered values are within the ±half-step quantisation bound.
+    const values = new Float64Array(64);
+    for (let i = 0; i < values.length; i++) {
+      values[i] = 273.15 + i * 0.01;
+    }
+    const params = simplePackingComputeParams(values, 16, 0);
+    const bytes = new Uint8Array(values.buffer, values.byteOffset, values.byteLength);
+    const desc = {
+      ...makeDescriptor([values.length], 'float64'),
+      encoding: 'simple_packing' as const,
+      ...params,
+    };
+    const msg = encode(defaultMeta(), [{ descriptor: desc, data: bytes }]);
+    const decoded = decode(msg);
+    try {
+      const recovered = decoded.objects[0].data() as Float64Array;
+      expect(recovered.length).toBe(values.length);
+      // Quantisation step upper bound: (max - min) / (2^bits - 1) ≈ 9.6e-6
+      const step = (values[values.length - 1] - values[0]) / (Math.pow(2, 16) - 1);
+      for (let i = 0; i < values.length; i++) {
+        expect(Math.abs(recovered[i] - values[i])).toBeLessThan(step * 2);
+      }
+    } finally {
+      decoded.close();
+    }
+  });
+});

--- a/typescript/tests/streamingEncoder.test.ts
+++ b/typescript/tests/streamingEncoder.test.ts
@@ -1,0 +1,428 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+/**
+ * `StreamingEncoder` tests.  Contract: frame-at-a-time writes produce a
+ * message whose semantic content (decoded values + metadata) equals the
+ * same message built via the one-shot `encode()` API.  Wire bytes
+ * differ — streaming puts the index / hash frames in the footer — so
+ * we compare decoded state, not byte-for-byte.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  decode,
+  encode,
+  InvalidArgumentError,
+  StreamingEncoder,
+} from '../src/index.js';
+import { defaultMeta, initOnce, makeDescriptor } from './helpers.js';
+
+describe('Scope C.1 — StreamingEncoder', () => {
+  initOnce();
+
+  it('single-object round-trip matches encode() semantics', () => {
+    const values = new Float32Array([1, 2, 3, 4]);
+    const enc = new StreamingEncoder(defaultMeta());
+    try {
+      expect(enc.objectCount).toBe(0);
+      enc.writeObject(makeDescriptor([4], 'float32'), values);
+      expect(enc.objectCount).toBe(1);
+      const bytes = enc.finish();
+
+      const decoded = decode(bytes);
+      try {
+        expect(decoded.objects).toHaveLength(1);
+        expect(Array.from(decoded.objects[0].data() as Float32Array)).toEqual([1, 2, 3, 4]);
+      } finally {
+        decoded.close();
+      }
+    } finally {
+      enc.close();
+    }
+  });
+
+  it('writes multiple objects in order', () => {
+    const enc = new StreamingEncoder(defaultMeta());
+    try {
+      enc.writeObject(makeDescriptor([2], 'float32'), new Float32Array([1, 2]));
+      enc.writeObject(makeDescriptor([3], 'float64'), new Float64Array([10, 20, 30]));
+      enc.writeObject(makeDescriptor([1], 'int64'), new BigInt64Array([42n]));
+      expect(enc.objectCount).toBe(3);
+      expect(enc.bytesWritten).toBeGreaterThan(0);
+      const bytes = enc.finish();
+
+      const decoded = decode(bytes);
+      try {
+        expect(decoded.objects).toHaveLength(3);
+        expect(Array.from(decoded.objects[0].data() as Float32Array)).toEqual([1, 2]);
+        expect(Array.from(decoded.objects[1].data() as Float64Array)).toEqual([10, 20, 30]);
+        expect(Array.from(decoded.objects[2].data() as BigInt64Array)).toEqual([42n]);
+      } finally {
+        decoded.close();
+      }
+    } finally {
+      enc.close();
+    }
+  });
+
+  it('writePreceder merges into base[i] on decode', () => {
+    const enc = new StreamingEncoder(defaultMeta());
+    try {
+      enc.writePreceder({ units: 'K', mars: { param: '2t' } });
+      enc.writeObject(makeDescriptor([2], 'float32'), new Float32Array([273.15, 274.0]));
+      const bytes = enc.finish();
+      const decoded = decode(bytes);
+      try {
+        const base0 = decoded.metadata.base?.[0];
+        expect(base0?.['units']).toBe('K');
+        const mars = base0?.['mars'] as Record<string, unknown> | undefined;
+        expect(mars?.['param']).toBe('2t');
+      } finally {
+        decoded.close();
+      }
+    } finally {
+      enc.close();
+    }
+  });
+
+  it('rejects consecutive preceders without an intervening object', () => {
+    const enc = new StreamingEncoder(defaultMeta());
+    try {
+      enc.writePreceder({ a: 1 });
+      expect(() => enc.writePreceder({ b: 2 })).toThrow();
+    } finally {
+      enc.close();
+    }
+  });
+
+  it('rejects a dangling preceder at finish', () => {
+    const enc = new StreamingEncoder(defaultMeta());
+    try {
+      enc.writePreceder({ a: 1 });
+      expect(() => enc.finish()).toThrow();
+    } finally {
+      enc.close();
+    }
+  });
+
+  it('semantic equivalence with encode() for the same inputs', () => {
+    const data = new Float32Array([1.5, 2.5, 3.5, 4.5]);
+    const desc = makeDescriptor([4], 'float32');
+
+    const buffered = encode(defaultMeta(), [{ descriptor: desc, data }]);
+    const decBuf = decode(buffered);
+
+    const enc = new StreamingEncoder(defaultMeta());
+    enc.writeObject(desc, data);
+    const streamed = enc.finish();
+    enc.close();
+    const decStr = decode(streamed);
+
+    try {
+      expect(decStr.objects).toHaveLength(decBuf.objects.length);
+      expect(Array.from(decStr.objects[0].data() as Float32Array)).toEqual(
+        Array.from(decBuf.objects[0].data() as Float32Array),
+      );
+      // Wire bytes intentionally differ (header-index vs footer-index).
+      // Hash value must match — it's the xxh3 of the same encoded payload.
+      expect(decStr.objects[0].descriptor.hash?.value).toBe(
+        decBuf.objects[0].descriptor.hash?.value,
+      );
+    } finally {
+      decBuf.close();
+      decStr.close();
+    }
+  });
+
+  it('finish() closes the encoder — subsequent calls throw', () => {
+    const enc = new StreamingEncoder(defaultMeta());
+    enc.writeObject(makeDescriptor([1], 'uint8'), new Uint8Array([7]));
+    enc.finish();
+    expect(() => enc.objectCount).toThrow(InvalidArgumentError);
+    expect(() =>
+      enc.writeObject(makeDescriptor([1], 'uint8'), new Uint8Array([8])),
+    ).toThrow(InvalidArgumentError);
+    expect(() => enc.finish()).toThrow(InvalidArgumentError);
+  });
+
+  it('close() is idempotent', () => {
+    const enc = new StreamingEncoder(defaultMeta());
+    enc.close();
+    expect(() => enc.close()).not.toThrow();
+  });
+
+  it('writeObjectPreEncoded writes verbatim bytes', () => {
+    const values = new Float32Array([1, 2, 3, 4]);
+    const bytes = new Uint8Array(values.buffer, values.byteOffset, values.byteLength);
+    const enc = new StreamingEncoder(defaultMeta(), { hash: 'xxh3' });
+    try {
+      enc.writeObjectPreEncoded(makeDescriptor([4], 'float32'), bytes);
+      const msg = enc.finish();
+      const decoded = decode(msg);
+      try {
+        expect(Array.from(decoded.objects[0].data() as Float32Array)).toEqual([1, 2, 3, 4]);
+      } finally {
+        decoded.close();
+      }
+    } finally {
+      enc.close();
+    }
+  });
+
+  it('rejects invalid metadata up front', () => {
+    // @ts-expect-error intentional: version is required
+    expect(() => new StreamingEncoder({})).toThrow(InvalidArgumentError);
+  });
+
+  it('rejects a non-ArrayBufferView data argument', () => {
+    const enc = new StreamingEncoder(defaultMeta());
+    try {
+      expect(() =>
+        enc.writeObject(
+          makeDescriptor([1], 'uint8'),
+          // @ts-expect-error intentional bad input
+          [0, 1, 2],
+        ),
+      ).toThrow(InvalidArgumentError);
+    } finally {
+      enc.close();
+    }
+  });
+
+  it('rejects writePreceder on a non-plain-object entry', () => {
+    const enc = new StreamingEncoder(defaultMeta());
+    try {
+      expect(() =>
+        // @ts-expect-error intentional: arrays are rejected
+        enc.writePreceder([1, 2, 3]),
+      ).toThrow(InvalidArgumentError);
+      expect(() =>
+        // @ts-expect-error intentional: null is rejected
+        enc.writePreceder(null),
+      ).toThrow(InvalidArgumentError);
+    } finally {
+      enc.close();
+    }
+  });
+
+  it('rejects writePreceder when entry contains _reserved_', () => {
+    // `_reserved_` is a valid JS key, so TypeScript doesn't catch it
+    // structurally — runtime validation carries the contract.
+    const enc = new StreamingEncoder(defaultMeta());
+    try {
+      expect(() =>
+        enc.writePreceder({ _reserved_: { foo: 'bar' } }),
+      ).toThrow(InvalidArgumentError);
+    } finally {
+      enc.close();
+    }
+  });
+
+  it('rejects writeObjectPreEncoded when data is not a Uint8Array', () => {
+    const enc = new StreamingEncoder(defaultMeta());
+    try {
+      expect(() =>
+        enc.writeObjectPreEncoded(
+          makeDescriptor([1], 'float32'),
+          // @ts-expect-error intentional: only Uint8Array is accepted for pre-encoded bytes
+          new Float32Array([1]),
+        ),
+      ).toThrow(InvalidArgumentError);
+    } finally {
+      enc.close();
+    }
+  });
+});
+
+// ── Streaming-callback mode (Pass 6) ────────────────────────────────────────
+
+/**
+ * Concatenate every chunk delivered to a collector into a single
+ * `Uint8Array`.  Used to rebuild the whole wire-format message from
+ * a stream-mode encoding and verify it decodes identically to the
+ * buffered path.
+ */
+function joinChunks(chunks: readonly Uint8Array[]): Uint8Array {
+  let total = 0;
+  for (const c of chunks) total += c.byteLength;
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const c of chunks) {
+    out.set(c, off);
+    off += c.byteLength;
+  }
+  return out;
+}
+
+describe('Scope C.1 — StreamingEncoder streaming mode', () => {
+  initOnce();
+
+  it('delivers preamble + header bytes during construction', () => {
+    const chunks: Uint8Array[] = [];
+    const enc = new StreamingEncoder(defaultMeta(), {
+      onBytes: (c) => chunks.push(new Uint8Array(c)),
+    });
+    try {
+      expect(chunks.length).toBeGreaterThan(0);
+      // First 8 bytes must be the preamble magic.
+      const first = chunks[0];
+      const magic = new TextDecoder('ascii').decode(first.subarray(0, 8));
+      expect(magic).toBe('TENSOGRM');
+      expect(enc.streaming).toBe(true);
+    } finally {
+      enc.close();
+    }
+  });
+
+  it('finish() returns an empty Uint8Array in streaming mode', () => {
+    const chunks: Uint8Array[] = [];
+    const enc = new StreamingEncoder(defaultMeta(), {
+      onBytes: (c) => chunks.push(new Uint8Array(c)),
+    });
+    enc.writeObject(makeDescriptor([2], 'float32'), new Float32Array([1, 2]));
+    const returned = enc.finish();
+    expect(returned).toBeInstanceOf(Uint8Array);
+    expect(returned.byteLength).toBe(0);
+    // But every byte must have flowed through the callback.
+    expect(chunks.length).toBeGreaterThan(0);
+  });
+
+  it('streamed bytes decode to the same message as buffered bytes', () => {
+    const values = new Float32Array([1.5, 2.5, 3.5, 4.5, 5.5]);
+    const desc = makeDescriptor([values.length], 'float32');
+
+    // Buffered baseline.
+    const buffered = new StreamingEncoder(defaultMeta());
+    buffered.writeObject(desc, values);
+    const bufferedBytes = buffered.finish();
+    buffered.close();
+
+    // Streaming variant — reassemble the bytes from chunks.
+    const chunks: Uint8Array[] = [];
+    const streamed = new StreamingEncoder(defaultMeta(), {
+      onBytes: (c) => chunks.push(new Uint8Array(c)),
+    });
+    streamed.writeObject(desc, values);
+    streamed.finish();
+    streamed.close();
+    const streamedBytes = joinChunks(chunks);
+
+    // Decode both and compare semantic state — wire bytes differ
+    // across calls because `_reserved_.uuid` is freshly generated.
+    const bufMsg = decode(bufferedBytes);
+    const strMsg = decode(streamedBytes);
+    try {
+      expect(strMsg.objects).toHaveLength(bufMsg.objects.length);
+      expect(Array.from(strMsg.objects[0].data() as Float32Array)).toEqual(
+        Array.from(bufMsg.objects[0].data() as Float32Array),
+      );
+    } finally {
+      bufMsg.close();
+      strMsg.close();
+    }
+  });
+
+  it('bytesWritten tracks chunks delivered (not a zero buffer)', () => {
+    const chunks: Uint8Array[] = [];
+    const enc = new StreamingEncoder(defaultMeta(), {
+      onBytes: (c) => chunks.push(new Uint8Array(c)),
+    });
+    try {
+      const before = enc.bytesWritten;
+      expect(before).toBeGreaterThan(0); // preamble + header already emitted
+      enc.writeObject(makeDescriptor([4], 'float32'), new Float32Array([1, 2, 3, 4]));
+      expect(enc.bytesWritten).toBeGreaterThan(before);
+      // bytesWritten equals the running sum of chunk lengths.
+      const callbackTotal = chunks.reduce((n, c) => n + c.byteLength, 0);
+      expect(enc.bytesWritten).toBe(callbackTotal);
+    } finally {
+      enc.close();
+    }
+  });
+
+  it('multi-object streaming delivers every frame through the callback', () => {
+    const chunks: Uint8Array[] = [];
+    const enc = new StreamingEncoder(defaultMeta(), {
+      onBytes: (c) => chunks.push(new Uint8Array(c)),
+    });
+    enc.writeObject(makeDescriptor([2], 'float32'), new Float32Array([1, 2]));
+    enc.writeObject(makeDescriptor([3], 'float64'), new Float64Array([10, 20, 30]));
+    enc.writeObject(makeDescriptor([1], 'int64'), new BigInt64Array([42n]));
+    enc.finish();
+    enc.close();
+
+    const bytes = joinChunks(chunks);
+    const msg = decode(bytes);
+    try {
+      expect(msg.objects).toHaveLength(3);
+      expect(Array.from(msg.objects[0].data() as Float32Array)).toEqual([1, 2]);
+      expect(Array.from(msg.objects[1].data() as Float64Array)).toEqual([10, 20, 30]);
+      expect(Array.from(msg.objects[2].data() as BigInt64Array)).toEqual([42n]);
+    } finally {
+      msg.close();
+    }
+  });
+
+  it('propagates a callback exception as an error from the next write', () => {
+    let throwOnNextCall = false;
+    const enc = new StreamingEncoder(defaultMeta(), {
+      onBytes: (_chunk) => {
+        if (throwOnNextCall) {
+          throw new Error('sink refused the chunk');
+        }
+      },
+    });
+    try {
+      // Flip the flag so the next emission raises.
+      throwOnNextCall = true;
+      // writeObject flushes a frame → callback fires → exception →
+      // Rust-side io::Error → TensogramError::Io → TS IoError.
+      expect(() =>
+        enc.writeObject(makeDescriptor([1], 'uint8'), new Uint8Array([7])),
+      ).toThrow();
+    } finally {
+      enc.close();
+    }
+  });
+
+  it('rejects a non-function onBytes with InvalidArgumentError', () => {
+    expect(
+      () =>
+        new StreamingEncoder(defaultMeta(), {
+          // @ts-expect-error intentional: onBytes must be callable
+          onBytes: 'not a function',
+        }),
+    ).toThrow(InvalidArgumentError);
+  });
+
+  it('streaming: get streaming returns true, buffered: false', () => {
+    const buffered = new StreamingEncoder(defaultMeta());
+    expect(buffered.streaming).toBe(false);
+    buffered.close();
+
+    const streamed = new StreamingEncoder(defaultMeta(), { onBytes: () => {} });
+    expect(streamed.streaming).toBe(true);
+    streamed.close();
+  });
+
+  it('honours hash: false alongside streaming', () => {
+    const chunks: Uint8Array[] = [];
+    const enc = new StreamingEncoder(defaultMeta(), {
+      hash: false,
+      onBytes: (c) => chunks.push(new Uint8Array(c)),
+    });
+    enc.writeObject(makeDescriptor([2], 'float32'), new Float32Array([1, 2]));
+    enc.finish();
+    enc.close();
+
+    const msg = decode(joinChunks(chunks));
+    try {
+      expect(msg.objects[0].descriptor.hash).toBeUndefined();
+    } finally {
+      msg.close();
+    }
+  });
+});

--- a/typescript/tests/streamingEncoder.test.ts
+++ b/typescript/tests/streamingEncoder.test.ts
@@ -154,6 +154,22 @@ describe('Scope C.1 — StreamingEncoder', () => {
     expect(() => enc.close()).not.toThrow();
   });
 
+  it('finish() releases the WASM handle exactly once (close() afterwards is a no-op)', () => {
+    // Regression for a leak where finish() closed the encoder + unregistered
+    // the FinalizationRegistry hook but never called .free() on the handle.
+    // A subsequent close() short-circuited on the "already closed" guard, so
+    // the handle leaked permanently.  finish() must release the handle itself.
+    const enc = new StreamingEncoder(defaultMeta());
+    enc.writeObject(makeDescriptor([1], 'uint8'), new Uint8Array([42]));
+    enc.finish();
+    // close() after finish() must be callable without throwing and without
+    // double-freeing the WASM handle (tolerated via the try/catch in the
+    // shared teardown path).
+    expect(() => enc.close()).not.toThrow();
+    // Calling close() a second time is also fine.
+    expect(() => enc.close()).not.toThrow();
+  });
+
   it('writeObjectPreEncoded writes verbatim bytes', () => {
     const values = new Float32Array([1, 2, 3, 4]);
     const bytes = new Uint8Array(values.buffer, values.byteOffset, values.byteLength);

--- a/typescript/tests/validate.test.ts
+++ b/typescript/tests/validate.test.ts
@@ -1,0 +1,240 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+/**
+ * `validate` / `validateBuffer` / `validateFile` tests.  Ground truth is
+ * "report, never throw, on corrupt input"; we also verify mode routing
+ * and golden-file parity with the Rust / Python / C++ suites.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import {
+  encode,
+  InvalidArgumentError,
+  IoError,
+  validate,
+  validateBuffer,
+  validateFile,
+} from '../src/index.js';
+import { defaultMeta, initOnce, makeDescriptor } from './helpers.js';
+
+/**
+ * Path to the Rust-core golden fixtures.  Re-used so TS validates the
+ * same `.tgm` files that Rust/Python/C++ suites use — a drift in wire
+ * semantics surfaces immediately.
+ */
+function goldenPath(name: string): string {
+  const url = new URL(`../../rust/tensogram/tests/golden/${name}`, import.meta.url);
+  return fileURLToPath(url);
+}
+
+describe('Scope C.1 — validate', () => {
+  initOnce();
+
+  describe('validate (single message)', () => {
+    it('returns a clean report for a well-formed message', () => {
+      const msg = encode(defaultMeta(), [
+        {
+          descriptor: makeDescriptor([4], 'float32'),
+          data: new Float32Array([1, 2, 3, 4]),
+        },
+      ]);
+      const report = validate(msg);
+      expect(report.object_count).toBe(1);
+      expect(report.hash_verified).toBe(true);
+      expect(report.issues.filter((i) => i.severity === 'error')).toEqual([]);
+    });
+
+    it('never throws on random garbage — reports issues instead', () => {
+      const report = validate(new Uint8Array(64));
+      expect(report.issues.length).toBeGreaterThan(0);
+      // First issue is a structural / magic / length problem.
+      expect(report.issues[0].level).toBe('structure');
+    });
+
+    it('detects truncated messages as issues (not exceptions)', () => {
+      const full = encode(defaultMeta(), [
+        {
+          descriptor: makeDescriptor([4], 'float32'),
+          data: new Float32Array([1, 2, 3, 4]),
+        },
+      ]);
+      const report = validate(full.subarray(0, Math.floor(full.byteLength / 2)));
+      expect(report.issues.some((i) => i.severity === 'error')).toBe(true);
+    });
+
+    it('routes mode="quick" to structure-only', () => {
+      const msg = encode(defaultMeta(), [
+        {
+          descriptor: makeDescriptor([4], 'float32'),
+          data: new Float32Array([1, 2, 3, 4]),
+        },
+      ]);
+      const report = validate(msg, { mode: 'quick' });
+      // Structure-only can't establish hash_verified=true.
+      expect(report.hash_verified).toBe(false);
+    });
+
+    it('routes mode="full" and detects NaN in a float64 payload', () => {
+      const data = new Float64Array([1, NaN, 3]);
+      const bytes = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+      // Use encode_pre_encoded to bypass simple_packing's NaN rejection.
+      const msg = encode(defaultMeta(), [
+        { descriptor: makeDescriptor([3], 'float64'), data: bytes },
+      ]);
+      const report = validate(msg, { mode: 'full' });
+      const nan = report.issues.find((i) => i.code === 'nan_detected');
+      expect(nan).toBeDefined();
+      expect(nan?.severity).toBe('error');
+    });
+
+    it('accepts canonical: true on a valid message', () => {
+      const msg = encode(defaultMeta(), [
+        {
+          descriptor: makeDescriptor([4], 'float32'),
+          data: new Float32Array([1, 2, 3, 4]),
+        },
+      ]);
+      const report = validate(msg, { canonical: true });
+      expect(report.issues.filter((i) => i.severity === 'error')).toEqual([]);
+    });
+
+    it('rejects non-Uint8Array input with InvalidArgumentError', () => {
+      expect(() =>
+        // @ts-expect-error intentional bad input
+        validate([1, 2, 3]),
+      ).toThrow(InvalidArgumentError);
+    });
+
+    it('rejects unknown mode with InvalidArgumentError', () => {
+      expect(() =>
+        // @ts-expect-error intentional: mode is a string-literal union
+        validate(new Uint8Array(40), { mode: 'thorough' }),
+      ).toThrow(InvalidArgumentError);
+    });
+  });
+
+  describe('validateBuffer (multi-message)', () => {
+    it('reports a gap of unrecognised bytes between messages', () => {
+      const m1 = encode(defaultMeta(), [
+        {
+          descriptor: makeDescriptor([2], 'float32'),
+          data: new Float32Array([1, 2]),
+        },
+      ]);
+      const m2 = encode(defaultMeta(), [
+        {
+          descriptor: makeDescriptor([2], 'float32'),
+          data: new Float32Array([3, 4]),
+        },
+      ]);
+      const garbage = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+      const combined = new Uint8Array(m1.byteLength + garbage.byteLength + m2.byteLength);
+      combined.set(m1, 0);
+      combined.set(garbage, m1.byteLength);
+      combined.set(m2, m1.byteLength + garbage.byteLength);
+
+      const report = validateBuffer(combined);
+      expect(report.messages).toHaveLength(2);
+      expect(report.file_issues).toHaveLength(1);
+      expect(report.file_issues[0].length).toBe(4);
+    });
+
+    it('reports "no valid messages" for pure garbage', () => {
+      const report = validateBuffer(new Uint8Array([1, 2, 3, 4]));
+      expect(report.messages).toHaveLength(0);
+      expect(report.file_issues).toHaveLength(1);
+      expect(report.file_issues[0].description).toMatch(/no valid messages/);
+    });
+
+    it('is okay with a single clean message', () => {
+      const msg = encode(defaultMeta(), [
+        {
+          descriptor: makeDescriptor([4], 'float32'),
+          data: new Float32Array([1, 2, 3, 4]),
+        },
+      ]);
+      const report = validateBuffer(msg);
+      expect(report.messages).toHaveLength(1);
+      expect(report.file_issues).toHaveLength(0);
+    });
+  });
+
+  describe('validateFile (Node filesystem)', () => {
+    let tmp: string;
+    beforeEach(() => {
+      tmp = mkdtempSync(join(tmpdir(), 'tensogram-ts-validate-'));
+    });
+    afterEach(() => {
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    it('reads a temp file and returns a clean report', async () => {
+      const p = join(tmp, 'sample.tgm');
+      const msg = encode(defaultMeta(), [
+        {
+          descriptor: makeDescriptor([4], 'float32'),
+          data: new Float32Array([1, 2, 3, 4]),
+        },
+      ]);
+      writeFileSync(p, msg);
+      const report = await validateFile(p);
+      expect(report.messages).toHaveLength(1);
+      expect(report.file_issues).toHaveLength(0);
+      expect(report.messages[0].hash_verified).toBe(true);
+    });
+
+    it('throws IoError on a missing file', async () => {
+      await expect(validateFile(join(tmp, 'nope.tgm'))).rejects.toThrow(IoError);
+    });
+
+    it('rejects non-string / non-URL paths', async () => {
+      await expect(
+        // @ts-expect-error intentional
+        validateFile(42),
+      ).rejects.toThrow(InvalidArgumentError);
+    });
+  });
+
+  describe('Golden file parity', () => {
+    // Every TS validate() call on a golden fixture must come back clean.
+    // This is the cross-language invariant — any drift in wire semantics
+    // breaks Rust / Python / C++ suites simultaneously.
+    const goldens = [
+      'simple_f32.tgm',
+      'multi_object.tgm',
+      'mars_metadata.tgm',
+      'hash_xxh3.tgm',
+    ];
+
+    for (const name of goldens) {
+      it(`validates ${name} with no errors`, () => {
+        const bytes = readFileSync(goldenPath(name));
+        const report = validate(
+          new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength),
+        );
+        const errs = report.issues.filter((i) => i.severity === 'error');
+        expect(errs).toEqual([]);
+      });
+    }
+
+    it('validates multi_message.tgm via validateBuffer', () => {
+      const bytes = readFileSync(goldenPath('multi_message.tgm'));
+      const report = validateBuffer(
+        new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength),
+      );
+      expect(report.messages.length).toBeGreaterThan(1);
+      expect(report.file_issues).toEqual([]);
+      for (const m of report.messages) {
+        expect(m.issues.filter((i) => i.severity === 'error')).toEqual([]);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes the API-surface, dtype-ergonomics, and cross-language parity gaps
flagged under `plans/TODO.md` → *typescript-wrapper (Scope C.1/C.2)* and
the cross-language follow-ups identified during Pass 4/5 review.

Six formal review passes (Pass 1-6) were applied during development —
simplification, hardening, edge-case coverage, error-path testing,
performance audit, cross-language parity.  See `plans/DONE.md` for the
per-pass breakdown.

## Added

### TypeScript wrapper — Scope C.1 API parity
- `decodeRange(buf, objIndex, ranges, opts?)` — partial sub-tensor decode
- `computeHash(data, algo?)` — standalone xxh3 digest
- `simplePackingComputeParams(values, bits, dsf?)` — GRIB-style packing params
- `validate(buf)` / `validateBuffer(buf)` / `validateFile(path)` — report-only structural + fidelity validation
- `encodePreEncoded(meta, objects, opts?)` — verbatim-bytes wrapping
- `StreamingEncoder` — frame-at-a-time construction.  Buffered by default; opt-in `onBytes` callback sink for true no-buffering streaming (browser upload, WebSocket push).
- `TensogramFile#append(meta, objects, opts?)` — Node local-path append
- `TensogramFile.fromUrl` — HTTP Range auto-detection via `HEAD` probe; 32-entry LRU cache for lazy payload fetches

### TypeScript wrapper — Scope C.2 first-class dtypes
- `Float16Polyfill` — TC39-Stage-3-accurate; native `Float16Array` when available
- `Bfloat16Array` — 1-8-7 brain-float layout
- `ComplexArray` — `.real(i)`, `.imag(i)`, `.get(i)`, iteration
- `typedArrayFor` now routes `float16` / `bfloat16` / `complex64|128` through these view classes

### Python bindings
- `tensogram.compute_hash(data, algo="xxh3")` — closes Pass-4 parity gap.  Zero-copy over `bytes` / `bytearray` via `PyBackedBytes`.

### Examples
- `examples/typescript/04_decode_range.ts` — partial sub-tensor decode
- `examples/typescript/08_validate.ts` — buffer + file validation
- `examples/typescript/11_encode_pre_encoded.ts` — verbatim bytes
- `examples/typescript/12_streaming_encoder.ts` — frame-at-a-time encoder
- `examples/typescript/13_range_access.ts` — lazy HTTP Range backend
- `examples/typescript/14_streaming_callback.ts` — `onBytes` callback sink

### Documentation
- New sections in `docs/src/guide/typescript-api.md` for every Scope-C addition
- `plans/TYPESCRIPT_WRAPPER.md` parity matrix refreshed — every row now ✓
- `plans/DONE.md` entries per review pass (1-6)

## Changed

### Rust core (benefits every binding)
- **`PackingError::InfiniteValue(usize)` variant** — `simple_packing::compute_params` and `encode` now reject ±Infinity alongside NaN (previously silently produced `binary_scale_factor = i32::MAX` garbage).  Exposed through Python, WASM, FFI, and C++ simultaneously.

### TypeScript wrapper (breaking)
- **`TensogramFile#rawMessage(index)`** now returns `Promise<Uint8Array>` (was sync).  Needed for the lazy HTTP backend's Range-on-demand fetches.
- **`typedArrayFor` on `float16` / `bfloat16` / `complex*`** returns view classes instead of raw `Uint16Array` / interleaved `Float32Array`.  Consumers wanting raw bits access them via `view.bits` / `view.data`.

## Quality gates

| Gate | Result |
|---|---|
| `cargo fmt --check` (workspace + wasm + python) | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo clippy` on `tensogram-wasm` (wasm32) + `tensogram-python` | clean |
| `cargo test --workspace` | **1247 pass** |
| `cargo test -p tensogram --features remote,async` | **all pass** |
| `wasm-pack test --node rust/tensogram-wasm` | **161 pass** |
| `npx tsc --noEmit -p tsconfig.test.json` | clean |
| `npx vitest run` | **309 pass** / 22 files |
| `ruff check` + `ruff format --check` (touched files) | clean |
| `pytest python/tests/` | **455 pass, 1 skip** |
| `pytest python/tensogram-xarray/tests/` | **201 pass** |
| `pytest python/tensogram-zarr/tests/` | **224 pass** |
| `mdbook build docs/` | clean |
| 7 TS examples smoke-tested via `npx tsx` | **7 / 7 green** |

## Cross-language parity matrix

| Feature | Rust | Python | FFI | C++ | WASM | TS |
|---|:-:|:-:|:-:|:-:|:-:|:-:|
| encode / decode / scan | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| decode_range | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| encode_pre_encoded | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| compute_hash | ✓ | ✓ (new) | ✓ | ✓ | ✓ | ✓ |
| simple_packing_compute_params | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| validate / validate_file | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| StreamingEncoder (buffered) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| StreamingEncoder (callback sink) | ✓ | — | — | — | ✓ (new) | ✓ (new) |
| TensogramFile + append | ✓ | ✓ | ✓ | ✓ | — (no FS) | ✓ (Node) |
| Inf-value rejection in simple_packing | ✓ (new) | ✓ | ✓ | ✓ | ✓ | ✓ |
| First-class `float16` / `bfloat16` / `complex*` | ✓ | ✓ | — (opaque) | — (opaque) | — | ✓ (new) |

## Statistics

- **58 files changed**, +7 803 / −520 lines
- **Tests**: +126 new (Rust `simple_packing` +3, WASM bindgen +27, TS vitest +164, Python pytest +18)
- **Examples**: +5 new runnable TypeScript examples, 1 updated for async `rawMessage`
- **Docs**: 2 plan files, 3 docs-guide sections, CHANGELOG entries

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-51
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->