### PR TITLE
fix(python): switch tensogram-xarray and tensogram-zarr to setuptools-scm

### DIFF
--- a/python/tensogram-xarray/pyproject.toml
+++ b/python/tensogram-xarray/pyproject.toml
@@ -12,7 +12,6 @@ license = "Apache-2.0"
 authors = [{name = "ECMWF", email = "software@ecmwf.int"}]
 classifiers = [
     "Development Status :: 4 - Beta",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Atmospheric Science",
@@ -40,6 +39,7 @@ where = ["src"]
 
 [tool.setuptools_scm]
 version_file = "src/tensogram_xarray/_version.py"
+root = "../.."
 
 [tool.ruff]
 line-length = 99

--- a/python/tensogram-xarray/pyproject.toml
+++ b/python/tensogram-xarray/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = [ "setuptools>=60", "setuptools-scm>=8" ]
+requires = [ "setuptools>=61", "setuptools-scm>=8" ]
 
 [project]
 name = "tensogram-xarray"

--- a/python/tensogram-xarray/pyproject.toml
+++ b/python/tensogram-xarray/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+build-backend = "setuptools.build_meta"
+requires = [ "setuptools>=60", "setuptools-scm>=8" ]
 
 [project]
 name = "tensogram-xarray"
-version = "0.16.1"
+dynamic = [ "version" ]
 description = "xarray backend engine for tensogram .tgm files"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -35,8 +35,11 @@ dask = ["dask[array]"]
 [project.entry-points."xarray.backends"]
 tensogram = "tensogram_xarray.backend:TensogramBackendEntrypoint"
 
-[tool.hatch.build.targets.wheel]
-packages = ["src/tensogram_xarray"]
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools_scm]
+version_file = "src/tensogram_xarray/_version.py"
 
 [tool.ruff]
 line-length = 99

--- a/python/tensogram-zarr/pyproject.toml
+++ b/python/tensogram-zarr/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = [ "setuptools>=60", "setuptools-scm>=8" ]
+requires = [ "setuptools>=61", "setuptools-scm>=8" ]
 
 [project]
 name = "tensogram-zarr"

--- a/python/tensogram-zarr/pyproject.toml
+++ b/python/tensogram-zarr/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+build-backend = "setuptools.build_meta"
+requires = [ "setuptools>=60", "setuptools-scm>=8" ]
 
 [project]
 name = "tensogram-zarr"
-version = "0.16.1"
+dynamic = [ "version" ]
 description = "Zarr v3 store backend for tensogram .tgm files"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -31,8 +31,11 @@ Documentation = "https://sites.ecmwf.int/docs/tensogram/main"
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "pytest-asyncio>=0.23", "ruff>=0.4"]
 
-[tool.hatch.build.targets.wheel]
-packages = ["src/tensogram_zarr"]
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools_scm]
+version_file = "src/tensogram_zarr/_version.py"
 
 [tool.ruff]
 line-length = 99

--- a/python/tensogram-zarr/pyproject.toml
+++ b/python/tensogram-zarr/pyproject.toml
@@ -12,7 +12,6 @@ license = "Apache-2.0"
 authors = [{name = "ECMWF", email = "software@ecmwf.int"}]
 classifiers = [
     "Development Status :: 4 - Beta",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Atmospheric Science",
@@ -36,6 +35,7 @@ where = ["src"]
 
 [tool.setuptools_scm]
 version_file = "src/tensogram_zarr/_version.py"
+root = "../.."
 
 [tool.ruff]
 line-length = 99


### PR DESCRIPTION
## Summary

- Replaces hatchling + hardcoded `version = "X.Y.Z"` in `tensogram-xarray` and `tensogram-zarr` with `setuptools` + `setuptools-scm`
- Version is now derived from git tags automatically, eliminating the manual `pyproject.toml` edit required at every release
- Consistent with the build system used in `tensogram-anemoi` and `anemoi-inference`
- `tensogram` (bindings) is unaffected -- maturin reads its version from `Cargo.toml` which is already the correct approach for Rust extensions

## Test plan

- [x] `pip install -e python/tensogram-xarray/` in a repo with a git tag -- confirm version resolves correctly
- [x] `pip install -e python/tensogram-zarr/` -- same check
- [x] Existing test suites pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-64
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->