### PR TITLE
Feat/remove manual pyversioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 **/pkg
 **/build/
 python/**/dist/
-python/bindings/Cargo.lock
 
 /docs/book
 **/.venv
@@ -24,6 +23,7 @@ python/bindings/Cargo.lock
 *~
 .DS_Store
 .idea/
-rust/tensogram-grib/Cargo.lock
-rust/tensogram-netcdf/Cargo.lock
-rust/tensogram-wasm/Cargo.lock
+
+# TODO we may want to actually commit those, but ignoring for now
+**/Cargo.lock
+**/uv.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,8 +137,6 @@ Serves at http://localhost:8080/ (set BASE_PATH env var to deploy under a subpat
       examples). Do not hardcode a crate list here — discover them with
       `find . -name Cargo.toml -not -path './target/*' -not -path './.venv/*'`
       and update every one to match `VERSION`.
-    - `pyproject.toml` in EVERY Python package under `python/`, AND
-      `examples/jupyter/pyproject.toml` (the Jupyter notebook deps manifest).
     - `package.json` in EVERY JS package — discover them with
       `find . -name package.json -not -path './**/node_modules/*' -not -path './target/*'`
       (currently `typescript/` and `examples/typescript/`; the list grows if

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ rust-lint: rust-clippy rust-fmt ## Run all Rust lints (clippy + fmt)
 # ── Python ────────────────────────────────────────────────────────────────
 
 PYTHON  ?= uv run python
-MATURIN ?= uv run --with maturin maturin
+MATURIN ?= uvx maturin
 RUFF    ?= uv run --with ruff ruff
 RUFF_CFG ?= python/bindings/pyproject.toml
 # Space-separated --interpreter flags passed to maturin build; defaults to
@@ -53,9 +53,11 @@ MATURIN_INTERP_ARGS ?= --find-interpreter
 
 python-build: ## Build Python bindings via maturin (dev install into .venv)
 	if [ ! -d .venv ] ; then uv venv ; fi
-	cd python/bindings && $(MATURIN) develop --release --uv
-	uv pip install ./python/tensogram-xarray
-	uv pip install ./python/tensogram-zarr
+	cd python/bindings && $(MATURIN) develop --release
+	VERSION=$$(cat VERSION) uv pip install ./python/tensogram-xarray
+	VERSION=$$(cat VERSION) uv pip install ./python/tensogram-zarr
+	VERSION=$$(cat VERSION) uv pip install ./python/tensogram-anemoi
+	VERSION=$$(cat VERSION) uv pip install ./examples/jupyter
 
 python-dist: ## Build tensogram distributable wheels for the current platform
 	if [ ! -d .venv ] ; then uv venv ; fi

--- a/examples/jupyter/pyproject.toml
+++ b/examples/jupyter/pyproject.toml
@@ -17,7 +17,7 @@
 
 [project]
 name = "tensogram-jupyter-examples"
-version = "0.16.1"
+dynamic = ["version"]
 description = "Jupyter notebook examples for the Tensogram tensor message format"
 license = "Apache-2.0"
 requires-python = ">=3.10"
@@ -58,10 +58,12 @@ Repository = "https://github.com/ecmwf/tensogram"
 Documentation = "https://sites.ecmwf.int/docs/tensogram/main/guide/jupyter-notebooks.html"
 
 [build-system]
-requires = ["setuptools>=61"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
-# This is not really a package — the layout is just notebooks + data.
-# Tell setuptools so, to keep `pip install -e .` happy.
-[tool.setuptools]
-packages = []
+[tool.hatch.version]
+source = "env"
+variable = "VERSION"
+
+[tool.hatch.build.targets.wheel]
+packages = ["tensogram_jupyter_examples"]

--- a/examples/jupyter/pyproject.toml
+++ b/examples/jupyter/pyproject.toml
@@ -62,8 +62,8 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.version]
-source = "env"
-variable = "VERSION"
+source = "code"
+path = "tensogram_jupyter_examples/_version.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["tensogram_jupyter_examples"]

--- a/examples/jupyter/tensogram_jupyter_examples/_version.py
+++ b/examples/jupyter/tensogram_jupyter_examples/_version.py
@@ -1,0 +1,3 @@
+import os
+
+__version__ = os.environ.get("VERSION", "0.0.0.dev1")

--- a/python/bindings/pyproject.toml
+++ b/python/bindings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensogram"
-version = "0.16.1"
+dynamic = ["version"]
 description = "Fast binary N-tensor message format for scientific data"
 license = "Apache-2.0"
 requires-python = ">=3.11"

--- a/python/tensogram-anemoi/pyproject.toml
+++ b/python/tensogram-anemoi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tensogram-anemoi"
-version = "0.16.1"
+dynamic = ["version"]
 description = "anemoi-inference output plugin for tensogram .tgm files"
 readme = {text = "anemoi-inference output plugin for tensogram .tgm files", content-type = "text/plain"}
 requires-python = ">=3.11"
@@ -33,6 +33,10 @@ dev = ["pytest>=7.0", "ruff>=0.4"]
 
 [project.entry-points."anemoi.inference.outputs"]
 tensogram = "tensogram_anemoi.output:TensogramOutput"
+
+[tool.hatch.version]
+source = "env"
+variable = "VERSION"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/tensogram_anemoi"]

--- a/python/tensogram-anemoi/pyproject.toml
+++ b/python/tensogram-anemoi/pyproject.toml
@@ -35,8 +35,8 @@ dev = ["pytest>=7.0", "ruff>=0.4"]
 tensogram = "tensogram_anemoi.output:TensogramOutput"
 
 [tool.hatch.version]
-source = "env"
-variable = "VERSION"
+source = "code"
+path = "src/tensogram_anemoi/_version.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/tensogram_anemoi"]

