### PR TITLE
ci: unify Linux wheel build jobs into a single job

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -29,13 +29,13 @@ jobs:
       - name: Install supported CPython versions
         run: |
           uv python install \
-            3.9 3.10 3.11 3.12 3.13 3.14 \
+            3.11 3.12 3.13 3.14 \
             cpython-3.13+freethreaded cpython-3.14+freethreaded
 
       - name: Build wheels
         run: |
           ARGS=""
-          for v in 3.9 3.10 3.11 3.12 3.13 3.14 \
+          for v in 3.11 3.12 3.13 3.14 \
                    cpython-3.13+freethreaded cpython-3.14+freethreaded; do
             ARGS="$ARGS --interpreter $(uv python find $v)"
           done
@@ -63,13 +63,13 @@ jobs:
       - name: Install supported CPython versions
         run: |
           uv python install \
-            3.9 3.10 3.11 3.12 3.13 3.14 \
+            3.11 3.12 3.13 3.14 \
             cpython-3.13+freethreaded cpython-3.14+freethreaded
 
       - name: Build wheels
         run: |
           ARGS=""
-          for v in 3.9 3.10 3.11 3.12 3.13 3.14 \
+          for v in 3.11 3.12 3.13 3.14 \
                    cpython-3.13+freethreaded cpython-3.14+freethreaded; do
             ARGS="$ARGS --interpreter $(uv python find $v)"
           done

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -13,26 +13,33 @@ jobs:
 
   build-tensogram-linux:
     name: Build tensogram wheels (Linux x86_64)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.x"
+      - uses: dtolnay/rust-toolchain@stable
 
-      # Uses the same maturin build args as `make python-dist`, wrapped in the
-      # manylinux_2_28 container that is required for Linux-compatible wheels.
-      - uses: PyO3/maturin-action@v1
-        with:
-          working-directory: python/bindings
-          target: x86_64
-          manylinux: manylinux_2_28
-          args: --release --out dist --find-interpreter
-          before-script-linux: yum install -y clang-devel
-          sccache: true
+      - uses: astral-sh/setup-uv@v3
+
+      # Install all supported CPython versions (including free-threaded) so
+      # they are available to maturin via explicit --interpreter flags.
+      # Maturin produces manylinux-tagged wheels automatically on Linux.
+      - name: Install supported CPython versions
+        run: |
+          uv python install \
+            3.9 3.10 3.11 3.12 3.13 3.14 \
+            cpython-3.13+freethreaded cpython-3.14+freethreaded
+
+      - name: Build wheels
+        run: |
+          ARGS=""
+          for v in 3.9 3.10 3.11 3.12 3.13 3.14 \
+                   cpython-3.13+freethreaded cpython-3.14+freethreaded; do
+            ARGS="$ARGS --interpreter $(uv python find $v)"
+          done
+          make python-dist MATURIN_INTERP_ARGS="$ARGS"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -73,35 +80,6 @@ jobs:
           name: wheels-tensogram-macos-arm64
           path: python/bindings/dist/
 
-  build-tensogram-freethreaded:
-    name: Build tensogram free-threaded wheels (Linux)
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: astral-sh/setup-uv@v3
-
-      - name: Install free-threaded Python versions
-        run: |
-          uv python install cpython-3.13+freethreaded cpython-3.14+freethreaded
-
-      - name: Build free-threaded wheels
-        run: |
-          ARGS=""
-          for v in cpython-3.13+freethreaded cpython-3.14+freethreaded; do
-            ARGS="$ARGS --interpreter $(uv python find $v)"
-          done
-          make python-dist MATURIN_INTERP_ARGS="$ARGS"
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: wheels-tensogram-freethreaded
-          path: python/bindings/dist/
-
   # ── Pure-Python extras (hatchling) ────────────────────────────────────────
 
   build-extras:
@@ -131,7 +109,6 @@ jobs:
     needs:
       - build-tensogram-linux
       - build-tensogram-macos
-      - build-tensogram-freethreaded
       - build-extras
     runs-on: ubuntu-latest
     environment: ${{ inputs.use_test_pypi && 'test-pypi' || 'pypi' }}


### PR DESCRIPTION
Replace the separate build-tensogram-linux (maturin-action + manylinux container) and build-tensogram-freethreaded jobs with a single unified build-tensogram-linux job.

Maturin produces manylinux-tagged wheels automatically on Linux, so the explicit manylinux_2_28 container is not needed. The unified job follows the same uv-based approach already used for macOS: install all supported CPython versions (3.9–3.14 plus 3.13t/3.14t free-threaded) via uv and pass them to maturin as explicit --interpreter arguments.


<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-75
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->