### PR TITLE
ci(publish-npm): switch to TEMPORARY_NPMJS_APIKEY secret

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -49,7 +49,7 @@ jobs:
         if: steps.version-check.outputs.already_published == 'false'
         working-directory: typescript
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_API_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.TEMPORARY_NPMJS_APIKEY }}
         run: |
           cp ../LICENSE ./LICENSE
           echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc


### PR DESCRIPTION
## Summary

Repoint the publish step in `publish-npm.yml` to the new `TEMPORARY_NPMJS_APIKEY` secret, unblocking manual dispatches of the npm publish workflow.

## Verification

Dispatched from this branch against the live registry — run `24784718204` succeeded and `@ecmwf.int/tensogram@0.16.1` is now published on npm.

```
$ npm view @ecmwf.int/tensogram version
0.16.1
```

## Follow-up

The secret name reflects its short-lived role. The package will migrate to npm trusted publishing (OIDC) in a follow-up PR — the publish job will move to a GitHub-hosted runner, gain `id-token: write`, and drop the `NODE_AUTH_TOKEN` path entirely. Both `TEMPORARY_NPMJS_APIKEY` and `NPMJS_API_TOKEN` will be removed from repo secrets then.