### PR TITLE
feat(python): add tensogram-anemoi anemoi-inference output plugin

### DIFF
--- a/.github/workflows/publish-pypi-anemoi.yml
+++ b/.github/workflows/publish-pypi-anemoi.yml
@@ -1,0 +1,11 @@
+name: Publish tensogram-anemoi to PyPI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  anemoi:
+    uses: ecmwf/reusable-workflows/.github/workflows/cd-pypi.yml@3832c3c496db0f664f53734211df431fe9eef868
+    with:
+      working-directory: python/tensogram-anemoi/
+    secrets: inherit

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -83,7 +83,8 @@ jobs:
           for pytoml in \
             python/bindings/pyproject.toml \
             python/tensogram-xarray/pyproject.toml \
-            python/tensogram-zarr/pyproject.toml; do
+            python/tensogram-zarr/pyproject.toml \
+            python/tensogram-anemoi/pyproject.toml; do
             VER=$(grep '^version' "$pytoml" | head -1 | sed 's/.*"\(.*\)"/\1/')
             check_version "$pytoml" "$VER"
           done

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Tensogram defines a network-transmissible binary message format, not a file form
 - **xarray backend** — `xr.open_dataset("file.tgm", engine="tensogram")` with lazy loading, coordinate auto-detection, and hypercube stacking via `open_datasets()`
 - **Dask integration** — parallel chunked computation via `xr.open_dataset(..., chunks={})` with per-chunk `decode_range` for efficient out-of-core processing
 - **Zarr v3 store** — `zarr.open_group(store=TensogramStore.open_tgm("file.tgm"), mode="r")` for standard Zarr API access with 14 bidirectionally-mapped dtypes
+- **anemoi-inference output** — store AI weather forecast steps directly to `.tgm` via an auto-discovered plugin; each step is encoded and appended immediately, with optional pressure-level stacking, lossy simple packing, variable filtering, and remote (S3/GCS/Azure) output
 - **GRIB import** — bring GRIB data into Tensogram with ecCodes-driven metadata lifting and configurable namespace extraction
 - **NetCDF import** — bring NetCDF-3 and NetCDF-4 files in with CF metadata lifting (`--cf`), packed-data unpacking, and a configurable encoding/compression pipeline shared with `convert-grib`
 - **CLI** — `tensogram info/ls/dump/get/set/copy/merge/split/reshuffle/convert-grib/convert-netcdf` with `--strategy first|last|error` merge conflict resolution
@@ -76,6 +77,25 @@ With xarray and Zarr backends:
 ```bash
 pip install tensogram[all]
 ```
+
+### anemoi-inference plugin
+
+```bash
+pip install tensogram-anemoi
+```
+
+Once installed, anemoi-inference auto-discovers the output plugin. Configure it in your run YAML:
+
+```yaml
+output:
+  tensogram:
+    path: forecast.tgm       # local path or s3://, gs://, az://, ...
+    compression: zstd        # none | zstd | lz4 | szip | blosc2
+    dtype: float32
+    stack_pressure_levels: true
+```
+
+Each forecast step is encoded and appended to the `.tgm` file as it is produced. See `examples/python/` and the [plugin docs](docs/src/guide/anemoi-plugin.md) for the full option reference and reading the output back.
 
 ### CLI
 
@@ -240,6 +260,7 @@ python/
 ├── bindings/             Python bindings (PyO3, excluded from default build)
 ├── tensogram-xarray/     xarray backend engine (Python package)
 ├── tensogram-zarr/       Zarr v3 store backend (Python package)
+├── tensogram-anemoi/     anemoi-inference output plugin (Python package)
 └── tests/                Python test suite
 cpp/
 ├── include/              C++ wrapper header + C header

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -41,6 +41,7 @@
 - [xarray Integration](guide/xarray-integration.md)
 - [Dask Integration](guide/dask-integration.md)
 - [Zarr v3 Backend](guide/zarr-backend.md)
+- [anemoi-inference Integration](guide/anemoi-integration.md)
 - [Free-Threaded Python](guide/free-threaded-python.md)
 - [Multi-Threaded Coding Pipeline](guide/multi-threaded-pipeline.md)
 - [Benchmarks](guide/benchmarks.md)

