### PR TITLE
fix(ci): build tensoscope

### DIFF
--- a/.github/workflows/build-tensoscope.yml
+++ b/.github/workflows/build-tensoscope.yml
@@ -32,16 +32,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build WASM
-        run: |
-          wasm-pack build rust/tensogram-wasm --release \
-            --target web --out-dir ../../typescript/wasm --out-name tensogram_wasm
-
-      - name: Build TypeScript wrapper
-        working-directory: typescript
-        run: |
-          npm ci || npm install --no-audit --no-fund
-          npx tsc
+      - name: Build WASM and TypeScript
+        run: make ts-build
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-tensoscope.yml
+++ b/.github/workflows/build-tensoscope.yml
@@ -1,4 +1,4 @@
-name: Deploy Tensoscope
+name: Build Tensoscope
 
 on:
   push:

--- a/.github/workflows/build-tensoscope.yml
+++ b/.github/workflows/build-tensoscope.yml
@@ -75,6 +75,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: tensoscope-build
+          path: typescript/
 
       - uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/deploy-tensoscope.yml
+++ b/.github/workflows/deploy-tensoscope.yml
@@ -21,8 +21,40 @@ env:
   IMAGE: eccr.ecmwf.int/tensogram/tensoscope
 
 jobs:
+  build-artifacts:
+    name: Build WASM and TypeScript
+    runs-on: [self-hosted, Linux, platform-builder-docker-xl, platform-builder-Ubuntu-22.04]
+    container:
+      image: eccr.ecmwf.int/tensogram/ci:1.3.0
+      credentials:
+        username: ${{ secrets.ECMWF_DOCKER_REGISTRY_USERNAME }}
+        password: ${{ secrets.ECMWF_DOCKER_REGISTRY_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build WASM
+        run: |
+          wasm-pack build rust/tensogram-wasm --release \
+            --target web --out-dir ../../typescript/wasm --out-name tensogram_wasm
+
+      - name: Build TypeScript wrapper
+        working-directory: typescript
+        run: |
+          npm ci || npm install --no-audit --no-fund
+          npx tsc
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: tensoscope-build
+          path: |
+            typescript/package.json
+            typescript/dist/
+            typescript/wasm/
+
   build-and-push:
     name: Build and push Tensoscope image
+    needs: build-artifacts
     runs-on: [self-hosted, Linux, platform-builder-docker-xl, platform-builder-Ubuntu-22.04]
     steps:
       - uses: actions/checkout@v4
@@ -39,16 +71,10 @@ jobs:
           fi
           echo "value=$TAG" >> "$GITHUB_OUTPUT"
 
-      - name: Build WASM
-        run: |
-          wasm-pack build rust/tensogram-wasm --release \
-            --target web --out-dir ../../typescript/wasm --out-name tensogram_wasm
-
-      - name: Build TypeScript wrapper
-        working-directory: typescript
-        run: |
-          npm ci || npm install --no-audit --no-fund
-          npx tsc
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: tensoscope-build
 
       - uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
## Summary

- Remove redundant Node.js install step: the CI runner image already has Node.js baked in at `/usr/local`, so the `tar` extraction was failing with `Permission denied` on pre-existing root-owned binaries.
- Split the deploy job into two to fix missing `wasm-pack`: the runner host has no Rust toolchain; those tools only exist inside the CI Docker image. The new `build-artifacts` job runs inside `eccr.ecmwf.int/tensogram/ci:1.3.0` (same pattern as `ci.yml`) and uploads compiled WASM and TypeScript as a GitHub artifact. The `build-and-push` job downloads those artifacts and runs the Docker build on the bare host where the Docker daemon is available.

## Test plan

- [ ] Trigger `workflow_dispatch` on this branch and confirm both jobs pass
- [ ] Confirm the Tensoscope Docker image is pushed to ECCR

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-73
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->