### PR TITLE
docs + ci: plan doc cleanup, expand macOS wheel matrix, self-hosted preflight

### DIFF
--- a/.github/workflows/publish-pypi-tensogram.yml
+++ b/.github/workflows/publish-pypi-tensogram.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t"]
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -10,28 +10,29 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  TMPDIR: ${{ github.workspace }}/.tmp
+  RUSTC_WRAPPER: sccache
+  SCCACHE_BUCKET: tensogram-ci-cache
+  SCCACHE_ENDPOINT: "https://object-store.os-api.cci1.ecmwf.int"
+  SCCACHE_REGION: us-east-1
+  SCCACHE_S3_USE_SSL: "true"
+  SCCACHE_S3_KEY_PREFIX: tensogram/
+  SCCACHE_BASEDIRS: ${{ github.workspace }}
+  SCCACHE_IGNORE_SERVER_IO_ERROR: "1"
+  AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
 
 jobs:
   preflight:
     name: Validate release readiness
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, Linux, platform-builder-docker-xl, platform-builder-Ubuntu-22.04]
+    container:
+      image: eccr.ecmwf.int/tensogram/ci:1.2.0
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq libeccodes-dev libnetcdf-dev
 
       - name: Check version consistency
         run: |
@@ -134,3 +135,11 @@ jobs:
 
       - name: Validate Python packages
         run: twine check python/bindings/target/wheels/*.whl python/tensogram-xarray/dist/* python/tensogram-zarr/dist/*
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-adv-stats
+
+      - name: Cleanup
+        if: always()
+        run: rm -rf "$TMPDIR" target

--- a/plans/BRAINSTORMING.md
+++ b/plans/BRAINSTORMING.md
@@ -400,7 +400,7 @@ every feature of the wire format, with a machine-readable manifest
 describing what each file tests and what the expected decode outputs
 are. Any implementation in any language passes or fails the suite.
 
-This is different from the golden files in `tensogram-core/tests/golden/`
+This is different from the golden files in `tensogram/tests/golden/`
 (which test the Rust implementation) — it's a language-neutral
 specification artifact. It would lower the barrier to writing a new
 implementation in Julia, R, Java, etc., and would prove that

--- a/plans/DESIGN.md
+++ b/plans/DESIGN.md
@@ -38,7 +38,7 @@ Three approaches were considered:
 
 Default Rust workspace:
 
-- `tensogram-core` — message encode/decode, CBOR metadata, framing, buffer + file API, iterators, validation (Levels 1-4), remote object-store access
+- `tensogram` — message encode/decode, CBOR metadata, framing, buffer + file API, iterators, validation (Levels 1-4), remote object-store access
 - `tensogram-encodings` — encoding pipeline, filters, compression codecs (all feature-gated, both C-FFI and pure-Rust variants)
 - `tensogram-ffi` — C-compatible FFI surface, auto-generated `tensogram.h` via cbindgen
 - `tensogram-cli` — CLI binary (`tensogram` command with subcommands)
@@ -111,7 +111,7 @@ Common options:
 
 `convert-grib` and `convert-netcdf` share a common pipeline flag set
 (`--encoding/--bits/--filter/--compression/--compression-level`) via
-`tensogram-core::pipeline::apply_pipeline`, so both converters produce
+`tensogram::pipeline::apply_pipeline`, so both converters produce
 byte-identical descriptors for the same options.
 
 ## Key Design Decisions

--- a/plans/TEST.md
+++ b/plans/TEST.md
@@ -12,7 +12,7 @@ Repo: ecmwf/tensogram
 
 | Component | Where tests live | Shape |
 |-----------|------------------|-------|
-| `tensogram-core` | `src/*.rs` unit + `tests/{integration,adversarial,edge_cases,golden_files,integration_pre_encoded,cross_language_pre_encoded,remote_http}.rs` | Unit + integration + adversarial + edge case + golden-file + remote HTTP |
+| `tensogram` | `src/*.rs` unit + `tests/{integration,adversarial,edge_cases,golden_files,integration_pre_encoded,cross_language_pre_encoded,remote_http}.rs` | Unit + integration + adversarial + edge case + golden-file + remote HTTP |
 | `tensogram-encodings` | `src/*.rs` unit | Unit — packing, shuffle, pipeline dispatch |
 | `tensogram-szip` | `src/*.rs` unit + `tests/{libaec_parity,proptest_roundtrip,stress,error_paths,ffi_crosscheck}.rs` | Unit + property-based + stress + FFI cross-validation against libaec |
 | `tensogram-sz3` | `src/*.rs` unit | Unit for the SZ3 Rust API over the clean-room shim |
@@ -34,7 +34,7 @@ languages — these numbers are the source of truth.
 
 ## Affected components
 
-- **`tensogram-core`**: encode, decode, `decode_metadata`,
+- **`tensogram`**: encode, decode, `decode_metadata`,
   `decode_descriptors`, `decode_object`, `decode_range`, scan,
   streaming, file, iterators, validation (Levels 1-4), remote access.
 - **`tensogram-encodings`**: `simple_packing`, shuffle filter,
@@ -139,7 +139,7 @@ languages — these numbers are the source of truth.
 
 ## Golden test files
 
-Canonical `.tgm` files in `rust/tensogram-core/tests/golden/`:
+Canonical `.tgm` files in `rust/tensogram/tests/golden/`:
 
 - `simple_f32.tgm` — single float32 object.
 - `multi_object.tgm` — 3 dtypes: u8, i32, f64.

--- a/plans/TODO.md
+++ b/plans/TODO.md
@@ -214,7 +214,7 @@ For speculative ideas, see `IDEAS.md`.
 ## Validation
 
 - [x] **tensogram-validate PR 1** — core library API + CLI (Levels 1-3):
-  - `validate_message(buf, options) -> ValidationReport` and `validate_file(path, options)` in tensogram-core.
+  - `validate_message(buf, options) -> ValidationReport` and `validate_file(path, options)` in tensogram.
   - Level 1 (Structure): raw byte walking — magic, preamble, frame headers/ENDF, total_length, postamble, first_footer_offset, frame ordering, preceder legality, preamble flags vs observed, overflow-safe arithmetic.
   - Level 2 (Metadata): raw CBOR parsing from frame payloads (before decode_message normalization), required keys, dtype/encoding/filter/compression recognized, shape/strides/ndim consistency, index/hash frame consistency.
   - Level 3 (Integrity): xxh3 hash verification (descriptor + hash frame fallback), decode pipeline execution for compressed objects. Unknown hash algorithms produce warnings. `hash_verified` only true when ALL objects verified.

--- a/plans/TYPESCRIPT_WRAPPER.md
+++ b/plans/TYPESCRIPT_WRAPPER.md
@@ -38,7 +38,7 @@ Included:
 - `TensogramFile.fromUrl(url)` (browser / fetch with Range requests).
 - `getMetaKey(meta, "mars.param")` — first-match across `base[*]` then
   `_extra_`, same semantics as Rust / Python / CLI.
-- `computeCommon(meta)` — TS mirror of `tensogram_core::compute_common`.
+- `computeCommon(meta)` — TS mirror of `tensogram::compute_common`.
 - Error class hierarchy mirroring the seven `TensogramError` variants.
 - Examples in `examples/typescript/`.
 
@@ -75,7 +75,7 @@ Not included (explicitly):
                   └────────────────┬─────────────────┘
                                    │
                   ┌────────────────▼─────────────────┐
-                  │  tensogram-core (Rust) via WASM  │
+                  │  tensogram (Rust) via WASM  │
                   └──────────────────────────────────┘
 ```
 
@@ -162,7 +162,7 @@ typescript/                             ← new top-level dir
 │   ├── errors.test.ts
 │   ├── streaming.test.ts               ← phase 3
 │   ├── file.node.test.ts               ← phase 4
-│   └── golden.test.ts                  ← rust/tensogram-core/tests/golden/* parity
+│   └── golden.test.ts                  ← rust/tensogram/tests/golden/* parity
 ├── wasm/                               ← wasm-pack output, gitignored
 └── dist/                               ← tsc output, gitignored
 
@@ -338,7 +338,7 @@ chasing upstream tooling regressions.
 | Type correctness | `tsc --strict --noEmit` | No `any` leakage, all discriminated unions exhaustive |
 | Bundle size | `size-limit` (follow-up) | Track WASM + JS glue growth over time |
 
-The golden files in `rust/tensogram-core/tests/golden/` (e.g.
+The golden files in `rust/tensogram/tests/golden/` (e.g.
 `simple_f32.tgm`, `multi_object.tgm`, `mars_metadata.tgm`,
 `multi_message.tgm`, `hash_xxh3.tgm`) are byte-for-byte deterministic
 and already used by the Rust, Python, and C++ suites for cross-language
@@ -352,7 +352,7 @@ on the cross-language parity matrix.
   the published surface.
 - **vitest** must pass on Node 20 and 22.
 - **Golden-file parity** tests must pass byte-for-byte against
-  `rust/tensogram-core/tests/golden/*.tgm`.
+  `rust/tensogram/tests/golden/*.tgm`.
 - **Property-based round-trip** must survive 1,000 generated shape /
   dtype combinations per dtype.
 - **CI** runs all of the above on every PR that touches

--- a/plans/TYPESCRIPT_WRAPPER.md
+++ b/plans/TYPESCRIPT_WRAPPER.md
@@ -75,7 +75,7 @@ Not included (explicitly):
                   └────────────────┬─────────────────┘
                                    │
                   ┌────────────────▼─────────────────┐
-                  │  tensogram (Rust) via WASM  │
+                  │    tensogram (Rust) via WASM     │
                   └──────────────────────────────────┘
 ```
 


### PR DESCRIPTION
## Summary

Update stale `tensogram-core` references in planning docs that describe the current state or future work.

## Changes

12 replacements across 5 files:

- **`plans/DESIGN.md`** — crate bullet in system overview, `pipeline::apply_pipeline` module path
- **`plans/TEST.md`** — crate row in test suite table, coverage bullet, golden files directory path
- **`plans/TODO.md`** — `validate_message`/`validate_file` location reference
- **`plans/TYPESCRIPT_WRAPPER.md`** — Rust function binding, architecture diagram label, golden test path references
- **`plans/BRAINSTORMING.md`** — golden files path reference

All are factual corrections: paths to directories that no longer exist (`rust/tensogram-core/tests/golden/` → `rust/tensogram/tests/golden/`) or module paths that changed with the rename (`tensogram_core::` → `tensogram::`).

## What this PR does NOT change

Historical docs keep the old name as an accurate record:
- `plans/RELEASE.md` — the original release plan we executed
- `plans/DONE.md` — completion log of past work
- `CHANGELOG.md` — 0.15.0 entry explaining the rename

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-54
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->