### PR TITLE
Feat/makefile and ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,7 @@ jobs:
       - run: mkdir -p "$TMPDIR"
 
       - name: Format + Clippy
-        run: |
-          cargo fmt --check
-          cargo clippy --workspace --all-targets -- -D warnings
-          cargo clippy -p tensogram --all-targets --features "remote,async" -- -D warnings
+        run: make rust-lint
 
       - name: sccache stats
         if: always()
@@ -409,7 +406,7 @@ jobs:
             | tar xz --strip-components=1 -C /usr/local "node-v${NODE_VERSION}-linux-x64/bin/node"
 
       - name: Build and test
-        run: wasm-pack test --node rust/tensogram-wasm
+        run: make wasm-test
 
       - name: sccache stats
         if: always()
@@ -437,26 +434,17 @@ jobs:
           curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" \
             | tar xJ --strip-components=1 -C /usr/local
 
-      - name: Build WASM (wasm-pack → typescript/wasm)
-        run: |
-          wasm-pack build rust/tensogram-wasm --release \
-            --target web --out-dir ../../typescript/wasm --out-name tensogram_wasm
-
       - name: Install typescript deps
-        working-directory: typescript
-        run: npm ci || npm install --no-audit --no-fund
+        run: make ts-install
+
+      - name: Build WASM + TypeScript (wasm-pack → typescript/wasm, tsc → dist)
+        run: make ts-build
 
       - name: Typecheck (strict, src + tests)
-        working-directory: typescript
-        run: npx tsc --noEmit -p tsconfig.test.json
+        run: make ts-typecheck
 
       - name: Run tests (vitest)
-        working-directory: typescript
-        run: npx vitest run
-
-      - name: Build distributable
-        working-directory: typescript
-        run: npx tsc
+        run: make ts-test
 
       - name: Smoke-test examples
         run: |

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ rust-test: ## Run all Rust tests
 
 rust-clippy: ## Run clippy on Rust workspace
 	cargo clippy --workspace --all-targets -- -D warnings
+	cargo clippy -p tensogram --all-targets --features "remote,async" -- -D warnings
 
 rust-fmt: ## Check Rust formatting
 	cargo fmt --check
@@ -42,26 +43,28 @@ rust-lint: rust-clippy rust-fmt ## Run all Rust lints (clippy + fmt)
 
 # ── Python ────────────────────────────────────────────────────────────────
 
-PYTHON ?= uv run python
+PYTHON  ?= uv run python
+MATURIN ?= uv run --with maturin maturin
+RUFF    ?= uv run --with ruff ruff
 RUFF_CFG ?= python/bindings/pyproject.toml
 
 python-build: ## Build Python bindings via maturin
 	if [ ! -d .venv ] ; then uv venv ; fi
-	cd python/bindings && maturin develop --release --uv
+	cd python/bindings && $(MATURIN) develop --release --uv
 	uv pip install ./python/tensogram-xarray
 	uv pip install ./python/tensogram-zarr
 
-python-test: ## Run all Python tests
-	uv pip install pytest pytest-asyncio # TODO should come from workspace-level pyproject
+python-test: python-build ## Run all Python tests
+	uv pip install pytest pytest-asyncio numpy
 	$(PYTHON) -m pytest python/tests/ -v
 	$(PYTHON) -m pytest python/tensogram-xarray/tests/ -v
 	$(PYTHON) -m pytest python/tensogram-zarr/tests/ -v
 
 python-lint: ## Run ruff check on Python code
-	ruff check --config $(RUFF_CFG) python/tests/ python/tensogram-xarray/ python/tensogram-zarr/
+	$(RUFF) check --config $(RUFF_CFG) python/tests/ python/tensogram-xarray/ python/tensogram-zarr/
 
 python-fmt: ## Check Python formatting
-	ruff format --check --config $(RUFF_CFG) python/tests/ python/tensogram-xarray/ python/tensogram-zarr/
+	$(RUFF) format --check --config $(RUFF_CFG) python/tests/ python/tensogram-xarray/ python/tensogram-zarr/
 
 # ── C++ ───────────────────────────────────────────────────────────────────
 
@@ -80,15 +83,15 @@ wasm-test: ## Run WASM tests
 # ── TypeScript ────────────────────────────────────────────────────────────
 
 ts-install: ## Install TypeScript wrapper dependencies
-	cd typescript && npm install
+	cd typescript && npm ci || npm install --no-audit --no-fund
 
-ts-build: ## Build the TypeScript wrapper (wasm-pack + tsc)
+ts-build: ts-install ## Build the TypeScript wrapper (wasm-pack + tsc)
 	cd typescript && npm run build
 
-ts-test: ## Run TypeScript wrapper tests (vitest)
+ts-test: ts-build ## Run TypeScript wrapper tests (vitest)
 	cd typescript && npm test
 
-ts-typecheck: ## Strict typecheck source + tests
+ts-typecheck: ts-build ## Strict typecheck source + tests
 	cd typescript && npx tsc --noEmit -p tsconfig.test.json
 
 # ── Docs ──────────────────────────────────────────────────────────────────
@@ -99,7 +102,7 @@ docs-build: ## Build mdbook documentation
 # ── Aggregates ────────────────────────────────────────────────────────────
 
 check: rust-check ## Check all builds
-test: rust-test python-build python-test ts-test ## Run all tests
+test: rust-test python-test ts-test ## Run all tests
 lint: rust-lint python-lint python-fmt ts-typecheck ## Run all lints
 fmt: rust-fmt python-fmt ## Check all formatting
 
@@ -108,6 +111,8 @@ fmt: rust-fmt python-fmt ## Check all formatting
 clean: ## Remove build artifacts
 	cargo clean
 	rm -rf build/
+	rm -rf .venv/
+	rm -rf docs/book/
 	rm -rf typescript/dist/ typescript/wasm/ typescript/node_modules/
 	rm -rf examples/typescript/node_modules/
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ RUFF_CFG ?= python/bindings/pyproject.toml
 
 python-build: ## Build Python bindings via maturin
 	if [ ! -d .venv ] ; then uv venv ; fi
-	cd python/bindings && maturin develop --release
+	cd python/bindings && maturin develop --release --uv
 	uv pip install ./python/tensogram-xarray
 	uv pip install ./python/tensogram-zarr
 

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ python-build: ## Build Python bindings via maturin
 	uv pip install ./python/tensogram-zarr
 
 python-test: python-build ## Run all Python tests
+	# TODO pip installs should come from workspace-level pyproject
 	uv pip install pytest pytest-asyncio numpy
 	$(PYTHON) -m pytest python/tests/ -v
 	$(PYTHON) -m pytest python/tensogram-xarray/tests/ -v
@@ -113,6 +114,8 @@ clean: ## Remove build artifacts
 	rm -rf build/
 	rm -rf .venv/
 	rm -rf docs/book/
+	rm -rf python/bindings/target/
+	find python/bindings/python -name '*.so' -o -name '*.pyd' | xargs rm -f 2>/dev/null || true
 	rm -rf typescript/dist/ typescript/wasm/ typescript/node_modules/
 	rm -rf examples/typescript/node_modules/
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true


### PR DESCRIPTION
1/ cleanups and improvements to Makefile, mostly minor
2/ utilize Makefile from .github/workflows/ci.yml where straightforward

Has some consequences for CI duration presumably -- now we run as less steps altogether, but eg `ts build` ends up executed twice, but due to caching should still be ok

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-61
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->