### PR TITLE
fix(tensoscope): eliminate map flash and reset on file open

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -454,3 +454,27 @@ jobs:
       - name: Cleanup
         if: always()
         run: rm -rf "$TMPDIR" target typescript/node_modules typescript/dist typescript/wasm examples/typescript/node_modules
+
+  # ── Tensoscope: vitest unit tests ────────────────────────────────
+  tensoscope:
+    name: Tensoscope
+    runs-on: [self-hosted, Linux, platform-builder-docker-xl, platform-builder-Ubuntu-22.04]
+    container:
+      image: eccr.ecmwf.int/tensogram/ci:1.3.0
+      credentials:
+        username: ${{ secrets.ECMWF_DOCKER_REGISTRY_USERNAME }}
+        password: ${{ secrets.ECMWF_DOCKER_REGISTRY_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install deps
+        working-directory: tensoscope
+        run: npm ci || npm install --no-audit --no-fund
+
+      - name: Run tests (vitest)
+        working-directory: tensoscope
+        run: npm test
+
+      - name: Cleanup
+        if: always()
+        run: rm -rf tensoscope/node_modules

--- a/tensoscope/package.json
+++ b/tensoscope/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@deck.gl/core": "^9.3.0",

--- a/tensoscope/src/App.css
+++ b/tensoscope/src/App.css
@@ -739,173 +739,51 @@ h2 {
 }
 
 /* ── Projection Picker ── */
-.projection-picker {
+/* ── Map Controls Bar (top-left) ── */
+.map-controls-bar {
   position: absolute;
   top: 16px;
   left: 16px;
   z-index: 11;
-}
-
-.projection-toggle {
-  background: rgba(30, 30, 30, 0.85);
-  border: 2px solid #444;
-  border-radius: 6px;
-  cursor: pointer;
-  padding: 0;
-  overflow: hidden;
-  display: block;
-}
-
-.projection-toggle:hover {
-  border-color: var(--accent);
-}
-
-.projection-toggle-img {
-  display: block;
-  width: 52px;
-  height: 40px;
-  object-fit: cover;
-  border-radius: 4px;
-  pointer-events: none;
-}
-
-.projection-panel {
-  display: none;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 6px;
-  padding: 10px;
-  background: rgba(26, 28, 36, 0.95);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
-  max-width: 160px;
-}
-
-.projection-panel-open {
-  display: flex;
-}
-
-.projection-thumb {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 4px;
-  background: none;
-  border: 2px solid transparent;
-  border-radius: 6px;
-  cursor: pointer;
-  padding: 4px;
-  transition: border-color 0.15s;
-}
-
-.projection-thumb:hover {
-  border-color: var(--border);
-}
-
-.projection-thumb-active {
-  border-color: var(--accent);
-}
-
-.projection-thumb-map {
-  width: 52px;
-  height: 40px;
-  border-radius: 4px;
-  overflow: hidden;
-  pointer-events: none;
-}
-
-.projection-thumb-label {
-  color: var(--text-dim);
-  font-size: 11px;
-}
-
-.projection-thumb-active .projection-thumb-label {
-  color: var(--accent);
-}
-
-/* ── Render Mode Picker ── */
-.render-mode-picker {
-  position: absolute;
-  top: 60px;   /* sits below the projection-picker toggle button */
-  left: 16px;
-  z-index: 10;
-}
-
-.render-mode-toggle {
-  display: flex;
-  align-items: center;
   gap: 6px;
-  background: rgba(20, 20, 30, 0.85);
-  border: 1px solid rgba(255,255,255,0.15);
-  border-radius: 8px;
-  padding: 5px 10px;
-  color: rgba(255,255,255,0.85);
-  font-size: 12px;
-  cursor: pointer;
-  white-space: nowrap;
-  transition: background 0.15s;
 }
 
-.render-mode-toggle:hover {
-  background: rgba(30, 30, 50, 0.95);
-}
-
-.render-mode-toggle-label {
-  flex: 1;
-}
-
-.render-mode-arrow {
-  display: inline-block;
-  font-size: 11px;
-  opacity: 0.7;
-  transition: transform 0.15s;
-}
-
-.render-mode-arrow-open {
-  transform: rotate(180deg);
-}
-
-.render-mode-panel {
-  margin-top: 4px;
-  background: rgba(20, 20, 30, 0.95);
-  border: 1px solid rgba(255,255,255,0.12);
-  border-radius: 8px;
-  padding: 4px;
+/* ── Shared pill style for projection + render-mode pickers ── */
+.map-picker-pill {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
-  opacity: 0;
-  pointer-events: none;
-  transform: translateY(-4px);
-  transition: opacity 0.15s, transform 0.15s;
+  background: rgba(20, 22, 32, 0.88);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 7px;
+  overflow: hidden;
+  backdrop-filter: blur(6px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
 }
 
-.render-mode-panel-open {
-  opacity: 1;
-  pointer-events: auto;
-  transform: translateY(0);
-}
-
-.render-mode-option {
-  padding: 5px 12px;
-  border-radius: 5px;
+.map-picker-btn {
+  padding: 5px 14px;
   border: none;
   background: transparent;
-  color: rgba(255,255,255,0.6);
+  color: rgba(255, 255, 255, 0.5);
   font-size: 12px;
   cursor: pointer;
-  text-align: left;
-  transition: background 0.1s, color 0.1s;
+  transition: background 0.12s, color 0.12s;
+  white-space: nowrap;
+  font-family: inherit;
 }
 
-.render-mode-option:hover {
-  background: rgba(255,255,255,0.08);
-  color: #fff;
+.map-picker-btn + .map-picker-btn {
+  border-left: 1px solid rgba(255, 255, 255, 0.1);
 }
 
-.render-mode-option-active {
-  background: rgba(255,255,255,0.15);
+.map-picker-btn:hover {
+  background: rgba(255, 255, 255, 0.07);
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.map-picker-btn-active {
+  background: rgba(255, 255, 255, 0.14);
   color: #fff;
-  font-weight: 600;
+  font-weight: 500;
 }

--- a/tensoscope/src/components/map/CesiumView.tsx
+++ b/tensoscope/src/components/map/CesiumView.tsx
@@ -10,6 +10,7 @@ import {
   Math as CesiumMath,
   Credit,
   Entity,
+  ConstantProperty,
 } from 'cesium';
 import 'cesium/Build/Cesium/Widgets/widgets.css';
 import './CesiumView.css';
@@ -90,24 +91,31 @@ export function CesiumView({ fieldImage, initialCenter, onUnmount }: CesiumViewP
     const viewer = viewerRef.current;
     if (!viewer) return;
 
-    if (overlayRef.current) {
-      viewer.entities.remove(overlayRef.current);
-      overlayRef.current = undefined;
+    if (!fieldImage) {
+      if (overlayRef.current) {
+        overlayRef.current.show = false;
+      }
+      return;
     }
 
-    if (!fieldImage) return;
-
-    overlayRef.current = viewer.entities.add({
-      rectangle: {
-        coordinates: Rectangle.fromDegrees(-180, -85, 180, 85),
-        material: new ImageMaterialProperty({
-          image: fieldImage.dataUrl,
-          transparent: true,
-          color: new Color(1, 1, 1, 0.7),
-        }),
-        fill: true,
-      },
-    });
+    if (overlayRef.current) {
+      // Update the image URL in-place to avoid a blank frame between remove and re-add.
+      overlayRef.current.show = true;
+      const mat = overlayRef.current.rectangle!.material as ImageMaterialProperty;
+      mat.image = new ConstantProperty(fieldImage.dataUrl);
+    } else {
+      overlayRef.current = viewer.entities.add({
+        rectangle: {
+          coordinates: Rectangle.fromDegrees(-180, -85, 180, 85),
+          material: new ImageMaterialProperty({
+            image: fieldImage.dataUrl,
+            transparent: true,
+            color: new Color(1, 1, 1, 0.7),
+          }),
+          fill: true,
+        },
+      });
+    }
   }, [fieldImage]);
 
   return <div ref={containerRef} className="cesium-container" />;

--- a/tensoscope/src/components/map/ColorScaleControls.tsx
+++ b/tensoscope/src/components/map/ColorScaleControls.tsx
@@ -533,6 +533,18 @@ function PalettePicker({
 
 // ── ColorScaleControls (public) ───────────────────────────────────────────────
 
+const MINIMISE_BTN: React.CSSProperties = {
+  background: 'none',
+  border: 'none',
+  color: '#666',
+  cursor: 'pointer',
+  fontSize: 13,
+  padding: '0 2px',
+  lineHeight: 1,
+  display: 'flex',
+  alignItems: 'center',
+};
+
 export function ColorScaleControls({
   palette,
   colorMin,
@@ -550,6 +562,8 @@ export function ColorScaleControls({
   onCustomStopsChange,
   onDisplayUnitChange,
 }: ColorScaleControlsProps) {
+  const [minimised, setMinimised] = useState(false);
+
   const group = getUnitGroup(nativeUnits);
   const toDisplay = useMemo(
     () => group ? (v: number) => group.toDisplay(v, displayUnit) : undefined,
@@ -571,49 +585,62 @@ export function ColorScaleControls({
 
   return (
     <div style={PANEL}>
-      <div style={SECTION_LABEL}>Colour Palette</div>
-      <PalettePicker
-        palette={palette}
-        paletteReversed={paletteReversed}
-        customStops={customStops}
-        onPaletteChange={onPaletteChange}
-        onPaletteReversedChange={onPaletteReversedChange}
-        onCustomStopsChange={onCustomStopsChange}
-      />
-
-      {palette === 'custom' && (
-        <GradientEditor stops={customStops} onChange={onCustomStopsChange} />
-      )}
-
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-        <div style={SECTION_LABEL}>Range</div>
-        <UnitToggle
-          nativeUnits={nativeUnits}
-          displayUnit={displayUnit}
-          onDisplayUnitChange={onDisplayUnitChange}
-        />
+        <div style={SECTION_LABEL}>Colour Palette</div>
+        <button
+          style={MINIMISE_BTN}
+          onClick={() => setMinimised(m => !m)}
+          title={minimised ? 'Expand' : 'Minimise'}
+        >
+          {minimised ? '▴' : '▾'}
+        </button>
       </div>
-      <div style={{ display: 'flex', gap: 8 }}>
-        <SpinboxInput
-          label="Min"
-          value={colorMin}
-          step={step}
-          onChange={onColorMinChange}
-          onDoubleClick={resetRange}
-          toDisplay={toDisplay}
-          toNative={toNative}
-        />
-        <SpinboxInput
-          label="Max"
-          value={colorMax}
-          step={step}
-          onChange={onColorMaxChange}
-          onDoubleClick={resetRange}
-          toDisplay={toDisplay}
-          toNative={toNative}
-        />
-      </div>
-      <span style={HINT}>Double-click to reset to data range</span>
+      {!minimised && (
+        <>
+          <PalettePicker
+            palette={palette}
+            paletteReversed={paletteReversed}
+            customStops={customStops}
+            onPaletteChange={onPaletteChange}
+            onPaletteReversedChange={onPaletteReversedChange}
+            onCustomStopsChange={onCustomStopsChange}
+          />
+
+          {palette === 'custom' && (
+            <GradientEditor stops={customStops} onChange={onCustomStopsChange} />
+          )}
+
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <div style={SECTION_LABEL}>Range</div>
+            <UnitToggle
+              nativeUnits={nativeUnits}
+              displayUnit={displayUnit}
+              onDisplayUnitChange={onDisplayUnitChange}
+            />
+          </div>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <SpinboxInput
+              label="Min"
+              value={colorMin}
+              step={step}
+              onChange={onColorMinChange}
+              onDoubleClick={resetRange}
+              toDisplay={toDisplay}
+              toNative={toNative}
+            />
+            <SpinboxInput
+              label="Max"
+              value={colorMax}
+              step={step}
+              onChange={onColorMaxChange}
+              onDoubleClick={resetRange}
+              toDisplay={toDisplay}
+              toNative={toNative}
+            />
+          </div>
+          <span style={HINT}>Double-click to reset to data range</span>
+        </>
+      )}
     </div>
   );
 }

--- a/tensoscope/src/components/map/MapView.tsx
+++ b/tensoscope/src/components/map/MapView.tsx
@@ -124,16 +124,17 @@ export function MapView(props: MapViewProps) {
               <Layer
                 id="field-overlay-layer"
                 type="raster"
-                paint={{ 'raster-opacity': 0.7 }}
+                paint={{ 'raster-opacity': 0.7, 'raster-fade-duration': 0 }}
               />
             </Source>
           )}
         </Map>
       )}
 
-      <ProjectionPicker current={activePreset.id} onSelect={handlePresetSelect} />
-
-      {data && <RenderModePicker mode={renderMode} onChange={setRenderMode} />}
+      <div className="map-controls-bar">
+        <ProjectionPicker current={activePreset.id} onSelect={handlePresetSelect} />
+        {data && <RenderModePicker mode={renderMode} onChange={setRenderMode} />}
+      </div>
 
       {data && (
         <>

--- a/tensoscope/src/components/map/ProjectionPicker.tsx
+++ b/tensoscope/src/components/map/ProjectionPicker.tsx
@@ -1,19 +1,14 @@
-import { useState, useEffect, useRef } from 'react';
-import globeImg from '../../assets/globe.png';
-import flatImg from '../../assets/flat.png';
-
 export interface ProjectionPreset {
   id: string;
   label: string;
   type: 'mercator' | 'globe';
   center: [number, number];
   zoom: number;
-  image: string;
 }
 
 export const PROJECTION_PRESETS: ProjectionPreset[] = [
-  { id: 'globe', label: 'Globe', type: 'globe',    center: [0, 20], zoom: 1.5, image: globeImg },
-  { id: 'flat',  label: 'Flat',  type: 'mercator', center: [0, 20], zoom: 1.5, image: flatImg  },
+  { id: 'globe', label: 'Globe', type: 'globe',    center: [0, 20], zoom: 1.5 },
+  { id: 'flat',  label: 'Flat',  type: 'mercator', center: [0, 20], zoom: 1.5 },
 ];
 
 interface ProjectionPickerProps {
@@ -22,55 +17,17 @@ interface ProjectionPickerProps {
 }
 
 export function ProjectionPicker({ current, onSelect }: ProjectionPickerProps) {
-  const [open, setOpen] = useState(false);
-  const [everOpened, setEverOpened] = useState(false);
-  const wrapperRef = useRef<HTMLDivElement>(null);
-
-  const activePreset = PROJECTION_PRESETS.find((p) => p.id === current) ?? PROJECTION_PRESETS[0];
-
-  useEffect(() => {
-    if (!open) return;
-    const handle = (e: MouseEvent) => {
-      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handle);
-    return () => document.removeEventListener('mousedown', handle);
-  }, [open]);
-
-  const handleToggle = () => {
-    if (!everOpened) setEverOpened(true);
-    setOpen((o) => !o);
-  };
-
-  const handleSelect = (preset: ProjectionPreset) => {
-    onSelect(preset);
-    setOpen(false);
-  };
-
   return (
-    <div ref={wrapperRef} className="projection-picker">
-      <button className="projection-toggle" onClick={handleToggle}>
-        <img src={activePreset.image} alt={activePreset.label} className="projection-toggle-img" />
-      </button>
-
-      {everOpened && (
-        <div className={`projection-panel${open ? ' projection-panel-open' : ''}`}>
-          {PROJECTION_PRESETS.map((preset) => (
-            <button
-              key={preset.id}
-              className={`projection-thumb${preset.id === current ? ' projection-thumb-active' : ''}`}
-              onClick={() => handleSelect(preset)}
-            >
-              <div className="projection-thumb-map">
-                <img src={preset.image} alt={preset.label} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
-              </div>
-              <span className="projection-thumb-label">{preset.label}</span>
-            </button>
-          ))}
-        </div>
-      )}
+    <div className="map-picker-pill">
+      {PROJECTION_PRESETS.map((preset) => (
+        <button
+          key={preset.id}
+          className={`map-picker-btn${preset.id === current ? ' map-picker-btn-active' : ''}`}
+          onClick={() => onSelect(preset)}
+        >
+          {preset.label}
+        </button>
+      ))}
     </div>
   );
 }

--- a/tensoscope/src/components/map/RenderModePicker.tsx
+++ b/tensoscope/src/components/map/RenderModePicker.tsx
@@ -1,5 +1,3 @@
-import { useState, useEffect, useRef } from 'react';
-
 const MODES: { id: 'heatmap' | 'contours'; label: string }[] = [
   { id: 'heatmap', label: 'Heatmap' },
   { id: 'contours', label: 'Contours' },
@@ -11,53 +9,17 @@ interface RenderModePickerProps {
 }
 
 export function RenderModePicker({ mode, onChange }: RenderModePickerProps) {
-  const [open, setOpen] = useState(false);
-  const [everOpened, setEverOpened] = useState(false);
-  const wrapperRef = useRef<HTMLDivElement>(null);
-
-  const currentLabel = MODES.find((m) => m.id === mode)?.label ?? mode;
-
-  useEffect(() => {
-    if (!open) return;
-    const handle = (e: MouseEvent) => {
-      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handle);
-    return () => document.removeEventListener('mousedown', handle);
-  }, [open]);
-
-  const handleToggle = () => {
-    if (!everOpened) setEverOpened(true);
-    setOpen((o) => !o);
-  };
-
-  const handleSelect = (id: 'heatmap' | 'contours') => {
-    onChange(id);
-    setOpen(false);
-  };
-
   return (
-    <div ref={wrapperRef} className="render-mode-picker">
-      <button className="render-mode-toggle" onClick={handleToggle}>
-        <span className="render-mode-toggle-label">{currentLabel}</span>
-        <span className={`render-mode-arrow${open ? ' render-mode-arrow-open' : ''}`}>▾</span>
-      </button>
-
-      {everOpened && (
-        <div className={`render-mode-panel${open ? ' render-mode-panel-open' : ''}`}>
-          {MODES.map((m) => (
-            <button
-              key={m.id}
-              className={`render-mode-option${m.id === mode ? ' render-mode-option-active' : ''}`}
-              onClick={() => handleSelect(m.id)}
-            >
-              {m.label}
-            </button>
-          ))}
-        </div>
-      )}
+    <div className="map-picker-pill">
+      {MODES.map((m) => (
+        <button
+          key={m.id}
+          className={`map-picker-btn${m.id === mode ? ' map-picker-btn-active' : ''}`}
+          onClick={() => onChange(m.id)}
+        >
+          {m.label}
+        </button>
+      ))}
     </div>
   );
 }

--- a/tensoscope/src/store/__tests__/useAppStore.test.ts
+++ b/tensoscope/src/store/__tests__/useAppStore.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Shared mock fns (must be hoisted alongside vi.mock) ──────────────────────
+
+const mocks = vi.hoisted(() => ({
+  buildIndex: vi.fn(),
+  fetchCoordinates: vi.fn(),
+  decodeField: vi.fn(),
+  decodeFieldSlice: vi.fn(),
+  close: vi.fn(),
+  fromFile: vi.fn(),
+  fromUrl: vi.fn(),
+}));
+
+vi.mock('../../tensogram', () => {
+  const makeViewer = () => ({
+    buildIndex: mocks.buildIndex,
+    fetchCoordinates: mocks.fetchCoordinates,
+    decodeField: mocks.decodeField,
+    decodeFieldSlice: mocks.decodeFieldSlice,
+    close: mocks.close,
+  });
+  mocks.fromFile.mockImplementation(async () => makeViewer());
+  mocks.fromUrl.mockImplementation(async () => makeViewer());
+  return {
+    Tensoscope: {
+      fromFile: mocks.fromFile,
+      fromUrl: mocks.fromUrl,
+    },
+  };
+});
+
+// ── Store import (after mock registration) ───────────────────────────────────
+
+import { useAppStore } from '../useAppStore';
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const DEFAULT_SCALE = {
+  min: 0, max: 1, palette: 'viridis', logScale: false,
+  paletteReversed: false,
+  customStops: [{ pos: 0, color: '#000000' }, { pos: 1, color: '#ffffff' }],
+  nativeUnits: '', displayUnit: '',
+};
+
+const FILE_INDEX = {
+  source: 'test.tgm',
+  messageCount: 2,
+  variables: [
+    { msgIndex: 0, objIndex: 0, name: 'xtest', shape: [4], dtype: 'f32', encoding: '', compression: '', metadata: {} },
+    { msgIndex: 1, objIndex: 0, name: 'ytest', shape: [4], dtype: 'f32', encoding: '', compression: '', metadata: {} },
+  ],
+  coordinates: [],
+};
+
+// 4-point coordinates to match shape [4] without triggering multi-dim slice logic
+const COORDS = {
+  lat: new Float32Array([10, 20, 30, 40]),
+  lon: new Float32Array([0, 10, 20, 30]),
+};
+
+const DECODED_FIELD = {
+  data: new Float32Array([1, 2, 3, 4]),
+  shape: [4],
+  stats: { min: 1, max: 4, mean: 2.5, std: 1.12 },
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function resetStore() {
+  useAppStore.setState({
+    viewer: null,
+    fileIndex: null,
+    selectedObject: null,
+    selectedLevel: null,
+    fieldData: null,
+    fieldShape: [],
+    fieldStats: null,
+    coordinates: null,
+    colorScale: { ...DEFAULT_SCALE },
+    loading: false,
+    error: null,
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('useAppStore — openLocalFile', () => {
+  beforeEach(() => {
+    resetStore();
+    vi.clearAllMocks();
+    mocks.buildIndex.mockResolvedValue(FILE_INDEX);
+    mocks.fetchCoordinates.mockResolvedValue(COORDS);
+    mocks.decodeField.mockResolvedValue(DECODED_FIELD);
+    mocks.fromFile.mockImplementation(async () => ({
+      buildIndex: mocks.buildIndex,
+      fetchCoordinates: mocks.fetchCoordinates,
+      decodeField: mocks.decodeField,
+      decodeFieldSlice: mocks.decodeFieldSlice,
+      close: mocks.close,
+    }));
+  });
+
+  it('auto-selects the first variable so the map is never blank', async () => {
+    await useAppStore.getState().openLocalFile(new File([], 'test.tgm'));
+
+    const { selectedObject, fieldData } = useAppStore.getState();
+    expect(selectedObject).toEqual({ msgIdx: 0, objIdx: 0 });
+    expect(fieldData).not.toBeNull();
+  });
+
+  it('selects the first variable by its msgIndex and objIndex', async () => {
+    const shifted = {
+      ...FILE_INDEX,
+      variables: [
+        { msgIndex: 3, objIndex: 1, name: 'xtest', shape: [4], dtype: 'f32', encoding: '', compression: '', metadata: {} },
+      ],
+    };
+    mocks.buildIndex.mockResolvedValue(shifted);
+
+    await useAppStore.getState().openLocalFile(new File([], 'test.tgm'));
+
+    expect(useAppStore.getState().selectedObject).toEqual({ msgIdx: 3, objIdx: 1 });
+  });
+
+  it('preserves the user palette when the variable has no auto-style', async () => {
+    useAppStore.setState({ colorScale: { ...DEFAULT_SCALE, palette: 'plasma' } });
+
+    await useAppStore.getState().openLocalFile(new File([], 'test.tgm'));
+
+    expect(useAppStore.getState().colorScale.palette).toBe('plasma');
+  });
+
+  it('preserves paletteReversed across file opens', async () => {
+    useAppStore.setState({ colorScale: { ...DEFAULT_SCALE, paletteReversed: true } });
+
+    await useAppStore.getState().openLocalFile(new File([], 'test.tgm'));
+
+    expect(useAppStore.getState().colorScale.paletteReversed).toBe(true);
+  });
+
+  it('updates colorScale min/max from the decoded field stats', async () => {
+    await useAppStore.getState().openLocalFile(new File([], 'test.tgm'));
+
+    const { colorScale } = useAppStore.getState();
+    expect(colorScale.min).toBe(DECODED_FIELD.stats.min);
+    expect(colorScale.max).toBe(DECODED_FIELD.stats.max);
+  });
+
+  it('clears loading and error on success', async () => {
+    await useAppStore.getState().openLocalFile(new File([], 'test.tgm'));
+
+    const { loading, error } = useAppStore.getState();
+    expect(loading).toBe(false);
+    expect(error).toBeNull();
+  });
+
+  it('sets error and clears loading when the file cannot be opened', async () => {
+    mocks.fromFile.mockRejectedValue(new Error('corrupt file'));
+
+    await useAppStore.getState().openLocalFile(new File([], 'bad.tgm'));
+
+    const { loading, error } = useAppStore.getState();
+    expect(loading).toBe(false);
+    expect(error).toContain('corrupt file');
+  });
+});
+
+describe('useAppStore — openUrl', () => {
+  beforeEach(() => {
+    resetStore();
+    vi.clearAllMocks();
+    mocks.buildIndex.mockResolvedValue(FILE_INDEX);
+    mocks.fetchCoordinates.mockResolvedValue(COORDS);
+    mocks.decodeField.mockResolvedValue(DECODED_FIELD);
+    mocks.fromUrl.mockImplementation(async () => ({
+      buildIndex: mocks.buildIndex,
+      fetchCoordinates: mocks.fetchCoordinates,
+      decodeField: mocks.decodeField,
+      decodeFieldSlice: mocks.decodeFieldSlice,
+      close: mocks.close,
+    }));
+  });
+
+  it('auto-selects the first variable after loading from a URL', async () => {
+    await useAppStore.getState().openUrl('https://example.com/data.tgm');
+
+    const { selectedObject, fieldData } = useAppStore.getState();
+    expect(selectedObject).toEqual({ msgIdx: 0, objIdx: 0 });
+    expect(fieldData).not.toBeNull();
+  });
+
+  it('preserves the user palette when opening from a URL', async () => {
+    useAppStore.setState({ colorScale: { ...DEFAULT_SCALE, palette: 'magma' } });
+
+    await useAppStore.getState().openUrl('https://example.com/data.tgm');
+
+    expect(useAppStore.getState().colorScale.palette).toBe('magma');
+  });
+
+  it('sets error and clears loading when the URL fetch fails', async () => {
+    mocks.fromUrl.mockRejectedValue(new Error('network error'));
+
+    await useAppStore.getState().openUrl('https://bad.example.com/data.tgm');
+
+    expect(useAppStore.getState().loading).toBe(false);
+    expect(useAppStore.getState().error).toContain('network error');
+  });
+});
+
+describe('useAppStore — initViewer does not reset colorScale', () => {
+  beforeEach(() => {
+    resetStore();
+    vi.clearAllMocks();
+    mocks.buildIndex.mockResolvedValue(FILE_INDEX);
+    mocks.fetchCoordinates.mockResolvedValue(COORDS);
+    mocks.decodeField.mockResolvedValue(DECODED_FIELD);
+    mocks.fromFile.mockImplementation(async () => ({
+      buildIndex: mocks.buildIndex,
+      fetchCoordinates: mocks.fetchCoordinates,
+      decodeField: mocks.decodeField,
+      decodeFieldSlice: mocks.decodeFieldSlice,
+      close: mocks.close,
+    }));
+  });
+
+  it('opening a second file keeps the custom palette from the first session', async () => {
+    // Simulate a user who has opened a file, customised their palette, then opens another.
+    useAppStore.setState({
+      colorScale: { ...DEFAULT_SCALE, palette: 'coolwarm', paletteReversed: true },
+    });
+
+    await useAppStore.getState().openLocalFile(new File([], 'second.tgm'));
+
+    const { colorScale } = useAppStore.getState();
+    expect(colorScale.palette).toBe('coolwarm');
+    expect(colorScale.paletteReversed).toBe(true);
+  });
+});

--- a/tensoscope/src/store/useAppStore.ts
+++ b/tensoscope/src/store/useAppStore.ts
@@ -72,7 +72,6 @@ async function initViewer(
     fieldData: null,
     fieldShape: [],
     fieldStats: null,
-    colorScale: DEFAULT_COLOR_SCALE,
     loading: false,
     error: null,
   });
@@ -98,6 +97,8 @@ export const useAppStore = create<AppState>((set, get) => ({
       if (prev) prev.close();
       const viewer = await Tensoscope.fromFile(file);
       await initViewer(viewer, set);
+      const first = get().fileIndex?.variables[0];
+      if (first) await get().selectField(first.msgIndex, first.objIndex);
     } catch (err) {
       set({ loading: false, error: String(err) });
     }
@@ -110,6 +111,8 @@ export const useAppStore = create<AppState>((set, get) => ({
       if (prev) prev.close();
       const viewer = await Tensoscope.fromUrl(url);
       await initViewer(viewer, set);
+      const first = get().fileIndex?.variables[0];
+      if (first) await get().selectField(first.msgIndex, first.objIndex);
     } catch (err) {
       set({ loading: false, error: String(err) });
     }


### PR DESCRIPTION
## Summary

- **Map flash during scrubbing**: Cesium was removing then re-adding the overlay entity on every frame change, producing a blank frame. Now updates the `ImageMaterialProperty` image in-place via `ConstantProperty`. MapLibre now uses `raster-fade-duration: 0` so image source swaps are instantaneous.
- **Colour palette / unit reset on file open**: `initViewer` was unconditionally resetting `colorScale` to defaults. Removed that reset — `selectField` already handles applying auto-styles and updating min/max from data stats, so user choices are preserved.
- **Blank map on file open**: After `initViewer` completes, `openLocalFile` and `openUrl` now auto-select the first variable so the map is never left blank waiting for a manual field selection.
- **UI**: Replaced the ProjectionPicker and RenderModePicker dropdown menus with compact segmented pill controls, grouped into a single `map-controls-bar` at top-left. Added a minimise/expand toggle to the ColorScaleControls panel.

## Test plan

- [x] Open a large `.tgm` file and scrub the time slider — verify no blank flash of country outlines
- [x] Switch to globe view and scrub — verify no blank frame on Cesium
- [x] Open a file from URL and verify the first field renders immediately without a blank map state
- [x] Open a second file — verify the previously selected palette and units are preserved
- [x] Verify Globe/Flat pill and Heatmap/Contours pill both switch correctly
- [x] Verify the colour palette panel minimises and restores correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-84
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->