### PR TITLE
fix(zarr): surface descriptor-level variable names, warn on misplacement (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- `tensogram-zarr`: `TensogramStore` now falls back to descriptor-level
+  keys (`name`, `param`, `shortName`, ...) for variable naming when
+  `meta.base[i]` does not supply one, matching the long-standing xarray
+  backend behaviour.  This rescues files where application metadata
+  was accidentally placed in the descriptor dict (a common Python-API
+  mistake, since unknown keys are silently routed to
+  `DataObjectDescriptor.params`).  Per-key precedence across sources
+  follows the existing name chain; `meta.base[i]` still wins for the
+  same key.  ([#67](https://github.com/ecmwf/tensogram/issues/67))
+
 - `tensogram-xarray`: `xr.open_dataset(engine="tensogram")` no longer
   raises `ValueError: conflicting sizes for dimension 'dim_0'` on
   messages that mix objects of different ranks without CF-recognised
@@ -22,6 +32,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   honour `_extra_["dim_names"]` (list and size-to-name dict) with the
   same priority chain as single-message `open_dataset`.  Previously
   only the single-message path read the hint.
+
+### Changed
+
+- `tensogram` (Python): `encode()` and `TensogramFile.append()` now
+  emit a `UserWarning` when a descriptor dict contains keys that look
+  like application metadata (`name`, `param`, `shortName`, `long_name`,
+  `description`, `units`, `dim_names`, `mars`, `cf`, `product`,
+  `instrument`), pointing callers at `meta["base"][i]` as the
+  canonical location.  The keys are still captured into
+  `DataObjectDescriptor.params` for wire compatibility, so existing
+  files keep round-tripping; the warning is suppressible via standard
+  `warnings.filterwarnings`.  One aggregated warning per descriptor
+  rather than one per key.
+  ([#67](https://github.com/ecmwf/tensogram/issues/67))
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
-- `tensogram` (Python): `encode()` and `TensogramFile.append()` now
-  emit a `UserWarning` when a descriptor dict contains keys that look
-  like application metadata (`name`, `param`, `shortName`, `long_name`,
+- `tensogram` (Python): `encode()`, `encode_pre_encoded()`,
+  `TensogramFile.append()`, `StreamingEncoder.write_object()`, and
+  `StreamingEncoder.write_object_pre_encoded()` now emit a
+  `UserWarning` when a descriptor dict contains keys that look like
+  application metadata (`name`, `param`, `shortName`, `long_name`,
   `description`, `units`, `dim_names`, `mars`, `cf`, `product`,
   `instrument`), pointing callers at `meta["base"][i]` as the
   canonical location.  The keys are still captured into

--- a/README.md
+++ b/README.md
@@ -132,9 +132,12 @@ See `examples/rust/` for metadata, streaming, compression, the file API, and mor
 
 ```python
 data = np.random.randn(100, 200).astype(np.float32)
-# The "product" key below is just an example namespace — the library is
+# Application metadata (names, units, vocabularies) lives in meta["base"][i].
+# The "product" key below is an example namespace — the library is
 # vocabulary-agnostic, so any application-defined keys work the same way
-# (MARS, CF, BIDS, DICOM, or your own).
+# (MARS, CF, BIDS, DICOM, or your own).  The descriptor dict is strictly
+# for tensor shape/dtype and encoding parameters; put "name"/"units"/etc.
+# there and xarray/zarr fall back but emit a UserWarning.
 msg = tensogram.encode(
     {"version": 2, "base": [{"product": {"name": "temperature", "units": "K"}}]},
     [({"type": "ntensor", "shape": [100, 200], "dtype": "float32",
@@ -143,6 +146,10 @@ msg = tensogram.encode(
 result = tensogram.decode(msg)
 arr = result.objects[0][1]  # numpy array
 ```
+
+For default zarr/xarray variable discovery, `meta["base"][i]["name"]` is
+the simplest form; use `variable_key="product.name"` (or any dotted path)
+to pick a name out of a namespaced vocabulary.
 
 ### xarray
 

--- a/docs/src/guide/xarray-integration.md
+++ b/docs/src/guide/xarray-integration.md
@@ -280,6 +280,17 @@ with tensogram.TensogramFile.create("mars.tgm") as f:
 The `variable_key` supports dotted paths: `"mars.param"` navigates into
 the nested `mars` dict within each object's metadata.
 
+### Where to put `name` / `param` / `units`
+
+Application metadata belongs in `meta["base"][i]`, not in the descriptor
+dict.  The descriptor is only for tensor shape/dtype and encoding
+parameters (`reference_value`, `bits_per_value`, ...).  Unknown keys in
+a descriptor dict are still preserved for wire compatibility (they land
+in `DataObjectDescriptor.params`), and xarray / zarr fall back to them
+for variable naming, but `tensogram.encode()` and
+`TensogramFile.append()` emit a `UserWarning` pointing at the canonical
+location.  See [issue #67](https://github.com/ecmwf/tensogram/issues/67).
+
 ---
 
 ## Example 4: Multi-Message File with Auto-Merge

--- a/docs/src/guide/xarray-integration.md
+++ b/docs/src/guide/xarray-integration.md
@@ -286,10 +286,16 @@ Application metadata belongs in `meta["base"][i]`, not in the descriptor
 dict.  The descriptor is only for tensor shape/dtype and encoding
 parameters (`reference_value`, `bits_per_value`, ...).  Unknown keys in
 a descriptor dict are still preserved for wire compatibility (they land
-in `DataObjectDescriptor.params`), and xarray / zarr fall back to them
-for variable naming, but `tensogram.encode()` and
-`TensogramFile.append()` emit a `UserWarning` pointing at the canonical
-location.  See [issue #67](https://github.com/ecmwf/tensogram/issues/67).
+in `DataObjectDescriptor.params`), and the xarray backend's per-object
+merge picks them up as a last-resort fallback — so naming-chain keys
+(`name`, `mars.param`, `param`, `mars.shortName`, `shortName`) and the
+`dim_names` hint still reach the consumer from either source.  Other
+keys (`units`, `long_name`, `description`, ...) survive on the
+descriptor but only reach xarray-visible attributes through the same
+fallback, which is why `tensogram.encode()`, `encode_pre_encoded()`,
+`TensogramFile.append()`, and `StreamingEncoder.write_object*()` emit a
+`UserWarning` pointing at the canonical location.  See
+[issue #67](https://github.com/ecmwf/tensogram/issues/67).
 
 ---
 

--- a/docs/src/guide/zarr-backend.md
+++ b/docs/src/guide/zarr-backend.md
@@ -78,11 +78,15 @@ By default, the store tries these metadata paths to name arrays:
 5. `shortName`
 6. Falls back to `object_<index>`
 
-Each path is resolved against the object's `meta.base[i]` dict first and
-then against the descriptor's `params` dict (matching the xarray
-backend's long-standing behaviour).  The per-key precedence still
-applies: a higher-priority key in either source wins; base wins only
-for the same key.
+The lookup runs against a **shallow root-key merge** of `meta.base[i]`
+and `desc.params` (matching the xarray backend's long-standing
+behaviour): for each top-level key, `meta.base[i]` wins if present,
+otherwise `desc.params` fills in.  Nested dicts are *not* deep-merged,
+so a `base[i]` entry with `{"mars": {"levtype": "sfc"}}` entirely
+shadows a `desc.params["mars"]` with `{"param": "2t"}`; no `mars.param`
+from the descriptor survives that case.  After merging, the priority
+chain above is applied to the combined dict, so a higher-priority key
+from either source beats a lower-priority one.
 
 You can override with any dot-path, including non-MARS vocabularies:
 

--- a/docs/src/guide/zarr-backend.md
+++ b/docs/src/guide/zarr-backend.md
@@ -78,6 +78,12 @@ By default, the store tries these metadata paths to name arrays:
 5. `shortName`
 6. Falls back to `object_<index>`
 
+Each path is resolved against the object's `meta.base[i]` dict first and
+then against the descriptor's `params` dict (matching the xarray
+backend's long-standing behaviour).  The per-key precedence still
+applies: a higher-priority key in either source wins; base wins only
+for the same key.
+
 You can override with any dot-path, including non-MARS vocabularies:
 
 ```python
@@ -90,6 +96,27 @@ store = TensogramStore.open_tgm("scans.tgm", variable_key="bids.task")
 # Custom vocabulary
 store = TensogramStore.open_tgm("data.tgm", variable_key="product.name")
 ```
+
+### Common pitfall: `name` in the descriptor dict
+
+Application metadata belongs in `meta["base"][i]`, not in the descriptor:
+
+```python
+# ✗ Avoid — triggers a UserWarning; works via fallback but is not canonical
+desc = {"type": "ntensor", "shape": [10, 8], "dtype": "float32",
+        "name": "temperature"}  # ← goes into desc.params, flagged
+tensogram.encode({"version": 2}, [(desc, data)])
+
+# ✓ Canonical — the simplest form
+meta = {"version": 2, "base": [{"name": "temperature"}]}
+desc = {"type": "ntensor", "shape": [10, 8], "dtype": "float32"}
+tensogram.encode(meta, [(desc, data)])
+```
+
+The descriptor fallback exists so files produced by the ✗ form still
+surface the correct names in zarr (and xarray); the write-side warning
+exists so the mistake is visible at the time it's made.
+See [issue #67](https://github.com/ecmwf/tensogram/issues/67).
 
 ## Multi-message files
 

--- a/python/bindings/src/lib.rs
+++ b/python/bindings/src/lib.rs
@@ -12,10 +12,11 @@
 //! numpy integration. All tensor data crosses the boundary as numpy arrays.
 
 use std::collections::BTreeMap;
+use std::ffi::CString;
 use std::path::Path;
 
 use numpy::PyArrayMethods;
-use pyo3::exceptions::{PyIOError, PyRuntimeError, PyValueError};
+use pyo3::exceptions::{PyIOError, PyRuntimeError, PyUserWarning, PyValueError};
 // `PyFileNotFoundError` is only referenced from the GRIB/NetCDF converter
 // error-mapping helpers, which are themselves cfg-gated.  Gate the import
 // so `--no-default-features --features async` builds do not warn.
@@ -3142,11 +3143,18 @@ fn dict_to_data_object_descriptor(dict: &Bound<'_, PyDict>) -> PyResult<DataObje
         "hash",
     ];
     let mut params = BTreeMap::new();
+    let mut misplaced_metadata_keys: Vec<String> = Vec::new();
     for (k, v) in dict.iter() {
         let key: String = k.extract()?;
         if !reserved_keys.contains(&key.as_str()) {
+            if is_metadata_like_key(&key) {
+                misplaced_metadata_keys.push(key.clone());
+            }
             params.insert(key, py_to_cbor(&v)?);
         }
+    }
+    if !misplaced_metadata_keys.is_empty() {
+        warn_misplaced_metadata(dict.py(), &misplaced_metadata_keys)?;
     }
 
     Ok(DataObjectDescriptor {
@@ -3162,6 +3170,62 @@ fn dict_to_data_object_descriptor(dict: &Bound<'_, PyDict>) -> PyResult<DataObje
         params,
         masks: None,
     })
+}
+
+/// Keys that look like application metadata rather than encoding parameters.
+///
+/// When a user places one of these in the descriptor dict, it is still
+/// captured into ``DataObjectDescriptor.params`` for wire compatibility,
+/// but a ``UserWarning`` is emitted pointing at ``meta['base'][i]`` as
+/// the correct location.  Keys fall into three groups:
+///
+/// * Consumed by zarr/xarray's naming chain (``resolve_variable_name``).
+/// * Consumed by xarray's dimension logic (``base[i]["dim_names"]``).
+/// * Obvious namespace roots from established vocabularies.
+///
+/// See issue #67 and ``python/tensogram-zarr/src/tensogram_zarr/mapping.py``
+/// for the naming-chain key list.
+const METADATA_LIKE_DESCRIPTOR_KEYS: &[&str] = &[
+    "name",
+    "param",
+    "shortName",
+    "long_name",
+    "description",
+    "units",
+    "dim_names",
+    "mars",
+    "cf",
+    "product",
+    "instrument",
+];
+
+fn is_metadata_like_key(key: &str) -> bool {
+    METADATA_LIKE_DESCRIPTOR_KEYS.contains(&key)
+}
+
+/// Emit a single aggregated ``UserWarning`` listing descriptor keys that
+/// look like application metadata.  Multi-object messages thus warn at
+/// most once per descriptor rather than once per key.
+fn warn_misplaced_metadata(py: Python<'_>, keys: &[String]) -> PyResult<()> {
+    let key_list = keys
+        .iter()
+        .map(|k| format!("'{k}'"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let message = format!(
+        "descriptor contains application-metadata-like keys ({key_list}) \
+         that were captured into DataObjectDescriptor.params.  Application \
+         metadata belongs in meta['base'][i] — placing it in the descriptor \
+         dict works (xarray/zarr fall back to descriptor params) but is not \
+         canonical and may produce unexpected results in downstream tools. \
+         See examples/python/02b_generic_metadata.py for the recommended \
+         pattern."
+    );
+    let c_message = CString::new(message)
+        .map_err(|_| PyValueError::new_err("internal: warning message contained NUL"))?;
+    let warning_type = py.get_type::<PyUserWarning>();
+    PyErr::warn(py, &warning_type, &c_message, 2)?;
+    Ok(())
 }
 
 fn parse_dtype(s: &str) -> PyResult<Dtype> {

--- a/python/bindings/src/lib.rs
+++ b/python/bindings/src/lib.rs
@@ -3224,7 +3224,7 @@ fn warn_misplaced_metadata(py: Python<'_>, keys: &[String]) -> PyResult<()> {
     let c_message = CString::new(message)
         .map_err(|_| PyValueError::new_err("internal: warning message contained NUL"))?;
     let warning_type = py.get_type::<PyUserWarning>();
-    PyErr::warn(py, &warning_type, &c_message, 2)?;
+    PyErr::warn(py, &warning_type, &c_message, 1)?;
     Ok(())
 }
 

--- a/python/tensogram-xarray/tests/test_issue_67_descriptor_name_fallback.py
+++ b/python/tensogram-xarray/tests/test_issue_67_descriptor_name_fallback.py
@@ -31,6 +31,27 @@ def _write(path: str, meta: dict, objs: list) -> None:
             f.append(meta, objs)
 
 
+class TestNestedRootIsAtomic:
+    """Shallow root-key merge: ``base[i]["mars"]`` entirely shadows
+    ``desc.params["mars"]``.  Pinned as a sibling to the zarr regression
+    so the two backends don't drift into different merge semantics.
+    """
+
+    def test_base_mars_without_param_shadows_descriptor_mars_param(self, tmp_path: Path):
+        path = str(tmp_path / "nested_shadow.tgm")
+        meta = {"version": 2, "base": [{"mars": {"levtype": "sfc"}}]}
+        desc = {
+            "type": "ntensor",
+            "shape": [4, 4],
+            "dtype": "float32",
+            "mars": {"param": "2t"},
+        }
+        _write(path, meta, [(desc, np.zeros((4, 4), dtype=np.float32))])
+
+        ds = xr.open_dataset(path, engine="tensogram")
+        assert list(ds.data_vars) == ["object_0"]
+
+
 class TestXarrayFallbackUnchanged:
     def test_descriptor_name_surfaces_as_variable_name(self, tmp_path: Path):
         path = str(tmp_path / "descriptor_name.tgm")

--- a/python/tensogram-xarray/tests/test_issue_67_descriptor_name_fallback.py
+++ b/python/tensogram-xarray/tests/test_issue_67_descriptor_name_fallback.py
@@ -1,0 +1,75 @@
+# (C) Copyright 2026- ECMWF and individual contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation nor
+# does it submit to any jurisdiction.
+
+"""Issue #67 regression: xarray must continue merging base[i] with desc.params.
+
+This pins the pre-existing ``scanner._merge_per_object_meta`` behaviour so
+it cannot silently regress.  The zarr backend was recently taught the
+same merge (see ``tensogram_zarr.store._merge_base_with_desc_params``);
+the two paths must stay in sync.
+"""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import numpy as np
+import tensogram
+import xarray as xr
+
+
+def _write(path: str, meta: dict, objs: list) -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(meta, objs)
+
+
+class TestXarrayFallbackUnchanged:
+    def test_descriptor_name_surfaces_as_variable_name(self, tmp_path: Path):
+        path = str(tmp_path / "descriptor_name.tgm")
+        meta = {"version": 2}
+        objects = [
+            (
+                {
+                    "type": "ntensor",
+                    "shape": [10, 8],
+                    "dtype": "float32",
+                    "name": "temperature",
+                },
+                np.random.rand(10, 8).astype("float32"),
+            ),
+            (
+                {
+                    "type": "ntensor",
+                    "shape": [10, 8],
+                    "dtype": "float32",
+                    "name": "humidity",
+                },
+                np.random.rand(10, 8).astype("float32"),
+            ),
+        ]
+        _write(path, meta, objects)
+
+        ds = xr.open_dataset(path, engine="tensogram")
+        assert sorted(ds.data_vars) == ["humidity", "temperature"]
+
+    def test_base_wins_over_descriptor_for_same_key(self, tmp_path: Path):
+        path = str(tmp_path / "base_wins.tgm")
+        meta = {"version": 2, "base": [{"name": "from_base"}]}
+        desc = {
+            "type": "ntensor",
+            "shape": [4, 4],
+            "dtype": "float32",
+            "name": "from_descriptor",
+        }
+        _write(path, meta, [(desc, np.zeros((4, 4), dtype=np.float32))])
+
+        ds = xr.open_dataset(path, engine="tensogram")
+        assert list(ds.data_vars) == ["from_base"]

--- a/python/tensogram-zarr/src/tensogram_zarr/mapping.py
+++ b/python/tensogram-zarr/src/tensogram_zarr/mapping.py
@@ -337,9 +337,14 @@ def resolve_variable_name(
     Tries ``variable_key`` first if given, then ``_VARIABLE_NAME_KEYS``,
     then falls back to ``object_<index>``.
 
-    Only ``per_object_meta`` (from ``meta.base[i]``) is consulted for
-    naming.  ``common_meta`` (from ``meta.extra``) is accepted for API
-    compatibility but is **not** searched — variable names should come
+    The lookup runs against whatever per-object dict the caller supplies.
+    ``TensogramStore._resolve_names`` passes a shallow root-key merge of
+    ``meta.base[i]`` and ``desc.params`` (base wins same-key), matching
+    the xarray backend's ``scanner._merge_per_object_meta``.  Callers
+    that want pure ``meta.base[i]`` semantics can simply pass that.
+
+    ``common_meta`` (historically from ``meta.extra``) is accepted for
+    API compatibility but is **not** searched — variable names must come
     from per-object metadata to avoid all objects in a message sharing
     the same name.
     """

--- a/python/tensogram-zarr/src/tensogram_zarr/store.py
+++ b/python/tensogram-zarr/src/tensogram_zarr/store.py
@@ -482,8 +482,9 @@ class TensogramStore(ZarrStore):
     def _resolve_names(self, descriptors: list, base: list) -> list[str]:
         names: list[str] = []
         name_counts: dict[str, int] = {}
-        for i, _desc in enumerate(descriptors):
-            per_obj = _filter_reserved(base[i]) if i < len(base) else {}
+        for i, desc in enumerate(descriptors):
+            base_entry = base[i] if i < len(base) else {}
+            per_obj = _merge_base_with_desc_params(base_entry, desc)
             raw_name = resolve_variable_name(i, per_obj, None, self._variable_key)
             name = _sanitize_key_segment(raw_name)
             if name in name_counts:
@@ -621,6 +622,24 @@ def _filter_reserved(entry: dict) -> dict:
     if not isinstance(entry, dict):
         return {}
     return {k: v for k, v in entry.items() if k != "_reserved_"}
+
+
+def _merge_base_with_desc_params(base_entry: Any, desc: Any) -> dict:
+    """Combine ``base[i]`` (filtered) with ``desc.params``; base wins same-key.
+
+    Mirrors ``tensogram_xarray.scanner._merge_per_object_meta``.  Used only
+    for variable-name resolution so that naming-chain keys accidentally
+    placed in the descriptor dict (see issue #67) are still surfaced.
+    Array attributes continue to use ``base[i]`` alone — descriptor params
+    remain available under the ``_tensogram_params`` prefix.
+    """
+    result = _filter_reserved(base_entry)
+    params = getattr(desc, "params", None)
+    if params and isinstance(params, dict):
+        for k, v in params.items():
+            if k not in result:
+                result[k] = v
+    return result
 
 
 def _apply_byte_range(data: bytes, byte_range: ByteRequest) -> bytes:

--- a/python/tensogram-zarr/src/tensogram_zarr/store.py
+++ b/python/tensogram-zarr/src/tensogram_zarr/store.py
@@ -484,8 +484,8 @@ class TensogramStore(ZarrStore):
         name_counts: dict[str, int] = {}
         for i, desc in enumerate(descriptors):
             base_entry = base[i] if i < len(base) else {}
-            per_obj = _merge_base_with_desc_params(base_entry, desc)
-            raw_name = resolve_variable_name(i, per_obj, None, self._variable_key)
+            merged_meta = _merge_base_with_desc_params(base_entry, desc)
+            raw_name = resolve_variable_name(i, merged_meta, None, self._variable_key)
             name = _sanitize_key_segment(raw_name)
             if name in name_counts:
                 name_counts[name] += 1

--- a/python/tensogram-zarr/tests/test_issue_67_descriptor_name_fallback.py
+++ b/python/tensogram-zarr/tests/test_issue_67_descriptor_name_fallback.py
@@ -1,0 +1,221 @@
+# (C) Copyright 2026- ECMWF and individual contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation nor
+# does it submit to any jurisdiction.
+
+"""Issue #67 regression: zarr variable naming falls back to descriptor keys.
+
+The Python binding silently routes unknown descriptor keys to
+``DataObjectDescriptor.params``.  xarray has long merged ``base[i]`` +
+``desc.params``; zarr did not, yielding ``object_0, object_1, ...``
+instead of the intended names.  These tests pin the new per-key
+precedence: ``base[i]`` wins for the same key, but a higher-priority
+key from ``desc.params`` beats a lower-priority key from ``base[i]``.
+"""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pytest
+import tensogram
+import zarr
+from tensogram_zarr import TensogramStore
+
+
+def _write(path: str, meta: dict, objs: list) -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(meta, objs)
+
+
+@pytest.fixture
+def descriptor_name_tgm(tmp_path: Path) -> str:
+    path = str(tmp_path / "descriptor_name.tgm")
+    meta = {"version": 2}
+    objects = [
+        (
+            {
+                "type": "ntensor",
+                "shape": [10, 8],
+                "dtype": "float32",
+                "compression": "zstd",
+                "name": "temperature",
+            },
+            np.random.rand(10, 8).astype("float32"),
+        ),
+        (
+            {
+                "type": "ntensor",
+                "shape": [10, 8],
+                "dtype": "float32",
+                "compression": "zstd",
+                "name": "humidity",
+            },
+            np.random.rand(10, 8).astype("float32"),
+        ),
+    ]
+    _write(path, meta, objects)
+    return path
+
+
+class TestIssue67Reproducer:
+    def test_keys_match_descriptor_names(self, descriptor_name_tgm: str):
+        with TensogramStore(descriptor_name_tgm, mode="r") as store:
+            root = zarr.open_group(store=store, mode="r")
+            assert sorted(root.keys()) == ["humidity", "temperature"]
+
+    def test_raw_store_keys_use_descriptor_names(self, descriptor_name_tgm: str):
+        with TensogramStore(descriptor_name_tgm, mode="r") as store:
+            names = sorted(
+                k.split("/")[0]
+                for k in store._keys
+                if k.endswith("/zarr.json") and k != "zarr.json"
+            )
+            assert names == ["humidity", "temperature"]
+
+
+class TestPrecedenceAcrossSources:
+    def test_base_wins_over_descriptor_for_same_key(self, tmp_path: Path):
+        path = str(tmp_path / "base_wins.tgm")
+        meta = {"version": 2, "base": [{"name": "from_base"}]}
+        desc = {
+            "type": "ntensor",
+            "shape": [4, 4],
+            "dtype": "float32",
+            "name": "from_descriptor",
+        }
+        _write(path, meta, [(desc, np.zeros((4, 4), dtype=np.float32))])
+
+        with TensogramStore(path, mode="r") as store:
+            root = zarr.open_group(store=store, mode="r")
+            assert list(root.keys()) == ["from_base"]
+
+    def test_higher_priority_descriptor_key_beats_lower_priority_base_key(
+        self, tmp_path: Path
+    ):
+        path = str(tmp_path / "priority.tgm")
+        meta = {"version": 2, "base": [{"param": "T"}]}
+        desc = {
+            "type": "ntensor",
+            "shape": [4, 4],
+            "dtype": "float32",
+            "name": "temperature",
+        }
+        _write(path, meta, [(desc, np.zeros((4, 4), dtype=np.float32))])
+
+        with TensogramStore(path, mode="r") as store:
+            root = zarr.open_group(store=store, mode="r")
+            assert list(root.keys()) == ["temperature"]
+
+
+class TestVariableKeyWithMergedMeta:
+    def test_dotted_variable_key_resolves_against_descriptor(self, tmp_path: Path):
+        path = str(tmp_path / "namespaced.tgm")
+        meta = {"version": 2}
+        desc = {
+            "type": "ntensor",
+            "shape": [4, 4],
+            "dtype": "float32",
+            "product": {"name": "intensity"},
+        }
+        _write(path, meta, [(desc, np.zeros((4, 4), dtype=np.float32))])
+
+        with TensogramStore(path, mode="r", variable_key="product.name") as store:
+            root = zarr.open_group(store=store, mode="r")
+            assert list(root.keys()) == ["intensity"]
+
+
+class TestPerObjectFallback:
+    def test_object_with_base_and_object_without_resolve_independently(
+        self, tmp_path: Path
+    ):
+        path = str(tmp_path / "mixed.tgm")
+        meta = {
+            "version": 2,
+            "base": [
+                {"name": "alpha"},
+                {},
+            ],
+        }
+        descs_and_data = [
+            (
+                {"type": "ntensor", "shape": [3], "dtype": "float32"},
+                np.zeros(3, dtype=np.float32),
+            ),
+            (
+                {
+                    "type": "ntensor",
+                    "shape": [3],
+                    "dtype": "float32",
+                    "name": "beta",
+                },
+                np.zeros(3, dtype=np.float32),
+            ),
+        ]
+        _write(path, meta, descs_and_data)
+
+        with TensogramStore(path, mode="r") as store:
+            root = zarr.open_group(store=store, mode="r")
+            assert sorted(root.keys()) == ["alpha", "beta"]
+
+
+class TestDuplicateNamesStillSuffixed:
+    def test_duplicate_descriptor_names_get_numeric_suffix(self, tmp_path: Path):
+        path = str(tmp_path / "duplicates.tgm")
+        meta = {"version": 2}
+        descs_and_data = [
+            (
+                {
+                    "type": "ntensor",
+                    "shape": [2],
+                    "dtype": "float32",
+                    "name": "temp",
+                },
+                np.zeros(2, dtype=np.float32),
+            ),
+            (
+                {
+                    "type": "ntensor",
+                    "shape": [2],
+                    "dtype": "float32",
+                    "name": "temp",
+                },
+                np.zeros(2, dtype=np.float32),
+            ),
+        ]
+        _write(path, meta, descs_and_data)
+
+        with TensogramStore(path, mode="r") as store:
+            root = zarr.open_group(store=store, mode="r")
+            assert sorted(root.keys()) == ["temp", "temp_1"]
+
+
+class TestExistingBehaviourUnchanged:
+    def test_canonical_base_name_still_works(self, tmp_path: Path):
+        path = str(tmp_path / "base_only.tgm")
+        meta = {"version": 2, "base": [{"name": "canonical"}]}
+        desc = {"type": "ntensor", "shape": [4, 4], "dtype": "float32"}
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(meta, [(desc, np.zeros((4, 4), dtype=np.float32))])
+
+        with TensogramStore(path, mode="r") as store:
+            root = zarr.open_group(store=store, mode="r")
+            assert list(root.keys()) == ["canonical"]
+
+    def test_unnamed_object_falls_back_to_object_index(self, tmp_path: Path):
+        path = str(tmp_path / "unnamed.tgm")
+        meta = {"version": 2}
+        desc = {"type": "ntensor", "shape": [4, 4], "dtype": "float32"}
+        with tensogram.TensogramFile.create(path) as f:
+            f.append(meta, [(desc, np.zeros((4, 4), dtype=np.float32))])
+
+        with TensogramStore(path, mode="r") as store:
+            root = zarr.open_group(store=store, mode="r")
+            assert list(root.keys()) == ["object_0"]

--- a/python/tensogram-zarr/tests/test_issue_67_descriptor_name_fallback.py
+++ b/python/tensogram-zarr/tests/test_issue_67_descriptor_name_fallback.py
@@ -197,6 +197,29 @@ class TestDuplicateNamesStillSuffixed:
             assert sorted(root.keys()) == ["temp", "temp_1"]
 
 
+class TestNestedRootIsAtomic:
+    """The base+params merge is shallow, root-key atomic: if ``base[i]`` has
+    a root key, the entire sub-tree in ``desc.params`` under that key is
+    shadowed — no deep merge.  Pinned to lock semantics against future
+    accidental deep-merge "fixes".  Matches xarray's ``_merge_per_object_meta``.
+    """
+
+    def test_base_mars_without_param_shadows_descriptor_mars_param(self, tmp_path: Path):
+        path = str(tmp_path / "nested_shadow.tgm")
+        meta = {"version": 2, "base": [{"mars": {"levtype": "sfc"}}]}
+        desc = {
+            "type": "ntensor",
+            "shape": [4, 4],
+            "dtype": "float32",
+            "mars": {"param": "2t"},
+        }
+        _write(path, meta, [(desc, np.zeros((4, 4), dtype=np.float32))])
+
+        with TensogramStore(path, mode="r") as store:
+            root = zarr.open_group(store=store, mode="r")
+            assert list(root.keys()) == ["object_0"]
+
+
 class TestExistingBehaviourUnchanged:
     def test_canonical_base_name_still_works(self, tmp_path: Path):
         path = str(tmp_path / "base_only.tgm")

--- a/python/tensogram-zarr/tests/test_remote.py
+++ b/python/tensogram-zarr/tests/test_remote.py
@@ -12,10 +12,12 @@ from __future__ import annotations
 
 import http.server
 import threading
+import warnings
 
 import numpy as np
 import pytest
 import tensogram
+import zarr
 from tensogram_zarr.store import TensogramStore
 
 
@@ -223,6 +225,29 @@ class TestZarrRemoteLazyReads:
         assert len(chunk_keys_in_keys) == 1, "local files should decode chunks eagerly"
         assert len(store._chunk_index) == 0, "no lazy index for local files"
         assert store._file is None, "no persistent handle for local files"
+
+
+class TestRemoteIssue67DescriptorNameFallback:
+    def test_remote_scan_surfaces_descriptor_level_name(self, serve_tgm_bytes):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            meta = {"version": 2}
+            desc = {
+                "type": "ntensor",
+                "shape": [4],
+                "dtype": "float32",
+                "byte_order": "little",
+                "encoding": "none",
+                "filter": "none",
+                "compression": "none",
+                "name": "temperature",
+            }
+            msg = tensogram.encode(meta, [(desc, np.arange(4, dtype=np.float32))])
+
+        url = serve_tgm_bytes(msg)
+        with TensogramStore.open_tgm(url) as store:
+            root = zarr.open_group(store=store, mode="r")
+            assert list(root.keys()) == ["temperature"]
 
 
 class TestZarrRemoteWriteRejection:

--- a/python/tests/test_descriptor_metadata_warning.py
+++ b/python/tests/test_descriptor_metadata_warning.py
@@ -142,6 +142,37 @@ def test_warning_fires_on_tensogram_file_append(tmp_path: Path):
     assert "'name'" in str(user_warnings[0].message)
 
 
+def test_warning_fires_on_encode_pre_encoded():
+    desc = {
+        "type": "ntensor",
+        "shape": [4],
+        "dtype": "float32",
+        "encoding": "none",
+        "filter": "none",
+        "compression": "none",
+        "name": "x",
+    }
+    payload = _zero().tobytes()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        tensogram.encode_pre_encoded({"version": 2}, [(desc, payload)])
+    user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+    assert len(user_warnings) == 1
+    assert "'name'" in str(user_warnings[0].message)
+
+
+def test_warning_fires_on_streaming_encoder_write_object():
+    desc = {"type": "ntensor", "shape": [4], "dtype": "float32", "name": "x"}
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        encoder = tensogram.StreamingEncoder({"version": 2})
+        encoder.write_object(desc, _zero())
+        encoder.finish()
+    user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+    assert len(user_warnings) == 1
+    assert "'name'" in str(user_warnings[0].message)
+
+
 def test_warning_is_suppressible_by_filterwarnings():
     desc = {"type": "ntensor", "shape": [4], "dtype": "float32", "name": "x"}
     with warnings.catch_warnings(record=True) as caught:
@@ -158,3 +189,22 @@ def test_key_preserved_in_params_despite_warning():
     decoded = tensogram.decode(msg)
     decoded_desc, _ = decoded.objects[0]
     assert decoded_desc.params["name"] == "kept"
+
+
+def test_warning_is_attributed_to_caller_line():
+    desc = {"type": "ntensor", "shape": [4], "dtype": "float32", "name": "x"}
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        tensogram.encode({"version": 2}, [(desc, _zero())])  # warning-source
+    user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+    assert len(user_warnings) == 1
+    w = user_warnings[0]
+    assert w.filename == __file__, (
+        f"warning should point at the user's encode() call site, got {w.filename}"
+    )
+    with open(__file__) as f:
+        source_line = f.readlines()[w.lineno - 1]
+    assert "warning-source" in source_line, (
+        f"line {w.lineno} of this file does not carry the warning-source "
+        f"marker (got: {source_line!r})"
+    )

--- a/python/tests/test_descriptor_metadata_warning.py
+++ b/python/tests/test_descriptor_metadata_warning.py
@@ -1,0 +1,160 @@
+# (C) Copyright 2026- ECMWF and individual contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation nor
+# does it submit to any jurisdiction.
+
+"""Write-side warning when application-metadata keys appear in a descriptor.
+
+See issue #67 and the ``METADATA_LIKE_DESCRIPTOR_KEYS`` list in
+``python/bindings/src/lib.rs``.  The warning fires once per descriptor
+(aggregated over multiple keys) to avoid spam on multi-object messages.
+"""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pytest
+import tensogram
+
+METADATA_LIKE_KEYS = [
+    "name",
+    "param",
+    "shortName",
+    "long_name",
+    "description",
+    "units",
+    "dim_names",
+    "mars",
+    "cf",
+    "product",
+    "instrument",
+]
+
+
+def _zero(shape=(4,)):
+    return np.zeros(shape, dtype=np.float32)
+
+
+@pytest.mark.parametrize("key", METADATA_LIKE_KEYS)
+def test_warning_fires_for_each_metadata_like_key(key: str):
+    desc = {"type": "ntensor", "shape": [4], "dtype": "float32", key: "some-value"}
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        tensogram.encode({"version": 2}, [(desc, _zero())])
+    user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+    assert len(user_warnings) == 1
+    assert f"'{key}'" in str(user_warnings[0].message)
+    assert "meta['base'][i]" in str(user_warnings[0].message)
+
+
+def test_single_aggregated_warning_for_multiple_keys():
+    desc = {
+        "type": "ntensor",
+        "shape": [4],
+        "dtype": "float32",
+        "name": "temp",
+        "units": "K",
+        "description": "two-metre temperature",
+    }
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        tensogram.encode({"version": 2}, [(desc, _zero())])
+    user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+    assert len(user_warnings) == 1
+    msg = str(user_warnings[0].message)
+    for key in ("name", "units", "description"):
+        assert f"'{key}'" in msg
+
+
+def test_no_warning_for_clean_descriptor():
+    desc = {"type": "ntensor", "shape": [4], "dtype": "float32"}
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        tensogram.encode({"version": 2}, [(desc, _zero())])
+    assert not [w for w in caught if issubclass(w.category, UserWarning)]
+
+
+def test_no_warning_for_known_encoding_param_names():
+    desc = {
+        "type": "ntensor",
+        "shape": [4],
+        "dtype": "float32",
+        "reference_value": 0.0,
+        "bits_per_value": 16,
+        "decimal_scale_factor": 2,
+    }
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        tensogram.encode({"version": 2}, [(desc, _zero())])
+    assert not [w for w in caught if issubclass(w.category, UserWarning)]
+
+
+def test_no_warning_for_unknown_non_metadata_key():
+    desc = {
+        "type": "ntensor",
+        "shape": [4],
+        "dtype": "float32",
+        "custom_encoding_knob": 42,
+    }
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        tensogram.encode({"version": 2}, [(desc, _zero())])
+    assert not [w for w in caught if issubclass(w.category, UserWarning)]
+
+
+def test_one_warning_per_descriptor_in_multi_object_message():
+    descs_and_data = [
+        (
+            {"type": "ntensor", "shape": [4], "dtype": "float32", "name": "a"},
+            _zero(),
+        ),
+        (
+            {"type": "ntensor", "shape": [4], "dtype": "float32", "name": "b"},
+            _zero(),
+        ),
+        (
+            {"type": "ntensor", "shape": [4], "dtype": "float32", "name": "c"},
+            _zero(),
+        ),
+    ]
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        tensogram.encode({"version": 2}, descs_and_data)
+    user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+    assert len(user_warnings) == 3
+
+
+def test_warning_fires_on_tensogram_file_append(tmp_path: Path):
+    path = str(tmp_path / "warn.tgm")
+    desc = {"type": "ntensor", "shape": [4], "dtype": "float32", "name": "x"}
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with tensogram.TensogramFile.create(path) as f:
+            f.append({"version": 2}, [(desc, _zero())])
+    user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+    assert len(user_warnings) == 1
+    assert "'name'" in str(user_warnings[0].message)
+
+
+def test_warning_is_suppressible_by_filterwarnings():
+    desc = {"type": "ntensor", "shape": [4], "dtype": "float32", "name": "x"}
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("ignore", UserWarning)
+        tensogram.encode({"version": 2}, [(desc, _zero())])
+    assert not caught
+
+
+def test_key_preserved_in_params_despite_warning():
+    desc = {"type": "ntensor", "shape": [4], "dtype": "float32", "name": "kept"}
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        msg = tensogram.encode({"version": 2}, [(desc, _zero())])
+    decoded = tensogram.decode(msg)
+    decoded_desc, _ = decoded.objects[0]
+    assert decoded_desc.params["name"] == "kept"


### PR DESCRIPTION
Closes #67.

## The bug

`TensogramStore` returned `object_0, object_1, ...` instead of the intended variable names when a user placed `name` inside the descriptor dict rather than in `meta.base[i]`. The xarray engine already handled the same layout via its `scanner._merge_per_object_meta` base+params merge, so `xr.open_dataset(engine="tensogram")` produced the right names on the same file that zarr fumbled. This PR closes the gap and makes the original misuse loud at write time so new files don't accumulate the same problem.

Reproducer from the issue:

```python
objects = [
    ({"type": "ntensor", "shape": [10, 8], "dtype": "float32",
      "compression": "zstd", "name": "temperature"}, data1),
    ({"type": "ntensor", "shape": [10, 8], "dtype": "float32",
      "compression": "zstd", "name": "humidity"}, data2),
]
with tensogram.TensogramFile.create(path) as f:
    f.append({"version": 2}, objects)

zarr.open_group(store=TensogramStore(path), mode="r").keys()
#  before:  ['object_0', 'object_1']
#  after:   ['temperature', 'humidity']
```

## What it does

**Read side — zarr.** `_resolve_names` now consults a shallow root-key merge of `meta.base[i]` and `desc.params` before running the existing `_VARIABLE_NAME_KEYS` priority chain (`name` → `mars.param` → `param` → `mars.shortName` → `shortName` → `object_{i}`). Per-key precedence on the merged dict: a higher-priority key in either source wins; `meta.base[i]` wins only for the same key. Applied per-object so mixed files (some objects in base, some only in descriptor) resolve independently. The array-attributes path is unchanged — descriptor params remain cleanly namespaced under `_tensogram_params`.

**Write side — bindings.** `dict_to_data_object_descriptor` now emits a single aggregated `UserWarning` per descriptor when any of these show up at top level: `name`, `param`, `shortName`, `long_name`, `description`, `units`, `dim_names`, `mars`, `cf`, `product`, `instrument`. One warning per descriptor listing all offending keys (not one per key) — matters on multi-object messages. The warning fires from `encode()`, `encode_pre_encoded()`, `TensogramFile.append()`, `StreamingEncoder.write_object()`, and `StreamingEncoder.write_object_pre_encoded()`. Keys are still captured into `DataObjectDescriptor.params`, preserving wire compatibility and the read-side fallbacks.

**Docs.**
- README: clarifier above the Python quick-start about where application metadata lives.
- `docs/src/guide/zarr-backend.md`: extended "Variable naming" with the per-key precedence rule and a "Common pitfall" subsection with ✗/✓ examples.
- `docs/src/guide/xarray-integration.md`: "Where to put name / param / units" callout.
- CHANGELOG: Fixed (zarr fallback) + Changed (warning).

## Test coverage

- `python/tests/test_descriptor_metadata_warning.py` — 22 tests: parametrised over all 11 keys, aggregation, no-warning-for-clean-descriptor, no-warning-for-encoding-params, one-warning-per-descriptor, fires on `encode_pre_encoded` and `StreamingEncoder`, suppressible, data round-trips, stacklevel attributes the warning to the user's call-site line.
- `python/tensogram-zarr/tests/test_issue_67_descriptor_name_fallback.py` — 10 tests: reproducer, base wins same-key, higher-priority descriptor key beats lower-priority base key, `variable_key` against merged dict, per-object fallback, duplicate-name suffix, nested-root shadowing (no deep merge), canonical `base[i]["name"]` still works, `object_{i}` fallback unchanged.
- `python/tensogram-zarr/tests/test_remote.py` — 1 test: HTTP-backed remote open with descriptor-level name.
- `python/tensogram-xarray/tests/test_issue_67_descriptor_name_fallback.py` — 3 tests: pins the pre-existing xarray merge, base wins same-key, nested-root shadowing. The two backends must keep identical merge semantics; the nested-shadow test locks that.

Locally verified: 463 tensogram + 235 tensogram-zarr + 242 tensogram-xarray pass, ruff clean, `cargo clippy --release --lib -- -D warnings` clean.

## Compatibility

- No wire-format change.
- No new reserved keys in `base` or `params`.
- Existing `.tgm` files round-trip identically; files produced via the misuse now surface the correct names in zarr instead of `object_{i}`.
- Warning is `UserWarning`, suppressible via standard `warnings.filterwarnings` — no behaviour break for existing scripts that relied on the silent passthrough.

## Out of scope

- Schema tightening (rejecting unknown descriptor keys outright). The descriptor param space is open by design — new codecs introduce their own params — so the warning list stays heuristic.
- Deprecation toward making descriptor misuse a hard error. Not justified without evidence of intentional reliance on the silent passthrough.
- Cleaning up existing xarray tests that now emit the warning (they intentionally exercise the descriptor-fallback path).

Docs preview: https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-XXX (will populate after CI)

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-76
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->