--- a/docs/src/guide/anemoi-integration.md
+++ b/docs/src/guide/anemoi-integration.md
@@ -1,0 +1,112 @@
+# anemoi-inference Integration
+
+The `tensogram-anemoi` package provides a plug-and-play output for
+[anemoi-inference](https://github.com/ecmwf/anemoi-inference), the ECMWF framework
+for running AI-based weather forecast models.  Once installed, anemoi-inference
+automatically discovers the plugin via Python entry points — no code changes to
+anemoi-inference are required.
+
+## Installation
+
+```bash
+pip install tensogram-anemoi
+```
+
+Or from source:
+
+```bash
+pip install -e python/tensogram-anemoi/
+```
+
+## Usage
+
+In an anemoi-inference run config, specify `tensogram` as the output:
+
+```yaml
+output:
+  tensogram:
+    path: forecast.tgm
+```
+
+All forecast steps are appended to a single `.tgm` file as they are produced.
+Remote destinations (S3, GCS, Azure, ...) are supported via fsspec:
+
+```yaml
+output:
+  tensogram:
+    path: s3://my-bucket/forecast.tgm
+    storage_options:
+      key: ...
+      secret: ...
+```
+
+## Configuration options
+
+All options after `path` must be supplied as keyword arguments.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `path` | `str` | — | Destination file path or remote URL |
+| `encoding` | `str` | `"none"` | `"none"` or `"simple_packing"` |
+| `bits` | `int` | `None` | Bits per value (required when `encoding="simple_packing"`) |
+| `compression` | `str` | `"zstd"` | `"none"`, `"zstd"`, `"lz4"`, `"szip"`, `"blosc2"` |
+| `dtype` | `str` | `"float32"` | Field array dtype: `"float32"` or `"float64"` |
+| `storage_options` | `dict` | `{}` | Forwarded to fsspec for remote paths |
+| `stack_pressure_levels` | `bool` | `False` | Stack pressure-level fields into 2-D objects |
+| `variables` | `list[str]` | `None` | Restrict output to a subset of variables |
+| `output_frequency` | `int` | `None` | Write every N steps |
+| `write_initial_state` | `bool` | `None` | Whether to write step 0 |
+
+## Message layout
+
+Each forecast step is written as one tensogram message containing:
+
+1. A **lat** coordinate object (`name: "grid_latitude"`)
+2. A **lon** coordinate object (`name: "grid_longitude"`)
+3. One **field object per variable** (or one stacked object per parameter when
+   `stack_pressure_levels=True`)
+
+Per-object metadata is stored under the `"anemoi"` namespace and the
+`"mars"` namespace (MARS keys from the checkpoint, plus `date`, `time`,
+`step` derived from the forecast state).
+
+Dimension-name hints are written to `_extra_["dim_names"]` so the
+`tensogram-xarray` backend can resolve axis names without explicit configuration:
+
+```python
+import tensogram_xarray  # noqa: F401
+import xarray as xr
+
+ds = xr.open_dataset("forecast.tgm", engine="tensogram")
+```
+
+## Pressure-level stacking
+
+When `stack_pressure_levels=True`, all fields sharing the same GRIB `param`
+are merged into a single 2-D object of shape `(n_grid, n_levels)`, sorted by
+level ascending.  The `"anemoi"` namespace carries `"levelist": [500, 850, ...]`
+instead of a scalar `"level"`.  Non-pressure-level fields are always written
+as individual 1-D objects.
+
+```yaml
+output:
+  tensogram:
+    path: forecast.tgm
+    stack_pressure_levels: true
+```
+
+## Simple packing
+
+For compact storage, use `simple_packing` with a `bits` value:
+
+```yaml
+output:
+  tensogram:
+    path: forecast.tgm
+    encoding: simple_packing
+    bits: 16
+    compression: zstd
+```
+
+Coordinate arrays (lat/lon) are never lossy-encoded; only field arrays
+are packed.

--- a/docs/src/guide/anemoi-integration.md
+++ b/docs/src/guide/anemoi-integration.md
@@ -84,8 +84,8 @@ ds = xr.open_dataset("forecast.tgm", engine="tensogram")
 
 When `stack_pressure_levels=True`, all fields sharing the same GRIB `param`
 are merged into a single 2-D object of shape `(n_grid, n_levels)`, sorted by
-level ascending.  The `"anemoi"` namespace carries `"levelist": [500, 850, ...]`
-instead of a scalar `"level"`.  Non-pressure-level fields are always written
+level ascending.  The `"mars"` namespace carries `"levelist": [500, 850, ...]`
+instead of a scalar `"level"` (following standard MARS convention).  Non-pressure-level fields are always written
 as individual 1-D objects.
 
 ```yaml

--- a/docs/src/guide/anemoi-integration.md
+++ b/docs/src/guide/anemoi-integration.md
@@ -28,7 +28,7 @@ output:
     path: forecast.tgm
 ```
 
-All forecast steps are appended to a single `.tgm` file as they are produced.
+All forecast steps are written to a single `.tgm` file as they are produced.
 Remote destinations (S3, GCS, Azure, ...) are supported via fsspec:
 
 ```yaml
@@ -57,36 +57,13 @@ All options after `path` must be supplied as keyword arguments.
 | `output_frequency` | `int` | `None` | Write every N steps |
 | `write_initial_state` | `bool` | `None` | Whether to write step 0 |
 
-## Message layout
-
-Each forecast step is written as one tensogram message containing:
-
-1. A **lat** coordinate object (`name: "grid_latitude"`)
-2. A **lon** coordinate object (`name: "grid_longitude"`)
-3. One **field object per variable** (or one stacked object per parameter when
-   `stack_pressure_levels=True`)
-
-Per-object metadata is stored under the `"anemoi"` namespace and the
-`"mars"` namespace (MARS keys from the checkpoint, plus `date`, `time`,
-`step` derived from the forecast state).
-
-Dimension-name hints are written to `_extra_["dim_names"]` so the
-`tensogram-xarray` backend can resolve axis names without explicit configuration:
-
-```python
-import tensogram_xarray  # noqa: F401
-import xarray as xr
-
-ds = xr.open_dataset("forecast.tgm", engine="tensogram")
-```
-
 ## Pressure-level stacking
 
 When `stack_pressure_levels=True`, all fields sharing the same GRIB `param`
 are merged into a single 2-D object of shape `(n_grid, n_levels)`, sorted by
 level ascending.  The `"mars"` namespace carries `"levelist": [500, 850, ...]`
-instead of a scalar `"level"` (following standard MARS convention).  Non-pressure-level fields are always written
-as individual 1-D objects.
+instead of a scalar `"level"` (following standard MARS convention).
+Non-pressure-level fields are always written as individual 1-D objects.
 
 ```yaml
 output:
@@ -108,5 +85,222 @@ output:
     compression: zstd
 ```
 
-Coordinate arrays (lat/lon) are never lossy-encoded; only field arrays
-are packed.
+Coordinate arrays (lat/lon) are never lossy-encoded; only field arrays are packed.
+
+---
+
+## Metadata reference
+
+Each `.tgm` file produced by `tensogram-anemoi` contains one message per forecast
+step.  This section documents exactly what is stored in each message and how to
+read it with the raw tensogram Python API.
+
+### Opening a file
+
+```python
+import tensogram
+
+tgm = tensogram.TensogramFile.open("forecast.tgm")
+print(len(tgm), "steps")
+
+meta, objects = tgm[0]   # first step
+```
+
+`meta` is the decoded message metadata.  `objects` is a list of
+`(descriptor, array)` pairs, one entry per object in the message.
+
+### Object layout
+
+Every message has the following fixed layout:
+
+| Index | `base[i]["name"]` | Content |
+|-------|-------------------|---------|
+| 0 | `"grid_latitude"` | Latitude coordinates, float64, shape `(n_grid,)` |
+| 1 | `"grid_longitude"` | Longitude coordinates, float64, shape `(n_grid,)` |
+| 2 … N | variable name or param name | Field data |
+
+```python
+meta, objects = tgm[0]
+
+lat_desc, lat_arr = objects[0]   # latitudes
+lon_desc, lon_arr = objects[1]   # longitudes
+fld_desc, fld_arr = objects[2]   # first field
+```
+
+The coordinate names `"grid_latitude"` and `"grid_longitude"` are intentionally
+distinct from the standard `"latitude"` / `"longitude"` names so that all objects
+in a message share a single flat grid dimension rather than each coordinate
+spawning its own dimension.
+
+### `base[i]` — per-object metadata
+
+Each object has a corresponding entry in `meta.base`:
+
+```python
+for i, entry in enumerate(meta.base):
+    print(i, entry)
+```
+
+Every entry contains:
+
+| Key | Type | Present on | Description |
+|-----|------|-----------|-------------|
+| `"name"` | `str` | all objects | Variable or coordinate name |
+| `"anemoi"` | `dict` | all objects | anemoi-specific metadata (see below) |
+| `"mars"` | `dict` | field objects only | MARS metadata (see below) |
+
+#### `"anemoi"` namespace
+
+| Key | Type | Present on | Description |
+|-----|------|-----------|-------------|
+| `"variable"` | `str` | all objects | Internal anemoi-inference variable name |
+
+For coordinates, `"variable"` is `"latitude"` or `"longitude"` (the canonical
+name, not the `"grid_*"` name stored in `"name"`):
+
+```python
+assert meta.base[0]["name"] == "grid_latitude"
+assert meta.base[0]["anemoi"]["variable"] == "latitude"
+
+assert meta.base[1]["name"] == "grid_longitude"
+assert meta.base[1]["anemoi"]["variable"] == "longitude"
+```
+
+For fields, `"variable"` is the internal anemoi-inference name (e.g. `"t500"`
+for 500 hPa temperature, `"2t"` for 2 m temperature):
+
+```python
+assert meta.base[2]["anemoi"]["variable"] == "2t"
+```
+
+#### `"mars"` namespace
+
+Coordinate objects carry no `"mars"` key.  Every field object carries a `"mars"`
+dict combining keys from the anemoi-inference checkpoint with the temporal keys
+derived from the forecast state:
+
+**Temporal keys** (present on every field object):
+
+| Key | Type | Description | Example |
+|-----|------|-------------|---------|
+| `"date"` | `str` | Analysis/base date (`YYYYMMDD`) | `"20240101"` |
+| `"time"` | `str` | Analysis/base time (`HHMM`) | `"0000"` |
+| `"step"` | `int` or `float` | Forecast lead time in hours | `6`, `1.5` |
+
+**Checkpoint keys** (present when available in the model checkpoint):
+
+| Key | Type | Description | Example |
+|-----|------|-------------|---------|
+| `"param"` | `str` | GRIB parameter short name | `"2t"`, `"t"`, `"u"` |
+| `"levtype"` | `str` | Level type | `"sfc"`, `"pl"`, `"ml"` |
+| `"level"` | `int` | Pressure level (unstacked fields only) | `500` |
+| `"levelist"` | `list[int]` | Pressure levels (stacked fields only) | `[500, 850, 1000]` |
+
+Reading field metadata:
+
+```python
+meta, objects = tgm[0]
+
+# Surface field (e.g. 2 m temperature)
+entry = meta.base[2]
+print(entry["name"])                    # "2t"
+print(entry["anemoi"]["variable"])      # "2t"
+print(entry["mars"]["param"])           # "2t"
+print(entry["mars"]["date"])            # "20240101"
+print(entry["mars"]["time"])            # "0000"
+print(entry["mars"]["step"])            # 6
+
+# Pressure-level field (unstacked)
+entry = meta.base[3]
+print(entry["mars"]["param"])           # "t"
+print(entry["mars"]["levtype"])         # "pl"
+print(entry["mars"]["level"])           # 500
+```
+
+With `stack_pressure_levels=True`, the pressure-level group has `"levelist"`
+instead of `"level"`, and the array is 2-D:
+
+```python
+entry = meta.base[2]                    # stacked t group
+print(entry["mars"]["levelist"])        # [500, 850, 1000]
+print(entry["mars"]["param"])           # "t"
+
+desc, arr = objects[2]
+print(arr.shape)                        # (n_grid, 3)  — columns sorted by level
+```
+
+### `meta.extra` — message-level metadata
+
+`meta.extra` carries metadata that applies to the whole message rather than
+individual objects.
+
+#### `"dim_names"` — axis-size hints
+
+```python
+dim_names = meta.extra["dim_names"]
+# e.g. {"21600": "values"}
+# or   {"21600": "values", "3": "level"}  (with stack_pressure_levels=True)
+```
+
+`dim_names` maps the string representation of an axis length to a semantic
+name.  It exists to allow downstream tools to assign meaningful axis names
+without requiring any anemoi-specific knowledge.  The grid axis is always
+labelled `"values"`; when pressure-level stacking is enabled, each unique
+level-axis size is labelled `"level"`.
+
+### Object descriptors
+
+Each `(descriptor, array)` pair returned by `objects[i]` gives low-level
+encoding detail:
+
+```python
+desc, arr = objects[2]
+
+print(desc.dtype)        # "float32" or "float64"
+print(desc.shape)        # [n_grid] for flat, [n_grid, n_levels] for stacked
+print(desc.encoding)     # "none" or "simple_packing"
+print(desc.compression)  # "zstd", "lz4", etc.
+```
+
+Coordinate arrays are always `float64` regardless of the `dtype` setting.
+Field arrays use the configured `dtype` (`"float32"` by default), promoted to
+`float64` automatically when `encoding="simple_packing"`.
+
+### Full inspection example
+
+```python
+import tensogram
+
+tgm = tensogram.TensogramFile.open("forecast.tgm")
+
+for step_idx, (meta, objects) in enumerate(tgm):
+    print(f"\n--- step {step_idx} ---")
+
+    # Dimension hints
+    print("dim_names:", meta.extra.get("dim_names", {}))
+
+    for i, entry in enumerate(meta.base):
+        desc, arr = objects[i]
+        anemoi = entry.get("anemoi", {})
+        mars = entry.get("mars", {})
+
+        print(
+            f"  [{i}] name={entry['name']!r:20s}"
+            f"  variable={anemoi.get('variable')!r:10s}"
+            f"  shape={arr.shape}"
+            f"  dtype={desc.dtype}"
+            + (f"  step={mars.get('step')}" if mars else "")
+        )
+```
+
+Example output for a single step with surface fields and stacked pressure levels:
+
+```
+--- step 0 ---
+dim_names: {'21600': 'values', '3': 'level'}
+  [0] name='grid_latitude'    variable='latitude'   shape=(21600,)  dtype=float64
+  [1] name='grid_longitude'   variable='longitude'  shape=(21600,)  dtype=float64
+  [2] name='2t'               variable='2t'         shape=(21600,)  dtype=float32  step=6
+  [3] name='t'                variable='t'          shape=(21600, 3)  dtype=float32  step=6
+  [4] name='u'                variable='u'          shape=(21600, 3)  dtype=float32  step=6
+```

--- a/plans/DONE.md
+++ b/plans/DONE.md
@@ -18,9 +18,9 @@
 
 - **Workspace.** Default Rust workspace + optional Rust crates
   (`tensogram-grib`, `tensogram-netcdf`, `tensogram-wasm`) + the PyO3
-  `python/bindings` crate + two separate Python packages
-  (`tensogram-xarray`, `tensogram-zarr`). See `ARCHITECTURE.md` for the
-  full crate list and what each one does.
+  `python/bindings` crate + three separate Python packages
+  (`tensogram-xarray`, `tensogram-zarr`, `tensogram-anemoi`). See
+  `ARCHITECTURE.md` for the full crate list and what each one does.
 - **Quality bar.** Zero clippy warnings, zero ruff issues,
   `panic = "abort"` on both release and dev profiles. Library code
   avoids `unwrap`/`expect`/`panic!` on any fallible input path;
@@ -823,3 +823,22 @@ byte-for-byte cross-language verification:
 - **Bindings.** `PyO3`, `pyo3-async-runtimes`, `cbindgen`,
   `wasm-bindgen`, `wasm-pack`.
 - **Dev.** `tempfile`, `proptest`, GoogleTest (FetchContent).
+
+## anemoi-inference output plugin (`tensogram-anemoi`)
+
+Standalone pip package at `python/tensogram-anemoi/` that registers
+`TensogramOutput` as an anemoi-inference output plugin.
+
+| Component | What was built |
+|-----------|---------------|
+| `src/tensogram_anemoi/output.py` | `TensogramOutput(Output)` — writes each forecast step as one tensogram message |
+| `pyproject.toml` | `setuptools-scm` build, entry point `anemoi.inference.outputs = tensogram` |
+| `tests/test_tensogram_output.py` | Round-trip, encoding, stacking, remote fsspec, metadata |
+
+**Design decisions:**
+- Registered via `[project.entry-points."anemoi.inference.outputs"]` so anemoi-inference discovers it on install — no fork required.
+- All parameters after `path` are keyword-only (enforced with `*`).
+- Per-object MARS keys (`date`, `time`, `step`) live in `base[i]["mars"]`; no redundant copy in `_extra_`.
+- Pressure-level stacking produces 2-D `(n_grid, n_levels)` objects with `"levelist": [...]` in the `"anemoi"` namespace (MARS convention).
+- `_extra_["dim_names"]` carries axis-size→name hints for the tensogram-xarray backend.
+- Coordinate arrays (lat/lon) use `"grid_latitude"` / `"grid_longitude"` names, outside `KNOWN_COORD_NAMES`, so all objects share one flat dimension in xarray.

--- a/python/tensogram-anemoi/pyproject.toml
+++ b/python/tensogram-anemoi/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-build-backend = "setuptools.build_meta"
-requires = [ "setuptools>=60", "setuptools-scm>=8" ]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "tensogram-anemoi"
-dynamic = [ "version" ]
+version = "0.16.1"
 description = "anemoi-inference output plugin for tensogram .tgm files"
 readme = {text = "anemoi-inference output plugin for tensogram .tgm files", content-type = "text/plain"}
 requires-python = ">=3.11"
@@ -34,13 +34,8 @@ dev = ["pytest>=7.0", "ruff>=0.4"]
 [project.entry-points."anemoi.inference.outputs"]
 tensogram = "tensogram_anemoi.output:TensogramOutput"
 
-[tool.setuptools.packages.find]
-where = ["src"]
-
-[tool.setuptools_scm]
-version_file = "src/tensogram_anemoi/_version.py"
-root = "../.."
-fallback_version = "0.0.0.dev0"
+[tool.hatch.build.targets.wheel]
+packages = ["src/tensogram_anemoi"]
 
 [tool.ruff]
 line-length = 99

--- a/python/tensogram-anemoi/pyproject.toml
+++ b/python/tensogram-anemoi/pyproject.toml
@@ -12,7 +12,6 @@ license = "Apache-2.0"
 authors = [{name = "ECMWF", email = "software@ecmwf.int"}]
 classifiers = [
     "Development Status :: 4 - Beta",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Atmospheric Science",
@@ -40,6 +39,7 @@ where = ["src"]
 
 [tool.setuptools_scm]
 version_file = "src/tensogram_anemoi/_version.py"
+fallback_version = "0.0.0.dev0"
 
 [tool.ruff]
 line-length = 99

--- a/python/tensogram-anemoi/pyproject.toml
+++ b/python/tensogram-anemoi/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 dependencies = [
     "tensogram>=0.16.1,<0.17",
-    "anemoi-inference",
+    "anemoi-inference>=0.4,<0.11",
     "fsspec",
     "numpy",
 ]

--- a/python/tensogram-anemoi/pyproject.toml
+++ b/python/tensogram-anemoi/pyproject.toml
@@ -39,6 +39,7 @@ where = ["src"]
 
 [tool.setuptools_scm]
 version_file = "src/tensogram_anemoi/_version.py"
+root = "../.."
 fallback_version = "0.0.0.dev0"
 
 [tool.ruff]

--- a/python/tensogram-anemoi/pyproject.toml
+++ b/python/tensogram-anemoi/pyproject.toml
@@ -6,7 +6,7 @@ requires = [ "setuptools>=60", "setuptools-scm>=8" ]
 name = "tensogram-anemoi"
 dynamic = [ "version" ]
 description = "anemoi-inference output plugin for tensogram .tgm files"
-readme = "README.md"
+readme = {text = "anemoi-inference output plugin for tensogram .tgm files", content-type = "text/plain"}
 requires-python = ">=3.11"
 license = "Apache-2.0"
 authors = [{name = "ECMWF", email = "software@ecmwf.int"}]

--- a/python/tensogram-anemoi/pyproject.toml
+++ b/python/tensogram-anemoi/pyproject.toml
@@ -1,0 +1,66 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = [ "setuptools>=60", "setuptools-scm>=8" ]
+
+[project]
+name = "tensogram-anemoi"
+dynamic = [ "version" ]
+description = "anemoi-inference output plugin for tensogram .tgm files"
+readme = "README.md"
+requires-python = ">=3.11"
+license = "Apache-2.0"
+authors = [{name = "ECMWF", email = "software@ecmwf.int"}]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Atmospheric Science",
+]
+dependencies = [
+    "tensogram>=0.16.1,<0.17",
+    "anemoi-inference",
+    "fsspec",
+    "numpy",
+]
+
+[project.urls]
+Homepage = "https://sites.ecmwf.int/docs/tensogram/main"
+Repository = "https://github.com/ecmwf/tensogram"
+Documentation = "https://sites.ecmwf.int/docs/tensogram/main"
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0", "ruff>=0.4"]
+
+[project.entry-points."anemoi.inference.outputs"]
+tensogram = "tensogram_anemoi.output:TensogramOutput"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools_scm]
+version_file = "src/tensogram_anemoi/_version.py"
+
+[tool.ruff]
+line-length = 99
+target-version = "py311"
+
+[tool.ruff.lint]
+select = [
+    "E",
+    "W",
+    "F",
+    "I",
+    "N",
+    "UP",
+    "B",
+    "SIM",
+    "PT",
+    "RUF",
+]
+
+[tool.ruff.lint.isort]
+known-third-party = ["numpy", "tensogram", "anemoi", "fsspec", "pytest"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/python/tensogram-anemoi/src/tensogram_anemoi/__init__.py
+++ b/python/tensogram-anemoi/src/tensogram_anemoi/__init__.py
@@ -1,0 +1,4 @@
+# (C) Copyright 2025 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.

--- a/python/tensogram-anemoi/src/tensogram_anemoi/output.py
+++ b/python/tensogram-anemoi/src/tensogram_anemoi/output.py
@@ -32,8 +32,8 @@ _COORD_NAME_MAP = {
 class TensogramOutput(Output):
     """Tensogram output plugin for anemoi-inference.
 
-    Writes each forecast step as one tensogram message appended to a .tgm file
-    or streamed over a TCP socket.  Each message contains lat/lon coordinate
+    Writes each forecast step as one tensogram message to a .tgm file.
+    Each message contains lat/lon coordinate
     objects followed by one object per field (or one stacked object per
     pressure-level parameter when ``stack_pressure_levels=True``).
 
@@ -185,7 +185,7 @@ class TensogramOutput(Output):
             try:
                 self._handle.flush()
             except Exception:
-                pass
+                LOG.warning("TensogramOutput: failed to flush output stream before close", exc_info=True)
             self._handle.close()
             self._handle = None
 

--- a/python/tensogram-anemoi/src/tensogram_anemoi/output.py
+++ b/python/tensogram-anemoi/src/tensogram_anemoi/output.py
@@ -1,0 +1,317 @@
+# (C) Copyright 2025 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+import logging
+from functools import cached_property
+from pathlib import Path
+
+import numpy as np
+
+from anemoi.inference.context import Context
+from anemoi.inference.decorators import main_argument
+from anemoi.inference.output import Output
+from anemoi.inference.types import ProcessorConfig
+from anemoi.inference.types import State
+
+LOG = logging.getLogger(__name__)
+
+# Written into base[i]["name"] for lat/lon objects.  These names are
+# deliberately NOT in tensogram-xarray's KNOWN_COORD_NAMES so that lat/lon
+# objects share the same flat dimension as all field objects rather than each
+# spawning its own dimension.  The canonical names are preserved in the "anemoi"
+# namespace for downstream consumers.
+_COORD_NAME_MAP = {
+    "latitude": "grid_latitude",
+    "longitude": "grid_longitude",
+}
+
+
+@main_argument("path")
+class TensogramOutput(Output):
+    """Tensogram output plugin for anemoi-inference.
+
+    Writes each forecast step as one tensogram message appended to a .tgm file
+    or streamed over a TCP socket.  Each message contains lat/lon coordinate
+    objects followed by one object per field (or one stacked object per
+    pressure-level parameter when ``stack_pressure_levels=True``).
+
+    Per-object metadata is stored under the ``"anemoi"`` namespace in CBOR.
+    Message-level metadata (date, step) is stored in ``_extra_["anemoi"]``.
+    Dimension-name hints are stored in ``_extra_["dim_names"]`` so the
+    tensogram-xarray backend can resolve meaningful names without the reader
+    having to pass ``dim_names`` explicitly.
+
+    Supports local paths and remote URLs (s3://, gs://, az://, ...) via fsspec.
+    Each step is encoded and written immediately -- no full-forecast buffering.
+
+    Pressure-level stacking
+    -----------------------
+    When ``stack_pressure_levels=True``, all fields sharing the same ``param``
+    are stacked into a single 2-D object of shape ``(n_grid, n_levels)``,
+    sorted by level in ascending order.  The per-object metadata stores
+    ``"levels": [500, 850, ...]`` (plural) instead of the scalar ``"level"``
+    key used for unstacked fields.
+
+    Without stacking (default), every field is a separate 1-D object and the
+    scalar ``"level"`` key is always stored when it is present in the
+    checkpoint's GRIB keys.
+    """
+
+    def __init__(
+        self,
+        context: Context,
+        path: str,
+        encoding: str = "none",
+        bits: int | None = None,
+        compression: str = "zstd",
+        dtype: str = "float32",
+        storage_options: dict | None = None,
+        stack_pressure_levels: bool = False,
+        variables: list[str] | None = None,
+        post_processors: list[ProcessorConfig] | None = None,
+        output_frequency: int | None = None,
+        write_initial_state: bool | None = None,
+    ) -> None:
+        super().__init__(
+            context,
+            variables=variables,
+            post_processors=post_processors,
+            output_frequency=output_frequency,
+            write_initial_state=write_initial_state,
+        )
+        if encoding == "simple_packing" and bits is None:
+            raise ValueError("bits must be set when encoding='simple_packing'")
+        self.path = path
+        self.encoding = encoding
+        self.bits = bits
+        self.compression = compression
+        self.dtype = dtype
+        self.storage_options = storage_options or {}
+        self.stack_pressure_levels = stack_pressure_levels
+        self._handle = None
+
+    def __repr__(self) -> str:
+        return f"TensogramOutput({self.path})"
+
+    @cached_property
+    def _numpy_dtype(self) -> np.dtype:
+        return np.dtype(self.dtype)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def open(self, state: State) -> None:
+        import fsspec
+
+        path_str = str(self.path)
+        if "://" not in path_str:
+            Path(path_str).parent.mkdir(parents=True, exist_ok=True)
+
+        self._handle = fsspec.open(path_str, "wb", **self.storage_options).open()
+        LOG.info("TensogramOutput: writing to %s", path_str)
+
+    def write_initial_state(self, state: State) -> None:
+        """Write the initial state, reducing multi-step fields to the last step."""
+        from anemoi.inference.state import reduce_state
+
+        state = reduce_state(state)
+        return super().write_initial_state(state)
+
+    def write_step(self, state: State) -> None:
+        """Encode one forecast step as a tensogram message and write it immediately."""
+        if self._handle is None:
+            raise RuntimeError(f"{self!r}: write_step called before open() or after close()")
+
+        global_meta = {
+            "version": 2,
+            "base": [],
+            "_extra_": {
+                "anemoi": {
+                    "date": state["date"].isoformat(),
+                    "step": state["step"].total_seconds(),
+                }
+            },
+        }
+        descriptors_and_data = []
+
+        step_seconds = state["step"].total_seconds()
+        step_hours = int(step_seconds / 3600) if step_seconds % 3600 == 0 else step_seconds / 3600
+        base_dt = state["date"] - state["step"]
+        mars_extra = {
+            "date": base_dt.strftime("%Y%m%d"),
+            "time": base_dt.strftime("%H%M"),
+            "step": step_hours,
+        }
+
+        for coord_name, coord_arr in [
+            ("latitude", state["latitudes"]),
+            ("longitude", state["longitudes"]),
+        ]:
+            arr = np.asarray(coord_arr, dtype=np.float64)
+            global_meta["base"].append(
+                {
+                    "name": _COORD_NAME_MAP[coord_name],
+                    "anemoi": {"variable": coord_name},
+                }
+            )
+            descriptors_and_data.append(
+                (
+                    {"type": "ntensor", "shape": list(arr.shape), "dtype": "float64"},
+                    arr,
+                )
+            )
+
+        if self.stack_pressure_levels:
+            self._add_fields_stacked(state, global_meta, descriptors_and_data, mars_extra)
+        else:
+            self._add_fields_flat(state, global_meta, descriptors_and_data, mars_extra)
+
+        n_grid = len(state["latitudes"])
+        dim_names_hint: dict[str, str] = {str(n_grid): "values"}
+        if self.stack_pressure_levels:
+            for _, arr in descriptors_and_data:
+                if arr.ndim == 2:
+                    level_size = str(arr.shape[1])
+                    if level_size not in dim_names_hint:
+                        dim_names_hint[level_size] = "level"
+        global_meta["_extra_"]["dim_names"] = dim_names_hint
+
+        import tensogram
+
+        msg_bytes = tensogram.encode(global_meta, descriptors_and_data)
+        self._handle.write(msg_bytes)
+
+    def close(self) -> None:
+        """Flush and close the output stream."""
+        if self._handle is not None:
+            try:
+                self._handle.flush()
+            except Exception:
+                pass
+            self._handle.close()
+            self._handle = None
+
+    # ------------------------------------------------------------------
+    # Field object builders
+    # ------------------------------------------------------------------
+
+    def _add_fields_flat(
+        self,
+        state: State,
+        global_meta: dict,
+        descriptors_and_data: list,
+        mars_extra: dict,
+    ) -> None:
+        """Add one object per field (default, no stacking)."""
+        for name, values in state["fields"].items():
+            if self.skip_variable(name):
+                continue
+            variable = self.typed_variables.get(name)
+            if variable is None:
+                LOG.warning("TensogramOutput: no typed variable for %r -- metadata will be incomplete", name)
+            grib = getattr(variable, "grib_keys", {}) if variable else {}
+            base_entry, descriptor, arr = self._build_field_object(name, grib, values, mars_extra)
+            global_meta["base"].append(base_entry)
+            descriptors_and_data.append((descriptor, arr))
+
+    def _add_fields_stacked(
+        self,
+        state: State,
+        global_meta: dict,
+        descriptors_and_data: list,
+        mars_extra: dict,
+    ) -> None:
+        """Group pressure-level fields by param and stack; write others flat."""
+        pl_groups: dict[str, list[tuple[int, str, dict, np.ndarray]]] = {}
+        non_pl: list[tuple[str, dict, np.ndarray]] = []
+
+        for name, values in state["fields"].items():
+            if self.skip_variable(name):
+                continue
+            variable = self.typed_variables.get(name)
+            if variable is None:
+                LOG.warning("TensogramOutput: no typed variable for %r -- metadata will be incomplete", name)
+            grib = getattr(variable, "grib_keys", {}) if variable else {}
+            if variable is not None and variable.is_pressure_level:
+                param = variable.param
+                level = variable.level
+                pl_groups.setdefault(param, []).append((level, name, grib, values))
+            else:
+                non_pl.append((name, grib, values))
+
+        if not pl_groups:
+            LOG.warning("TensogramOutput: stack_pressure_levels=True but no pressure-level fields found")
+
+        for name, grib, values in non_pl:
+            base_entry, descriptor, arr = self._build_field_object(name, grib, values, mars_extra)
+            global_meta["base"].append(base_entry)
+            descriptors_and_data.append((descriptor, arr))
+
+        for param in sorted(pl_groups):
+            group = sorted(pl_groups[param], key=lambda x: x[0])
+            base_entry, descriptor, arr = self._build_stacked_object(param, group, mars_extra)
+            global_meta["base"].append(base_entry)
+            descriptors_and_data.append((descriptor, arr))
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _prepare_array(self, values: np.ndarray) -> np.ndarray:
+        arr = np.asarray(values, dtype=self._numpy_dtype)
+        if self.encoding == "simple_packing":
+            arr = arr.astype(np.float64)
+        return arr
+
+    def _build_descriptor(self, arr: np.ndarray) -> dict:
+        descriptor = {
+            "type": "ntensor",
+            "shape": list(arr.shape),
+            "dtype": arr.dtype.name,
+            "encoding": self.encoding,
+            "compression": self.compression,
+        }
+        if self.encoding == "simple_packing" and self.bits is not None:
+            import tensogram
+
+            sp_params = tensogram.compute_packing_params(arr.ravel(), self.bits, 0)
+            descriptor.update(sp_params)
+        return descriptor
+
+    def _build_field_object(
+        self,
+        name: str,
+        grib: dict,
+        values: np.ndarray,
+        mars_extra: dict,
+    ) -> tuple[dict, dict, np.ndarray]:
+        """Build (base_entry, descriptor, array) for a single flat field object."""
+        mars = {**mars_extra, **grib}
+        base_entry: dict = {"name": name, "anemoi": {"variable": name}}
+        if mars:
+            base_entry["mars"] = mars
+        arr = self._prepare_array(values)
+        return base_entry, self._build_descriptor(arr), arr
+
+    def _build_stacked_object(
+        self,
+        param: str,
+        group: list[tuple[int, str, dict, np.ndarray]],
+        mars_extra: dict,
+    ) -> tuple[dict, dict, np.ndarray]:
+        """Build (base_entry, descriptor, array) for a stacked pressure-level object."""
+        levels = [item[0] for item in group]
+        first_grib = group[0][2]
+
+        arrays = [self._prepare_array(item[3]) for item in group]
+        stacked = np.column_stack(arrays)
+
+        mars = {**mars_extra, **{k: v for k, v in first_grib.items() if k != "level"}}
+
+        base_entry: dict = {"name": param, "anemoi": {"variable": param, "levels": levels}}
+        if mars:
+            base_entry["mars"] = mars
+        return base_entry, self._build_descriptor(stacked), stacked

--- a/python/tensogram-anemoi/src/tensogram_anemoi/output.py
+++ b/python/tensogram-anemoi/src/tensogram_anemoi/output.py
@@ -50,8 +50,8 @@ class TensogramOutput(Output):
     When ``stack_pressure_levels=True``, all fields sharing the same ``param``
     are stacked into a single 2-D object of shape ``(n_grid, n_levels)``,
     sorted by level in ascending order.  The per-object metadata stores
-    ``"levelist": [500, 850, ...]`` instead of the scalar ``"level"``
-    key used for unstacked fields.
+    ``"levelist": [500, 850, ...]`` in the ``"mars"`` namespace instead of
+    the scalar ``"level"`` key used for unstacked fields.
 
     Without stacking (default), every field is a separate 1-D object and the
     scalar ``"level"`` key is always stored when it is present in the
@@ -304,9 +304,9 @@ class TensogramOutput(Output):
         arrays = [self._prepare_array(item[3]) for item in group]
         stacked = np.column_stack(arrays)
 
-        mars = {**mars_extra, **{k: v for k, v in first_grib.items() if k != "level"}}
+        mars = {**mars_extra, **{k: v for k, v in first_grib.items() if k != "level"}, "levelist": levels}
 
-        base_entry: dict = {"name": param, "anemoi": {"variable": param, "levelist": levels}}
+        base_entry: dict = {"name": param, "anemoi": {"variable": param}}
         if mars:
             base_entry["mars"] = mars
         return base_entry, self._build_descriptor(stacked), stacked

--- a/python/tensogram-anemoi/src/tensogram_anemoi/output.py
+++ b/python/tensogram-anemoi/src/tensogram_anemoi/output.py
@@ -38,7 +38,6 @@ class TensogramOutput(Output):
     pressure-level parameter when ``stack_pressure_levels=True``).
 
     Per-object metadata is stored under the ``"anemoi"`` namespace in CBOR.
-    Message-level metadata (date, step) is stored in ``_extra_["anemoi"]``.
     Dimension-name hints are stored in ``_extra_["dim_names"]`` so the
     tensogram-xarray backend can resolve meaningful names without the reader
     having to pass ``dim_names`` explicitly.
@@ -51,7 +50,7 @@ class TensogramOutput(Output):
     When ``stack_pressure_levels=True``, all fields sharing the same ``param``
     are stacked into a single 2-D object of shape ``(n_grid, n_levels)``,
     sorted by level in ascending order.  The per-object metadata stores
-    ``"levels": [500, 850, ...]`` (plural) instead of the scalar ``"level"``
+    ``"levelist": [500, 850, ...]`` instead of the scalar ``"level"``
     key used for unstacked fields.
 
     Without stacking (default), every field is a separate 1-D object and the
@@ -63,6 +62,7 @@ class TensogramOutput(Output):
         self,
         context: Context,
         path: str,
+        *,
         encoding: str = "none",
         bits: int | None = None,
         compression: str = "zstd",
@@ -128,12 +128,7 @@ class TensogramOutput(Output):
         global_meta = {
             "version": 2,
             "base": [],
-            "_extra_": {
-                "anemoi": {
-                    "date": state["date"].isoformat(),
-                    "step": state["step"].total_seconds(),
-                }
-            },
+            "_extra_": {},
         }
         descriptors_and_data = []
 
@@ -311,7 +306,7 @@ class TensogramOutput(Output):
 
         mars = {**mars_extra, **{k: v for k, v in first_grib.items() if k != "level"}}
 
-        base_entry: dict = {"name": param, "anemoi": {"variable": param, "levels": levels}}
+        base_entry: dict = {"name": param, "anemoi": {"variable": param, "levelist": levels}}
         if mars:
             base_entry["mars"] = mars
         return base_entry, self._build_descriptor(stacked), stacked

--- a/python/tensogram-anemoi/tests/test_tensogram_output.py
+++ b/python/tensogram-anemoi/tests/test_tensogram_output.py
@@ -1,0 +1,541 @@
+# (C) Copyright 2025 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+"""Tests for TensogramOutput."""
+
+from datetime import datetime
+from datetime import timedelta
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from tensogram_anemoi.output import TensogramOutput
+
+tensogram = pytest.importorskip("tensogram", reason="tensogram not installed")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+N_GRID = 100
+FIELD_NAMES = ["2t", "10u", "10v"]
+
+
+def _make_variable(param=None, levtype=None, level=None):
+    grib = {"param": param} if param is not None else {}
+    if levtype is not None:
+        grib["levtype"] = levtype
+    if level is not None:
+        grib["level"] = level
+    is_pl = levtype is not None and level is not None
+    return SimpleNamespace(
+        grib_keys=grib,
+        is_computed_forcing=False,
+        is_pressure_level=is_pl,
+        param=param,
+        level=level,
+    )
+
+
+def _make_context(field_names=FIELD_NAMES):
+    typed_variables = {name: _make_variable(param=name) for name in field_names}
+
+    checkpoint = SimpleNamespace(
+        typed_variables=typed_variables,
+    )
+    context = SimpleNamespace(
+        checkpoint=checkpoint,
+        reference_date=datetime(2024, 1, 1),
+        write_initial_state=False,
+        output_frequency=None,
+        typed_variables={},
+    )
+    return context
+
+
+def _make_state(step_hours=1, field_names=FIELD_NAMES, n_grid=N_GRID, seed=0):
+    rng = np.random.default_rng(seed)
+    date = datetime(2024, 1, 1) + timedelta(hours=step_hours)
+    return {
+        "date": date,
+        "step": timedelta(hours=step_hours),
+        "latitudes": np.linspace(-90, 90, n_grid, dtype=np.float64),
+        "longitudes": np.linspace(0, 360, n_grid, dtype=np.float64),
+        "fields": {name: rng.random(n_grid).astype(np.float32) for name in field_names},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_write_step_before_open_raises():
+    """write_step raises RuntimeError when called before open()."""
+    context = _make_context()
+    output = TensogramOutput(context, "/tmp/never.tgm")
+    with pytest.raises(RuntimeError, match="open"):
+        output.write_step(_make_state())
+
+
+def test_write_initial_state_reduces_multistep(tmp_path):
+    """write_initial_state reduces a multi-step field array to its last step."""
+    from unittest.mock import patch
+
+    path = tmp_path / "init.tgm"
+    context = _make_context(["2t"])
+    output = TensogramOutput(context, str(path), write_initial_state=True)
+
+    rng = np.random.default_rng(1)
+    multi_step_values = rng.random((3, N_GRID)).astype(np.float32)
+    state = {
+        "date": datetime(2024, 1, 1),
+        "step": timedelta(0),
+        "latitudes": np.linspace(-90, 90, N_GRID, dtype=np.float64),
+        "longitudes": np.linspace(0, 360, N_GRID, dtype=np.float64),
+        "fields": {"2t": multi_step_values},
+    }
+
+    written_states = []
+
+    def capture_write_step(s):
+        written_states.append(s)
+
+    output.open(state)
+    with patch.object(output, "write_step", side_effect=capture_write_step):
+        output.write_initial_state(state)
+    output.close()
+
+    assert written_states, "write_step was not called by write_initial_state"
+    written_field = written_states[0]["fields"]["2t"]
+    np.testing.assert_array_equal(written_field, multi_step_values[-1])
+
+
+def test_write_and_read_local(tmp_path):
+    """Write 3 steps to a local .tgm file and verify round-trip."""
+    path = tmp_path / "forecast.tgm"
+    context = _make_context()
+    output = TensogramOutput(context, str(path))
+
+    states = [_make_state(h) for h in range(1, 4)]
+    output.open(states[0])
+    for state in states:
+        output.write_step(state)
+    output.close()
+
+    assert path.exists()
+
+    tgm_file = tensogram.TensogramFile.open(str(path))
+    assert len(tgm_file) == 3
+
+    for i, msg in enumerate(tgm_file):
+        meta, objects = msg
+
+        assert len(objects) == 5
+
+        assert meta.base[0]["name"] == "grid_latitude"
+        assert meta.base[1]["name"] == "grid_longitude"
+        assert meta.base[0]["anemoi"]["variable"] == "latitude"
+        assert meta.base[1]["anemoi"]["variable"] == "longitude"
+        lat_desc, lat_arr = objects[0]
+        lon_desc, lon_arr = objects[1]
+        assert lat_desc.dtype == "float64"
+        assert lon_desc.dtype == "float64"
+        np.testing.assert_allclose(lat_arr, states[i]["latitudes"])
+        np.testing.assert_allclose(lon_arr, states[i]["longitudes"])
+
+        expected_step = int(states[i]["step"].total_seconds() / 3600)
+        base_dt = states[i]["date"] - states[i]["step"]
+        expected_date = base_dt.strftime("%Y%m%d")
+        expected_time = base_dt.strftime("%H%M")
+        for j, name in enumerate(FIELD_NAMES):
+            obj_idx = 2 + j
+            assert meta.base[obj_idx]["name"] == name
+            assert meta.base[obj_idx]["anemoi"]["variable"] == name
+            assert meta.base[obj_idx]["mars"]["param"] == name
+            assert meta.base[obj_idx]["mars"]["step"] == expected_step
+            assert meta.base[obj_idx]["mars"]["date"] == expected_date
+            assert meta.base[obj_idx]["mars"]["time"] == expected_time
+            _, field_arr = objects[obj_idx]
+            np.testing.assert_allclose(field_arr, states[i]["fields"][name], rtol=1e-6)
+
+        extra = meta.extra["anemoi"]
+        assert extra["step"] == states[i]["step"].total_seconds()
+        assert extra["date"] == states[i]["date"].isoformat()
+
+
+def test_variable_filter(tmp_path):
+    """Only the selected variable and coordinates are written."""
+    path = tmp_path / "filtered.tgm"
+    context = _make_context()
+    output = TensogramOutput(context, str(path), variables=["2t"])
+
+    state = _make_state()
+    output.open(state)
+    output.write_step(state)
+    output.close()
+
+    tgm_file = tensogram.TensogramFile.open(str(path))
+    msg = tgm_file[0]
+    meta, objects = msg
+
+    assert len(objects) == 3
+    assert meta.base[2]["anemoi"]["variable"] == "2t"
+
+
+def test_simple_packing_encoding(tmp_path):
+    """simple_packing round-trip stays within expected quantisation error."""
+    path = tmp_path / "packed.tgm"
+    context = _make_context(["2t"])
+    output = TensogramOutput(context, str(path), encoding="simple_packing", bits=16, compression="zstd")
+
+    rng = np.random.default_rng(42)
+    values = (rng.random(N_GRID) * 50 + 250).astype(np.float32)
+    state = {
+        "date": datetime(2024, 1, 1, 1),
+        "step": timedelta(hours=1),
+        "latitudes": np.linspace(-90, 90, N_GRID, dtype=np.float64),
+        "longitudes": np.linspace(0, 360, N_GRID, dtype=np.float64),
+        "fields": {"2t": values},
+    }
+
+    output.open(state)
+    output.write_step(state)
+    output.close()
+
+    tgm_file = tensogram.TensogramFile.open(str(path))
+    meta, objects = tgm_file[0]
+    _, decoded = objects[2]
+
+    np.testing.assert_allclose(decoded, values, atol=0.002)
+
+
+def test_simple_packing_requires_bits(tmp_path):
+    """encoding='simple_packing' without bits raises ValueError immediately."""
+    context = _make_context(["2t"])
+    with pytest.raises(ValueError, match="bits must be set"):
+        TensogramOutput(context, str(tmp_path / "out.tgm"), encoding="simple_packing")
+
+
+def test_mars_metadata_forwarded(tmp_path):
+    """grib_keys appear in per-object 'mars' namespace, following tensogram-grib convention."""
+    path = tmp_path / "levs.tgm"
+    typed_variables = {
+        "t500": _make_variable(param="t", levtype="pl", level=500),
+    }
+    checkpoint = SimpleNamespace(typed_variables=typed_variables)
+    context = SimpleNamespace(
+        checkpoint=checkpoint,
+        reference_date=datetime(2024, 1, 1),
+        write_initial_state=False,
+        output_frequency=None,
+        typed_variables={},
+    )
+
+    output = TensogramOutput(context, str(path))
+    state = {
+        "date": datetime(2024, 1, 1, 6),
+        "step": timedelta(hours=6),
+        "latitudes": np.zeros(10, dtype=np.float64),
+        "longitudes": np.zeros(10, dtype=np.float64),
+        "fields": {"t500": np.ones(10, dtype=np.float32)},
+    }
+    output.open(state)
+    output.write_step(state)
+    output.close()
+
+    tgm_file = tensogram.TensogramFile.open(str(path))
+    meta, _ = tgm_file[0]
+    mars = meta.base[2]["mars"]
+    assert mars["param"] == "t"
+    assert mars["levtype"] == "pl"
+    assert mars["level"] == 500
+    assert mars["step"] == 6
+    assert mars["date"] == "20240101"
+    assert mars["time"] == "0000"
+    assert meta.base[2]["anemoi"]["variable"] == "t500"
+
+
+def test_remote_write_via_memory_fs():
+    """Write to fsspec memory filesystem and read back valid tensogram messages."""
+    import fsspec
+
+    url = "memory://test_forecast.tgm"
+    context = _make_context()
+    output = TensogramOutput(context, url)
+
+    states = [_make_state(h) for h in range(1, 3)]
+    output.open(states[0])
+    for state in states:
+        output.write_step(state)
+    output.close()
+
+    fs = fsspec.filesystem("memory")
+    raw = fs.open(url, "rb").read()
+
+    messages = tensogram.scan(raw)
+    assert len(messages) == 2
+
+    for i, (offset, length) in enumerate(messages):
+        msg_bytes = raw[offset : offset + length]
+        meta, objects = tensogram.decode(msg_bytes)
+        assert len(objects) == 5
+        assert meta.extra["anemoi"]["step"] == states[i]["step"].total_seconds()
+
+
+def test_dtype_float64(tmp_path):
+    """dtype=float64 stores field arrays as float64."""
+    path = tmp_path / "f64.tgm"
+    context = _make_context(["2t"])
+    output = TensogramOutput(context, str(path), dtype="float64")
+
+    state = _make_state(field_names=["2t"])
+    output.open(state)
+    output.write_step(state)
+    output.close()
+
+    tgm_file = tensogram.TensogramFile.open(str(path))
+    meta, objects = tgm_file[0]
+    desc, arr = objects[2]
+    assert desc.dtype == "float64"
+    assert arr.dtype == np.float64
+
+
+def test_close_is_idempotent(tmp_path):
+    """close() can be called multiple times without error."""
+    path = tmp_path / "idem.tgm"
+    context = _make_context()
+    output = TensogramOutput(context, str(path))
+    output.open(_make_state())
+    output.write_step(_make_state())
+    output.close()
+    output.close()
+
+
+def test_dim_names_in_metadata(tmp_path):
+    """dim_names hint is written into _extra_['dim_names'] for the xarray backend."""
+    path = tmp_path / "dimnames.tgm"
+    context = _make_context()
+    output = TensogramOutput(context, str(path))
+    state = _make_state()
+    output.open(state)
+    output.write_step(state)
+    output.close()
+
+    tgm_file = tensogram.TensogramFile.open(str(path))
+    meta, _ = tgm_file[0]
+    dim_names = meta.extra["dim_names"]
+    assert str(N_GRID) in dim_names
+    assert dim_names[str(N_GRID)] == "values"
+
+
+def test_stacked_dim_names_in_metadata(tmp_path):
+    """Stacked fields write both 'values' and 'level' hints into _extra_['dim_names']."""
+    path = tmp_path / "stacked_dims.tgm"
+    context = _make_pl_context(params=["t"], levels=[500, 850, 1000])
+    output = TensogramOutput(context, str(path), stack_pressure_levels=True)
+    state = _make_pl_state(params=["t"], levels=[500, 850, 1000])
+    output.open(state)
+    output.write_step(state)
+    output.close()
+
+    tgm_file = tensogram.TensogramFile.open(str(path))
+    meta, _ = tgm_file[0]
+    dim_names = meta.extra["dim_names"]
+    assert str(N_GRID) in dim_names
+    assert dim_names[str(N_GRID)] == "values"
+    assert str(3) in dim_names
+    assert dim_names[str(3)] == "level"
+
+
+# ---------------------------------------------------------------------------
+# Pressure-level stacking tests
+# ---------------------------------------------------------------------------
+
+PL_LEVELS = [500, 850, 1000]
+PL_PARAMS = ["t", "u"]
+
+
+def _make_pl_context(params=PL_PARAMS, levels=PL_LEVELS, extra_fields=None):
+    """Context with pressure-level variables plus optional non-PL extras."""
+    typed_variables = {}
+    for param in params:
+        for level in levels:
+            name = f"{param}{level}"
+            typed_variables[name] = _make_variable(param=param, levtype="pl", level=level)
+    for name in extra_fields or []:
+        typed_variables[name] = _make_variable(param=name)
+
+    checkpoint = SimpleNamespace(typed_variables=typed_variables)
+    return SimpleNamespace(
+        checkpoint=checkpoint,
+        reference_date=datetime(2024, 1, 1),
+        write_initial_state=False,
+        output_frequency=None,
+        typed_variables={},
+    )
+
+
+def _make_pl_state(params=PL_PARAMS, levels=PL_LEVELS, extra_fields=None, n_grid=N_GRID, seed=0):
+    rng = np.random.default_rng(seed)
+    fields = {}
+    for param in params:
+        for level in levels:
+            fields[f"{param}{level}"] = rng.random(n_grid).astype(np.float32)
+    for name in extra_fields or []:
+        fields[name] = rng.random(n_grid).astype(np.float32)
+    return {
+        "date": datetime(2024, 1, 1, 1),
+        "step": timedelta(hours=1),
+        "latitudes": np.linspace(-90, 90, n_grid, dtype=np.float64),
+        "longitudes": np.linspace(0, 360, n_grid, dtype=np.float64),
+        "fields": fields,
+    }
+
+
+def test_stack_object_count(tmp_path):
+    """With stacking: one object per param, not per level."""
+    path = tmp_path / "stacked.tgm"
+    context = _make_pl_context()
+    output = TensogramOutput(context, str(path), stack_pressure_levels=True)
+
+    state = _make_pl_state()
+    output.open(state)
+    output.write_step(state)
+    output.close()
+
+    tgm_file = tensogram.TensogramFile.open(str(path))
+    meta, objects = tgm_file[0]
+
+    assert len(objects) == 2 + len(PL_PARAMS)
+
+
+def test_stack_shape(tmp_path):
+    """Stacked objects have shape (n_grid, n_levels) -- grid axis first."""
+    path = tmp_path / "stacked.tgm"
+    context = _make_pl_context()
+    output = TensogramOutput(context, str(path), stack_pressure_levels=True)
+
+    state = _make_pl_state()
+    output.open(state)
+    output.write_step(state)
+    output.close()
+
+    tgm_file = tensogram.TensogramFile.open(str(path))
+    meta, objects = tgm_file[0]
+
+    for obj_idx in range(2, 2 + len(PL_PARAMS)):
+        desc, arr = objects[obj_idx]
+        assert arr.shape == (N_GRID, len(PL_LEVELS)), f"expected ({N_GRID}, {len(PL_LEVELS)}), got {arr.shape}"
+
+
+def test_stack_levels_metadata(tmp_path):
+    """Stacked objects store 'levels' (plural) sorted ascending; no scalar 'level'."""
+    path = tmp_path / "stacked.tgm"
+    context = _make_pl_context()
+    output = TensogramOutput(context, str(path), stack_pressure_levels=True)
+
+    state = _make_pl_state()
+    output.open(state)
+    output.write_step(state)
+    output.close()
+
+    tgm_file = tensogram.TensogramFile.open(str(path))
+    meta, _ = tgm_file[0]
+
+    for obj_idx in range(2, 2 + len(PL_PARAMS)):
+        entry = meta.base[obj_idx]
+        anemoi = entry["anemoi"]
+        mars = entry["mars"]
+        assert "levels" in anemoi
+        assert "level" not in anemoi
+        assert "level" not in mars
+        assert anemoi["levels"] == sorted(PL_LEVELS)
+        assert mars["levtype"] == "pl"
+        assert "name" in entry
+        assert entry["name"] == mars["param"]
+
+
+def test_stack_values_round_trip(tmp_path):
+    """Stacked values decode to the same data as the input, in level-sorted order."""
+    path = tmp_path / "stacked.tgm"
+    context = _make_pl_context(params=["t"], levels=[850, 500, 1000])
+    output = TensogramOutput(context, str(path), stack_pressure_levels=True)
+
+    rng = np.random.default_rng(7)
+    fields = {f"t{lv}": rng.random(N_GRID).astype(np.float32) for lv in [850, 500, 1000]}
+    state = {
+        "date": datetime(2024, 1, 1, 1),
+        "step": timedelta(hours=1),
+        "latitudes": np.linspace(-90, 90, N_GRID, dtype=np.float64),
+        "longitudes": np.linspace(0, 360, N_GRID, dtype=np.float64),
+        "fields": fields,
+    }
+
+    output.open(state)
+    output.write_step(state)
+    output.close()
+
+    tgm_file = tensogram.TensogramFile.open(str(path))
+    meta, objects = tgm_file[0]
+
+    anemoi = meta.base[2]["anemoi"]
+    assert anemoi["levels"] == [500, 850, 1000]
+
+    _, arr = objects[2]
+    np.testing.assert_allclose(arr[:, 0], fields["t500"], rtol=1e-6)
+    np.testing.assert_allclose(arr[:, 1], fields["t850"], rtol=1e-6)
+    np.testing.assert_allclose(arr[:, 2], fields["t1000"], rtol=1e-6)
+
+
+def test_stack_non_pl_fields_written_flat(tmp_path):
+    """Non-PL fields are written as individual objects even with stacking enabled."""
+    path = tmp_path / "mixed.tgm"
+    context = _make_pl_context(params=["t"], levels=[500, 850], extra_fields=["2t"])
+    output = TensogramOutput(context, str(path), stack_pressure_levels=True)
+
+    state = _make_pl_state(params=["t"], levels=[500, 850], extra_fields=["2t"])
+    output.open(state)
+    output.write_step(state)
+    output.close()
+
+    tgm_file = tensogram.TensogramFile.open(str(path))
+    meta, objects = tgm_file[0]
+
+    assert len(objects) == 4
+
+    flat_entries = [
+        meta.base[i]["anemoi"] for i in range(2, len(objects)) if meta.base[i]["anemoi"].get("variable") == "2t"
+    ]
+    assert len(flat_entries) == 1
+    assert "levels" not in flat_entries[0]
+    assert "level" not in flat_entries[0]
+
+
+def test_no_stack_level_metadata_correct(tmp_path):
+    """Without stacking, each PL field stores scalar 'level' and 'levtype'."""
+    path = tmp_path / "flat_pl.tgm"
+    context = _make_pl_context(params=["t"], levels=[500, 850])
+    output = TensogramOutput(context, str(path), stack_pressure_levels=False)
+
+    state = _make_pl_state(params=["t"], levels=[500, 850])
+    output.open(state)
+    output.write_step(state)
+    output.close()
+
+    tgm_file = tensogram.TensogramFile.open(str(path))
+    meta, objects = tgm_file[0]
+
+    assert len(objects) == 4
+
+    for obj_idx in range(2, 4):
+        mars = meta.base[obj_idx]["mars"]
+        anemoi = meta.base[obj_idx]["anemoi"]
+        assert "level" in mars
+        assert "levtype" in mars
+        assert mars["levtype"] == "pl"
+        assert mars["param"] == "t"
+        assert "levels" not in anemoi

--- a/python/tensogram-anemoi/tests/test_tensogram_output.py
+++ b/python/tensogram-anemoi/tests/test_tensogram_output.py
@@ -162,9 +162,6 @@ def test_write_and_read_local(tmp_path):
             _, field_arr = objects[obj_idx]
             np.testing.assert_allclose(field_arr, states[i]["fields"][name], rtol=1e-6)
 
-        extra = meta.extra["anemoi"]
-        assert extra["step"] == states[i]["step"].total_seconds()
-        assert extra["date"] == states[i]["date"].isoformat()
 
 
 def test_variable_filter(tmp_path):
@@ -283,7 +280,6 @@ def test_remote_write_via_memory_fs():
         msg_bytes = raw[offset : offset + length]
         meta, objects = tensogram.decode(msg_bytes)
         assert len(objects) == 5
-        assert meta.extra["anemoi"]["step"] == states[i]["step"].total_seconds()
 
 
 def test_dtype_float64(tmp_path):
@@ -433,7 +429,7 @@ def test_stack_shape(tmp_path):
 
 
 def test_stack_levels_metadata(tmp_path):
-    """Stacked objects store 'levels' (plural) sorted ascending; no scalar 'level'."""
+    """Stacked objects store 'levelist' sorted ascending; no scalar 'level'."""
     path = tmp_path / "stacked.tgm"
     context = _make_pl_context()
     output = TensogramOutput(context, str(path), stack_pressure_levels=True)
@@ -450,10 +446,10 @@ def test_stack_levels_metadata(tmp_path):
         entry = meta.base[obj_idx]
         anemoi = entry["anemoi"]
         mars = entry["mars"]
-        assert "levels" in anemoi
+        assert "levelist" in anemoi
         assert "level" not in anemoi
         assert "level" not in mars
-        assert anemoi["levels"] == sorted(PL_LEVELS)
+        assert anemoi["levelist"] == sorted(PL_LEVELS)
         assert mars["levtype"] == "pl"
         assert "name" in entry
         assert entry["name"] == mars["param"]
@@ -483,7 +479,7 @@ def test_stack_values_round_trip(tmp_path):
     meta, objects = tgm_file[0]
 
     anemoi = meta.base[2]["anemoi"]
-    assert anemoi["levels"] == [500, 850, 1000]
+    assert anemoi["levelist"] == [500, 850, 1000]
 
     _, arr = objects[2]
     np.testing.assert_allclose(arr[:, 0], fields["t500"], rtol=1e-6)

--- a/python/tensogram-anemoi/tests/test_tensogram_output.py
+++ b/python/tensogram-anemoi/tests/test_tensogram_output.py
@@ -73,10 +73,10 @@ def _make_state(step_hours=1, field_names=FIELD_NAMES, n_grid=N_GRID, seed=0):
 # ---------------------------------------------------------------------------
 
 
-def test_write_step_before_open_raises():
+def test_write_step_before_open_raises(tmp_path):
     """write_step raises RuntimeError when called before open()."""
     context = _make_context()
-    output = TensogramOutput(context, "/tmp/never.tgm")
+    output = TensogramOutput(context, str(tmp_path / "never.tgm"))
     with pytest.raises(RuntimeError, match="open"):
         output.write_step(_make_state())
 

--- a/python/tensogram-anemoi/tests/test_tensogram_output.py
+++ b/python/tensogram-anemoi/tests/test_tensogram_output.py
@@ -446,10 +446,10 @@ def test_stack_levels_metadata(tmp_path):
         entry = meta.base[obj_idx]
         anemoi = entry["anemoi"]
         mars = entry["mars"]
-        assert "levelist" in anemoi
+        assert "levelist" not in anemoi
         assert "level" not in anemoi
         assert "level" not in mars
-        assert anemoi["levelist"] == sorted(PL_LEVELS)
+        assert mars["levelist"] == sorted(PL_LEVELS)
         assert mars["levtype"] == "pl"
         assert "name" in entry
         assert entry["name"] == mars["param"]
@@ -478,8 +478,8 @@ def test_stack_values_round_trip(tmp_path):
     tgm_file = tensogram.TensogramFile.open(str(path))
     meta, objects = tgm_file[0]
 
-    anemoi = meta.base[2]["anemoi"]
-    assert anemoi["levelist"] == [500, 850, 1000]
+    mars = meta.base[2]["mars"]
+    assert mars["levelist"] == [500, 850, 1000]
 
     _, arr = objects[2]
     np.testing.assert_allclose(arr[:, 0], fields["t500"], rtol=1e-6)


### PR DESCRIPTION
## Summary

- Adds `tensogram/python/tensogram-anemoi/`, a standalone pip package that provides `TensogramOutput` as an anemoi-inference output plugin
- Registers via `[project.entry-points."anemoi.inference.outputs"] tensogram = "tensogram_anemoi.output:TensogramOutput"` so anemoi-inference discovers it automatically on install -- no fork of anemoi-inference required
- Follows the pattern of [`anemoi-plugins-ecmwf/inference`](https://github.com/ecmwf/anemoi-plugins-ecmwf/tree/main/inference)
- Build backend matches anemoi-inference: `setuptools` + `setuptools-scm` with dynamic version

## Test plan

- [x] `pip install -e python/tensogram-anemoi/` in an env with anemoi-inference
- [x] Run `pytest python/tensogram-anemoi/tests/` -- covers round-trip, encoding, pressure-level stacking, remote fsspec, metadata
- [x] Confirm `tensogram` appears in `anemoi.inference.outputs` registry after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-63
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->