### PR TITLE
fix(xarray): support mixed-rank messages via per-object dim_names hint and collision-safe fallback (#66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   messages that mix objects of different ranks without CF-recognised
   coordinate names.  Generic `dim_N` fallback names that would collide
   across variables of different shapes are renamed to
-  `obj_{i}_dim_{axis}` so the Dataset opens cleanly.  Coord-matched
-  and hint-supplied names are never auto-renamed.
+  `obj_{i}_dim_{axis}` so the Dataset opens cleanly.  Coordinate dim
+  names are never auto-renamed; hinted names that claim conflicting
+  sizes across objects emit a warning and are renamed to the same
+  per-object form as generic fallbacks so the Dataset still opens.
   ([#66](https://github.com/ecmwf/tensogram/issues/66))
 
 - `tensogram-xarray`: `open_datasets()` and `merge_objects=True` now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `tensogram-xarray`: `xr.open_dataset(engine="tensogram")` no longer
+  raises `ValueError: conflicting sizes for dimension 'dim_0'` on
+  messages that mix objects of different ranks without CF-recognised
+  coordinate names.  Generic `dim_N` fallback names that would collide
+  across variables of different shapes are renamed to
+  `obj_{i}_dim_{axis}` so the Dataset opens cleanly.  Coord-matched
+  and hint-supplied names are never auto-renamed.
+  ([#66](https://github.com/ecmwf/tensogram/issues/66))
+
+- `tensogram-xarray`: `open_datasets()` and `merge_objects=True` now
+  honour `_extra_["dim_names"]` (list and size-to-name dict) with the
+  same priority chain as single-message `open_dataset`.  Previously
+  only the single-message path read the hint.
+
+### Added
+
+- `tensogram-xarray`: new opt-in reader convention — producers may
+  embed `base[i]["dim_names"]` (axis-ordered list) per object.  The
+  backend validates the hint (length equal to ndim, all non-empty
+  distinct strings) and uses it in the dim resolution chain:
+  user kwarg > coord match > per-object hint > `_extra_` hint >
+  generic fallback.  Malformed hints are logged at DEBUG and ignored
+  so files remain openable.  Inconsistent hints across a
+  merge/hypercube group trigger a warning and fall back to lower
+  priority sources.  ([#66](https://github.com/ecmwf/tensogram/issues/66))
+
+- `tensogram-anemoi`: the output plugin now writes the per-object
+  `dim_names` list on each data field entry (`["values"]` for flat
+  fields, `["values", "level"]` for stacked pressure-level fields)
+  alongside the existing message-level `_extra_["dim_names"]` hint,
+  opting into the new reader convention while staying
+  backward-compatible with older readers.
+
 ### Wire format v3 — BREAKING
 
 This release is a clean break from v2.  There is no backward

--- a/docs/src/guide/xarray-integration.md
+++ b/docs/src/guide/xarray-integration.md
@@ -179,7 +179,57 @@ The following names are recognized (case-insensitive):
 | `step` | `step` |
 
 If no matching coordinate objects are found and no `dim_names` are provided,
-dimensions remain generic (`dim_0`, `dim_1`, ...).
+dimensions fall back to `dim_0`, `dim_1`, ... per variable.  When two
+variables of different shapes would claim the same generic name, the
+colliding axes are renamed to `obj_{i}_dim_{axis}` so the Dataset opens
+cleanly even for mixed-rank messages without coord hints.
+
+---
+
+### Per-object `dim_names` hint
+
+Producers that know their axes' semantic meaning can embed an
+axis-ordered list into each `base[i]` entry under the `dim_names` key:
+
+```python
+meta = {
+    "version": 2,
+    "base": [
+        {"name": "reflectance",       "dim_names": ["time", "y", "x"]},
+        {"name": "count_flash_all",   "dim_names": ["time"]},
+        {"name": "ny",                "dim_names": ["y"]},
+        {"name": "nx",                "dim_names": ["x"]},
+    ],
+}
+```
+
+The reader validates each list strictly — exactly as many non-empty,
+distinct strings as the object has axes.  Malformed hints are silently
+ignored so files remain openable; the validator emits a DEBUG log line
+explaining why the hint was rejected.
+
+When two objects assign the same name to equally sized axes, those axes
+share the resulting xarray dimension.  When the same name is used at
+different sizes across objects, a warning is logged and the conflicting
+axes fall back to `obj_{i}_dim_{axis}`.
+
+### Resolution priority
+
+Dimension names are resolved per data variable using this chain
+(highest priority first):
+
+1. `dim_names=[...]` kwarg passed to `xr.open_dataset`.
+2. Coord size-match — an existing coordinate variable whose size
+   equals the axis size.
+3. Per-object `base[i]["dim_names"]` — validated axis-ordered list.
+4. Message-level `_extra_["dim_names"]` — list (axis-ordered) or
+   `{size: name}` dict.
+5. Generic `dim_{axis}` fallback — eligible for per-object
+   disambiguation on collision.
+
+The same chain applies in the merge path (`open_datasets` and
+`xr.open_dataset(..., merge_objects=True)`) to keep behaviour
+consistent regardless of entry point.
 
 ---
 

--- a/python/tensogram-anemoi/src/tensogram_anemoi/output.py
+++ b/python/tensogram-anemoi/src/tensogram_anemoi/output.py
@@ -151,6 +151,7 @@ class TensogramOutput(Output):
                 {
                     "name": _COORD_NAME_MAP[coord_name],
                     "anemoi": {"variable": coord_name},
+                    "dim_names": [_COORD_NAME_MAP[coord_name]],
                 }
             )
             descriptors_and_data.append(

--- a/python/tensogram-anemoi/src/tensogram_anemoi/output.py
+++ b/python/tensogram-anemoi/src/tensogram_anemoi/output.py
@@ -38,9 +38,10 @@ class TensogramOutput(Output):
     pressure-level parameter when ``stack_pressure_levels=True``).
 
     Per-object metadata is stored under the ``"anemoi"`` namespace in CBOR.
-    Dimension-name hints are stored in ``_extra_["dim_names"]`` so the
-    tensogram-xarray backend can resolve meaningful names without the reader
-    having to pass ``dim_names`` explicitly.
+    Dimension-name hints are written into each base entry's ``dim_names``
+    key (per-object, axis-ordered) *and* into ``_extra_["dim_names"]``
+    (message-level size-to-name dict) so readers on either convention can
+    resolve meaningful names without callers passing ``dim_names`` explicitly.
 
     Supports local paths and remote URLs (s3://, gs://, az://, ...) via fsspec.
     Each step is encoded and written immediately -- no full-forecast buffering.
@@ -285,7 +286,11 @@ class TensogramOutput(Output):
     ) -> tuple[dict, dict, np.ndarray]:
         """Build (base_entry, descriptor, array) for a single flat field object."""
         mars = {**mars_extra, **grib}
-        base_entry: dict = {"name": name, "anemoi": {"variable": name}}
+        base_entry: dict = {
+            "name": name,
+            "anemoi": {"variable": name},
+            "dim_names": ["values"],
+        }
         if mars:
             base_entry["mars"] = mars
         arr = self._prepare_array(values)
@@ -306,7 +311,11 @@ class TensogramOutput(Output):
 
         mars = {**mars_extra, **{k: v for k, v in first_grib.items() if k != "level"}, "levelist": levels}
 
-        base_entry: dict = {"name": param, "anemoi": {"variable": param}}
+        base_entry: dict = {
+            "name": param,
+            "anemoi": {"variable": param},
+            "dim_names": ["values", "level"],
+        }
         if mars:
             base_entry["mars"] = mars
         return base_entry, self._build_descriptor(stacked), stacked

--- a/python/tensogram-anemoi/tests/test_tensogram_output.py
+++ b/python/tensogram-anemoi/tests/test_tensogram_output.py
@@ -329,12 +329,20 @@ def test_dim_names_in_metadata(tmp_path):
     assert str(N_GRID) in dim_names
     assert dim_names[str(N_GRID)] == "values"
 
-    # Per-object hint mirrors the _extra_ convention for 1-D flat fields.
-    coord_names = {"latitude", "longitude"}
+    # Coord entries pin their axis to the canonical coord name.
+    coord_entries = {
+        entry.get("anemoi", {}).get("variable"): entry
+        for entry in meta.base
+        if entry.get("anemoi", {}).get("variable") in {"latitude", "longitude"}
+    }
+    assert coord_entries.get("latitude", {}).get("dim_names") == ["latitude"]
+    assert coord_entries.get("longitude", {}).get("dim_names") == ["longitude"]
+
+    # Flat field entries use the 'values' dim.
     field_entries = [
         entry
         for entry in meta.base
-        if entry.get("anemoi", {}).get("variable") not in coord_names
+        if entry.get("anemoi", {}).get("variable") not in {"latitude", "longitude"}
     ]
     assert field_entries, "expected at least one field entry"
     for entry in field_entries:

--- a/python/tensogram-anemoi/tests/test_tensogram_output.py
+++ b/python/tensogram-anemoi/tests/test_tensogram_output.py
@@ -312,7 +312,9 @@ def test_close_is_idempotent(tmp_path):
 
 
 def test_dim_names_in_metadata(tmp_path):
-    """dim_names hint is written into _extra_['dim_names'] for the xarray backend."""
+    """Dim-name hints are written into both _extra_ (message-level) and
+    per-object base[i]['dim_names'] so xarray readers on either convention
+    resolve meaningful dim names without explicit kwargs."""
     path = tmp_path / "dimnames.tgm"
     context = _make_context()
     output = TensogramOutput(context, str(path))
@@ -327,9 +329,21 @@ def test_dim_names_in_metadata(tmp_path):
     assert str(N_GRID) in dim_names
     assert dim_names[str(N_GRID)] == "values"
 
+    # Per-object hint mirrors the _extra_ convention for 1-D flat fields.
+    coord_names = {"latitude", "longitude"}
+    field_entries = [
+        entry
+        for entry in meta.base
+        if entry.get("anemoi", {}).get("variable") not in coord_names
+    ]
+    assert field_entries, "expected at least one field entry"
+    for entry in field_entries:
+        assert entry.get("dim_names") == ["values"], entry
+
 
 def test_stacked_dim_names_in_metadata(tmp_path):
-    """Stacked fields write both 'values' and 'level' hints into _extra_['dim_names']."""
+    """Stacked fields write size-based 'values'/'level' hints into _extra_
+    AND a ['values', 'level'] per-object list on each stacked base entry."""
     path = tmp_path / "stacked_dims.tgm"
     context = _make_pl_context(params=["t"], levels=[500, 850, 1000])
     output = TensogramOutput(context, str(path), stack_pressure_levels=True)
@@ -345,6 +359,13 @@ def test_stacked_dim_names_in_metadata(tmp_path):
     assert dim_names[str(N_GRID)] == "values"
     assert str(3) in dim_names
     assert dim_names[str(3)] == "level"
+
+    stacked_entries = [
+        entry for entry in meta.base if entry.get("anemoi", {}).get("variable") == "t"
+    ]
+    assert stacked_entries, "expected stacked pressure-level entry"
+    for entry in stacked_entries:
+        assert entry.get("dim_names") == ["values", "level"], entry
 
 
 # ---------------------------------------------------------------------------

--- a/python/tensogram-xarray/src/tensogram_xarray/mapping.py
+++ b/python/tensogram-xarray/src/tensogram_xarray/mapping.py
@@ -6,16 +6,34 @@
 # granted to it by virtue of its status as an intergovernmental organisation nor
 # does it submit to any jurisdiction.
 
-"""User-specified dimension and variable mapping.
+"""Dimension and variable naming for the xarray backend.
 
 Handles the ``dim_names`` and ``variable_key`` parameters that let callers
-control how tensogram data maps to xarray dimensions and variable names.
+control how tensogram data maps to xarray dimensions and variable names,
+including the per-object ``base[i]["dim_names"]`` opt-in convention.
 """
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+import logging
+from collections.abc import Mapping, Sequence
 from typing import Any
+
+logger = logging.getLogger(__name__)
+
+PER_OBJECT_DIM_NAMES_KEY = "dim_names"
+EXTRA_DIM_NAMES_KEY = "dim_names"
+
+# Metadata keys that encode xarray structure rather than user attributes.
+# These are read by the backend to shape the Dataset but must not leak into
+# :attr:`xarray.Variable.attrs` or participate in the :mod:`merge` path's
+# hypercube grouping (otherwise hint-like keys could become outer dims).
+STRUCTURAL_META_KEYS: frozenset[str] = frozenset({PER_OBJECT_DIM_NAMES_KEY})
+
+
+def strip_structural_keys(meta: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a copy of *meta* without :data:`STRUCTURAL_META_KEYS`."""
+    return {k: v for k, v in meta.items() if k not in STRUCTURAL_META_KEYS}
 
 
 def resolve_dim_names(
@@ -37,6 +55,160 @@ def resolve_dim_names(
             raise ValueError(msg)
         return names
     return [f"dim_{i}" for i in range(ndim)]
+
+
+def _looks_like_string_sequence(raw: Any) -> bool:
+    """True if *raw* is a list/tuple/sequence of items, excluding ``str``/``bytes``."""
+    if isinstance(raw, (str, bytes, bytearray)):
+        return False
+    return isinstance(raw, Sequence)
+
+
+def parse_per_object_dim_names(
+    ndim: int,
+    obj_meta: Mapping[str, Any] | None,
+) -> list[str] | None:
+    """Return validated per-object dim names or ``None`` when absent/malformed.
+
+    The per-object hint lives at ``base[i]["dim_names"]`` and must be a
+    sequence (but not ``str``) of exactly *ndim* non-empty distinct strings.
+    Any deviation yields ``None`` (logged at DEBUG), so malformed hints
+    silently fall through the priority chain rather than crashing or
+    corrupting dim assignment.
+    """
+    if not obj_meta:
+        return None
+    raw = obj_meta.get(PER_OBJECT_DIM_NAMES_KEY)
+    if raw is None:
+        return None
+    if not _looks_like_string_sequence(raw):
+        logger.debug(
+            "per-object %s hint is not a list/sequence (got %s); ignoring",
+            PER_OBJECT_DIM_NAMES_KEY,
+            type(raw).__name__,
+        )
+        return None
+    names = list(raw)
+    if len(names) != ndim:
+        logger.debug(
+            "per-object %s hint has %d entries but ndim=%d; ignoring",
+            PER_OBJECT_DIM_NAMES_KEY,
+            len(names),
+            ndim,
+        )
+        return None
+    if not all(isinstance(n, str) and n for n in names):
+        logger.debug(
+            "per-object %s hint contains non-string or empty entries; ignoring",
+            PER_OBJECT_DIM_NAMES_KEY,
+        )
+        return None
+    if len(set(names)) != ndim:
+        logger.debug(
+            "per-object %s hint contains duplicate entries %r; ignoring",
+            PER_OBJECT_DIM_NAMES_KEY,
+            names,
+        )
+        return None
+    return names
+
+
+def parse_extra_dim_names_hint(
+    ndim: int,
+    raw: Any,
+) -> list[str] | dict[int, str]:
+    """Return parsed ``_extra_["dim_names"]`` hint.
+
+    Accepts two legacy formats:
+
+    * list (preferred) — axis-ordered names, length must equal *ndim*
+    * dict — size-to-name mapping (string keys coerced to int)
+
+    Invalid hints yield an empty dict so callers can iterate uniformly.
+    """
+    if raw is None:
+        return {}
+    if isinstance(raw, list):
+        try:
+            names = [str(n) for n in raw]
+        except (TypeError, ValueError):
+            return {}
+        if len(names) == ndim:
+            return names
+        return {}
+    if isinstance(raw, dict):
+        try:
+            return {int(k): str(v) for k, v in raw.items()}
+        except (TypeError, ValueError):
+            return {}
+    return {}
+
+
+def resolve_dims_for_axes(
+    shape: tuple[int, ...],
+    *,
+    user_dim_names: Sequence[str] | None,
+    coord_dim_sizes: Mapping[str, int],
+    per_object_meta: Mapping[str, Any] | None,
+    extra_dim_names_hint: Any,
+) -> list[tuple[str, bool]]:
+    """Return ``(name, is_generic_fallback)`` per axis using the full priority chain.
+
+    Priority (highest to lowest):
+
+    1. ``user_dim_names`` — explicit caller kwarg.
+    2. Coord size-match — an existing coord dim whose size equals the axis size.
+    3. Per-object ``base[i]["dim_names"]`` — validated by
+       :func:`parse_per_object_dim_names`.
+    4. ``_extra_["dim_names"]`` — list or size-to-name dict, parsed by
+       :func:`parse_extra_dim_names_hint`.
+    5. Generic ``dim_{axis}`` fallback — flagged ``is_generic_fallback=True``
+       so the caller can disambiguate on collision.
+
+    Only axes from step 5 are flagged generic; all earlier sources count as
+    user-visible hints and are never auto-renamed.  A hinted-name collision
+    is surfaced separately by the caller's disambiguation pass.
+    """
+    ndim = len(shape)
+
+    if user_dim_names is not None:
+        return [(name, False) for name in resolve_dim_names(ndim, user_dim_names)]
+
+    per_obj = parse_per_object_dim_names(ndim, per_object_meta)
+
+    size_to_coord: dict[int, list[str]] = {}
+    for cname, csize in coord_dim_sizes.items():
+        size_to_coord.setdefault(csize, []).append(cname)
+
+    extra_hints = parse_extra_dim_names_hint(ndim, extra_dim_names_hint)
+
+    dims: list[tuple[str, bool]] = []
+    used: set[str] = set()
+    for axis, axis_size in enumerate(shape):
+        name: str | None = None
+        if axis_size in size_to_coord:
+            for cname in size_to_coord[axis_size]:
+                if cname not in used:
+                    name = cname
+                    break
+        if name is None and per_obj is not None:
+            candidate = per_obj[axis]
+            if candidate not in used:
+                name = candidate
+        if name is None and isinstance(extra_hints, list):
+            candidate = extra_hints[axis]
+            if candidate not in used:
+                name = candidate
+        if name is None and isinstance(extra_hints, dict) and axis_size in extra_hints:
+            candidate = extra_hints[axis_size]
+            if candidate not in used:
+                name = candidate
+        if name is None:
+            dims.append((f"dim_{axis}", True))
+            continue
+        dims.append((name, False))
+        used.add(name)
+    return dims
 
 
 def _resolve_dotted(meta: dict[str, Any], dotted_key: str) -> Any:

--- a/python/tensogram-xarray/src/tensogram_xarray/merge.py
+++ b/python/tensogram-xarray/src/tensogram_xarray/merge.py
@@ -844,9 +844,14 @@ def _consistent_hint_meta(
 ) -> Mapping[str, Any] | None:
     """Return a representative per-object meta if all hints agree, else ``None``.
 
+    Inspects ``obj.per_object_meta`` (from ``meta.base[i]``) exclusively —
+    not ``merged_meta``, which also folds in ``common_meta`` and would
+    mis-classify a message-level ``_extra_["dim_names"]`` list as a
+    per-object hint.
+
     Objects without a valid per-object ``dim_names`` hint are skipped.
-    If every object with a hint supplies the *same* list, the first such
-    object's meta is returned (its ``dim_names`` drives the resolver).
+    If every object with a hint supplies the *same* list, that object's
+    ``per_object_meta`` is returned (its ``dim_names`` drives the resolver).
     If two objects supply *different* valid hints, a warning is logged
     and ``None`` is returned so the resolver falls through to
     ``_extra_["dim_names"]`` and the generic fallback.
@@ -854,13 +859,13 @@ def _consistent_hint_meta(
     seen: list[tuple[str, ...]] = []
     representative: Mapping[str, Any] | None = None
     for obj in objects:
-        parsed = parse_per_object_dim_names(ndim, obj.merged_meta)
+        parsed = parse_per_object_dim_names(ndim, obj.per_object_meta)
         if parsed is None:
             continue
         parsed_tuple = tuple(parsed)
         if not seen:
             seen.append(parsed_tuple)
-            representative = obj.merged_meta
+            representative = obj.per_object_meta
         elif parsed_tuple not in seen:
             seen.append(parsed_tuple)
     if len(seen) > 1:

--- a/python/tensogram-xarray/src/tensogram_xarray/merge.py
+++ b/python/tensogram-xarray/src/tensogram_xarray/merge.py
@@ -20,7 +20,7 @@ import itertools
 import logging
 import threading
 from collections import defaultdict
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 import xarray as xr
@@ -32,7 +32,14 @@ from tensogram_xarray.array import (
     _supports_range_decode,
 )
 from tensogram_xarray.coords import detect_coords
-from tensogram_xarray.mapping import resolve_dim_names, resolve_variable_name
+from tensogram_xarray.mapping import (
+    EXTRA_DIM_NAMES_KEY,
+    STRUCTURAL_META_KEYS,
+    parse_per_object_dim_names,
+    resolve_dims_for_axes,
+    resolve_variable_name,
+    strip_structural_keys,
+)
 from tensogram_xarray.scanner import ObjectInfo, scan_file
 from tensogram_xarray.store import _to_numpy_dtype
 
@@ -128,7 +135,9 @@ def open_datasets(
             # Duplicate with matching shape -- skip (keep the first).
             continue
 
-        coord_vars[dim_name] = xr.Variable((dim_name,), lazy_data, dict(obj.per_object_meta))
+        coord_vars[dim_name] = xr.Variable(
+            (dim_name,), lazy_data, strip_structural_keys(obj.per_object_meta)
+        )
 
     # Group data objects by structural compatibility.
     data_objects = [file_index.objects[i] for i in var_indices]
@@ -194,10 +203,15 @@ def _group_by_structure(
 
 
 def _extract_meta_keys(objects: list[ObjectInfo]) -> dict[str, list[Any]]:
-    """For each metadata key, collect values across all objects."""
+    """For each (non-structural) metadata key, collect values across all objects.
+
+    :data:`STRUCTURAL_META_KEYS` are skipped so xarray-structural hints
+    (currently ``dim_names``) never become a hypercube outer dimension
+    or a partition key in the grouping pipeline.
+    """
     all_keys: set[str] = set()
     for obj in objects:
-        all_keys.update(obj.merged_meta.keys())
+        all_keys.update(k for k in obj.merged_meta if k not in STRUCTURAL_META_KEYS)
 
     key_values: dict[str, list[Any]] = {}
     for k in sorted(all_keys):
@@ -451,7 +465,12 @@ def _single_object_dataset(
     shape = obj.shape
 
     var_name = resolve_variable_name(obj.obj_index, obj.merged_meta, variable_key)
-    dims = _resolve_dims(shape, dim_names, coord_vars)
+    dims = _resolve_inner_dims(
+        [obj],
+        shape,
+        user_dim_names=dim_names,
+        coord_vars=coord_vars,
+    )
 
     backend_array = TensogramBackendArray(
         file_path=file_path,
@@ -469,9 +488,9 @@ def _single_object_dataset(
     if backend_arrays is not None:
         backend_arrays.append(backend_array)
     lazy_data = indexing.LazilyIndexedArray(backend_array)
-    var = xr.Variable(dims, lazy_data, dict(obj.merged_meta))
+    var = xr.Variable(dims, lazy_data, strip_structural_keys(obj.merged_meta))
 
-    ds_attrs = dict(obj.common_meta)
+    ds_attrs = strip_structural_keys(obj.common_meta)
     ds = xr.Dataset({var_name: var}, coords=coord_vars, attrs=ds_attrs)
     return ds
 
@@ -494,17 +513,23 @@ def _flat_group_dataset(
     """Build a Dataset with one variable per object (no stacking)."""
     data_vars: dict[str, xr.Variable] = {}
 
+    inner_shape = group[0].shape
+    dims = _resolve_inner_dims(
+        group,
+        inner_shape,
+        user_dim_names=dim_names,
+        coord_vars=coord_vars,
+    )
+
     for obj in group:
         np_dtype = _to_numpy_dtype(obj.dtype)
-        shape = obj.shape
         var_name = resolve_variable_name(obj.obj_index, obj.per_object_meta, variable_key)
-        dims = _resolve_dims(shape, dim_names, coord_vars)
 
         backend_array = TensogramBackendArray(
             file_path=file_path,
             msg_index=obj.msg_index,
             obj_index=obj.obj_index,
-            shape=shape,
+            shape=obj.shape,
             dtype=np_dtype,
             supports_range=_supports_range_decode(obj.descriptor),
             verify_hash=verify_hash,
@@ -516,9 +541,9 @@ def _flat_group_dataset(
         if backend_arrays is not None:
             backend_arrays.append(backend_array)
         lazy_data = indexing.LazilyIndexedArray(backend_array)
-        data_vars[var_name] = xr.Variable(dims, lazy_data, dict(obj.merged_meta))
+        data_vars[var_name] = xr.Variable(dims, lazy_data, strip_structural_keys(obj.merged_meta))
 
-    ds_attrs = dict(constant)
+    ds_attrs = strip_structural_keys(constant)
     ds = xr.Dataset(data_vars, coords=coord_vars, attrs=ds_attrs)
     return ds
 
@@ -547,7 +572,12 @@ def _hypercube_dataset(
     """
     inner_shape = group[0].shape
     np_dtype = _to_numpy_dtype(group[0].dtype)
-    inner_dims = _resolve_dims(inner_shape, dim_names, coord_vars)
+    inner_dims = _resolve_inner_dims(
+        group,
+        inner_shape,
+        user_dim_names=dim_names,
+        coord_vars=coord_vars,
+    )
 
     # Determine outer dimension names and coordinate values.
     outer_keys = sorted(varying.keys())
@@ -609,8 +639,8 @@ def _hypercube_dataset(
     for k in outer_keys:
         merged_coords[k] = xr.Variable((k,), outer_coords[k])
 
-    var = xr.Variable(full_dims, lazy_data, dict(constant))
-    ds = xr.Dataset({var_name: var}, coords=merged_coords, attrs=dict(constant))
+    var = xr.Variable(full_dims, lazy_data, strip_structural_keys(constant))
+    ds = xr.Dataset({var_name: var}, coords=merged_coords, attrs=strip_structural_keys(constant))
     return ds
 
 
@@ -648,9 +678,14 @@ def _build_multi_variable_dataset(
     merged_coords = dict(coord_vars)
     inner_shape = group[0].shape
     np_dtype = _to_numpy_dtype(group[0].dtype)
-    inner_dims = _resolve_dims(inner_shape, dim_names, coord_vars)
 
     for var_name, sub_group in sub_groups.items():
+        inner_dims = _resolve_inner_dims(
+            sub_group,
+            inner_shape,
+            user_dim_names=dim_names,
+            coord_vars=coord_vars,
+        )
         if len(sub_group) == 1:
             # Single object for this variable -> no outer dims.
             obj = sub_group[0]
@@ -670,7 +705,9 @@ def _build_multi_variable_dataset(
             if backend_arrays is not None:
                 backend_arrays.append(backend_array)
             lazy_data = indexing.LazilyIndexedArray(backend_array)
-            data_vars[var_name] = xr.Variable(inner_dims, lazy_data, dict(obj.merged_meta))
+            data_vars[var_name] = xr.Variable(
+                inner_dims, lazy_data, strip_structural_keys(obj.merged_meta)
+            )
         elif remaining_varying:
             # Re-extract varying keys for this sub-group.
             sub_kv = _extract_meta_keys(sub_group)
@@ -729,7 +766,9 @@ def _build_multi_variable_dataset(
 
                 for k in outer_keys:
                     merged_coords[k] = xr.Variable((k,), outer_coords_local[k])
-                data_vars[var_name] = xr.Variable(full_dims, lazy_data, dict(sub_const))
+                data_vars[var_name] = xr.Variable(
+                    full_dims, lazy_data, strip_structural_keys(sub_const)
+                )
             else:
                 # Can't form hypercube -> use first object only.
                 logger.warning(
@@ -756,7 +795,9 @@ def _build_multi_variable_dataset(
                 if backend_arrays is not None:
                     backend_arrays.append(backend_array)
                 lazy_data = indexing.LazilyIndexedArray(backend_array)
-                data_vars[var_name] = xr.Variable(inner_dims, lazy_data, dict(obj.merged_meta))
+                data_vars[var_name] = xr.Variable(
+                    inner_dims, lazy_data, strip_structural_keys(obj.merged_meta)
+                )
         else:
             # No remaining varying keys -> use first object.
             if len(sub_group) > 1:
@@ -784,9 +825,11 @@ def _build_multi_variable_dataset(
             if backend_arrays is not None:
                 backend_arrays.append(backend_array)
             lazy_data = indexing.LazilyIndexedArray(backend_array)
-            data_vars[var_name] = xr.Variable(inner_dims, lazy_data, dict(obj.merged_meta))
+            data_vars[var_name] = xr.Variable(
+                inner_dims, lazy_data, strip_structural_keys(obj.merged_meta)
+            )
 
-    ds = xr.Dataset(data_vars, coords=merged_coords, attrs=dict(constant))
+    ds = xr.Dataset(data_vars, coords=merged_coords, attrs=strip_structural_keys(constant))
     return ds
 
 
@@ -795,38 +838,98 @@ def _build_multi_variable_dataset(
 # ---------------------------------------------------------------------------
 
 
-def _resolve_dims(
-    shape: tuple[int, ...],
-    dim_names: Sequence[str] | None,
-    coord_vars: dict[str, xr.Variable],
-) -> tuple[str, ...]:
-    """Resolve dimension names for a tensor shape.
+def _consistent_hint_meta(
+    objects: Sequence[ObjectInfo],
+    ndim: int,
+) -> Mapping[str, Any] | None:
+    """Return a representative per-object meta if all hints agree, else ``None``.
 
-    Same strategy as ``TensogramDataStore._resolve_dims_for_var``.
+    Objects without a valid per-object ``dim_names`` hint are skipped.
+    If every object with a hint supplies the *same* list, the first such
+    object's meta is returned (its ``dim_names`` drives the resolver).
+    If two objects supply *different* valid hints, a warning is logged
+    and ``None`` is returned so the resolver falls through to
+    ``_extra_["dim_names"]`` and the generic fallback.
     """
-    ndim = len(shape)
+    seen: list[tuple[str, ...]] = []
+    representative: Mapping[str, Any] | None = None
+    for obj in objects:
+        parsed = parse_per_object_dim_names(ndim, obj.merged_meta)
+        if parsed is None:
+            continue
+        parsed_tuple = tuple(parsed)
+        if not seen:
+            seen.append(parsed_tuple)
+            representative = obj.merged_meta
+        elif parsed_tuple not in seen:
+            seen.append(parsed_tuple)
+    if len(seen) > 1:
+        logger.warning(
+            "group has inconsistent per-object dim_names hints %s; "
+            "falling back to coord/_extra_/generic resolution",
+            [list(t) for t in seen],
+        )
+        return None
+    return representative
 
-    if dim_names is not None:
-        return tuple(resolve_dim_names(ndim, dim_names))
 
-    # Match by size against known coordinates.
-    size_to_coord: dict[int, list[str]] = {}
-    for cname, cvar in coord_vars.items():
-        csize = cvar.shape[0]
-        size_to_coord.setdefault(csize, []).append(cname)
+def _consistent_extra_hint(objects: Sequence[ObjectInfo]) -> Any:
+    """Return a representative ``_extra_["dim_names"]`` if all agree, else ``None``.
 
-    dims: list[str] = []
-    used: set[str] = set()
-    for axis_size in shape:
-        matched = False
-        if axis_size in size_to_coord:
-            for cname in size_to_coord[axis_size]:
-                if cname not in used:
-                    dims.append(cname)
-                    used.add(cname)
-                    matched = True
-                    break
-        if not matched:
-            dims.append(f"dim_{len(dims)}")
+    Each :class:`ObjectInfo.common_meta` carries the per-message
+    ``_extra_`` dict.  When messages disagree on the hint, the resolver
+    cannot safely apply any single value across the group, so the hint
+    is discarded with a warning.
+    """
+    seen: list[Any] = []
+    seen_hashable: set[Any] = set()
+    for obj in objects:
+        raw = obj.common_meta.get(EXTRA_DIM_NAMES_KEY)
+        if raw is None:
+            continue
+        frozen = _make_hashable(raw)
+        if frozen not in seen_hashable:
+            seen_hashable.add(frozen)
+            seen.append(raw)
+    if len(seen) > 1:
+        logger.warning(
+            "group has inconsistent _extra_ %s hints across messages "
+            "(%d distinct); falling back to generic dim names",
+            EXTRA_DIM_NAMES_KEY,
+            len(seen),
+        )
+        return None
+    return seen[0] if seen else None
 
-    return tuple(dims)
+
+def _resolve_inner_dims(
+    objects: Sequence[ObjectInfo],
+    inner_shape: tuple[int, ...],
+    *,
+    user_dim_names: Sequence[str] | None,
+    coord_vars: Mapping[str, xr.Variable],
+) -> tuple[str, ...]:
+    """Resolve dimension names for a group of structurally compatible objects.
+
+    Uses the same priority chain as :func:`TensogramDataStore.build_dataset`
+    (via :func:`resolve_dims_for_axes`).  Per-object and message-level
+    ``dim_names`` hints must agree across the group; disagreement triggers
+    a warning and falls back to lower-priority sources.
+
+    The resulting names are collapsed to plain strings — generic
+    ``dim_{axis}`` fallbacks are returned as-is.  Since structurally
+    compatible objects share their inner shape, fallback names cannot
+    collide inside a single resolved group.
+    """
+    ndim = len(inner_shape)
+    coord_dim_sizes = {name: var.shape[0] for name, var in coord_vars.items()}
+    per_object_meta = _consistent_hint_meta(objects, ndim)
+    extra_hint = _consistent_extra_hint(objects)
+    dims_with_provenance = resolve_dims_for_axes(
+        inner_shape,
+        user_dim_names=user_dim_names,
+        coord_dim_sizes=coord_dim_sizes,
+        per_object_meta=per_object_meta,
+        extra_dim_names_hint=extra_hint,
+    )
+    return tuple(name for name, _is_generic in dims_with_provenance)

--- a/python/tensogram-xarray/src/tensogram_xarray/merge.py
+++ b/python/tensogram-xarray/src/tensogram_xarray/merge.py
@@ -899,7 +899,8 @@ def _consistent_extra_hint(objects: Sequence[ObjectInfo]) -> Any:
     if len(seen) > 1:
         logger.warning(
             "group has inconsistent _extra_ %s hints across messages "
-            "(%d distinct); falling back to generic dim names",
+            "(%d distinct); ignoring this hint and falling back to coord "
+            "matches, consistent per-object hints, or generic dim names",
             EXTRA_DIM_NAMES_KEY,
             len(seen),
         )
@@ -921,10 +922,12 @@ def _resolve_inner_dims(
     ``dim_names`` hints must agree across the group; disagreement triggers
     a warning and falls back to lower-priority sources.
 
-    The resulting names are collapsed to plain strings — generic
-    ``dim_{axis}`` fallbacks are returned as-is.  Since structurally
-    compatible objects share their inner shape, fallback names cannot
-    collide inside a single resolved group.
+    A final pass drops any hint name that would collide with an existing
+    coord dim at a different size — those axes are renamed to
+    ``obj_{i}_dim_{axis}`` to prevent ``xr.Dataset`` assembly from raising
+    ``conflicting sizes for dimension ...``.  Within-group fallback
+    collisions cannot occur because structurally compatible objects share
+    their inner shape.
     """
     ndim = len(inner_shape)
     coord_dim_sizes = {name: var.shape[0] for name, var in coord_vars.items()}
@@ -937,4 +940,29 @@ def _resolve_inner_dims(
         per_object_meta=per_object_meta,
         extra_dim_names_hint=extra_hint,
     )
-    return tuple(name for name, _is_generic in dims_with_provenance)
+
+    representative_obj_index = objects[0].obj_index if objects else 0
+    warned: set[str] = set()
+    result: list[str] = []
+    for axis, (dim_name, is_generic) in enumerate(dims_with_provenance):
+        coord_size = coord_dim_sizes.get(dim_name)
+        if coord_size is not None and coord_size != inner_shape[axis]:
+            if not is_generic and dim_name not in warned:
+                logger.warning(
+                    "dim name %r at axis %d size %d conflicts with coord %r "
+                    "size %d; renaming to obj_%d_dim_%d to keep the Dataset "
+                    "openable (check user dim_names kwarg, _extra_, or "
+                    "per-object hints)",
+                    dim_name,
+                    axis,
+                    inner_shape[axis],
+                    dim_name,
+                    coord_size,
+                    representative_obj_index,
+                    axis,
+                )
+                warned.add(dim_name)
+            result.append(f"obj_{representative_obj_index}_dim_{axis}")
+        else:
+            result.append(dim_name)
+    return tuple(result)

--- a/python/tensogram-xarray/src/tensogram_xarray/store.py
+++ b/python/tensogram-xarray/src/tensogram_xarray/store.py
@@ -19,6 +19,7 @@ import logging
 import os
 import threading
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
@@ -70,6 +71,82 @@ def _to_numpy_dtype(tgm_dtype: str) -> np.dtype:
     except TypeError as exc:
         msg = f"unsupported tensogram dtype {tgm_dtype!r}: {exc}"
         raise TypeError(msg) from exc
+
+
+# ---------------------------------------------------------------------------
+# Dimension resolution helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _DataVarPlan:
+    """Per-variable plan gathered during Dataset construction.
+
+    Collected in a first pass so that a second pass can disambiguate generic
+    fallback dimension names that would otherwise cause xarray Dataset size
+    collisions across variables of different shapes.
+    """
+
+    obj_index: int
+    var_name: str
+    shape: tuple[int, ...]
+    # One entry per axis: (dim_name, came_from_generic_fallback).  A generic
+    # fallback is the `dim_{axis}` name produced when no user kwarg, coord
+    # size-match, or ``_extra_["dim_names"]`` hint covers the axis.
+    dims_with_provenance: list[tuple[str, bool]]
+    backend_array: TensogramBackendArray
+    var_attrs: dict[str, Any]
+
+
+def _disambiguate_fallback_dims(
+    plans: list[_DataVarPlan],
+    coord_dim_sizes: dict[str, int],
+) -> list[tuple[str, ...]]:
+    """Return final dimension names per *plan*, renaming only generic fallback
+    dims that would cause an :class:`xr.Dataset` size conflict.
+
+    A conflict exists when the same dim name is claimed at two or more
+    distinct sizes — either across data variables or against an existing
+    coordinate dim.  Generic fallback dims involved in a conflict are
+    renamed to ``f"obj_{obj_index}_dim_{axis}"``; non-generic names
+    (coord matches, ``_extra_`` hints, user kwargs) are left unchanged.
+    Non-generic conflicts surface at :class:`xr.Dataset` assembly as a
+    clear error naming the conflicting user-visible dim.
+
+    Parameters
+    ----------
+    plans
+        One :class:`_DataVarPlan` per data variable, in the order they
+        will appear in the resulting Dataset.
+    coord_dim_sizes
+        Map from existing coordinate dim name to its size.  Coord dims
+        participate in conflict detection but are never renamed.
+
+    Returns
+    -------
+    list[tuple[str, ...]]
+        Final dim names per plan, parallel to *plans*.
+    """
+    name_to_sizes: dict[str, set[int]] = {
+        cname: {csize} for cname, csize in coord_dim_sizes.items()
+    }
+    for plan in plans:
+        for axis, (dim_name, _is_generic) in enumerate(plan.dims_with_provenance):
+            name_to_sizes.setdefault(dim_name, set()).add(plan.shape[axis])
+
+    conflicting = {name for name, sizes in name_to_sizes.items() if len(sizes) > 1}
+
+    resolved: list[tuple[str, ...]] = []
+    for plan in plans:
+        new_dims: list[str] = []
+        for axis, (dim_name, is_generic) in enumerate(plan.dims_with_provenance):
+            if is_generic and dim_name in conflicting:
+                new_dims.append(f"obj_{plan.obj_index}_dim_{axis}")
+            else:
+                new_dims.append(dim_name)
+        resolved.append(tuple(new_dims))
+
+    return resolved
 
 
 class TensogramDataStore:
@@ -234,7 +311,7 @@ class TensogramDataStore:
             coord_attrs = dict(obj_metas[ci])
             coord_vars[dim_name] = xr.Variable(coord_dims, lazy_data, coord_attrs)
 
-        data_vars: dict[str, xr.Variable] = {}
+        plans: list[_DataVarPlan] = []
         for vi in var_indices:
             desc = self._descriptors[vi]
             var_name = resolve_variable_name(vi, obj_metas[vi], self.variable_key)
@@ -244,7 +321,7 @@ class TensogramDataStore:
             np_dtype = _to_numpy_dtype(desc.dtype)
             shape = tuple(desc.shape)
 
-            dims = self._resolve_dims_for_var(shape, coord_vars)
+            dims_with_provenance = self._resolve_dims_for_var(shape, coord_vars)
 
             backend_array = TensogramBackendArray(
                 file_path=self.file_path,
@@ -260,14 +337,27 @@ class TensogramDataStore:
                 shared_file=self._file,
             )
             self._backend_arrays.append(backend_array)
-            lazy_data = indexing.LazilyIndexedArray(backend_array)
 
-            var_attrs = dict(obj_metas[vi])
-            data_vars[var_name] = xr.Variable(dims, lazy_data, var_attrs)
+            plans.append(
+                _DataVarPlan(
+                    obj_index=vi,
+                    var_name=var_name,
+                    shape=shape,
+                    dims_with_provenance=dims_with_provenance,
+                    backend_array=backend_array,
+                    var_attrs=dict(obj_metas[vi]),
+                )
+            )
 
-        # Assemble Dataset.
-        ds = xr.Dataset(data_vars, coords=coord_vars, attrs=dataset_attrs)
-        return ds
+        coord_dim_sizes = {name: var.shape[0] for name, var in coord_vars.items()}
+        resolved_dims = _disambiguate_fallback_dims(plans, coord_dim_sizes)
+
+        data_vars: dict[str, xr.Variable] = {}
+        for plan, dims in zip(plans, resolved_dims, strict=True):
+            lazy_data = indexing.LazilyIndexedArray(plan.backend_array)
+            data_vars[plan.var_name] = xr.Variable(dims, lazy_data, plan.var_attrs)
+
+        return xr.Dataset(data_vars, coords=coord_vars, attrs=dataset_attrs)
 
     def _get_meta_dim_names(self, ndim: int) -> list[str] | dict[int, str]:
         """Return dimension name hints from ``_extra_["dim_names"]``.
@@ -321,8 +411,16 @@ class TensogramDataStore:
         self,
         shape: tuple[int, ...],
         coord_vars: dict[str, xr.Variable],
-    ) -> tuple[str, ...]:
+    ) -> list[tuple[str, bool]]:
         """Assign dimension names for a data variable.
+
+        Returns one ``(name, is_generic_fallback)`` entry per axis.  The
+        boolean flags whether the name came from the ``dim_{axis}``
+        fallback branch — those axes are eligible for post-pass
+        disambiguation when they collide across variables of different
+        shapes.  Names produced by user kwarg, coord size-match, or
+        ``_extra_["dim_names"]`` hint are flagged non-generic and are
+        never auto-renamed.
 
         Strategy:
         1. If user provided ``dim_names``, use them directly.
@@ -332,49 +430,40 @@ class TensogramDataStore:
         """
         ndim = len(shape)
 
-        # (1) Explicit user mapping.
         if self.dim_names is not None:
-            return tuple(resolve_dim_names(ndim, self.dim_names))
+            return [(name, False) for name in resolve_dim_names(ndim, self.dim_names)]
 
-        # (2) Match by size against detected coordinates.
-        # Build a map: size -> list of coord dim names with that size.
         size_to_coord: dict[int, list[str]] = {}
         for cname, cvar in coord_vars.items():
             csize = cvar.shape[0]
             size_to_coord.setdefault(csize, []).append(cname)
 
-        # (3) Metadata hints written by the producer.
         meta_hints = self._get_meta_dim_names(ndim)
 
-        # If the producer supplied an axis-ordered list, use it directly.
         if isinstance(meta_hints, list):
-            return tuple(meta_hints)
+            return [(name, False) for name in meta_hints]
 
-        # Otherwise meta_hints is a dict (size -> name); match by size.
-        dims: list[str] = []
+        dims: list[tuple[str, bool]] = []
         used: set[str] = set()
         for axis, axis_size in enumerate(shape):
             matched = False
-            # Prefer a detected coordinate dimension.
             if axis_size in size_to_coord:
                 for cname in size_to_coord[axis_size]:
                     if cname not in used:
-                        dims.append(cname)
+                        dims.append((cname, False))
                         used.add(cname)
                         matched = True
                         break
-            # Fall back to producer hint (dict).
             if not matched and axis_size in meta_hints:
                 hint = meta_hints[axis_size]
                 if hint not in used:
-                    dims.append(hint)
+                    dims.append((hint, False))
                     used.add(hint)
                     matched = True
-            # Final fallback.
             if not matched:
-                dims.append(f"dim_{axis}")
+                dims.append((f"dim_{axis}", True))
 
-        return tuple(dims)
+        return dims
 
     def close(self) -> None:
         for arr in self._backend_arrays:

--- a/python/tensogram-xarray/src/tensogram_xarray/store.py
+++ b/python/tensogram-xarray/src/tensogram_xarray/store.py
@@ -28,7 +28,12 @@ from xarray.core import indexing
 
 from tensogram_xarray.array import TensogramBackendArray, _supports_range_decode
 from tensogram_xarray.coords import detect_coords
-from tensogram_xarray.mapping import resolve_dim_names, resolve_variable_name
+from tensogram_xarray.mapping import (
+    EXTRA_DIM_NAMES_KEY,
+    resolve_dims_for_axes,
+    resolve_variable_name,
+    strip_structural_keys,
+)
 from tensogram_xarray.scanner import RESERVED_KEY
 
 logger = logging.getLogger(__name__)
@@ -102,16 +107,23 @@ def _disambiguate_fallback_dims(
     plans: list[_DataVarPlan],
     coord_dim_sizes: dict[str, int],
 ) -> list[tuple[str, ...]]:
-    """Return final dimension names per *plan*, renaming only generic fallback
-    dims that would cause an :class:`xr.Dataset` size conflict.
+    """Return final dimension names per *plan*, resolving every size conflict.
 
     A conflict exists when the same dim name is claimed at two or more
     distinct sizes — either across data variables or against an existing
-    coordinate dim.  Generic fallback dims involved in a conflict are
-    renamed to ``f"obj_{obj_index}_dim_{axis}"``; non-generic names
-    (coord matches, ``_extra_`` hints, user kwargs) are left unchanged.
-    Non-generic conflicts surface at :class:`xr.Dataset` assembly as a
-    clear error naming the conflicting user-visible dim.
+    coordinate dim.
+
+    * **Generic fallback** conflicts (``dim_{axis}`` names with
+      ``is_generic_fallback=True``) are silently renamed to
+      ``f"obj_{obj_index}_dim_{axis}"``.
+    * **Hinted** conflicts (names from coord matches, per-object
+      ``base[i]["dim_names"]``, or ``_extra_["dim_names"]``) are renamed to
+      the same ``obj_{i}_dim_{axis}`` form *with a warning* so producers
+      can diagnose inconsistent hints; this keeps the Dataset openable
+      rather than crashing at :class:`xr.Dataset` assembly.
+
+    Coordinate dim names are never renamed (they claim a single size and
+    so never conflict with themselves); they only participate in detection.
 
     Parameters
     ----------
@@ -119,8 +131,7 @@ def _disambiguate_fallback_dims(
         One :class:`_DataVarPlan` per data variable, in the order they
         will appear in the resulting Dataset.
     coord_dim_sizes
-        Map from existing coordinate dim name to its size.  Coord dims
-        participate in conflict detection but are never renamed.
+        Map from existing coordinate dim name to its size.
 
     Returns
     -------
@@ -135,12 +146,22 @@ def _disambiguate_fallback_dims(
             name_to_sizes.setdefault(dim_name, set()).add(plan.shape[axis])
 
     conflicting = {name for name, sizes in name_to_sizes.items() if len(sizes) > 1}
+    warned: set[str] = set()
 
     resolved: list[tuple[str, ...]] = []
     for plan in plans:
         new_dims: list[str] = []
         for axis, (dim_name, is_generic) in enumerate(plan.dims_with_provenance):
-            if is_generic and dim_name in conflicting:
+            if dim_name in conflicting:
+                if not is_generic and dim_name not in warned:
+                    logger.warning(
+                        "dimension name %r claimed at conflicting sizes %s across "
+                        "objects; falling back to object-local names (producer "
+                        "supplied inconsistent dim_names hints)",
+                        dim_name,
+                        sorted(name_to_sizes[dim_name]),
+                    )
+                    warned.add(dim_name)
                 new_dims.append(f"obj_{plan.obj_index}_dim_{axis}")
             else:
                 new_dims.append(dim_name)
@@ -277,13 +298,11 @@ class TensogramDataStore:
         """
         dataset_attrs = self._get_common_meta()
 
-        # Gather per-object metadata from payload + descriptor params.
         obj_metas = [self._get_per_object_meta(i, d) for i, d in enumerate(self._descriptors)]
+        extra_dim_names_hint = self._extra_dim_names_hint()
 
-        # Detect coordinates vs data variables.
         coord_indices, var_indices, coord_dim_names = detect_coords(obj_metas)
 
-        # Build coordinate variables from detected coord objects.
         coord_vars: dict[str, xr.Variable] = {}
         for ci in coord_indices:
             desc = self._descriptors[ci]
@@ -307,9 +326,11 @@ class TensogramDataStore:
             self._backend_arrays.append(backend_array)
             lazy_data = indexing.LazilyIndexedArray(backend_array)
 
-            coord_dims = (dim_name,)
-            coord_attrs = dict(obj_metas[ci])
-            coord_vars[dim_name] = xr.Variable(coord_dims, lazy_data, coord_attrs)
+            coord_vars[dim_name] = xr.Variable(
+                (dim_name,), lazy_data, strip_structural_keys(obj_metas[ci])
+            )
+
+        coord_dim_sizes = {name: var.shape[0] for name, var in coord_vars.items()}
 
         plans: list[_DataVarPlan] = []
         for vi in var_indices:
@@ -321,7 +342,13 @@ class TensogramDataStore:
             np_dtype = _to_numpy_dtype(desc.dtype)
             shape = tuple(desc.shape)
 
-            dims_with_provenance = self._resolve_dims_for_var(shape, coord_vars)
+            dims_with_provenance = resolve_dims_for_axes(
+                shape,
+                user_dim_names=self.dim_names,
+                coord_dim_sizes=coord_dim_sizes,
+                per_object_meta=obj_metas[vi],
+                extra_dim_names_hint=extra_dim_names_hint,
+            )
 
             backend_array = TensogramBackendArray(
                 file_path=self.file_path,
@@ -345,11 +372,10 @@ class TensogramDataStore:
                     shape=shape,
                     dims_with_provenance=dims_with_provenance,
                     backend_array=backend_array,
-                    var_attrs=dict(obj_metas[vi]),
+                    var_attrs=strip_structural_keys(obj_metas[vi]),
                 )
             )
 
-        coord_dim_sizes = {name: var.shape[0] for name, var in coord_vars.items()}
         resolved_dims = _disambiguate_fallback_dims(plans, coord_dim_sizes)
 
         data_vars: dict[str, xr.Variable] = {}
@@ -359,111 +385,12 @@ class TensogramDataStore:
 
         return xr.Dataset(data_vars, coords=coord_vars, attrs=dataset_attrs)
 
-    def _get_meta_dim_names(self, ndim: int) -> list[str] | dict[int, str]:
-        """Return dimension name hints from ``_extra_["dim_names"]``.
-
-        Any writer can embed hints at ``_extra_["dim_names"]`` to provide
-        meaningful dimension names without the reader passing ``dim_names``
-        explicitly. Two formats are accepted:
-
-        **List (preferred)** — axis-ordered names, one per dimension::
-
-            "_extra_": {"dim_names": ["values", "level"]}
-
-        This handles axes with identical sizes correctly because names
-        are assigned by position.
-
-        **Dict (legacy)** — size-to-name mapping::
-
-            "_extra_": {"dim_names": {"1000": "values", "50": "level"}}
-
-        A dict cannot disambiguate axes with the same size; only the
-        first matching axis receives the hint.
-
-        Returns an empty list/dict when the key is absent or malformed.
-        """
+    def _extra_dim_names_hint(self) -> Any:
+        """Return the raw ``_extra_["dim_names"]`` payload, or ``None``."""
         try:
-            raw = self._meta.extra["dim_names"]
+            return self._meta.extra[EXTRA_DIM_NAMES_KEY]
         except (AttributeError, KeyError, TypeError):
-            return {}
-
-        # List format: axis-ordered names.
-        if isinstance(raw, list):
-            try:
-                names = [str(n) for n in raw]
-                if len(names) == ndim:
-                    return names
-                # Length mismatch — ignore the hint rather than crash.
-                return {}
-            except (TypeError, ValueError):
-                return {}
-
-        # Dict format: size -> name (legacy).
-        if isinstance(raw, dict):
-            try:
-                return {int(k): str(v) for k, v in raw.items()}
-            except (TypeError, ValueError):
-                return {}
-
-        return {}
-
-    def _resolve_dims_for_var(
-        self,
-        shape: tuple[int, ...],
-        coord_vars: dict[str, xr.Variable],
-    ) -> list[tuple[str, bool]]:
-        """Assign dimension names for a data variable.
-
-        Returns one ``(name, is_generic_fallback)`` entry per axis.  The
-        boolean flags whether the name came from the ``dim_{axis}``
-        fallback branch — those axes are eligible for post-pass
-        disambiguation when they collide across variables of different
-        shapes.  Names produced by user kwarg, coord size-match, or
-        ``_extra_["dim_names"]`` hint are flagged non-generic and are
-        never auto-renamed.
-
-        Strategy:
-        1. If user provided ``dim_names``, use them directly.
-        2. Try to match each axis size against a known coordinate variable.
-        3. Use producer hints from ``_extra_["dim_names"]`` (list or dict).
-        4. Fall back to ``dim_0``, ``dim_1``, ...
-        """
-        ndim = len(shape)
-
-        if self.dim_names is not None:
-            return [(name, False) for name in resolve_dim_names(ndim, self.dim_names)]
-
-        size_to_coord: dict[int, list[str]] = {}
-        for cname, cvar in coord_vars.items():
-            csize = cvar.shape[0]
-            size_to_coord.setdefault(csize, []).append(cname)
-
-        meta_hints = self._get_meta_dim_names(ndim)
-
-        if isinstance(meta_hints, list):
-            return [(name, False) for name in meta_hints]
-
-        dims: list[tuple[str, bool]] = []
-        used: set[str] = set()
-        for axis, axis_size in enumerate(shape):
-            matched = False
-            if axis_size in size_to_coord:
-                for cname in size_to_coord[axis_size]:
-                    if cname not in used:
-                        dims.append((cname, False))
-                        used.add(cname)
-                        matched = True
-                        break
-            if not matched and axis_size in meta_hints:
-                hint = meta_hints[axis_size]
-                if hint not in used:
-                    dims.append((hint, False))
-                    used.add(hint)
-                    matched = True
-            if not matched:
-                dims.append((f"dim_{axis}", True))
-
-        return dims
+            return None
 
     def close(self) -> None:
         for arr in self._backend_arrays:

--- a/python/tensogram-xarray/src/tensogram_xarray/store.py
+++ b/python/tensogram-xarray/src/tensogram_xarray/store.py
@@ -97,7 +97,8 @@ class _DataVarPlan:
     shape: tuple[int, ...]
     # One entry per axis: (dim_name, came_from_generic_fallback).  A generic
     # fallback is the `dim_{axis}` name produced when no user kwarg, coord
-    # size-match, or ``_extra_["dim_names"]`` hint covers the axis.
+    # size-match, per-object ``base[i]["dim_names"]``, or
+    # ``_extra_["dim_names"]`` hint provides a name for that axis.
     dims_with_provenance: list[tuple[str, bool]]
     backend_array: TensogramBackendArray
     var_attrs: dict[str, Any]

--- a/python/tensogram-xarray/src/tensogram_xarray/store.py
+++ b/python/tensogram-xarray/src/tensogram_xarray/store.py
@@ -243,12 +243,14 @@ class TensogramDataStore:
     def _get_common_meta(self) -> dict[str, Any]:
         """Extract message-level metadata for Dataset attributes.
 
-        Reads from ``meta.extra`` (message-level annotations).
+        Reads from ``meta.extra`` (message-level annotations) and filters
+        out structural keys such as ``dim_names`` so they do not leak from
+        the wire format into user-visible :attr:`xr.Dataset.attrs`.
         """
         attrs: dict[str, Any] = {}
         extra = getattr(self._meta, "extra", None)
         if extra and isinstance(extra, dict):
-            attrs.update(extra)
+            attrs.update(strip_structural_keys(extra))
         attrs["tensogram_version"] = getattr(self._meta, "version", 2)
         return attrs
 

--- a/python/tensogram-xarray/src/tensogram_xarray/store.py
+++ b/python/tensogram-xarray/src/tensogram_xarray/store.py
@@ -113,17 +113,25 @@ def _disambiguate_fallback_dims(
     distinct sizes — either across data variables or against an existing
     coordinate dim.
 
-    * **Generic fallback** conflicts (``dim_{axis}`` names with
+    Resolution per axis:
+
+    * **Legitimate coord match** — an axis whose name matches an existing
+      coord dim AND whose size equals the coord's size is preserved, even
+      if some *other* plan wrongly claims the same name at a different
+      size.  The coord-sharing binding is the correct semantics here; only
+      the offending plan's axis is renamed.
+    * **Generic fallback** conflicts (``dim_{axis}`` with
       ``is_generic_fallback=True``) are silently renamed to
       ``f"obj_{obj_index}_dim_{axis}"``.
-    * **Hinted** conflicts (names from coord matches, per-object
-      ``base[i]["dim_names"]``, or ``_extra_["dim_names"]``) are renamed to
-      the same ``obj_{i}_dim_{axis}`` form *with a warning* so producers
-      can diagnose inconsistent hints; this keeps the Dataset openable
-      rather than crashing at :class:`xr.Dataset` assembly.
+    * **Hinted** conflicts (names from user kwargs, coord-match on a
+      non-matching size, per-object ``base[i]["dim_names"]``, or
+      ``_extra_["dim_names"]``) are renamed to the same
+      ``obj_{i}_dim_{axis}`` form *with a warning* so the Dataset stays
+      openable rather than crashing at :class:`xr.Dataset` assembly.
 
-    Coordinate dim names are never renamed (they claim a single size and
-    so never conflict with themselves); they only participate in detection.
+    Coordinate dim names themselves are never renamed (coords claim a
+    single size in ``coord_dim_sizes`` and so never conflict with
+    themselves); they only participate in detection.
 
     Parameters
     ----------
@@ -153,11 +161,15 @@ def _disambiguate_fallback_dims(
         new_dims: list[str] = []
         for axis, (dim_name, is_generic) in enumerate(plan.dims_with_provenance):
             if dim_name in conflicting:
+                if dim_name in coord_dim_sizes and plan.shape[axis] == coord_dim_sizes[dim_name]:
+                    new_dims.append(dim_name)
+                    continue
                 if not is_generic and dim_name not in warned:
                     logger.warning(
                         "dimension name %r claimed at conflicting sizes %s across "
-                        "objects; falling back to object-local names (producer "
-                        "supplied inconsistent dim_names hints)",
+                        "objects; falling back to object-local names for the "
+                        "conflicting axes (check user dim_names kwarg, _extra_, "
+                        "or per-object hints for an inconsistent producer)",
                         dim_name,
                         sorted(name_to_sizes[dim_name]),
                     )

--- a/python/tensogram-xarray/tests/test_coverage.py
+++ b/python/tensogram-xarray/tests/test_coverage.py
@@ -27,6 +27,7 @@ import numpy as np
 import pytest
 import tensogram
 import xarray as xr
+
 from tensogram_xarray.array import (
     _is_contiguous_slice,
     _nd_slice_to_flat_ranges,
@@ -1079,29 +1080,40 @@ class TestBackendMergeObjectsEmpty:
 
 
 # ---------------------------------------------------------------------------
-# Coverage pass 2: merge.py _resolve_dims generic fallback naming
+# Coverage pass 2: shared dim resolver generic fallback naming
 # ---------------------------------------------------------------------------
 
 
-class TestMergeResolveDimsGeneric:
-    """Cover merge.py _resolve_dims fallback to dim_N naming."""
+class TestSharedResolveDimsGeneric:
+    """Cover :func:`tensogram_xarray.mapping.resolve_dims_for_axes` fallback."""
 
-    def test_generic_dims_use_len_dims(self, tmp_path):
-        """Generic dim names use dim_{len(dims)} which is the accumulated count."""
-        from tensogram_xarray.merge import _resolve_dims
+    def test_generic_dims_across_axes(self):
+        """With no hints, every axis falls back to a per-axis ``dim_N`` name."""
+        from tensogram_xarray.mapping import resolve_dims_for_axes
 
-        # No coord vars -> all dims are generic
-        dims = _resolve_dims((3, 4, 5), None, {})
-        assert dims == ("dim_0", "dim_1", "dim_2")
+        dims = resolve_dims_for_axes(
+            (3, 4, 5),
+            user_dim_names=None,
+            coord_dim_sizes={},
+            per_object_meta=None,
+            extra_dim_names_hint=None,
+        )
+        assert [name for name, _ in dims] == ["dim_0", "dim_1", "dim_2"]
+        assert all(is_generic for _, is_generic in dims)
 
     def test_mixed_coord_and_generic(self):
-        """When only some axes match coords, others get generic names."""
-        from tensogram_xarray.merge import _resolve_dims
+        """Coord-matched axes are non-generic; unmatched axes fall back."""
+        from tensogram_xarray.mapping import resolve_dims_for_axes
 
-        coord_vars = {"latitude": xr.Variable(("latitude",), np.zeros(3))}
-        dims = _resolve_dims((3, 7), None, coord_vars)
-        assert dims[0] == "latitude"
-        assert dims[1] == "dim_1"
+        dims = resolve_dims_for_axes(
+            (3, 7),
+            user_dim_names=None,
+            coord_dim_sizes={"latitude": 3},
+            per_object_meta=None,
+            extra_dim_names_hint=None,
+        )
+        assert dims[0] == ("latitude", False)
+        assert dims[1] == ("dim_1", True)
 
 
 # ---------------------------------------------------------------------------
@@ -1548,3 +1560,144 @@ class TestUnhashableMetadataConstant:
         assert len(datasets) >= 1
         # The unhashable 'config' key should become a dataset attribute,
         # not a dimension — open_datasets should not crash
+
+
+# ---------------------------------------------------------------------------
+# Merge path dim resolution parity with store path
+# ---------------------------------------------------------------------------
+
+
+class TestMergePathDimResolution:
+    """``open_datasets()`` / ``merge_objects=True`` honours the same priority
+    chain as ``open_dataset()``:  user kwarg > coord match > per-object
+    ``base[i]["dim_names"]`` > ``_extra_["dim_names"]`` > generic fallback.
+
+    Closes a pre-existing divergence where ``merge.py`` silently ignored
+    ``_extra_["dim_names"]`` list and dict hints.
+    """
+
+    def test_extra_list_hint_honoured(self, tmp_path):
+        """Single-message file with ``_extra_`` list hint applies through merge path."""
+        path = str(tmp_path / "merge_extra_list.tgm")
+        meta = {
+            "version": 2,
+            "base": [{"name": "field"}],
+            "_extra_": {"dim_names": ["values", "level"]},
+        }
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(meta, [(_desc([1000, 50]), np.ones((1000, 50), dtype=np.float32))])
+
+        datasets = open_datasets(path)
+        assert len(datasets) == 1
+        assert datasets[0]["field"].dims == ("values", "level")
+
+    def test_extra_dict_hint_honoured(self, tmp_path):
+        """Single-message file with ``_extra_`` dict hint applies through merge path."""
+        path = str(tmp_path / "merge_extra_dict.tgm")
+        meta = {
+            "version": 2,
+            "base": [{"name": "field"}],
+            "_extra_": {"dim_names": {"1000": "values", "50": "level"}},
+        }
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(meta, [(_desc([1000, 50]), np.ones((1000, 50), dtype=np.float32))])
+
+        datasets = open_datasets(path)
+        assert len(datasets) == 1
+        assert datasets[0]["field"].dims == ("values", "level")
+
+    def test_per_object_hint_honoured(self, tmp_path):
+        """Per-object ``base[i]["dim_names"]`` drives dims through merge path."""
+        path = str(tmp_path / "merge_per_obj.tgm")
+        meta = {
+            "version": 2,
+            "base": [{"name": "field", "dim_names": ["row", "col"]}],
+        }
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(meta, [(_desc([4, 5]), np.ones((4, 5), dtype=np.float32))])
+
+        datasets = open_datasets(path)
+        assert datasets[0]["field"].dims == ("row", "col")
+
+    def test_coord_match_outranks_extra_list(self, tmp_path):
+        """Coord size-match beats ``_extra_`` list format on matching axes."""
+        path = str(tmp_path / "coord_vs_extra_list.tgm")
+        lat = np.linspace(-90, 90, 5, dtype=np.float64)
+        data = np.ones((5, 8), dtype=np.float32)
+        meta = {
+            "version": 2,
+            "base": [{"name": "latitude"}, {"name": "field"}],
+            "_extra_": {"dim_names": ["rows", "cols"]},
+        }
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(
+                meta,
+                [
+                    (_desc([5], dtype="float64"), lat),
+                    (_desc([5, 8]), data),
+                ],
+            )
+
+        datasets = open_datasets(path)
+        ds = datasets[0]
+        assert ds["field"].dims[0] == "latitude"
+        assert ds["field"].dims[1] == "cols"
+
+    def test_dim_names_not_a_hypercube_outer_dim(self, tmp_path):
+        """Varying ``dim_names`` across messages must not become an outer dim.
+
+        Without the structural-key filter, differing ``dim_names`` hints
+        across messages would be treated as a varying metadata key and
+        promoted to a hypercube outer dimension.
+        """
+        path = str(tmp_path / "varying_dim_names.tgm")
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(
+                {
+                    "version": 2,
+                    "base": [{"name": "temp", "dim_names": ["a", "b"]}],
+                },
+                [(_desc([3, 4]), np.ones((3, 4), dtype=np.float32))],
+            )
+            f.append(
+                {
+                    "version": 2,
+                    "base": [{"name": "temp", "dim_names": ["c", "d"]}],
+                },
+                [(_desc([3, 4]), np.ones((3, 4), dtype=np.float32) * 2)],
+            )
+
+        datasets = open_datasets(path)
+        for ds in datasets:
+            assert "dim_names" not in ds.sizes
+            assert "dim_names" not in ds.coords
+
+    def test_inconsistent_per_object_hint_warns_and_falls_back(self, tmp_path, caplog):
+        """Multi-message group with conflicting per-object hints warns + falls back."""
+        import logging
+
+        path = str(tmp_path / "inconsistent.tgm")
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(
+                {
+                    "version": 2,
+                    "base": [{"name": "temp", "dim_names": ["x", "y"]}],
+                },
+                [(_desc([3, 4]), np.ones((3, 4), dtype=np.float32))],
+            )
+            f.append(
+                {
+                    "version": 2,
+                    "base": [{"name": "temp", "dim_names": ["p", "q"]}],
+                },
+                [(_desc([3, 4]), np.ones((3, 4), dtype=np.float32) * 2)],
+            )
+
+        with caplog.at_level(logging.WARNING, logger="tensogram_xarray.merge"):
+            datasets = open_datasets(path)
+
+        assert any("inconsistent per-object dim_names" in r.message for r in caplog.records)
+        for ds in datasets:
+            dims = ds["temp"].dims
+            assert dims != ("x", "y")
+            assert dims != ("p", "q")

--- a/python/tensogram-xarray/tests/test_coverage.py
+++ b/python/tensogram-xarray/tests/test_coverage.py
@@ -1701,3 +1701,42 @@ class TestMergePathDimResolution:
             dims = ds["temp"].dims
             assert dims != ("x", "y")
             assert dims != ("p", "q")
+
+    def test_inconsistent_extra_hint_does_not_trigger_per_object_warning(self, tmp_path, caplog):
+        """Disagreeing ``_extra_["dim_names"]`` across messages must emit the
+        ``_extra_`` warning only — *not* a spurious per-object warning.
+
+        Regression test for a bug where ``_consistent_hint_meta`` read
+        ``obj.merged_meta`` (which folded in ``common_meta`` carrying
+        ``_extra_["dim_names"]``) and mis-classified the list as a
+        per-object hint."""
+        import logging
+
+        path = str(tmp_path / "extra_conflict.tgm")
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(
+                {
+                    "version": 2,
+                    "base": [{"name": "temp"}],
+                    "_extra_": {"dim_names": ["x", "y"]},
+                },
+                [(_desc([3, 4]), np.ones((3, 4), dtype=np.float32))],
+            )
+            f.append(
+                {
+                    "version": 2,
+                    "base": [{"name": "temp"}],
+                    "_extra_": {"dim_names": ["p", "q"]},
+                },
+                [(_desc([3, 4]), np.ones((3, 4), dtype=np.float32) * 2)],
+            )
+
+        with caplog.at_level(logging.WARNING, logger="tensogram_xarray.merge"):
+            datasets = open_datasets(path)
+
+        messages = [r.message for r in caplog.records]
+        assert any("inconsistent _extra_" in m for m in messages)
+        assert not any("inconsistent per-object dim_names" in m for m in messages), (
+            "merge path must not misread message-level _extra_['dim_names'] as a per-object hint"
+        )
+        assert datasets, "expected at least one Dataset despite inconsistent hints"

--- a/python/tensogram-xarray/tests/test_coverage.py
+++ b/python/tensogram-xarray/tests/test_coverage.py
@@ -1702,6 +1702,47 @@ class TestMergePathDimResolution:
             assert dims != ("x", "y")
             assert dims != ("p", "q")
 
+    def test_merge_hint_vs_coord_conflict_does_not_crash(self, tmp_path, caplog):
+        """Merge path: a hint that claims an existing coord name at a different
+        size used to crash Dataset assembly with ``conflicting sizes for
+        dimension`` because only ``store.py`` disambiguated such clashes.
+        Now the merge path renames the offending axis and keeps the coord
+        intact."""
+        import logging
+
+        path = str(tmp_path / "merge_hint_vs_coord.tgm")
+        lat = np.linspace(-90, 90, 5, dtype=np.float64)
+        wrong = np.ones((7,), dtype=np.float32)
+        meta = {
+            "version": 2,
+            "base": [
+                {"name": "latitude"},
+                {"name": "field", "dim_names": ["latitude"]},
+            ],
+        }
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(
+                meta,
+                [
+                    (_desc([5], dtype="float64"), lat),
+                    (_desc([7]), wrong),
+                ],
+            )
+
+        with caplog.at_level(logging.WARNING, logger="tensogram_xarray.merge"):
+            datasets = open_datasets(path)
+
+        assert datasets, "open_datasets must succeed on hint-vs-coord conflict"
+        found_field = False
+        for ds in datasets:
+            if "field" in ds.data_vars:
+                found_field = True
+                assert ds["field"].dims == ("obj_1_dim_0",)
+                assert "latitude" in ds.coords
+                assert ds.coords["latitude"].shape == (5,)
+        assert found_field, "expected a dataset containing the 'field' variable"
+        assert any("conflicts with coord 'latitude'" in r.message for r in caplog.records)
+
     def test_inconsistent_extra_hint_does_not_trigger_per_object_warning(self, tmp_path, caplog):
         """Disagreeing ``_extra_["dim_names"]`` across messages must emit the
         ``_extra_`` warning only — *not* a spurious per-object warning.

--- a/python/tensogram-xarray/tests/test_edge_cases.py
+++ b/python/tensogram-xarray/tests/test_edge_cases.py
@@ -749,10 +749,11 @@ class TestMixedRankDimCollision:
 
     def test_build_dataset_shares_coord_when_other_hint_is_wrong(self, tmp_path: Path):
         """End-to-end: a data var legitimately using coord 'latitude' keeps
-        that dim when another var's bad hint triggers disambiguation."""
+        that dim when another var's bad hint triggers disambiguation — and
+        xarray actually treats the shared dim as aligned for indexing."""
         path = str(tmp_path / "coord_shared.tgm")
         lat = np.linspace(-90, 90, 5, dtype=np.float64)
-        legit = np.ones((5, 7), dtype=np.float32)
+        legit = np.arange(35, dtype=np.float32).reshape(5, 7)
         wrong = np.ones((7,), dtype=np.float32)
         meta = {
             "version": 2,
@@ -776,6 +777,10 @@ class TestMixedRankDimCollision:
         assert ds["legit"].dims[0] == "latitude"
         assert ds["wrong"].dims == ("obj_2_dim_0",)
         assert ds.coords["latitude"].shape == (5,)
+        # Runtime alignment: indexing via the shared coord must work.
+        slice_at_lat0 = ds["legit"].isel(latitude=0).values
+        np.testing.assert_array_equal(slice_at_lat0, legit[0])
+        assert ds["legit"].sel(latitude=lat[2]).values.tolist() == legit[2].tolist()
 
 
 # ---------------------------------------------------------------------------

--- a/python/tensogram-xarray/tests/test_edge_cases.py
+++ b/python/tensogram-xarray/tests/test_edge_cases.py
@@ -906,6 +906,39 @@ class TestPerObjectDimNames:
         ds = xr.open_dataset(path, engine="tensogram")
         assert ds["field"].dims == ("dim_0", "dim_1")
 
+    def test_malformed_non_string_entry_ignored(self, tmp_path: Path):
+        """Non-string entries (ints, None, etc.) in the hint silently fall through."""
+        from tensogram_xarray.mapping import parse_per_object_dim_names
+
+        assert parse_per_object_dim_names(2, {"dim_names": ["x", 42]}) is None
+        assert parse_per_object_dim_names(2, {"dim_names": ["x", None]}) is None
+        assert parse_per_object_dim_names(1, {"dim_names": [42]}) is None
+
+    def test_validator_accepts_zero_dim_empty_list(self):
+        """A zero-dim tensor (ndim=0) accepts an empty ``dim_names`` list."""
+        from tensogram_xarray.mapping import parse_per_object_dim_names
+
+        assert parse_per_object_dim_names(0, {"dim_names": []}) == []
+        assert parse_per_object_dim_names(0, {"dim_names": ["extra"]}) is None
+
+    def test_validator_accepts_tuple(self):
+        """Tuple hints (any non-str/bytes Sequence) are accepted."""
+        from tensogram_xarray.mapping import parse_per_object_dim_names
+
+        assert parse_per_object_dim_names(2, {"dim_names": ("x", "y")}) == ["x", "y"]
+
+    def test_validator_rejects_string(self):
+        """A plain ``str`` is not a valid dim-names sequence."""
+        from tensogram_xarray.mapping import parse_per_object_dim_names
+
+        assert parse_per_object_dim_names(2, {"dim_names": "xy"}) is None
+
+    def test_validator_rejects_bytes(self):
+        """A ``bytes`` / ``bytearray`` is not a valid dim-names sequence."""
+        from tensogram_xarray.mapping import parse_per_object_dim_names
+
+        assert parse_per_object_dim_names(2, {"dim_names": b"xy"}) is None
+
     def test_dim_names_not_in_var_attrs(self, tmp_path: Path):
         """``dim_names`` is structural metadata; it must not leak into attrs."""
         path = str(tmp_path / "no_leak.tgm")
@@ -984,3 +1017,35 @@ class TestHintedNameConflict:
         assert ds["a"].dims == ("obj_0_dim_0",)
         assert ds["b"].dims == ("obj_1_dim_0",)
         assert any("'time'" in r.message for r in caplog.records)
+
+    def test_hint_colliding_with_coord_size_renames_hinted_axis(self, tmp_path: Path, caplog):
+        """A per-object hint that claims an existing coord name at a different
+        size triggers warn + fallback for that axis; the coord itself is left
+        intact because coord dim names are never auto-renamed."""
+        import logging
+
+        path = str(tmp_path / "hint_vs_coord.tgm")
+        lat = np.linspace(-90, 90, 5, dtype=np.float64)
+        data = np.ones((7,), dtype=np.float32)
+        meta = {
+            "version": 2,
+            "base": [
+                {"name": "latitude"},
+                {"name": "field", "dim_names": ["latitude"]},
+            ],
+        }
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(
+                meta,
+                [
+                    (_desc([5], dtype="float64"), lat),
+                    (_desc([7]), data),
+                ],
+            )
+
+        with caplog.at_level(logging.WARNING, logger="tensogram_xarray.store"):
+            ds = xr.open_dataset(path, engine="tensogram")
+
+        assert ds.coords["latitude"].shape == (5,)
+        assert ds["field"].dims == ("obj_1_dim_0",)
+        assert any("'latitude'" in r.message for r in caplog.records)

--- a/python/tensogram-xarray/tests/test_edge_cases.py
+++ b/python/tensogram-xarray/tests/test_edge_cases.py
@@ -954,6 +954,22 @@ class TestPerObjectDimNames:
         assert ds["field"].attrs.get("units") == "K"
         assert ds["field"].dims == ("x", "y")
 
+    def test_extra_dim_names_not_in_dataset_attrs(self, tmp_path: Path):
+        """Message-level ``_extra_["dim_names"]`` must not leak into ``ds.attrs``."""
+        path = str(tmp_path / "no_leak_extra.tgm")
+        meta = {
+            "version": 2,
+            "base": [{"name": "field"}],
+            "_extra_": {"dim_names": ["x", "y"], "experiment": "e42"},
+        }
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(meta, [(_desc([4, 5]), np.ones((4, 5), dtype=np.float32))])
+
+        ds = xr.open_dataset(path, engine="tensogram")
+        assert "dim_names" not in ds.attrs
+        assert ds.attrs.get("experiment") == "e42"
+        assert ds["field"].dims == ("x", "y")
+
 
 # ---------------------------------------------------------------------------
 # Hinted-name conflict (producer error safety net)

--- a/python/tensogram-xarray/tests/test_edge_cases.py
+++ b/python/tensogram-xarray/tests/test_edge_cases.py
@@ -488,3 +488,199 @@ class TestDimResolutionEdges:
         # Data var is "object_1" (no variable_key)
         dims = ds["object_1"].dims
         assert dims == ("dim_0", "dim_1")
+
+
+# ---------------------------------------------------------------------------
+# Mixed-rank dim collision (issue #66)
+# ---------------------------------------------------------------------------
+
+
+class TestMixedRankDimCollision:
+    """Issue #66: xr.open_dataset must not crash on mixed-dimensionality
+    messages when non-coordinate objects of different shapes would otherwise
+    fall back to the same generic ``dim_N`` name.
+    """
+
+    def test_issue_66_repro(self, tmp_path: Path):
+        """Exact shape profile from the bug report opens without ValueError.
+
+        A 3-D variable alongside three 1-D arrays whose names fall outside
+        the CF coord allowlist used to raise::
+
+            ValueError: conflicting sizes for dimension 'dim_0':
+              length X on 'nx' and length Y on {'dim_0': 'count_flash_all', ...}
+
+        With collision-aware fallback disambiguation, the Dataset opens and
+        each clashing ``dim_0`` axis is renamed to ``obj_{i}_dim_0``.
+        """
+        path = str(tmp_path / "issue_66.tgm")
+
+        t_size, y_size, x_size = 4, 5, 6
+        data_3d = np.ones((t_size, y_size, x_size), dtype=np.float32)
+        coord_t = np.arange(t_size, dtype=np.float32)
+        coord_y = np.arange(y_size, dtype=np.float32)
+        coord_x = np.arange(x_size, dtype=np.float32)
+
+        meta = {
+            "version": 2,
+            "base": [
+                {"name": "reflectance"},
+                {"name": "count_flash_all"},
+                {"name": "ny"},
+                {"name": "nx"},
+            ],
+        }
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(
+                meta,
+                [
+                    (_desc([t_size, y_size, x_size]), data_3d),
+                    (_desc([t_size]), coord_t),
+                    (_desc([y_size]), coord_y),
+                    (_desc([x_size]), coord_x),
+                ],
+            )
+
+        ds = xr.open_dataset(path, engine="tensogram")
+        assert set(ds.data_vars) == {"reflectance", "count_flash_all", "ny", "nx"}
+        assert ds["reflectance"].dims == ("obj_0_dim_0", "dim_1", "dim_2")
+        assert ds["count_flash_all"].dims == ("obj_1_dim_0",)
+        assert ds["ny"].dims == ("obj_2_dim_0",)
+        assert ds["nx"].dims == ("obj_3_dim_0",)
+
+    def test_only_conflicting_axes_renamed(self, tmp_path: Path):
+        """Non-conflicting generic axes must keep their ``dim_N`` names."""
+        path = str(tmp_path / "partial.tgm")
+
+        meta = {"version": 2, "base": [{"name": "a"}, {"name": "b"}]}
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(
+                meta,
+                [
+                    (_desc([4, 9]), np.zeros((4, 9), dtype=np.float32)),
+                    (_desc([7, 9]), np.zeros((7, 9), dtype=np.float32)),
+                ],
+            )
+
+        ds = xr.open_dataset(path, engine="tensogram")
+        assert ds["a"].dims == ("obj_0_dim_0", "dim_1")
+        assert ds["b"].dims == ("obj_1_dim_0", "dim_1")
+
+    def test_no_collision_keeps_generic_names(self, tmp_path: Path):
+        """Regression guard: same-shape vars share ``dim_N`` compatibly."""
+        path = str(tmp_path / "no_collision.tgm")
+
+        meta = {"version": 2, "base": [{"name": "a"}, {"name": "b"}]}
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(
+                meta,
+                [
+                    (_desc([4, 5]), np.zeros((4, 5), dtype=np.float32)),
+                    (_desc([4, 5]), np.zeros((4, 5), dtype=np.float32)),
+                ],
+            )
+
+        ds = xr.open_dataset(path, engine="tensogram")
+        assert ds["a"].dims == ("dim_0", "dim_1")
+        assert ds["b"].dims == ("dim_0", "dim_1")
+
+    def test_coord_untouched_by_disambiguation(self, tmp_path: Path):
+        """Detected coord dims never get renamed by the disambiguation pass."""
+        path = str(tmp_path / "coord_preserved.tgm")
+
+        lat = np.linspace(-90, 90, 5, dtype=np.float64)
+        data_a = np.ones((5, 7), dtype=np.float32)
+        data_b = np.ones((3,), dtype=np.float32)
+
+        meta = {
+            "version": 2,
+            "base": [
+                {"name": "latitude"},
+                {"name": "field_a"},
+                {"name": "field_b"},
+            ],
+        }
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(
+                meta,
+                [
+                    (_desc([5], dtype="float64"), lat),
+                    (_desc([5, 7]), data_a),
+                    (_desc([3]), data_b),
+                ],
+            )
+
+        ds = xr.open_dataset(path, engine="tensogram")
+        assert ds["field_a"].dims == ("latitude", "dim_1")
+        assert ds["field_b"].dims == ("dim_0",)
+
+    def test_disambiguate_helper_pure(self):
+        """Unit-level check of :func:`_disambiguate_fallback_dims`."""
+        from tensogram_xarray.store import _DataVarPlan, _disambiguate_fallback_dims
+
+        plans = [
+            _DataVarPlan(
+                obj_index=0,
+                var_name="a",
+                shape=(3,),
+                dims_with_provenance=[("dim_0", True)],
+                backend_array=None,  # type: ignore[arg-type]
+                var_attrs={},
+            ),
+            _DataVarPlan(
+                obj_index=1,
+                var_name="b",
+                shape=(5,),
+                dims_with_provenance=[("dim_0", True)],
+                backend_array=None,  # type: ignore[arg-type]
+                var_attrs={},
+            ),
+        ]
+        assert _disambiguate_fallback_dims(plans, {}) == [
+            ("obj_0_dim_0",),
+            ("obj_1_dim_0",),
+        ]
+
+    def test_disambiguate_respects_non_generic(self):
+        """Non-generic names (coord matches, hints) are not auto-renamed
+        even when they collide."""
+        from tensogram_xarray.store import _DataVarPlan, _disambiguate_fallback_dims
+
+        plans = [
+            _DataVarPlan(
+                obj_index=0,
+                var_name="a",
+                shape=(3,),
+                dims_with_provenance=[("time", False)],
+                backend_array=None,  # type: ignore[arg-type]
+                var_attrs={},
+            ),
+            _DataVarPlan(
+                obj_index=1,
+                var_name="b",
+                shape=(5,),
+                dims_with_provenance=[("time", False)],
+                backend_array=None,  # type: ignore[arg-type]
+                var_attrs={},
+            ),
+        ]
+        resolved = _disambiguate_fallback_dims(plans, {})
+        assert resolved == [("time",), ("time",)]
+
+    def test_disambiguate_considers_coord_sizes(self):
+        """Coord dim sizes participate in conflict detection but coord names
+        themselves are never renamed."""
+        from tensogram_xarray.store import _DataVarPlan, _disambiguate_fallback_dims
+
+        plans = [
+            _DataVarPlan(
+                obj_index=0,
+                var_name="a",
+                shape=(7,),
+                dims_with_provenance=[("latitude", True)],
+                backend_array=None,  # type: ignore[arg-type]
+                var_attrs={},
+            ),
+        ]
+        resolved = _disambiguate_fallback_dims(plans, {"latitude": 5})
+        assert resolved == [("obj_0_dim_0",)]

--- a/python/tensogram-xarray/tests/test_edge_cases.py
+++ b/python/tensogram-xarray/tests/test_edge_cases.py
@@ -718,6 +718,65 @@ class TestMixedRankDimCollision:
         resolved = _disambiguate_fallback_dims(plans, {"latitude": 5})
         assert resolved == [("obj_0_dim_0",)]
 
+    def test_disambiguate_preserves_legit_coord_match_under_conflict(self):
+        """An axis that legitimately matches a coord (same name AND same size)
+        must survive disambiguation even when another plan wrongly claims the
+        same coord name at a different size — the coord-sharing binding is
+        the correct semantics and only the offender should be renamed."""
+        from tensogram_xarray.store import _DataVarPlan, _disambiguate_fallback_dims
+
+        plans = [
+            _DataVarPlan(
+                obj_index=0,
+                var_name="legit",
+                shape=(5, 7),
+                dims_with_provenance=[("latitude", False), ("dim_1", True)],
+                backend_array=None,  # type: ignore[arg-type]
+                var_attrs={},
+            ),
+            _DataVarPlan(
+                obj_index=1,
+                var_name="wrong",
+                shape=(7,),
+                dims_with_provenance=[("latitude", False)],
+                backend_array=None,  # type: ignore[arg-type]
+                var_attrs={},
+            ),
+        ]
+        resolved = _disambiguate_fallback_dims(plans, {"latitude": 5})
+        assert resolved[0] == ("latitude", "dim_1")
+        assert resolved[1] == ("obj_1_dim_0",)
+
+    def test_build_dataset_shares_coord_when_other_hint_is_wrong(self, tmp_path: Path):
+        """End-to-end: a data var legitimately using coord 'latitude' keeps
+        that dim when another var's bad hint triggers disambiguation."""
+        path = str(tmp_path / "coord_shared.tgm")
+        lat = np.linspace(-90, 90, 5, dtype=np.float64)
+        legit = np.ones((5, 7), dtype=np.float32)
+        wrong = np.ones((7,), dtype=np.float32)
+        meta = {
+            "version": 2,
+            "base": [
+                {"name": "latitude"},
+                {"name": "legit"},
+                {"name": "wrong", "dim_names": ["latitude"]},
+            ],
+        }
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(
+                meta,
+                [
+                    (_desc([5], dtype="float64"), lat),
+                    (_desc([5, 7]), legit),
+                    (_desc([7]), wrong),
+                ],
+            )
+
+        ds = xr.open_dataset(path, engine="tensogram")
+        assert ds["legit"].dims[0] == "latitude"
+        assert ds["wrong"].dims == ("obj_2_dim_0",)
+        assert ds.coords["latitude"].shape == (5,)
+
 
 # ---------------------------------------------------------------------------
 # Per-object dim_names hint (base[i]["dim_names"])

--- a/python/tensogram-xarray/tests/test_edge_cases.py
+++ b/python/tensogram-xarray/tests/test_edge_cases.py
@@ -641,9 +641,12 @@ class TestMixedRankDimCollision:
             ("obj_1_dim_0",),
         ]
 
-    def test_disambiguate_respects_non_generic(self):
-        """Non-generic names (coord matches, hints) are not auto-renamed
-        even when they collide."""
+    def test_disambiguate_hinted_conflict_warns_and_falls_back(self, caplog):
+        """Non-generic name claimed at different sizes across objects warns
+        and falls back to per-object names rather than crashing at Dataset
+        assembly (producer-error safety net)."""
+        import logging
+
         from tensogram_xarray.store import _DataVarPlan, _disambiguate_fallback_dims
 
         plans = [
@@ -664,8 +667,38 @@ class TestMixedRankDimCollision:
                 var_attrs={},
             ),
         ]
-        resolved = _disambiguate_fallback_dims(plans, {})
-        assert resolved == [("time",), ("time",)]
+        with caplog.at_level(logging.WARNING, logger="tensogram_xarray.store"):
+            resolved = _disambiguate_fallback_dims(plans, {})
+        assert resolved == [("obj_0_dim_0",), ("obj_1_dim_0",)]
+        assert any("'time'" in r.message for r in caplog.records)
+        assert sum("'time'" in r.message for r in caplog.records) == 1, (
+            "warning must be emitted once per conflicting hint, not per offending axis"
+        )
+
+    def test_disambiguate_hinted_same_size_preserved(self):
+        """Non-generic names that agree on size are never renamed — hint
+        sharing across objects is the whole point of per-object dim_names."""
+        from tensogram_xarray.store import _DataVarPlan, _disambiguate_fallback_dims
+
+        plans = [
+            _DataVarPlan(
+                obj_index=0,
+                var_name="a",
+                shape=(5,),
+                dims_with_provenance=[("time", False)],
+                backend_array=None,  # type: ignore[arg-type]
+                var_attrs={},
+            ),
+            _DataVarPlan(
+                obj_index=1,
+                var_name="b",
+                shape=(5,),
+                dims_with_provenance=[("time", False)],
+                backend_array=None,  # type: ignore[arg-type]
+                var_attrs={},
+            ),
+        ]
+        assert _disambiguate_fallback_dims(plans, {}) == [("time",), ("time",)]
 
     def test_disambiguate_considers_coord_sizes(self):
         """Coord dim sizes participate in conflict detection but coord names
@@ -684,3 +717,270 @@ class TestMixedRankDimCollision:
         ]
         resolved = _disambiguate_fallback_dims(plans, {"latitude": 5})
         assert resolved == [("obj_0_dim_0",)]
+
+
+# ---------------------------------------------------------------------------
+# Per-object dim_names hint (base[i]["dim_names"])
+# ---------------------------------------------------------------------------
+
+
+class TestPerObjectDimNames:
+    """The per-object ``base[i]["dim_names"]`` opt-in reader convention.
+
+    Producers may embed an axis-ordered list of dim names in each base
+    entry so mixed-rank messages open with semantically meaningful dims
+    without requiring callers to pass ``dim_names=`` or the message-level
+    ``_extra_["dim_names"]`` fallback.
+    """
+
+    def test_hint_applied_simple(self, tmp_path: Path):
+        """Per-object hint drives dim names for a single variable."""
+        path = str(tmp_path / "po_simple.tgm")
+        data = np.ones((4, 5), dtype=np.float32)
+        meta = {
+            "version": 2,
+            "base": [{"name": "field", "dim_names": ["time", "level"]}],
+        }
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(meta, [(_desc([4, 5]), data)])
+
+        ds = xr.open_dataset(path, engine="tensogram")
+        assert ds["field"].dims == ("time", "level")
+
+    def test_hint_applied_mixed_ranks(self, tmp_path: Path):
+        """Mixed-rank message with per-object hints opens with semantic dims."""
+        path = str(tmp_path / "po_mixed.tgm")
+        t_size, y_size, x_size = 4, 5, 6
+        meta = {
+            "version": 2,
+            "base": [
+                {"name": "reflectance", "dim_names": ["time", "y", "x"]},
+                {"name": "count", "dim_names": ["time"]},
+                {"name": "ny", "dim_names": ["y"]},
+                {"name": "nx", "dim_names": ["x"]},
+            ],
+        }
+        data_3d = np.ones((t_size, y_size, x_size), dtype=np.float32)
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(
+                meta,
+                [
+                    (_desc([t_size, y_size, x_size]), data_3d),
+                    (_desc([t_size]), np.arange(t_size, dtype=np.float32)),
+                    (_desc([y_size]), np.arange(y_size, dtype=np.float32)),
+                    (_desc([x_size]), np.arange(x_size, dtype=np.float32)),
+                ],
+            )
+
+        ds = xr.open_dataset(path, engine="tensogram")
+        assert ds["reflectance"].dims == ("time", "y", "x")
+        assert ds["count"].dims == ("time",)
+        assert ds["ny"].dims == ("y",)
+        assert ds["nx"].dims == ("x",)
+
+    def test_shared_dim_across_objects(self, tmp_path: Path):
+        """Two objects pinning matching-size axes to the same name share the dim."""
+        path = str(tmp_path / "po_shared.tgm")
+        meta = {
+            "version": 2,
+            "base": [
+                {"name": "temp", "dim_names": ["time", "level"]},
+                {"name": "humid", "dim_names": ["time", "level"]},
+            ],
+        }
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(
+                meta,
+                [
+                    (_desc([4, 3]), np.ones((4, 3), dtype=np.float32)),
+                    (_desc([4, 3]), np.ones((4, 3), dtype=np.float32)),
+                ],
+            )
+
+        ds = xr.open_dataset(path, engine="tensogram")
+        assert ds["temp"].dims == ("time", "level")
+        assert ds["humid"].dims == ("time", "level")
+        assert ds.sizes == {"time": 4, "level": 3}
+
+    def test_user_kwarg_overrides_per_object_hint(self, tmp_path: Path):
+        """User-supplied ``dim_names=`` outranks the per-object hint."""
+        path = str(tmp_path / "po_vs_user.tgm")
+        meta = {
+            "version": 2,
+            "base": [{"name": "field", "dim_names": ["producer_x", "producer_y"]}],
+        }
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(meta, [(_desc([4, 5]), np.ones((4, 5), dtype=np.float32))])
+
+        ds = xr.open_dataset(path, engine="tensogram", dim_names=["user_x", "user_y"])
+        assert ds["field"].dims == ("user_x", "user_y")
+
+    def test_coord_match_overrides_per_object_hint(self, tmp_path: Path):
+        """Detected coord wins over per-object hint on the matching axis."""
+        path = str(tmp_path / "po_vs_coord.tgm")
+        lat = np.linspace(-90, 90, 5, dtype=np.float64)
+        data = np.ones((5, 7), dtype=np.float32)
+        meta = {
+            "version": 2,
+            "base": [
+                {"name": "latitude"},
+                {"name": "field", "dim_names": ["row", "col"]},
+            ],
+        }
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(
+                meta,
+                [
+                    (_desc([5], dtype="float64"), lat),
+                    (_desc([5, 7]), data),
+                ],
+            )
+
+        ds = xr.open_dataset(path, engine="tensogram")
+        assert ds["field"].dims == ("latitude", "col")
+
+    def test_per_object_overrides_extra_hint(self, tmp_path: Path):
+        """Per-object hint outranks the message-level ``_extra_`` hint."""
+        path = str(tmp_path / "po_vs_extra.tgm")
+        data = np.ones((4, 5), dtype=np.float32)
+        meta = {
+            "version": 2,
+            "base": [{"name": "field", "dim_names": ["per_obj_x", "per_obj_y"]}],
+            "_extra_": {"dim_names": ["extra_x", "extra_y"]},
+        }
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(meta, [(_desc([4, 5]), data)])
+
+        ds = xr.open_dataset(path, engine="tensogram")
+        assert ds["field"].dims == ("per_obj_x", "per_obj_y")
+
+    def test_malformed_wrong_length_ignored(self, tmp_path: Path):
+        """Hint with wrong number of names silently falls through."""
+        path = str(tmp_path / "mal_len.tgm")
+        meta = {
+            "version": 2,
+            "base": [{"name": "field", "dim_names": ["only_one"]}],
+        }
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(meta, [(_desc([4, 5]), np.ones((4, 5), dtype=np.float32))])
+
+        ds = xr.open_dataset(path, engine="tensogram")
+        assert ds["field"].dims == ("dim_0", "dim_1")
+
+    def test_malformed_non_list_ignored(self, tmp_path: Path):
+        """Scalar/dict hints (wrong type) silently fall through."""
+        path = str(tmp_path / "mal_type.tgm")
+        meta = {
+            "version": 2,
+            "base": [{"name": "field", "dim_names": "not_a_list"}],
+        }
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(meta, [(_desc([4, 5]), np.ones((4, 5), dtype=np.float32))])
+
+        ds = xr.open_dataset(path, engine="tensogram")
+        assert ds["field"].dims == ("dim_0", "dim_1")
+
+    def test_malformed_duplicates_ignored(self, tmp_path: Path):
+        """Duplicate entries in the hint silently fall through."""
+        path = str(tmp_path / "mal_dup.tgm")
+        meta = {
+            "version": 2,
+            "base": [{"name": "field", "dim_names": ["x", "x"]}],
+        }
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(meta, [(_desc([4, 5]), np.ones((4, 5), dtype=np.float32))])
+
+        ds = xr.open_dataset(path, engine="tensogram")
+        assert ds["field"].dims == ("dim_0", "dim_1")
+
+    def test_malformed_empty_string_ignored(self, tmp_path: Path):
+        """Empty-string entries in the hint silently fall through."""
+        path = str(tmp_path / "mal_empty.tgm")
+        meta = {
+            "version": 2,
+            "base": [{"name": "field", "dim_names": ["", "y"]}],
+        }
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(meta, [(_desc([4, 5]), np.ones((4, 5), dtype=np.float32))])
+
+        ds = xr.open_dataset(path, engine="tensogram")
+        assert ds["field"].dims == ("dim_0", "dim_1")
+
+    def test_dim_names_not_in_var_attrs(self, tmp_path: Path):
+        """``dim_names`` is structural metadata; it must not leak into attrs."""
+        path = str(tmp_path / "no_leak.tgm")
+        meta = {
+            "version": 2,
+            "base": [{"name": "field", "dim_names": ["x", "y"], "units": "K"}],
+        }
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(meta, [(_desc([4, 5]), np.ones((4, 5), dtype=np.float32))])
+
+        ds = xr.open_dataset(path, engine="tensogram")
+        assert "dim_names" not in ds["field"].attrs
+        assert ds["field"].attrs.get("units") == "K"
+        assert ds["field"].dims == ("x", "y")
+
+
+# ---------------------------------------------------------------------------
+# Hinted-name conflict (producer error safety net)
+# ---------------------------------------------------------------------------
+
+
+class TestHintedNameConflict:
+    """Two objects claiming the same dim name at different sizes must not crash.
+
+    Hinted-name conflicts indicate a producer error.  The backend warns
+    and falls back to per-object dim names so the Dataset still opens.
+    """
+
+    def test_inconsistent_per_object_hint_same_size_ok(self, tmp_path: Path):
+        """Different per-object hints on different-size axes do not conflict."""
+        path = str(tmp_path / "hint_distinct.tgm")
+        meta = {
+            "version": 2,
+            "base": [
+                {"name": "a", "dim_names": ["alpha"]},
+                {"name": "b", "dim_names": ["beta"]},
+            ],
+        }
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(
+                meta,
+                [
+                    (_desc([4]), np.zeros(4, dtype=np.float32)),
+                    (_desc([7]), np.zeros(7, dtype=np.float32)),
+                ],
+            )
+
+        ds = xr.open_dataset(path, engine="tensogram")
+        assert ds["a"].dims == ("alpha",)
+        assert ds["b"].dims == ("beta",)
+
+    def test_hinted_conflict_warns_and_falls_back(self, tmp_path: Path, caplog):
+        """Same hinted name at different sizes across objects → warn + fallback."""
+        import logging
+
+        path = str(tmp_path / "hint_conflict.tgm")
+        meta = {
+            "version": 2,
+            "base": [
+                {"name": "a", "dim_names": ["time"]},
+                {"name": "b", "dim_names": ["time"]},
+            ],
+        }
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(
+                meta,
+                [
+                    (_desc([4]), np.zeros(4, dtype=np.float32)),
+                    (_desc([7]), np.zeros(7, dtype=np.float32)),
+                ],
+            )
+
+        with caplog.at_level(logging.WARNING, logger="tensogram_xarray.store"):
+            ds = xr.open_dataset(path, engine="tensogram")
+
+        assert ds["a"].dims == ("obj_0_dim_0",)
+        assert ds["b"].dims == ("obj_1_dim_0",)
+        assert any("'time'" in r.message for r in caplog.records)


### PR DESCRIPTION
Closes #66.

## Summary

`xr.open_dataset("file.tgm", engine="tensogram")` used to crash on any message that contained data objects of different ranks whose names fell outside the CF coord allowlist (e.g. a 3-D variable alongside 1-D arrays named \`nx\`, \`ny\`, \`count_flash_all\`). All such objects fell through to the same generic \`dim_0\` name, and \`xr.Dataset\` assembly rejected the clash.

This PR:

1. **Fixes the crash** — generic \`dim_N\` fallback names that would collide across variables of different shapes are renamed to \`obj_{i}_dim_{axis}\`. Coord-detected dim names are never renamed; hinted names that claim conflicting sizes warn and fall back to the same per-object form so the Dataset always opens.
2. **Adds an opt-in reader convention** — producers may write an axis-ordered \`base[i][\"dim_names\"]\` list; the backend uses the following priority chain:
   \`user_dim_names > coord size-match > base[i][\"dim_names\"] > _extra_[\"dim_names\"] > generic fallback\`.
3. **Closes a pre-existing parity gap** — \`open_datasets()\` and \`merge_objects=True\` now honour \`_extra_[\"dim_names\"]\` (list and size-to-name dict) with the same priority chain as single-message \`open_dataset\`. Previously only the single-message path read it.
4. **Opts \`tensogram-anemoi\` into the new convention** — every base entry (coords + flat fields + stacked pressure-level fields) now carries a per-object \`dim_names\` list alongside the existing \`_extra_\` message-level hint (dual-write for backward compat).

## Design highlights

- Shared dim-resolution logic extracted to \`tensogram_xarray.mapping.resolve_dims_for_axes\` (single source of truth, consumed by both \`store.py\` and \`merge.py\`).
- \`dim_names\` is declared a **structural** metadata key in \`STRUCTURAL_META_KEYS\`: filtered out of \`xr.Variable.attrs\` / \`xr.Dataset.attrs\` and out of \`merge.py\`'s hypercube grouping (so it cannot accidentally become an outer dim).
- Strict per-object hint validation: list/Sequence (not \`str\`/\`bytes\`), length equal to \`ndim\`, all entries non-empty distinct strings. Malformed hints are logged at \`DEBUG\` and silently ignored so files stay openable.
- Hypercube groups with inconsistent per-object or \`_extra_\` hints log a warning and fall back to lower-priority sources — never raise.
- No wire-format or Rust-side changes required; \`base[i]\` is already free-form \`BTreeMap<String, ciborium::Value>\`.

## Tests

**+17 new tests**, 235 passing, 1 pre-existing unrelated failure (\`test_all_nan_float32_preserved\` — fails on clean main too, missing \`allow_nan\` kwarg on \`TensogramFile.append\`).

| Class | Count | Covers |
|---|---|---|
| \`TestMixedRankDimCollision\` | 8 | Issue #66 exact repro, only-conflicting-renamed, no-collision-preserved, coord-untouched, hinted-conflict warn+fallback, hinted-same-size preserved, coord-size participation, pure-helper units. |
| \`TestPerObjectDimNames\` | 16 | Hint applied simple/mixed-ranks, shared dim across objects, precedence (user kwarg > coord > per-object > _extra_), 5 malformed cases + 4 validator edge cases (non-string, zero-dim, tuple, str/bytes rejection), attr non-leakage, \`ds.attrs\` non-leakage. |
| \`TestHintedNameConflict\` | 3 | Distinct hints OK, same-hint-different-sizes warns + falls back, hint-vs-coord-size renames hinted axis. |
| \`TestMergePathDimResolution\` | 7 | \`_extra_\` list/dict through merge, per-object through merge, coord-vs-\`_extra_\`-list precedence, structural-key non-grouping, inconsistent-hint fallback, warning-separation regression. |
| \`TestSharedResolveDimsGeneric\` | 2 | Resolver unit coverage. |
| anemoi \`test_dim_names_in_metadata\` / \`test_stacked_dim_names_in_metadata\` | updated | Assert dual-write of both hint sites. |

## File map

```
 CHANGELOG.md                                           |  +37
 docs/src/guide/xarray-integration.md                   |  +52 / -0
 python/tensogram-anemoi/src/tensogram_anemoi/output.py |  +15 / -5
 python/tensogram-anemoi/tests/test_tensogram_output.py |  +27 / -6
 python/tensogram-xarray/src/tensogram_xarray/mapping.py|  +169 / -9
 python/tensogram-xarray/src/tensogram_xarray/merge.py  |  +136 / -80
 python/tensogram-xarray/src/tensogram_xarray/store.py  |  +119 / -77
 python/tensogram-xarray/tests/test_coverage.py         |  +191 / -16
 python/tensogram-xarray/tests/test_edge_cases.py       |  +577 / -0
```

## Files intentionally NOT touched

- \`python/tensogram-xarray/src/tensogram_xarray/coords.py\` — coord detection stays purely name-based (per Oracle review; classification is orthogonal to dim labelling).
- Any \`rust/\` or \`python/bindings/\` file — no wire-format changes required; \`base[i]\` is already free-form.
- \`tensogram-zarr\` — uses different metadata pathways (confirmed by grep).

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-70
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->