--- a/python/tensogram-anemoi/src/tensogram_anemoi/_version.py
+++ b/python/tensogram-anemoi/src/tensogram_anemoi/_version.py
@@ -1,0 +1,3 @@
+import os
+
+__version__ = os.environ.get("VERSION", "0.0.0.dev1")

--- a/python/tensogram-xarray/pyproject.toml
+++ b/python/tensogram-xarray/pyproject.toml
@@ -36,8 +36,8 @@ dask = ["dask[array]"]
 tensogram = "tensogram_xarray.backend:TensogramBackendEntrypoint"
 
 [tool.hatch.version]
-source = "env"
-variable = "VERSION"
+source = "code"
+path = "src/tensogram_xarray/_version.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/tensogram_xarray"]

--- a/python/tensogram-xarray/pyproject.toml
+++ b/python/tensogram-xarray/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tensogram-xarray"
-version = "0.16.1"
+dynamic = ["version"]
 description = "xarray backend engine for tensogram .tgm files"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -34,6 +34,10 @@ dask = ["dask[array]"]
 
 [project.entry-points."xarray.backends"]
 tensogram = "tensogram_xarray.backend:TensogramBackendEntrypoint"
+
+[tool.hatch.version]
+source = "env"
+variable = "VERSION"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/tensogram_xarray"]

--- a/python/tensogram-xarray/src/tensogram_xarray/_version.py
+++ b/python/tensogram-xarray/src/tensogram_xarray/_version.py
@@ -1,0 +1,3 @@
+import os
+
+__version__ = os.environ.get("VERSION", "0.0.0.dev1")

--- a/python/tensogram-zarr/pyproject.toml
+++ b/python/tensogram-zarr/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tensogram-zarr"
-version = "0.16.1"
+dynamic = ["version"]
 description = "Zarr v3 store backend for tensogram .tgm files"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -30,6 +30,10 @@ Documentation = "https://sites.ecmwf.int/docs/tensogram/main"
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "pytest-asyncio>=0.23", "ruff>=0.4"]
+
+[tool.hatch.version]
+source = "env"
+variable = "VERSION"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/tensogram_zarr"]

--- a/python/tensogram-zarr/pyproject.toml
+++ b/python/tensogram-zarr/pyproject.toml
@@ -32,8 +32,8 @@ Documentation = "https://sites.ecmwf.int/docs/tensogram/main"
 dev = ["pytest>=7.0", "pytest-asyncio>=0.23", "ruff>=0.4"]
 
 [tool.hatch.version]
-source = "env"
-variable = "VERSION"
+source = "code"
+path = "src/tensogram_zarr/_version.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/tensogram_zarr"]

--- a/python/tensogram-zarr/src/tensogram_zarr/_version.py
+++ b/python/tensogram-zarr/src/tensogram_zarr/_version.py
@@ -1,0 +1,3 @@
+import os
+
+__version__ = os.environ.get("VERSION", "0.0.0.dev1")


### PR DESCRIPTION
Makes the VERSION management easier for python:
 - all python packages dont maintain their own VERSION anymore, but instead take from envvar
 - Makefile now handles this envvar when invoking python-build

Consequences:
 - you can't just install the package, you need to export version yourself or use the Makefile (we can make the Makefile more granular, or have per-wheel Makefile, etc)
 - tenosgram-anemoi and jupyter-examples are now covered by the default python-build test

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-71
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->