### PR TITLE
feat: Python converter parity + hard-fail simple_packing + safety net + docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,29 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   mismatch, not a data-quality problem) keeps its stderr-warning +
   fallback behaviour unchanged.
 
+### Added — simple_packing standalone-API safety net
+
+- **`simple_packing::encode_with_threads` now validates its
+  `SimplePackingParams` input** with an always-on safety net.  Catches
+  hand-crafted or mutated params that would otherwise produce
+  silently-wrong output:
+  - Non-finite `reference_value` (NaN / ±Inf) → new
+    `PackingError::InvalidParams { field: "reference_value", .. }`.
+  - `|binary_scale_factor| > 256` → new
+    `PackingError::InvalidParams { field: "binary_scale_factor", .. }`.
+    The threshold catches the `i32::MAX` fingerprint that results from
+    feeding Inf through `compute_params`.  Real-world weather data
+    (`|bsf| ≤ 60`) comfortably fits.  Exposed as the public constant
+    `MAX_REASONABLE_BINARY_SCALE = 256`.
+  - `bits_per_value = 0` remains valid (legitimate constant-field
+    encoding); `> 64` continues to be caught by the pre-existing
+    `BitsPerValueTooLarge`.
+  The validation fires on every encode path — direct Rust calls via
+  `simple_packing::encode()`, via the high-level `tensogram::encode()`,
+  via PyO3, WASM, C FFI, and C++ wrapper.  Cross-language parity tests
+  pin the behaviour. See `plans/RESEARCH_NAN_HANDLING.md` §4.2.3 for
+  the rationale and the failure-mode catalogue.
+
 ## [0.16.1] - 2026-04-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   `EncodeOptions`.  CLI parity (`tensogram convert-grib --reject-nan`)
   already existed; this closes the corresponding Python gap.
 
+### Changed — BREAKING (converter behaviour)
+
+- **`tensogram convert-grib` / `convert-netcdf` now hard-fail when
+  `--encoding simple_packing` is requested on data containing NaN or
+  Inf.** The previous behaviour (stderr warning + silent downgrade to
+  `encoding="none"`) hid real data-quality problems; the new behaviour
+  fails cleanly with an error that names the offending variable and
+  the sample index. Recovery options: (a) pick a non-simple_packing
+  encoding up front, (b) pre-process NaN/Inf out of the data, or (c)
+  use `tensogram.encode(..., reject_nan=True)` which surfaces the same
+  failure at encode time.  The non-f64-payload branch (structural
+  mismatch, not a data-quality problem) keeps its stderr-warning +
+  fallback behaviour unchanged.
+
 ## [0.16.1] - 2026-04-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`simple_packing::encode` safety net handles `i32::MIN` correctly.**
+  Before: `params.binary_scale_factor.abs()` panics on debug builds
+  (integer-overflow) and silently returns `i32::MIN` (still negative)
+  on release, so the comparison `> 256` falsely accepts the
+  worst-case value, and the subsequent encode silently corrupts.
+  After: uses `saturating_abs()` which clamps `i32::MIN` to
+  `i32::MAX`, correctly rejecting it via
+  `PackingError::InvalidParams`.  Regression test added.
+
 ### Added
 
 - **Strict-finite kwargs on Python converter functions.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added
+
+- **Strict-finite kwargs on Python converter functions.**
+  `tensogram.convert_grib`, `tensogram.convert_grib_buffer`, and
+  `tensogram.convert_netcdf` now accept `reject_nan: bool = False`
+  and `reject_inf: bool = False` kwargs that forward to the shared
+  `EncodeOptions`.  CLI parity (`tensogram convert-grib --reject-nan`)
+  already existed; this closes the corresponding Python gap.
+
 ## [0.16.1] - 2026-04-19
 
 ### Fixed

--- a/cpp/tests/test_strict_finite.cpp
+++ b/cpp/tests/test_strict_finite.cpp
@@ -344,3 +344,80 @@ TEST(StrictFinite, RejectInfBlocksSimplePackingSilentCorruption) {
         tensogram::encoding_error
     );
 }
