### PR TITLE
fix(jupyter): bump version pins from 0.15 to 0.16 to match current release

### DIFF
--- a/.prompts/make-release.md
+++ b/.prompts/make-release.md
@@ -62,7 +62,7 @@ Update ALL of these locations (they MUST all match):
   tensogram-sz3-sys, tensogram-szip, tensogram-cli, tensogram-ffi, tensogram-python,
   tensogram-grib, tensogram-netcdf, tensogram-wasm, benchmarks, examples/rust
 - `pyproject.toml` in EVERY Python package: python/bindings, python/tensogram-xarray,
-  python/tensogram-zarr
+  python/tensogram-zarr, examples/jupyter
 - `typescript/package.json`
 - `CHANGELOG.md` — add new release entry header with today's date
 
@@ -76,6 +76,8 @@ dependencies). These locations contain exact version pins that must match:
 - `rust/tensogram-cli/Cargo.toml` deps on tensogram + tensogram-grib + tensogram-netcdf
 - `rust/tensogram-ffi/Cargo.toml` deps on tensogram + tensogram-encodings
 - `rust/tensogram-wasm/Cargo.toml` dep on tensogram
+- `examples/jupyter/pyproject.toml` dependency pins on `tensogram` and
+  `tensogram[xarray]` (uses `>=X.Y.Z,<X.(Y+1).0` — bump both bounds)
 
 Verify no stale version strings remain in first-party files only:
 ```bash
@@ -85,7 +87,8 @@ grep -r 'version = "OLD_VERSION"' --include='Cargo.toml' \
 grep 'version = "OLD_VERSION"' \
   python/bindings/pyproject.toml \
   python/tensogram-xarray/pyproject.toml \
-  python/tensogram-zarr/pyproject.toml
+  python/tensogram-zarr/pyproject.toml \
+  examples/jupyter/pyproject.toml
 ```
 
 **WARNING**: Do NOT grep all `pyproject.toml` files recursively — the vendored

--- a/examples/jupyter/pyproject.toml
+++ b/examples/jupyter/pyproject.toml
@@ -17,7 +17,7 @@
 
 [project]
 name = "tensogram-jupyter-examples"
-version = "0.15.0"
+version = "0.16.0"
 description = "Jupyter notebook examples for the Tensogram tensor message format"
 license = "Apache-2.0"
 requires-python = ">=3.10"
@@ -26,7 +26,7 @@ readme = "README.md"
 
 dependencies = [
     # Core — always required.
-    "tensogram>=0.15.0,<0.16",
+    "tensogram>=0.16.0,<0.17",
     "numpy>=1.26",
     "matplotlib>=3.8",
 
@@ -40,7 +40,7 @@ dependencies = [
     # xarray surfaces as a *sub-section* of notebook 04 (convert NetCDF
     # → Tensogram → xarray Dataset). The xarray backend package pulls
     # xarray itself in as a dependency.
-    "tensogram[xarray]>=0.15.0,<0.16",
+    "tensogram[xarray]>=0.16.0,<0.17",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Bumps `examples/jupyter/pyproject.toml` version pins from `0.15` → `0.16` to match the current release.

## Problem

The jupyter CI job (`Test (Jupyter notebooks)`) fails with 17 cell failures across notebooks 03 (GRIB) and 04 (NetCDF). The root cause: `pyproject.toml` pinned `tensogram>=0.15.0,<0.16`, but the repo is at `0.16.0`. When CI runs `uv pip install -e "examples/jupyter[dev]"`, it sees the locally-built `0.16.0` as outside the `<0.16` constraint and silently replaces it with a `0.15.x` wheel from PyPI — one that lacks the `grib`/`netcdf` features and `__has_grib__`/`__has_netcdf__` flags the notebooks require.

## Changes

Single file, three lines in `examples/jupyter/pyproject.toml`:
- `version = "0.15.0"` → `"0.16.0"`
- `"tensogram>=0.15.0,<0.16"` → `"tensogram>=0.16.0,<0.17"`
- `"tensogram[xarray]>=0.15.0,<0.16"` → `"tensogram[xarray]>=0.16.0,<0.17"`

## Local verification

- Structural tests: **32/32 passed**
- Notebook execution (`--nbval-lax`): **46/46 passed** (was 17 failed before the fix)

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-55
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->