+
+// ── Standalone-API safety net — plans/RESEARCH_NAN_HANDLING.md §4.2.3 ────
+
+namespace {
+
+// Build a simple_packing descriptor JSON with hand-crafted params.
+std::string simple_packing_json(
+    double reference_value,
+    long long binary_scale_factor,
+    long long bits_per_value = 16
+) {
+    return std::string{R"({
+        "version": 2,
+        "descriptors": [{
+            "type": "ntensor",
+            "ndim": 1,
+            "shape": [4],
+            "strides": [1],
+            "dtype": "float64",
+            "byte_order": "little",
+            "encoding": "simple_packing",
+            "filter": "none",
+            "compression": "none",
+            "reference_value": )"} + std::to_string(reference_value) +
+        R"(, "binary_scale_factor": )" + std::to_string(binary_scale_factor) +
+        R"(, "decimal_scale_factor": 0, "bits_per_value": )" +
+        std::to_string(bits_per_value) +
+        R"(}]})";
+}
+
+}  // namespace
+
+TEST(StrictFinite, SafetyNetRejectsHugeBinaryScaleFactor) {
+    // i32::MAX is the fingerprint of feeding Inf through compute_params's
+    // range arithmetic; the safety net in encode_with_threads catches it.
+    std::vector<double> values = {273.15, 283.0, 293.0, 303.0};
+    const std::string json = simple_packing_json(273.15, 2147483647LL);
+    try {
+        tensogram::encode(json, bytes_pair(values));
+        FAIL() << "expected encoding_error";
+    } catch (const tensogram::encoding_error& e) {
+        std::string msg{e.what()};
+        EXPECT_NE(msg.find("binary_scale_factor"), std::string::npos);
+        EXPECT_NE(msg.find("256"), std::string::npos);
+    }
+}
+
+TEST(StrictFinite, SafetyNetThresholdIs256) {
+    // Threshold is inclusive: 256 accepted, 257 rejected.
+    std::vector<double> values = {1.0, 2.0, 3.0, 4.0};
+
+    EXPECT_NO_THROW(
+        tensogram::encode(simple_packing_json(0.0, 256), bytes_pair(values))
+    );
+    EXPECT_THROW(
+        tensogram::encode(simple_packing_json(0.0, 257), bytes_pair(values)),
+        tensogram::encoding_error
+    );
+}
+
+TEST(StrictFinite, SafetyNetAcceptsRealisticBinaryScaleFactors) {
+    // Regression guard: real-world weather-data values must pass.
+    std::vector<double> values = {273.15, 283.0, 293.0, 303.0};
+    for (long long bsf : {-60LL, -20LL, 0LL, 20LL, 60LL}) {
+        EXPECT_NO_THROW(
+            tensogram::encode(simple_packing_json(273.15, bsf), bytes_pair(values))
+        ) << "realistic bsf " << bsf << " should pass";
+    }
+}
+
+TEST(StrictFinite, SafetyNetAcceptsConstantFieldEncoding) {
+    // bits_per_value=0 is a legitimate constant-field encoding.
+    // The safety net must not reject it.
+    std::vector<double> values = {42.0, 42.0, 42.0, 42.0};
+    const std::string json = simple_packing_json(42.0, 0, /*bits_per_value=*/0);
+    EXPECT_NO_THROW(tensogram::encode(json, bytes_pair(values)));
+}

--- a/docs/src/encodings/simple-packing.md
+++ b/docs/src/encodings/simple-packing.md
@@ -39,20 +39,53 @@ flowchart TD
 
 ## Limitations and Edge Cases
 
-### NaN is Rejected
+### NaN and ±Infinity are Rejected
 
-`compute_params()` and `encode()` return an error if the data contains any NaN values. Simple packing has no representation for NaN (unlike IEEE 754 floats). Remove or replace NaN values before encoding.
+`compute_params()` and `encode()` return an error if the data
+contains any NaN or ±Infinity values. Simple packing has no
+representation for non-finite numbers (unlike IEEE 754 floats), and
+feeding `Inf` through the range / scale-factor derivation would
+produce an `i32::MAX`-saturated `binary_scale_factor` that silently
+decodes to `NaN` everywhere. Both are errors at the codec entry:
 
-For **domain-strict workflows** that also need to reject `+Inf` / `-Inf` (which simple_packing accepts but silently corrupts — see [§3.1 of the NaN research memo][memo]), use the pipeline-independent [strict-finite encode flags](../guide/strict-finite.md): `reject_nan` and `reject_inf`. They run upstream of the encoding pipeline and give the same contract regardless of `encoding` / `filter` / `compression`.
+- NaN → `PackingError::NanValue(index)`
+- +Inf / -Inf → `PackingError::InfiniteValue(index)`
+
+Remove or replace non-finite values before encoding. For
+**domain-strict workflows** that also want the same guarantee over
+the other encodings (`encoding="none"` + any compressor), use the
+pipeline-independent [strict-finite encode flags](../guide/strict-finite.md)
+(`reject_nan` / `reject_inf`) which run upstream of the codec.
 
 [memo]: https://github.com/ecmwf/tensogram/blob/main/plans/RESEARCH_NAN_HANDLING.md
 
 ```rust
-// This will fail:
-let values = vec![1.0f64, 2.0, f64::NAN, 4.0];
-let params = compute_params(&values, 16, 0);
-assert!(params.is_err());
+// Both rejected:
+let with_nan = vec![1.0_f64, 2.0, f64::NAN, 4.0];
+let with_inf = vec![1.0_f64, 2.0, f64::INFINITY, 4.0];
+assert!(compute_params(&with_nan, 16, 0).is_err());
+assert!(compute_params(&with_inf, 16, 0).is_err());
 ```
+
+### Params Safety Net
+
+Beyond input-value validation, `encode()` also checks the
+`SimplePackingParams` it receives:
+
+- `reference_value` must be finite (`NaN` / `±Inf` → error).
+- `|binary_scale_factor| ≤ 256`. The threshold catches the
+  `i32::MAX`-saturation fingerprint from feeding `Inf` through
+  `compute_params` indirectly; real-world data (`|bsf| ≤ 60`) fits
+  comfortably. The constant `MAX_REASONABLE_BINARY_SCALE = 256` is
+  exported from `tensogram_encodings::simple_packing`.
+
+This closes the standalone-API footgun where a caller constructs or
+mutates `SimplePackingParams` directly rather than deriving them
+from `compute_params`. Both failures surface as
+`PackingError::InvalidParams { field, reason }` with a clear message
+naming the offending field. See the
+[Strict-Finite Encode Checks guide](../guide/strict-finite.md#simple_packing-params-safety-net-always-on)
+for cross-language examples.
 
 ### Constant Fields
 

--- a/docs/src/guide/convert-netcdf.md
+++ b/docs/src/guide/convert-netcdf.md
@@ -186,9 +186,39 @@ wire format. They use the same names and semantics as `convert-grib`:
 | Compression | `--compression blosc2 --compression-level 9` | Uses `blosc2_codec=lz4` by default. |
 | Compression | `--compression szip` | Sets `szip_rsi=128`, `szip_block_size=16`, `szip_flags=8`. **Requires** preceding `simple_packing` or `shuffle` because libaec szip caps at 32 bits per sample (raw `f64` is 64 bits). |
 
-Variables that contain `NaN` (typically from unpacked fill values) cannot be
-`simple_packed` because the algorithm rejects NaN inputs. Such variables are
-skipped (with a warning) and pass through with `encoding=none`.
+Variables that contain `NaN` or `±Inf` (typically from unpacked
+`_FillValue` / `missing_value` substitution or degenerate arithmetic
+upstream) cannot be represented by `simple_packing` — the algorithm's
+range / scale-factor derivation has no slot for non-finite values.
+
+**The importer hard-fails when `--encoding simple_packing` is
+requested on data containing NaN or Inf.** The error names the
+offending variable and suggests recovery options:
+
+```
+error: simple_packing failed for forecast_temperature: NaN value
+encountered at index 42. The variable contains NaN or Inf which
+cannot be represented by simple_packing. Pre-process the data or
+choose a different encoding (e.g. encoding="none").
+```
+
+Recovery options, in order of effort:
+
+1. **Drop the `--encoding simple_packing` flag.** The default
+   (`encoding="none"`) accepts NaN bits transparently and produces a
+   valid Tensogram file.
+2. **Substitute non-finite values** with an in-band sentinel before
+   conversion if you need simple_packing throughout.
+3. **Split the conversion** with `--split-by variable` and re-run
+   per-variable, using `--encoding simple_packing` only for the
+   variables you know are NaN-free.
+
+> **Prior behaviour (pre-0.17).** The importer used to soft-downgrade
+> NaN-bearing variables to `encoding="none"` with a stderr warning.
+> That silently hid data-quality problems from automated pipelines;
+> the hard-fail surfaces them. The non-f64-payload branch (a
+> structural mismatch rather than a data-quality problem) keeps its
+> stderr-warning + fallback behaviour unchanged.
 
 ```bash
 # Pack temperature to 24-bit + zstd

--- a/docs/src/guide/error-handling.md
+++ b/docs/src/guide/error-handling.md
@@ -192,16 +192,22 @@ Soft warnings (stderr, exit 0):
 warning: {file}: sub-groups found; only root-group variables are converted
 warning: skipping variable '{name}': Char variables are not supported
 warning: skipping variable '{name}': complex type Compound(_) is not supported
-warning: skipping simple_packing for variable '{name}' (Float32 is not float64)
-warning: skipping simple_packing for variable '{name}': NaN value encountered at index N
+warning: skipping simple_packing for variable '{name}' (not a float64 payload)
 warning: variable '{name}': failed to read attribute '{attr}': {cause}
 warning: failed to read global attribute '{name}': {cause}
 ```
 
-The last two are rare — they only fire on corrupt attribute values
-or unsupported upstream AttributeValue variants — but they surface
-instead of dropping data silently so operators can trace unexpected
-missing metadata.
+Note: NaN/Inf in a variable that targets `simple_packing` now
+**hard-fails** the conversion (see
+[NetCDF Importer — simple_packing on Mixed-dtype Files](#netcdf-importer--simple_packing-on-mixed-dtype-files)
+below).  The previous "warning: skipping simple_packing ... NaN value
+encountered" line no longer fires; that case is an error rather than
+a warning.
+
+The last two lines above are rare — they only fire on corrupt
+attribute values or unsupported upstream AttributeValue variants —
+but they surface instead of dropping data silently so operators can
+trace unexpected missing metadata.
 
 ```
 tensogram-grib errors (rust/tensogram-grib/src/error.rs)
@@ -403,11 +409,19 @@ Accessing `decode_object(buf, index=N)` where N ≥ number of objects
 produces an **Object error** (Rust/C/C++) or **ValueError** (Python).
 File indexing `file[N]` raises **IndexError** for out-of-range N.
 
-### NaN in Simple Packing
+### NaN / Inf in Simple Packing
 
-`compute_packing_params()` rejects NaN values with a **ValueError** that
-includes the index of the first NaN. Inf values are accepted but produce
-extreme scale factors — filter them before packing.
+`compute_packing_params()` rejects both **NaN** and **±Inf** values
+with a **ValueError** that includes the index of the first offending
+sample. `simple_packing`'s scale-factor derivation has no meaningful
+value for non-finite input — rejecting them up front prevents the
+silent corruption path where an `i32::MAX`-saturated
+`binary_scale_factor` decodes to NaN everywhere.
+
+For the pipeline-independent strict-finite check that applies the same
+contract to `encoding="none"` and to every compressor, see the
+[strict-finite encode flags](strict-finite.md) (`reject_nan=True` /
+`reject_inf=True`).
 
 ### File Not Found / Permission Denied
 
@@ -428,10 +442,18 @@ multi-input batch triggered it.
 typical CF temperature file has `f32` lat/lon coordinates alongside
 `f64` data) are handled gracefully: non-f64 variables emit a stderr
 warning and pass through with `encoding="none"`, and the conversion
-overall succeeds. The same fallback fires when a specific f64
-variable contains NaN values (common with unpacked fill values) —
-`simple_packing::compute_params` rejects NaN, so that variable
-falls back to `encoding="none"` with a warning.
+overall succeeds.
+
+**NaN or Inf in a targeted f64 variable is now a hard error** (0.17+).
+The importer fails with
+`NetcdfError::InvalidData("simple_packing failed for {var}: ...")`
+and a recovery hint, rather than silently downgrading the variable
+to `encoding="none"`. Pre-0.17 soft-downgrade hid data-quality
+problems; the new behaviour surfaces them at conversion time.
+Callers relying on the old fallback should either pick a
+non-simple_packing encoding up front, pre-process NaN / Inf out of
+the data, or use `--split-by variable` and choose per-variable
+encodings.
 
 ### NetCDF Importer — Unknown Codec Name
 

--- a/docs/src/guide/python-api.md
+++ b/docs/src/guide/python-api.md
@@ -521,6 +521,8 @@ msgs = tensogram.convert_grib(
     compression_level=None,    # applies to zstd / blosc2 (None = codec default)
     threads=0,                 # 0 = sequential; honours TENSOGRAM_THREADS env var
     hash="xxh3",               # "xxh3" | None
+    reject_nan=False,          # pipeline-independent NaN guard (see strict-finite.md)
+    reject_inf=False,          # pipeline-independent Inf guard (see strict-finite.md)
 )
 with open("forecast.tgm", "wb") as fh:
     for msg in msgs:
@@ -564,6 +566,8 @@ resp = requests.get(
 msgs = tensogram.convert_grib_buffer(
     resp.content,
     encoding="simple_packing", bits=16, compression="szip",
+    # Pipeline-independent strict-finite guards (see strict-finite.md).
+    reject_nan=True, reject_inf=True,
 )
 ```
 
@@ -590,8 +594,19 @@ msgs = tensogram.convert_netcdf(
     compression_level=3,
     threads=0,
     hash="xxh3",
+    reject_nan=False,          # hard-fail if any float payload has NaN
+    reject_inf=False,          # same, for ±Inf
 )
 ```
+
+> **Note on NaN and `--encoding simple_packing`.** Since 0.17 the
+> importer hard-fails on NaN or Inf in a variable targeted for
+> `simple_packing` (previous behaviour: stderr warning + fallback
+> to `encoding="none"`). If your NetCDF has `_FillValue` /
+> `missing_value` fields unpacked to NaN, either stick with the
+> default `encoding="none"` or pre-process the values. See the
+> [NetCDF Importer error-handling reference](error-handling.md#netcdf-importer--simple_packing-on-mixed-dtype-files)
+> for the full contract.
 
 Requires `libnetcdf` + `libhdf5` at the OS level and the wheel built
 with `--features netcdf`.

--- a/docs/src/guide/strict-finite.md
+++ b/docs/src/guide/strict-finite.md
@@ -93,9 +93,26 @@ except ValueError as e:
     # rejected: EncodingError: strict-NaN check: NaN at element 1 of float32 array
 ```
 
-Both `tensogram.encode()`, `TensogramFile.append()`, and
-`StreamingEncoder(...)` accept `reject_nan=False` and
-`reject_inf=False` kwargs.
+The following Python entry points all accept
+`reject_nan=False` and `reject_inf=False` kwargs:
+
+- `tensogram.encode(...)`
+- `tensogram.TensogramFile.append(...)`
+- `tensogram.StreamingEncoder(...)`
+- `tensogram.convert_grib(...)` / `convert_grib_buffer(...)`
+- `tensogram.convert_netcdf(...)`
+
+Turning them on at the converter level gives you the same strict
+contract as the CLI:
+
+```python
+msgs = tensogram.convert_netcdf(
+    "sparse.nc",
+    encoding="simple_packing",
+    reject_nan=True,   # hard-fail on _FillValue → NaN substitution
+    reject_inf=True,   # hard-fail on any Inf in the payload
+)
+```
 
 ### TypeScript
 

--- a/docs/src/guide/strict-finite.md
+++ b/docs/src/guide/strict-finite.md
@@ -203,6 +203,56 @@ pass `threads = 0` (sequential).
   `ValidateOptions::Fidelity` level. The strict flags are an encode
   gate, not a decode gate — both complement each other.
 
+## `simple_packing` params safety net (always on)
+
+Independent of the strict-finite flags above, `simple_packing::encode`
+and `simple_packing::encode_with_threads` now validate their
+[`SimplePackingParams`] input against the values
+that would produce silently-wrong output:
+
+- `reference_value` must be finite (`NaN` / `±Inf` rejected).
+- `|binary_scale_factor|` must be ≤ `256` (the constant
+  [`MAX_REASONABLE_BINARY_SCALE`] is exposed as a public constant).
+  This threshold catches the `i32::MAX`-saturation fingerprint that
+  results from feeding `Inf` through `compute_params`'s range
+  arithmetic, while leaving ample headroom for real-world scientific
+  data (typical range: `[-60, 30]`).
+
+Validation runs unconditionally at the top of `encode_with_threads`;
+the high-level `tensogram::encode()` path hits the same check through
+delegation.  Errors surface as `PackingError::InvalidParams { field,
+reason }` at the Rust core and propagate unchanged through every
+language binding:
+
+```rust
+// Rust
+match encode(&values, &params) {
+    Err(PackingError::InvalidParams { field, reason }) => {
+        eprintln!("bad {field}: {reason}");
+    }
+    Ok(bytes) => /* ... */,
+    Err(other) => /* ... */,
+}
+```
+
+```python
+# Python
+import tensogram
+desc = {..., "binary_scale_factor": 2**31 - 1, ...}
+try:
+    tensogram.encode(meta, [(desc, data)])
+except ValueError as e:
+    # "binary_scale_factor: value 2147483647 is outside the reasonable range ±256; ..."
+    print(e)
+```
+
+**Legitimate edge cases that the safety net does NOT reject:**
+
+- `bits_per_value = 0` — a valid constant-field encoding; the
+  decoder reconstructs every value from `reference_value` alone and
+  the packed-int output is empty.  Saves bytes when a whole tensor
+  collapses to one value.
+
 ## Design notes
 
 `plans/RESEARCH_NAN_HANDLING.md` §3.1 enumerates the user-visible

--- a/plans/RESEARCH_NAN_HANDLING.md
+++ b/plans/RESEARCH_NAN_HANDLING.md
@@ -596,13 +596,24 @@ how `verify_hash` is opt-in, and it gives users an explicit contract.
 
 Cost: ~100 LOC + tests + docs per codec.
 
-**4.2.2 Propagate "simple_packing downgrade" into metadata.**
+**4.2.2 Converter downgrade behaviour — IMPLEMENTED as hard-fail.**
+
+> **Status**: ✅ LANDED (0.17, commit `2410c162`).  The implementation
+> departed from the original "provenance-note" proposal below.  In
+> discussion with the maintainer, the soft-downgrade was deemed to
+> hide data-quality problems rather than surface them, so the
+> converter now **hard-fails** when `--encoding simple_packing` is
+> requested on data containing NaN or Inf.  See the
+> [convert-netcdf guide](../docs/src/guide/convert-netcdf.md#encoding-pipeline-flags)
+> for the user-facing contract.
+
+*Original proposal (kept for historical context — SUPERSEDED by the
+hard-fail above):*
 
 Addresses §3.8. When the converters (GRIB / NetCDF, via
 `apply_pipeline`) soft-downgrade a variable from `simple_packing` to
 `none` because of NaN, emit a provenance note in `base[i]["_extra_"]`
 or under a reserved key (pending §5 Q5 on `_reserved_` extensions).
-
 Concretely:
 
 ```json
@@ -617,26 +628,34 @@ Concretely:
 }
 ```
 
-Cost: ~30 LOC + schema doc + converter tests.
+**4.2.3 Standalone-API safety net — IMPLEMENTED.**
 
-**4.2.3 Standalone-API safety net.**
+> **Status**: ✅ LANDED (0.17, commit `281a99cc`).  See the
+> [strict-finite guide](../docs/src/guide/strict-finite.md#simple_packing-params-safety-net-always-on)
+> for the user-facing contract.
 
-Addresses §3.5. Have `simple_packing::compute_params` additionally
-validate that its output is itself finite and sane. Something like:
+Addresses §3.5. `simple_packing::encode_with_threads` now validates
+its [`SimplePackingParams`] input unconditionally at the top of every
+encode call:
 
-```rust
-let params = SimplePackingParams { reference_value, binary_scale_factor, ... };
-if !reference_value.is_finite() || binary_scale_factor.abs() > some_threshold {
-    return Err(PackingError::UnreasonableParams { ... });
-}
-Ok(params)
-```
+- `reference_value.is_finite()` else
+  `PackingError::InvalidParams { field: "reference_value", .. }`.
+- `|binary_scale_factor| <= MAX_REASONABLE_BINARY_SCALE` (public const,
+  value `256`) else
+  `PackingError::InvalidParams { field: "binary_scale_factor", .. }`.
+- `bits_per_value` extremes unchanged: `> 64` caught by the
+  pre-existing `BitsPerValueTooLarge`; `= 0` intentionally accepted
+  (legitimate constant-field encoding).
 
-Paired with §4.1.1 (reject Inf in data) this closes the standalone
-footgun entirely. The threshold choice is the design question — see
-§5 Q2.
+Cross-language parity: Rust unit + integration tests, Python, TS,
+C++.  Fires on every encode path including the high-level
+`tensogram::encode()` via delegation.
 
-Cost: ~20 LOC + tests.
+*Original proposal (for posterity):* Have `simple_packing::compute_params`
+additionally validate that its output is itself finite and sane. The
+final implementation lives on `encode_with_threads` instead (per
+maintainer's Q6 answer) so hand-crafted or mutated params are caught
+regardless of whether `compute_params` was ever called.
 
 ### 4.3 Tier 3 — wire-format / API changes (candidates for IDEAS)
 

--- a/python/bindings/src/lib.rs
+++ b/python/bindings/src/lib.rs
@@ -2342,7 +2342,8 @@ fn py_convert_grib(
 ///
 /// In-memory equivalent of [`convert_grib`].  Accepts any Python
 /// bytes-like object (`bytes`, `bytearray`, memoryview, `numpy.uint8[:]`)
-/// and releases the GIL during the conversion itself.
+/// and releases the GIL during the conversion itself.  Accepts the
+/// same `reject_nan` / `reject_inf` kwargs as [`convert_grib`].
 ///
 /// # Python exceptions raised
 /// - [`ValueError`] — `buffer` is not a bytes-like object; the buffer
@@ -2472,6 +2473,11 @@ fn py_convert_grib_buffer(
 ///   be overridden by `TENSOGRAM_THREADS=N`; use `1` to force
 ///   single-threaded execution.
 /// - `hash`: `"xxh3"` (default) or `None` to skip hashing.
+/// - `reject_nan` / `reject_inf`: pipeline-independent strict-finite
+///   guards; see [`convert_grib`].  Particularly useful with
+///   `encoding="simple_packing"`, where NaN / Inf input is rejected
+///   at the codec level — turning `reject_nan` on surfaces the
+///   failure earlier and with the element index included.
 #[pyfunction]
 #[pyo3(name = "convert_netcdf", signature = (
     path,

--- a/python/bindings/src/lib.rs
+++ b/python/bindings/src/lib.rs
@@ -2094,6 +2094,8 @@ fn build_grib_options(
     compression_level: Option<i32>,
     threads: u32,
     hash: Option<&str>,
+    reject_nan: bool,
+    reject_inf: bool,
 ) -> PyResult<tensogram_grib::ConvertOptions> {
     let grouping = match grouping {
         "one_to_one" => tensogram_grib::Grouping::OneToOne,
@@ -2109,11 +2111,7 @@ fn build_grib_options(
         grouping,
         preserve_all_keys,
         pipeline: build_data_pipeline(encoding, bits, filter, compression, compression_level),
-        // Strict-finite flags are not exposed through the Python
-        // `convert_grib` surface (yet); the CLI `tensogram convert-grib
-        // --reject-nan` path uses its own builder.  Hardcoded false so
-        // converter behaviour matches pre-0.15 exactly.
-        encode_options: make_encode_options(hash, threads, false, false)?,
+        encode_options: make_encode_options(hash, threads, reject_nan, reject_inf)?,
     })
 }
 
@@ -2131,6 +2129,8 @@ fn build_netcdf_options(
     compression_level: Option<i32>,
     threads: u32,
     hash: Option<&str>,
+    reject_nan: bool,
+    reject_inf: bool,
 ) -> PyResult<tensogram_netcdf::ConvertOptions> {
     let split_by = match split_by {
         "file" => tensogram_netcdf::SplitBy::File,
@@ -2147,8 +2147,7 @@ fn build_netcdf_options(
         split_by,
         cf,
         pipeline: build_data_pipeline(encoding, bits, filter, compression, compression_level),
-        // Strict-finite flags: see convert_grib for rationale.
-        encode_options: make_encode_options(hash, threads, false, false)?,
+        encode_options: make_encode_options(hash, threads, reject_nan, reject_inf)?,
     })
 }
 
@@ -2249,6 +2248,11 @@ fn messages_to_pybytes_list(py: Python<'_>, messages: Vec<Vec<u8>>) -> PyResult<
 ///   be overridden by `TENSOGRAM_THREADS=N`; use `1` to force
 ///   single-threaded execution.
 /// - `hash`: `"xxh3"` (default) or `None` to skip hashing.
+/// - `reject_nan`: if `True`, fail conversion with `ValueError` as soon as
+///   any float payload contains NaN.  Default `False`
+///   (backwards-compatible).  See the Rust `EncodeOptions::reject_nan`
+///   docs for full semantics.
+/// - `reject_inf`: same, for `+Inf` / `-Inf`.  Default `False`.
 #[pyfunction]
 #[pyo3(name = "convert_grib", signature = (
     path,
@@ -2262,6 +2266,8 @@ fn messages_to_pybytes_list(py: Python<'_>, messages: Vec<Vec<u8>>) -> PyResult<
     compression_level = None,
     threads = 0,
     hash = Some("xxh3"),
+    reject_nan = false,
+    reject_inf = false,
 ))]
 #[allow(clippy::too_many_arguments)]
 fn py_convert_grib(
@@ -2276,6 +2282,8 @@ fn py_convert_grib(
     compression_level: Option<i32>,
     threads: u32,
     hash: Option<&str>,
+    reject_nan: bool,
+    reject_inf: bool,
 ) -> PyResult<PyObject> {
     #[cfg(feature = "grib")]
     {
@@ -2289,6 +2297,8 @@ fn py_convert_grib(
             compression_level,
             threads,
             hash,
+            reject_nan,
+            reject_inf,
         )?;
         let path_buf = std::path::PathBuf::from(path);
 
@@ -2323,6 +2333,8 @@ fn py_convert_grib(
         compression_level,
         threads,
         hash,
+        reject_nan,
+        reject_inf,
     )
 }
 
@@ -2356,6 +2368,8 @@ fn py_convert_grib(
     compression_level = None,
     threads = 0,
     hash = Some("xxh3"),
+    reject_nan = false,
+    reject_inf = false,
 ))]
 #[allow(clippy::too_many_arguments)]
 fn py_convert_grib_buffer(
@@ -2370,6 +2384,8 @@ fn py_convert_grib_buffer(
     compression_level: Option<i32>,
     threads: u32,
     hash: Option<&str>,
+    reject_nan: bool,
+    reject_inf: bool,
 ) -> PyResult<PyObject> {
     #[cfg(feature = "grib")]
     {
@@ -2395,6 +2411,8 @@ fn py_convert_grib_buffer(
             compression_level,
             threads,
             hash,
+            reject_nan,
+            reject_inf,
         )?;
 
         let messages = py
@@ -2418,6 +2436,8 @@ fn py_convert_grib_buffer(
         compression_level,
         threads,
         hash,
+        reject_nan,
+        reject_inf,
     )
 }
 
@@ -2465,6 +2485,8 @@ fn py_convert_grib_buffer(
     compression_level = None,
     threads = 0,
     hash = Some("xxh3"),
+    reject_nan = false,
+    reject_inf = false,
 ))]
 #[allow(clippy::too_many_arguments)]
 fn py_convert_netcdf(
@@ -2479,6 +2501,8 @@ fn py_convert_netcdf(
     compression_level: Option<i32>,
     threads: u32,
     hash: Option<&str>,
+    reject_nan: bool,
+    reject_inf: bool,
 ) -> PyResult<PyObject> {
     #[cfg(feature = "netcdf")]
     {
@@ -2492,6 +2516,8 @@ fn py_convert_netcdf(
             compression_level,
             threads,
             hash,
+            reject_nan,
+            reject_inf,
         )?;
         let path_buf = std::path::PathBuf::from(path);
 
@@ -2523,6 +2549,8 @@ fn py_convert_netcdf(
         compression_level,
         threads,
         hash,
+        reject_nan,
+        reject_inf,
     )
 }
 

--- a/python/tests/test_convert_grib.py
+++ b/python/tests/test_convert_grib.py
@@ -386,6 +386,50 @@ def test_convert_grib_invalid_hash() -> None:
         tensogram.convert_grib(str(_testdata("2t.grib2")), hash="sha256")
 
 
+# ── Strict-finite flag parity with CLI convert-grib ─────────────────────────
+
+
+@requires_grib
+def test_convert_grib_accepts_reject_nan_kwarg() -> None:
+    """The ``reject_nan=True`` kwarg is accepted and plumbed through.
+
+    ECMWF opendata GRIB fixtures are NaN-free, so the flag does not
+    fire — we just verify conversion still completes.  The NetCDF
+    suite (where CF unpacking produces NaN) exercises the rejection
+    path.
+    """
+    messages = tensogram.convert_grib(
+        str(_testdata("2t.grib2")),
+        reject_nan=True,
+    )
+    assert isinstance(messages, list)
+    assert messages
+
+
+@requires_grib
+def test_convert_grib_accepts_reject_inf_kwarg() -> None:
+    """Same, for ``reject_inf=True``."""
+    messages = tensogram.convert_grib(
+        str(_testdata("2t.grib2")),
+        reject_inf=True,
+    )
+    assert isinstance(messages, list)
+    assert messages
+
+
+@requires_grib
+def test_convert_grib_buffer_accepts_strict_kwargs() -> None:
+    """``convert_grib_buffer`` takes the same kwargs as ``convert_grib``."""
+    with open(_testdata("2t.grib2"), "rb") as fh:
+        messages = tensogram.convert_grib_buffer(
+            fh.read(),
+            reject_nan=True,
+            reject_inf=True,
+        )
+    assert isinstance(messages, list)
+    assert messages
+
+
 def test_convert_grib_stub_when_feature_missing() -> None:
     """When the build lacks the 'grib' feature, the stub explains how to fix it."""
     if _has_grib_feature():

--- a/python/tests/test_convert_netcdf.py
+++ b/python/tests/test_convert_netcdf.py
@@ -169,9 +169,15 @@ def _write_with_missing_values(path: Path) -> None:
         # Masked array — netCDF4 replaces the masked cells with the
         # fill value on disk.  On read with CF unpacking, the fill
         # value becomes NaN in the f64 output.
+        mask = [
+            [False, True, False],
+            [False, False, False],
+            [True, False, False],
+            [False, False, False],
+        ]
         arr = np.ma.array(
             np.full((4, 3), 1.0, dtype=np.float64),
-            mask=[[False, True, False], [False, False, False], [True, False, False], [False, False, False]],
+            mask=mask,
         )
         var[:] = arr
 

--- a/python/tests/test_convert_netcdf.py
+++ b/python/tests/test_convert_netcdf.py
@@ -151,6 +151,31 @@ def _write_three_variables(path: Path) -> None:
             v[:] = np.full((4, 3), 1.0, dtype=np.float64)
 
 
+def _write_with_missing_values(path: Path) -> None:
+    """Write an int16 variable with a ``_FillValue`` that netCDF4 turns
+    into NaN on CF unpacking.
+
+    Used by the strict-finite parity tests to exercise the rejection
+    path that the converter otherwise soft-downgrades (today) or
+    hard-fails (after Workstream B).
+    """
+    with nc4.Dataset(path, "w", format="NETCDF4") as ds:
+        ds.Conventions = "CF-1.10"
+        ds.createDimension("y", 4)
+        ds.createDimension("x", 3)
+        var = ds.createVariable("sparse", "i2", ("y", "x"), fill_value=-32768)
+        var.scale_factor = 0.1
+        var.add_offset = 0.0
+        # Masked array — netCDF4 replaces the masked cells with the
+        # fill value on disk.  On read with CF unpacking, the fill
+        # value becomes NaN in the f64 output.
+        arr = np.ma.array(
+            np.full((4, 3), 1.0, dtype=np.float64),
+            mask=[[False, True, False], [False, False, False], [True, False, False], [False, False, False]],
+        )
+        var[:] = arr
+
+
 def _run_convert(
     binary: str, *args: str, timeout: float = 30.0
 ) -> subprocess.CompletedProcess[str]:
@@ -470,6 +495,58 @@ def test_py_api_missing_file(tmp_path: Path) -> None:
     """
     with pytest.raises(FileNotFoundError):
         tensogram.convert_netcdf(str(tmp_path / "does_not_exist.nc"))
+
+
+# ── Strict-finite flag parity with CLI convert-netcdf ───────────────────────
+
+
+@requires_netcdf
+def test_py_api_reject_nan_catches_fill_value_substitution(tmp_path: Path) -> None:
+    """``reject_nan=True`` fires when CF unpacking substitutes ``_FillValue``
+    with NaN — the canonical NetCDF source of NaN in converted data."""
+    nc_path = tmp_path / "sparse.nc"
+    _write_with_missing_values(nc_path)
+    with pytest.raises(ValueError, match=r"(?i)nan"):
+        tensogram.convert_netcdf(str(nc_path), reject_nan=True)
+
+
+@requires_netcdf
+def test_py_api_reject_nan_off_by_default(tmp_path: Path) -> None:
+    """Default behaviour unchanged: NaN-bearing variables convert successfully."""
+    nc_path = tmp_path / "sparse_default.nc"
+    _write_with_missing_values(nc_path)
+    # Default encoding="none": NaN bits pass through byte-exactly.
+    messages = tensogram.convert_netcdf(str(nc_path))
+    assert isinstance(messages, list)
+    assert messages
+
+
+@requires_netcdf
+def test_py_api_reject_inf_accepts_kwarg(tmp_path: Path) -> None:
+    """``reject_inf=True`` is accepted and plumbed through.
+
+    NetCDF fixtures rarely contain Inf (CF uses fill-values, not
+    Inf), so the scan does not fire here; we just verify conversion
+    still completes with the kwarg set.
+    """
+    nc_path = tmp_path / "simple.nc"
+    _write_simple_f64(nc_path)
+    messages = tensogram.convert_netcdf(str(nc_path), reject_inf=True)
+    assert isinstance(messages, list)
+    assert messages
+
+
+@requires_netcdf
+def test_py_api_reject_nan_and_inf_together(tmp_path: Path) -> None:
+    """Both flags together on NaN-bearing data still rejects with ValueError."""
+    nc_path = tmp_path / "sparse_both.nc"
+    _write_with_missing_values(nc_path)
+    with pytest.raises(ValueError, match=r"(?i)nan"):
+        tensogram.convert_netcdf(
+            str(nc_path),
+            reject_nan=True,
+            reject_inf=True,
+        )
 
 
 def test_py_api_stub_when_feature_missing() -> None:

--- a/python/tests/test_strict_finite.py
+++ b/python/tests/test_strict_finite.py
@@ -290,8 +290,81 @@ def test_reject_nan_empty_array_passes():
 def test_error_message_mentions_dtype_and_index():
     data = np.array([1.0, 2.0, 3.0, np.nan, 5.0], dtype=np.float64)
     with pytest.raises(ValueError, match=r"NaN.*element 3.*float64") as excinfo:
-        tensogram.encode(_meta(), [(_desc([5], "float64"), data)], reject_nan=True)
+        tensogram.encode(
+            _meta(), [(_desc([5], "float64"), data)], reject_nan=True
+        )
     msg = str(excinfo.value)
     assert "NaN" in msg
     assert "element 3" in msg
     assert "float64" in msg
+
+
+# ── Standalone-API safety net (plans/RESEARCH_NAN_HANDLING.md §4.2.3) ────────
+#
+# simple_packing::encode_with_threads now validates SimplePackingParams
+# against silent-corruption-producing values.  Here we exercise the
+# validation through the high-level `tensogram.encode` path — the
+# caller supplies a descriptor with a degenerate `binary_scale_factor`,
+# and the error must surface as ValueError.
+
+
+def _simple_packing_desc(
+    ref_value: float = 0.0,
+    binary_scale_factor: int = 0,
+    bits_per_value: int = 16,
+):
+    # The PyO3 binding folds every non-reserved descriptor key into
+    # `params`, so simple_packing's reference_value / binary_scale_factor
+    # / etc. go at the top level of the dict, NOT nested under "params".
+    return {
+        "type": "ntensor",
+        "shape": [4],
+        "dtype": "float64",
+        "byte_order": "little",
+        "encoding": "simple_packing",
+        "filter": "none",
+        "compression": "none",
+        "reference_value": ref_value,
+        "binary_scale_factor": binary_scale_factor,
+        "decimal_scale_factor": 0,
+        "bits_per_value": bits_per_value,
+    }
+
+
+def test_standalone_safety_net_rejects_huge_binary_scale_factor():
+    """Caller supplies ``binary_scale_factor=i32::MAX`` — the
+    fingerprint of feeding Inf through compute_params's range
+    arithmetic.  The safety net catches it at the Rust core."""
+    desc = _simple_packing_desc(binary_scale_factor=2**31 - 1)
+    data = np.array([273.15, 283.0, 293.0, 303.0], dtype=np.float64)
+    with pytest.raises(ValueError, match=r"binary_scale_factor"):
+        tensogram.encode(_meta(), [(desc, data)])
+
+
+def test_standalone_safety_net_threshold_is_256():
+    """Pinning the 256-step threshold is inclusive: 256 passes, 257 fails."""
+    data = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float64)
+    # At threshold → accepted
+    desc_ok = _simple_packing_desc(binary_scale_factor=256)
+    tensogram.encode(_meta(), [(desc_ok, data)])
+    # Above threshold → rejected
+    desc_fail = _simple_packing_desc(binary_scale_factor=257)
+    with pytest.raises(ValueError, match=r"binary_scale_factor"):
+        tensogram.encode(_meta(), [(desc_fail, data)])
+
+
+def test_standalone_safety_net_accepts_realistic_binary_scale_factors():
+    """Regression guard: real-world weather values (|bsf| ≤ 60) pass."""
+    data = np.array([273.15, 283.0, 293.0, 303.0], dtype=np.float64)
+    for bsf in (-60, -20, 0, 20, 60):
+        desc = _simple_packing_desc(ref_value=273.15, binary_scale_factor=bsf)
+        tensogram.encode(_meta(), [(desc, data)])
+
+
+def test_standalone_safety_net_constant_field_still_works():
+    """``bits_per_value=0`` is a legitimate constant-field encoding;
+    the safety net must not reject it."""
+    desc = _simple_packing_desc(ref_value=42.0, bits_per_value=0)
+    data = np.array([42.0] * 4, dtype=np.float64)
+    # Should succeed and the packed payload is empty (0 bits per value).
+    tensogram.encode(_meta(), [(desc, data)])

--- a/rust/tensogram-encodings/src/simple_packing.rs
+++ b/rust/tensogram-encodings/src/simple_packing.rs
@@ -20,6 +20,18 @@ pub enum PackingError {
     InfiniteValue(usize),
     #[error("bits_per_value {0} exceeds maximum of 64")]
     BitsPerValueTooLarge(u32),
+    /// Standalone-API safety net: a [`SimplePackingParams`] field is
+    /// outside the range that `encode`/`encode_with_threads` can
+    /// produce meaningful output for.  Fires when a caller hand-crafts
+    /// or mutates params instead of deriving them from
+    /// [`compute_params`].  Always-on, raw-pipeline-only —
+    /// `tensogram::encode` callers also hit this through delegation.
+    ///
+    /// `field` names the offending field; `reason` explains the
+    /// specific rule violated.  See [`MAX_REASONABLE_BINARY_SCALE`] for
+    /// the `binary_scale_factor` threshold.
+    #[error("invalid {field}: {reason}")]
+    InvalidParams { field: &'static str, reason: String },
     #[error("insufficient data: expected at least {expected} bytes, got {actual}")]
     InsufficientData { expected: usize, actual: usize },
     #[error("output size overflow: {num_values} values × {bytes_per_value} bytes")]
@@ -33,6 +45,63 @@ pub enum PackingError {
     /// so the library remains panic-free even on developer error.
     #[error("internal error: aligned packing does not support byte width {0}")]
     UnsupportedAlignedWidth(usize),
+}
+
+/// Upper bound on `|binary_scale_factor|` that [`encode_with_threads`]
+/// will accept.  Real-world scientific data almost never needs more
+/// than a handful of bits of scaling (weather forecasts: `±60`,
+/// astronomy / genomics: similar).  A value of `±256` gives ample
+/// headroom while reliably catching the `i32::MAX`-saturation
+/// fingerprint that results from feeding non-finite values through
+/// `compute_params`'s range arithmetic.
+///
+/// Exposed as a constant (rather than baked into the check) so
+/// downstream callers can sanity-check their own params if they bypass
+/// the encoder — the same threshold applies.
+pub const MAX_REASONABLE_BINARY_SCALE: i32 = 256;
+
+/// Standalone-API safety net: validate that `params` are within the
+/// range `encode_with_threads` can produce meaningful output for.
+///
+/// Runs unconditionally at the top of every encode call.  Cheap —
+/// two scalar checks, no allocations on the happy path.
+///
+/// Covered failure modes (per `plans/RESEARCH_NAN_HANDLING.md` §4.2.3):
+/// - FM1: non-finite `reference_value` → silent corruption (decode
+///   recovers `Inf` / `NaN` everywhere).
+/// - FM2: `|binary_scale_factor| > MAX_REASONABLE_BINARY_SCALE` →
+///   silent flattening to `reference_value` (i32::MAX-saturation
+///   fingerprint from degenerate input).
+///
+/// Not covered here:
+/// - `bits_per_value > 64` — already [`PackingError::BitsPerValueTooLarge`].
+/// - `bits_per_value == 0` — a **legitimate** space optimisation for
+///   constant fields: the decoder reconstructs every value from
+///   `reference_value` alone and the packed-int output is empty.
+///   [`compute_params`] can produce it for a constant input, so
+///   rejecting it here would break the round-trip.
+fn validate_params(params: &SimplePackingParams) -> Result<(), PackingError> {
+    if !params.reference_value.is_finite() {
+        return Err(PackingError::InvalidParams {
+            field: "reference_value",
+            reason: format!("must be finite, got {}", params.reference_value),
+        });
+    }
+    if params.binary_scale_factor.abs() > MAX_REASONABLE_BINARY_SCALE {
+        return Err(PackingError::InvalidParams {
+            field: "binary_scale_factor",
+            reason: format!(
+                "value {} is outside the reasonable range ±{}; a value this \
+                 large usually indicates params were hand-crafted or computed \
+                 from degenerate input (e.g. Inf values). Recompute via \
+                 simple_packing::compute_params on finite data.",
+                params.binary_scale_factor, MAX_REASONABLE_BINARY_SCALE,
+            ),
+        });
+    }
+    // `bits_per_value > 64` is caught by `BitsPerValueTooLarge` below;
+    // `bits_per_value == 0` is valid for constant-field encodings.
+    Ok(())
 }
 
 /// Minimum number of values below which the parallel simple_packing
@@ -209,6 +278,12 @@ pub fn encode_with_threads(
     params: &SimplePackingParams,
     #[allow(unused_variables)] threads: u32,
 ) -> Result<Vec<u8>, PackingError> {
+    // Safety net: check params before any real work.  Catches
+    // hand-crafted or mutated params that would otherwise produce
+    // silently-wrong output (see `plans/RESEARCH_NAN_HANDLING.md`
+    // §4.2.3 for the full catalogue of failure modes).
+    validate_params(params)?;
+
     if params.bits_per_value > 64 {
         return Err(PackingError::BitsPerValueTooLarge(params.bits_per_value));
     }
@@ -1218,6 +1293,185 @@ mod tests {
             bits_per_value: 65,
         };
         assert!(encode(&[1.0], &params).is_err());
+    }
+
+    // ── Standalone-API safety-net tests (plans/RESEARCH_NAN_HANDLING.md §4.2.3) ──
+    //
+    // These pin the behaviour of `encode_with_threads`'s `validate_params`
+    // check for hand-crafted / mutated `SimplePackingParams` that would
+    // otherwise produce silently-wrong output.
+
+    #[test]
+    fn test_encode_rejects_nan_reference_value() {
+        // FM1: non-finite `reference_value` silently produces
+        // Inf/NaN-everywhere on decode.  The safety net catches it up
+        // front with a clear error.
+        let params = SimplePackingParams {
+            reference_value: f64::NAN,
+            binary_scale_factor: 0,
+            decimal_scale_factor: 0,
+            bits_per_value: 16,
+        };
+        let err = encode(&[1.0, 2.0], &params).unwrap_err();
+        match err {
+            PackingError::InvalidParams { field, reason } => {
+                assert_eq!(field, "reference_value");
+                assert!(reason.contains("finite"), "reason: {reason}");
+            }
+            other => panic!("expected InvalidParams, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_encode_rejects_positive_inf_reference_value() {
+        let params = SimplePackingParams {
+            reference_value: f64::INFINITY,
+            binary_scale_factor: 0,
+            decimal_scale_factor: 0,
+            bits_per_value: 16,
+        };
+        assert!(matches!(
+            encode(&[1.0], &params),
+            Err(PackingError::InvalidParams {
+                field: "reference_value",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn test_encode_rejects_negative_inf_reference_value() {
+        let params = SimplePackingParams {
+            reference_value: f64::NEG_INFINITY,
+            binary_scale_factor: 0,
+            decimal_scale_factor: 0,
+            bits_per_value: 16,
+        };
+        assert!(matches!(
+            encode(&[1.0], &params),
+            Err(PackingError::InvalidParams {
+                field: "reference_value",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn test_encode_rejects_binary_scale_factor_above_threshold() {
+        // FM2: huge `binary_scale_factor` (the i32::MAX-saturation
+        // fingerprint from feeding Inf through compute_params).
+        // The safety net fires for `|bsf| > 256`.
+        let params = SimplePackingParams {
+            reference_value: 0.0,
+            binary_scale_factor: 1024,
+            decimal_scale_factor: 0,
+            bits_per_value: 16,
+        };
+        let err = encode(&[1.0, 2.0], &params).unwrap_err();
+        match err {
+            PackingError::InvalidParams { field, reason } => {
+                assert_eq!(field, "binary_scale_factor");
+                assert!(reason.contains("1024"), "reason: {reason}");
+                assert!(reason.contains("256"), "reason: {reason}");
+            }
+            other => panic!("expected InvalidParams, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_encode_rejects_binary_scale_factor_below_negative_threshold() {
+        let params = SimplePackingParams {
+            reference_value: 0.0,
+            binary_scale_factor: -1024,
+            decimal_scale_factor: 0,
+            bits_per_value: 16,
+        };
+        assert!(matches!(
+            encode(&[1.0], &params),
+            Err(PackingError::InvalidParams {
+                field: "binary_scale_factor",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn test_encode_rejects_i32_max_binary_scale_factor() {
+        // The specific signature of the §3.1 silent-Inf-corruption
+        // bug: `binary_scale_factor = i32::MAX`.
+        let params = SimplePackingParams {
+            reference_value: 1.0,
+            binary_scale_factor: i32::MAX,
+            decimal_scale_factor: 0,
+            bits_per_value: 16,
+        };
+        assert!(matches!(
+            encode(&[1.0], &params),
+            Err(PackingError::InvalidParams {
+                field: "binary_scale_factor",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn test_encode_accepts_binary_scale_factor_at_threshold() {
+        // Threshold is inclusive: `|bsf| == 256` passes, `|bsf| == 257` fails.
+        let params_ok = SimplePackingParams {
+            reference_value: 0.0,
+            binary_scale_factor: 256,
+            decimal_scale_factor: 0,
+            bits_per_value: 16,
+        };
+        // May not produce meaningful bits with this scale, but must not error.
+        assert!(encode(&[1.0, 2.0], &params_ok).is_ok());
+
+        let params_fail = SimplePackingParams {
+            binary_scale_factor: 257,
+            ..params_ok
+        };
+        assert!(encode(&[1.0, 2.0], &params_fail).is_err());
+    }
+
+    #[test]
+    fn test_encode_accepts_realistic_binary_scale_factor() {
+        // Weather data lives in [-60, 30]; pinning this to catch future
+        // tightening of the threshold below real-world needs.
+        for bsf in [-60, -30, -1, 0, 1, 30, 60] {
+            let params = SimplePackingParams {
+                reference_value: 273.15,
+                binary_scale_factor: bsf,
+                decimal_scale_factor: 0,
+                bits_per_value: 16,
+            };
+            assert!(
+                encode(&[273.15, 283.15, 293.15], &params).is_ok(),
+                "realistic bsf {bsf} must be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn test_encode_bits_per_value_zero_still_valid() {
+        // Regression: `bits_per_value = 0` is a legitimate constant-field
+        // encoding (decoder reconstructs from `reference_value` alone).
+        // The safety net must NOT reject this.
+        let params = SimplePackingParams {
+            reference_value: 42.0,
+            binary_scale_factor: 0,
+            decimal_scale_factor: 0,
+            bits_per_value: 0,
+        };
+        let encoded = encode(&[42.0; 100], &params).unwrap();
+        assert!(encoded.is_empty(), "constant field → zero packed bytes");
+    }
+
+    #[test]
+    fn test_max_reasonable_binary_scale_constant_is_exposed() {
+        // `MAX_REASONABLE_BINARY_SCALE` is public so downstream callers
+        // can align their own validations.  This just pins the value
+        // so a future change is a conscious decision.
+        assert_eq!(MAX_REASONABLE_BINARY_SCALE, 256);
     }
 
     #[test]

--- a/rust/tensogram-encodings/src/simple_packing.rs
+++ b/rust/tensogram-encodings/src/simple_packing.rs
@@ -87,7 +87,10 @@ fn validate_params(params: &SimplePackingParams) -> Result<(), PackingError> {
             reason: format!("must be finite, got {}", params.reference_value),
         });
     }
-    if params.binary_scale_factor.abs() > MAX_REASONABLE_BINARY_SCALE {
+    // `saturating_abs` handles `i32::MIN` without panicking (debug)
+    // or silently returning a negative value (release).  `i32::MIN`
+    // clamps to `i32::MAX`, comfortably above the threshold.
+    if params.binary_scale_factor.saturating_abs() > MAX_REASONABLE_BINARY_SCALE {
         return Err(PackingError::InvalidParams {
             field: "binary_scale_factor",
             reason: format!(
@@ -1411,6 +1414,53 @@ mod tests {
                 field: "binary_scale_factor",
                 ..
             })
+        ));
+    }
+
+    #[test]
+    fn test_encode_rejects_i32_min_binary_scale_factor() {
+        // Regression: `i32::MIN.abs()` overflows (panics in debug,
+        // returns `i32::MIN` in release).  `saturating_abs` handles it.
+        // Either way: `i32::MIN` is massively out of the reasonable
+        // range, so rejection is the right answer.
+        let params = SimplePackingParams {
+            reference_value: 1.0,
+            binary_scale_factor: i32::MIN,
+            decimal_scale_factor: 0,
+            bits_per_value: 16,
+        };
+        assert!(matches!(
+            encode(&[1.0], &params),
+            Err(PackingError::InvalidParams {
+                field: "binary_scale_factor",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn test_safety_net_catches_compute_params_extreme_range() {
+        // End-to-end path: even with all-finite input, a caller who
+        // asks to pack `[f64::MIN, f64::MAX]` at 16 bits gets params
+        // with `binary_scale_factor ≈ i32::MAX` (log2(f64::MAX / 2^16)
+        // saturates the cast to i32).  This is the same signature as
+        // the Inf-corruption §3.1 path, only via a different origin.
+        // The safety net treats both the same: hard error with a
+        // "recompute from finite data" hint.  The remedy here is to
+        // use more bits or split the range; the message is accurate
+        // for both.
+        let values = [f64::MIN, f64::MAX];
+        let params = compute_params(&values, 16, 0).unwrap();
+        // compute_params succeeds but the params are unusable.
+        assert_eq!(params.binary_scale_factor, i32::MAX);
+        // encode catches it.
+        let err = encode(&values, &params).unwrap_err();
+        assert!(matches!(
+            err,
+            PackingError::InvalidParams {
+                field: "binary_scale_factor",
+                ..
+            }
         ));
     }
 

--- a/rust/tensogram-netcdf/tests/integration.rs
+++ b/rust/tensogram-netcdf/tests/integration.rs
@@ -723,10 +723,11 @@ fn unknown_filter_errors() {
 }
 
 #[test]
-fn simple_packing_skips_non_f64_variables() {
-    // multi_dtype.nc has int8/u16/f32/f64 variables. simple_packing should
-    // be applied to f64 only and silently passed through (with a stderr
-    // warning) for the others — the file conversion as a whole succeeds.
+fn simple_packing_on_multi_dtype_fails_on_nan_variable() {
+    // Post-0.17: simple_packing on a NetCDF that contains ANY NaN-bearing
+    // f64 variable now hard-fails (previously soft-downgraded with a
+    // warning, which hid data-quality problems).  `multi_dtype.nc` has
+    // a `f64_with_nan` variable so the whole-file conversion must error.
     let path = testdata("multi_dtype.nc");
     let opts = ConvertOptions {
         pipeline: DataPipeline {
@@ -736,35 +737,22 @@ fn simple_packing_skips_non_f64_variables() {
         },
         ..Default::default()
     };
-    let msgs = convert_netcdf_file(&path, &opts).unwrap();
-    let (meta, objects) = decode_first(&msgs);
-
-    // Find the "f64" variable and verify it has simple_packing.
-    // Find an integer variable and verify it does NOT.
-    let mut saw_packed_f64 = false;
-    let mut saw_unpacked_int = false;
-    for (i, obj) in objects.iter().enumerate() {
-        let name = match meta.base[i].get("name") {
-            Some(ciborium::Value::Text(s)) => s.as_str(),
-            _ => continue,
-        };
-        if name == "f64" {
-            assert_eq!(
-                obj.0.encoding, "simple_packing",
-                "f64 variable should be simple_packed"
-            );
-            saw_packed_f64 = true;
-        } else if name == "i32" || name == "i16" || name == "i8" {
-            assert_eq!(
-                obj.0.encoding, "none",
-                "{name} (non-f64) should NOT be simple_packed"
-            );
-            saw_unpacked_int = true;
-        }
-    }
-    assert!(saw_packed_f64, "should have seen the f64 variable");
-    assert!(saw_unpacked_int, "should have seen an int variable");
+    let err = convert_netcdf_file(&path, &opts).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("simple_packing") && msg.contains("f64_with_nan"),
+        "error must name encoding + offending variable: {msg}"
+    );
+    assert!(msg.contains("NaN"), "error must name the trigger kind: {msg}");
 }
+
+// Note: the pre-0.17 test `simple_packing_skips_non_f64_variables` was
+// removed.  Its fixture (`multi_dtype.nc`) contains a `f64_with_nan`
+// variable that now hard-fails simple_packing; the replacement
+// `simple_packing_on_multi_dtype_fails_on_nan_variable` covers the
+// new contract.  The "skip non-f64" branch is now covered by the unit
+// test `simple_packing_with_non_f64_payload_still_skips_with_warning`
+// in `rust/tensogram/src/pipeline.rs`.
 
 #[test]
 fn pipeline_round_trip_zstd_decodes_back_to_input() {

--- a/rust/tensogram-wasm/Cargo.lock
+++ b/rust/tensogram-wasm/Cargo.lock
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "tensogram"
-version = "0.15.0"
+version = "0.16.1"
 dependencies = [
  "ciborium",
  "serde",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "tensogram-encodings"
-version = "0.15.0"
+version = "0.16.1"
 dependencies = [
  "lz4_flex",
  "ruzstd",
@@ -483,14 +483,14 @@ dependencies = [
 
 [[package]]
 name = "tensogram-szip"
-version = "0.15.0"
+version = "0.16.1"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "tensogram-wasm"
-version = "0.15.0"
+version = "0.16.1"
 dependencies = [
  "ciborium",
  "getrandom 0.2.17",

--- a/rust/tensogram/src/pipeline.rs
+++ b/rust/tensogram/src/pipeline.rs
@@ -137,18 +137,19 @@ pub fn apply_pipeline(
             }
             Some(values) => {
                 let bits = pipeline.bits.unwrap_or(16);
-                // Hard-fail on NaN/Inf (pre-0.17 behaviour soft-
-                // downgraded silently to `encoding="none"` with only a
-                // stderr warning, which hid data-quality problems from
-                // callers).  If the variable contains non-finite
-                // values the user must either pick a different
-                // encoding or pre-process the data.
+                // Hard-fail on any `compute_params` error — most often
+                // NaN or Inf in the input data.  Pre-0.17 behaviour
+                // soft-downgraded silently to `encoding="none"` with
+                // only a stderr warning, which hid data-quality
+                // problems from callers.  The remedy hint is
+                // appropriate for every failure mode: fix the data
+                // (NaN/Inf) or pick a different encoding (which also
+                // covers `BitsPerValueTooLarge` via `--bits`).
                 let params = simple_packing::compute_params(values, bits, 0).map_err(|e| {
                     format!(
                         "simple_packing failed for {var_label}: {e}. \
-                         The variable contains NaN or Inf which cannot be represented \
-                         by simple_packing. Pre-process the data or choose a \
-                         different encoding (e.g. encoding=\"none\")."
+                         Pre-process the data or choose a different \
+                         encoding (e.g. encoding=\"none\")."
                     )
                 })?;
                 desc.encoding = "simple_packing".to_string();

--- a/rust/tensogram/src/pipeline.rs
+++ b/rust/tensogram/src/pipeline.rs
@@ -125,6 +125,11 @@ pub fn apply_pipeline(
         "none" => {}
         "simple_packing" => match values {
             None => {
+                // Non-f64 payloads cannot be simple-packed.  The dtype
+                // is the caller's choice and this branch is a sanity
+                // check, not a NaN/Inf failure — leave the stderr
+                // warning + fallback to `encoding="none"` so the rest
+                // of the conversion still succeeds.
                 eprintln!(
                     "warning: skipping simple_packing for {var_label} \
                      (not a float64 payload)"
@@ -132,35 +137,38 @@ pub fn apply_pipeline(
             }
             Some(values) => {
                 let bits = pipeline.bits.unwrap_or(16);
-                match simple_packing::compute_params(values, bits, 0) {
-                    Ok(params) => {
-                        desc.encoding = "simple_packing".to_string();
-                        desc.params.insert(
-                            "reference_value".to_string(),
-                            CborValue::Float(params.reference_value),
-                        );
-                        desc.params.insert(
-                            "binary_scale_factor".to_string(),
-                            CborValue::Integer((i64::from(params.binary_scale_factor)).into()),
-                        );
-                        desc.params.insert(
-                            "decimal_scale_factor".to_string(),
-                            CborValue::Integer((i64::from(params.decimal_scale_factor)).into()),
-                        );
-                        desc.params.insert(
-                            "bits_per_value".to_string(),
-                            CborValue::Integer((i64::from(params.bits_per_value)).into()),
-                        );
-                        applied_simple_packing = true;
-                    }
-                    Err(e) => {
-                        // Common cause: NaN values from unpacked fill_value.
-                        // simple_packing rejects NaN; the variable falls
-                        // back to encoding="none" so the conversion still
-                        // succeeds.
-                        eprintln!("warning: skipping simple_packing for {var_label}: {e}");
-                    }
-                }
+                // Hard-fail on NaN/Inf (pre-0.17 behaviour soft-
+                // downgraded silently to `encoding="none"` with only a
+                // stderr warning, which hid data-quality problems from
+                // callers).  If the variable contains non-finite
+                // values the user must either pick a different
+                // encoding or pre-process the data.
+                let params = simple_packing::compute_params(values, bits, 0).map_err(|e| {
+                    format!(
+                        "simple_packing failed for {var_label}: {e}. \
+                         The variable contains NaN or Inf which cannot be represented \
+                         by simple_packing. Pre-process the data or choose a \
+                         different encoding (e.g. encoding=\"none\")."
+                    )
+                })?;
+                desc.encoding = "simple_packing".to_string();
+                desc.params.insert(
+                    "reference_value".to_string(),
+                    CborValue::Float(params.reference_value),
+                );
+                desc.params.insert(
+                    "binary_scale_factor".to_string(),
+                    CborValue::Integer((i64::from(params.binary_scale_factor)).into()),
+                );
+                desc.params.insert(
+                    "decimal_scale_factor".to_string(),
+                    CborValue::Integer((i64::from(params.decimal_scale_factor)).into()),
+                );
+                desc.params.insert(
+                    "bits_per_value".to_string(),
+                    CborValue::Integer((i64::from(params.bits_per_value)).into()),
+                );
+                applied_simple_packing = true;
             }
         },
         other => {
@@ -335,15 +343,86 @@ mod tests {
     }
 
     #[test]
-    fn simple_packing_with_nan_values_skips_with_warning() {
+    fn simple_packing_with_nan_values_fails_hard() {
+        // Post-0.17: NaN in input to simple_packing is a hard failure.
+        // The converter no longer silently downgrades to encoding="none"
+        // because that hid data-quality problems from callers.
         let mut desc = mk_desc();
         let p = DataPipeline {
             encoding: "simple_packing".to_string(),
             ..Default::default()
         };
         let values = [1.0_f64, f64::NAN, 3.0];
-        apply_pipeline(&mut desc, Some(&values), &p, "nan_var").unwrap();
-        assert_eq!(desc.encoding, "none", "NaN → skip");
+        let err = apply_pipeline(&mut desc, Some(&values), &p, "nan_var").unwrap_err();
+        assert!(
+            err.contains("simple_packing"),
+            "error should name the encoding: {err}"
+        );
+        assert!(
+            err.contains("nan_var"),
+            "error should name the variable: {err}"
+        );
+        assert!(
+            err.contains("NaN"),
+            "error should name the trigger kind: {err}"
+        );
+    }
+
+    #[test]
+    fn simple_packing_with_inf_values_fails_hard() {
+        // Sibling of the NaN hard-fail.  `simple_packing::compute_params`
+        // rejects Inf in input (added in 0.16); this pins that the
+        // converter propagates rather than silently downgrading.
+        let mut desc = mk_desc();
+        let p = DataPipeline {
+            encoding: "simple_packing".to_string(),
+            ..Default::default()
+        };
+        let values = [1.0_f64, f64::INFINITY, 3.0];
+        let err = apply_pipeline(&mut desc, Some(&values), &p, "inf_var").unwrap_err();
+        assert!(
+            err.contains("simple_packing"),
+            "error should name the encoding: {err}"
+        );
+        assert!(
+            err.contains("inf_var"),
+            "error should name the variable: {err}"
+        );
+        // The underlying PackingError::InfiniteValue stringifies as "Inf value at index N".
+        assert!(
+            err.to_lowercase().contains("inf"),
+            "error should name the trigger kind: {err}"
+        );
+    }
+
+    #[test]
+    fn simple_packing_with_finite_data_still_succeeds() {
+        // Regression guard: the hard-fail must not break the happy path.
+        let mut desc = mk_desc();
+        let p = DataPipeline {
+            encoding: "simple_packing".to_string(),
+            bits: Some(12),
+            ..Default::default()
+        };
+        let values = [1.0_f64, 2.0, 3.0, 4.0];
+        apply_pipeline(&mut desc, Some(&values), &p, "clean_var").unwrap();
+        assert_eq!(desc.encoding, "simple_packing");
+        assert!(desc.params.contains_key("reference_value"));
+    }
+
+    #[test]
+    fn simple_packing_with_non_f64_payload_still_skips_with_warning() {
+        // The non-f64 branch is NOT a NaN/Inf failure — it's "variable
+        // is not float64, skip simple_packing".  That branch keeps its
+        // soft behaviour (stderr warning + encoding="none") because it
+        // reflects a structural mismatch, not a data-quality problem.
+        let mut desc = mk_desc();
+        let p = DataPipeline {
+            encoding: "simple_packing".to_string(),
+            ..Default::default()
+        };
+        apply_pipeline(&mut desc, None, &p, "int_var").unwrap();
+        assert_eq!(desc.encoding, "none");
     }
 
     #[test]

--- a/rust/tensogram/tests/edge_cases.rs
+++ b/rust/tensogram/tests/edge_cases.rs
@@ -383,6 +383,88 @@ fn neg_infinity_reference_value_rejected() {
     assert!(result.is_err());
 }
 
+// ── 7b. Standalone-API safety net via the high-level `encode()` path ────────
+//
+// `simple_packing::encode_with_threads` now validates the params it
+// receives (see plans/RESEARCH_NAN_HANDLING.md §4.2.3).  The high-level
+// `tensogram::encode` delegates to it through the pipeline, so the
+// validation also fires when a caller supplies a malformed
+// `binary_scale_factor` via the descriptor params.
+
+#[test]
+fn unreasonable_binary_scale_factor_rejected() {
+    // Caller supplies a descriptor with `binary_scale_factor = i32::MAX`
+    // (the fingerprint of feeding Inf through `compute_params`'s range
+    // arithmetic).  Without the safety net, the decode silently
+    // reconstructs the constant `reference_value` — with it, the
+    // encode fails clearly.
+    let mut desc = make_simple_packing_desc(273.15);
+    desc.params.insert(
+        "binary_scale_factor".to_string(),
+        ciborium::Value::Integer((i64::from(i32::MAX)).into()),
+    );
+    let data: Vec<u8> = [270.0_f64, 275.0, 280.0, 285.0]
+        .iter()
+        .flat_map(|v| v.to_le_bytes())
+        .collect();
+
+    let err = encode(
+        &make_global_meta(),
+        &[(&desc, &data)],
+        &EncodeOptions::default(),
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(
+        err.contains("binary_scale_factor"),
+        "error must name the field: {err}"
+    );
+    assert!(err.contains("256"), "error must quote the threshold: {err}");
+}
+
+#[test]
+fn binary_scale_factor_at_threshold_accepted() {
+    // Threshold is inclusive: `|bsf| == 256` passes the safety net.
+    let mut desc = make_simple_packing_desc(0.0);
+    desc.params.insert(
+        "binary_scale_factor".to_string(),
+        ciborium::Value::Integer(256i64.into()),
+    );
+    let data: Vec<u8> = [1.0_f64, 2.0, 3.0, 4.0]
+        .iter()
+        .flat_map(|v| v.to_le_bytes())
+        .collect();
+    encode(
+        &make_global_meta(),
+        &[(&desc, &data)],
+        &EncodeOptions::default(),
+    )
+    .expect("bsf=256 must be accepted");
+}
+
+#[test]
+fn realistic_binary_scale_factor_accepted() {
+    // Regression guard: pin that the safety net's threshold does not
+    // block real-world weather/climate values.
+    for bsf in [-60_i64, -20, -1, 0, 1, 20, 60] {
+        let mut desc = make_simple_packing_desc(273.15);
+        desc.params.insert(
+            "binary_scale_factor".to_string(),
+            ciborium::Value::Integer(bsf.into()),
+        );
+        let data: Vec<u8> = [273.15_f64, 283.0, 293.0, 303.0]
+            .iter()
+            .flat_map(|v| v.to_le_bytes())
+            .collect();
+        encode(
+            &make_global_meta(),
+            &[(&desc, &data)],
+            &EncodeOptions::default(),
+        )
+        .unwrap_or_else(|e| panic!("realistic bsf {bsf} rejected: {e}"));
+    }
+}
+
 // ── 8. Unknown hash algorithm on decode ──────────────────────────────────────
 
 #[test]

--- a/typescript/tests/strict_finite.test.ts
+++ b/typescript/tests/strict_finite.test.ts
@@ -251,4 +251,66 @@ describe('strict-finite — rejectNan / rejectInf', () => {
       encode(defaultMeta(), [{ descriptor: desc, data }]),
     ).not.toThrow();
   });
+
+  // ── Standalone-API safety net — see plans/RESEARCH_NAN_HANDLING.md §4.2.3 ──
+
+  describe('simple_packing params safety net', () => {
+    const simplePackingDesc = (
+      binaryScaleFactor: number,
+      bitsPerValue: number = 16,
+    ) => ({
+      ...makeDescriptor([4], 'float64'),
+      encoding: 'simple_packing',
+      reference_value: 273.15,
+      binary_scale_factor: binaryScaleFactor,
+      decimal_scale_factor: 0,
+      bits_per_value: bitsPerValue,
+    });
+
+    it('rejects binary_scale_factor = i32::MAX (silent-corruption fingerprint)', async () => {
+      await init();
+      const data = new Float64Array([273.15, 283.0, 293.0, 303.0]);
+      const desc = simplePackingDesc(2 ** 31 - 1);
+      expect(() => encode(defaultMeta(), [{ descriptor: desc, data }])).toThrow(
+        /binary_scale_factor/,
+      );
+    });
+
+    it('256 is accepted, 257 is rejected (threshold boundary)', async () => {
+      await init();
+      const data = new Float64Array([1.0, 2.0, 3.0, 4.0]);
+      expect(() =>
+        encode(defaultMeta(), [{ descriptor: simplePackingDesc(256), data }]),
+      ).not.toThrow();
+      expect(() =>
+        encode(defaultMeta(), [{ descriptor: simplePackingDesc(257), data }]),
+      ).toThrow(/binary_scale_factor/);
+    });
+
+    it('accepts realistic weather-data binary_scale_factor values', async () => {
+      await init();
+      const data = new Float64Array([273.15, 283.0, 293.0, 303.0]);
+      for (const bsf of [-60, -20, 0, 20, 60]) {
+        expect(() =>
+          encode(defaultMeta(), [{ descriptor: simplePackingDesc(bsf), data }]),
+        ).not.toThrow();
+      }
+    });
+
+    it('accepts bits_per_value = 0 for constant-field encoding', async () => {
+      await init();
+      const data = new Float64Array([42.0, 42.0, 42.0, 42.0]);
+      const desc = {
+        ...makeDescriptor([4], 'float64'),
+        encoding: 'simple_packing',
+        reference_value: 42.0,
+        binary_scale_factor: 0,
+        decimal_scale_factor: 0,
+        bits_per_value: 0,
+      };
+      expect(() =>
+        encode(defaultMeta(), [{ descriptor: desc, data }]),
+      ).not.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Continuation of the NaN/Inf handling work from PR #53 (merged).  Four commits on top of `main@0.16.1`:

- **A. Python converter parity** (`836774a6`) — `tensogram.convert_grib` / `convert_grib_buffer` / `convert_netcdf` now accept `reject_nan` / `reject_inf` kwargs, closing the CLI↔Python gap.
- **B. Hard-fail on simple_packing + NaN/Inf** (`2410c162`) — **BREAKING**: `apply_pipeline` no longer soft-downgrades to `encoding="none"` when `compute_params` rejects NaN or Inf.  The error propagates to the converters with the variable name and a remedy hint.
- **C. Standalone-API safety net** (`281a99cc`) — `simple_packing::encode_with_threads` now validates `SimplePackingParams` (non-finite `reference_value`, `|binary_scale_factor| > 256`) with a new always-on `PackingError::InvalidParams { field, reason }` variant.  Public const `MAX_REASONABLE_BINARY_SCALE`.  Cross-language parity tests (Rust, Python, TS, C++).
- **Docs** (`8de78d8d`) — six doc pages updated to match: stale soft-downgrade references removed, kwargs added to Python converter examples, safety-net section added to the strict-finite and simple-packing guides, §4.2.2 / §4.2.3 in the research memo tagged IMPLEMENTED with SUPERSEDED notes explaining the design divergences.

## Breaking changes (0.17 pre-release)

The converter soft-downgrade from `simple_packing` to `encoding="none"` on NaN/Inf input is removed.  See the CHANGELOG `[Unreleased] → Changed — BREAKING` section for the full contract and recovery options.

## Testing

| Surface | Tests | Delta |
|---|---:|---|
| Rust workspace | 1,340 | +13 from baseline (10 simple_packing unit + 3 edge_cases integration) |
| Rust NetCDF | 64 | 1 renamed/inverted |
| Rust GRIB | 36 | unchanged |
| Python | 262+ | 4 new strict_finite + 4 new convert_netcdf, 3 new convert_grib |
| TypeScript | 330 | 4 new strict_finite |
| C++ (GoogleTest) | 158 | 4 new strict_finite |

All clippy/fmt/ruff/tsc clean.  `mdbook build docs` passes.

## Follow-ups not in this PR

From `plans/RESEARCH_NAN_HANDLING.md` §4 — the Tier-3 items (§4.3.1 descriptor-level `nan_policy`, §4.3.2 NaN bitmask companion) remain in research.  Those are wire-format-visible and need maintainer sign-off before implementation.

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-56
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->