### PR TITLE
fix(tensoscope): make GRIB-derived files render (integer mars.param, 2-D gridded data, 1-D axes, and axis-less regular_ll)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,8 +466,16 @@ jobs:
         password: ${{ secrets.ECMWF_DOCKER_REGISTRY_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+      - run: mkdir -p "$TMPDIR"
 
-      - name: Install deps
+      # tensoscope depends on @ecmwf.int/tensogram via file:../typescript;
+      # vitest cannot resolve the package until the wrapper is built.
+      - name: Install typescript deps
+        run: make ts-install
+      - name: Build WASM + TypeScript (wasm-pack → typescript/wasm, tsc → dist)
+        run: make ts-build
+
+      - name: Install tensoscope deps
         working-directory: tensoscope
         run: npm ci || npm install --no-audit --no-fund
 
@@ -475,6 +483,10 @@ jobs:
         working-directory: tensoscope
         run: npm test
 
+      - name: sccache stats
+        if: always()
+        run: sccache --show-adv-stats
+
       - name: Cleanup
         if: always()
-        run: rm -rf tensoscope/node_modules
+        run: rm -rf "$TMPDIR" target tensoscope/node_modules typescript/node_modules typescript/dist typescript/wasm

--- a/tensoscope/src/App.tsx
+++ b/tensoscope/src/App.tsx
@@ -30,11 +30,18 @@ function App() {
     error,
   } = useAppStore();
 
-  // Determine the selected parameter name for animation
+  // Determine the selected parameter identifier for animation.
+  // `mars.param` may be a short string ("2t", "t") or a GRIB integer
+  // code (167, 130); useAnimationSequence does a `===` comparison so
+  // we keep the value in its original type (no coercion) — string
+  // matches string, integer matches integer.
   const selectedParam = selectedObject && fileIndex
-    ? (fileIndex.variables.find(
+    ? ((fileIndex.variables.find(
         (v) => v.msgIndex === selectedObject.msgIdx && v.objIndex === selectedObject.objIdx,
-      )?.metadata?.mars as Record<string, unknown> | undefined)?.param as string | undefined
+      )?.metadata?.mars as Record<string, unknown> | undefined)?.param as
+        | string
+        | number
+        | undefined)
     : undefined;
 
   const frames = useAnimationSequence(fileIndex, selectedParam ?? null, selectedLevel);
@@ -96,8 +103,18 @@ function App() {
         (v) => v.msgIndex === selectedObject.msgIdx && v.objIndex === selectedObject.objIdx,
       )
     : undefined;
-  const marsParam = (selectedVar?.metadata?.mars as Record<string, unknown>)?.param as string | undefined;
-  const units = (selectedVar?.metadata?.units as string) ?? marsParam ?? '';
+  // Units: prefer an explicit `units` field on the object; fall back
+  // to the param identifier (coerced to string) so the colorbar has
+  // *something* to display even for raw GRIB files where the code is
+  // the only identifier available.
+  const marsParamRaw = (selectedVar?.metadata?.mars as Record<string, unknown>)?.param;
+  const marsParam =
+    marsParamRaw == null
+      ? ''
+      : typeof marsParamRaw === 'string'
+        ? marsParamRaw
+        : String(marsParamRaw);
+  const units = (selectedVar?.metadata?.units as string) ?? marsParam;
 
   return (
     <div className="app-layout">

--- a/tensoscope/src/components/animation/useAnimationSequence.ts
+++ b/tensoscope/src/components/animation/useAnimationSequence.ts
@@ -31,11 +31,11 @@ function getMarsLevel(mars: Record<string, unknown>): number | null {
  */
 export function useAnimationSequence(
   fileIndex: FileIndex | null,
-  paramName: string | null,
+  paramName: string | number | null,
   selectedLevel: number | null,
 ): AnimationFrame[] {
   return useMemo(() => {
-    if (!fileIndex || !paramName) return [];
+    if (!fileIndex || paramName == null) return [];
 
     const matched = fileIndex.variables.filter((v) => {
       const mars = v.metadata?.mars as Record<string, unknown> | undefined;

--- a/tensoscope/src/components/file-browser/FieldSelector.tsx
+++ b/tensoscope/src/components/file-browser/FieldSelector.tsx
@@ -2,132 +2,13 @@
 
 import { useState, useMemo } from 'react';
 import { useAppStore } from '../../store/useAppStore';
-import type { ObjectInfo } from '../../tensogram';
-
-// ── Metadata helpers ────────────────────────────────────────────────
-
-interface MarsMetadata {
-  step?: number;
-  param?: string;
-  levtype?: string;
-  levelist?: number | string;
-  level?: number | string;
-  [key: string]: unknown;
-}
-
-function getMars(v: ObjectInfo): MarsMetadata {
-  return (v.metadata?.mars as MarsMetadata) ?? {};
-}
-
-function getMarsLevel(mars: MarsMetadata): number | null {
-  const raw = mars.levelist ?? mars.level;
-  if (raw == null) return null;
-  if (mars.levtype === 'sfc') return null;
-  const n = Number(raw);
-  return Number.isFinite(n) ? n : null;
-}
-
-function getPackedLevels(v: ObjectInfo, coordLength: number): number[] | null {
-  if (v.shape.length <= 1) return null;
-  const levelDimSize = v.shape.find((s) => s !== coordLength);
-  if (!levelDimSize || levelDimSize <= 1) return null;
-
-  const anemoi = v.metadata?.anemoi as Record<string, unknown> | undefined;
-  const levels = anemoi?.levels as number[] | undefined;
-  if (levels && levels.length === levelDimSize) return levels;
-
-  return Array.from({ length: levelDimSize }, (_, i) => i);
-}
-
-// ── Grouping types ──────────────────────────────────────────────────
-
-type LevelStrategy =
-  | { kind: 'none' }
-  | { kind: 'packed'; levels: number[]; dim: number }
-  | { kind: 'per-object'; levels: number[] };
-
-interface ParamEntry {
-  step: number;
-  marsLevel: number | null;
-  variable: ObjectInfo;
-}
-
-interface ParamGroup {
-  param: string;
-  levtype: string;
-  units: string;
-  levelStrategy: LevelStrategy;
-  entries: ParamEntry[];
-}
-
-function groupByParam(variables: ObjectInfo[], coordLength: number): ParamGroup[] {
-  const map = new Map<string, ParamGroup>();
-
-  for (const v of variables) {
-    const mars = getMars(v);
-    const param = mars.param ?? v.name;
-    const step = Number(mars.step ?? 0);
-    const marsLevel = getMarsLevel(mars);
-
-    let group = map.get(param);
-    if (!group) {
-      const packed = getPackedLevels(v, coordLength);
-      let levelStrategy: LevelStrategy;
-      if (packed && packed.length > 1) {
-        const dim = v.shape.findIndex((s) => s !== coordLength);
-        levelStrategy = { kind: 'packed', levels: packed, dim: dim >= 0 ? dim : 1 };
-      } else {
-        levelStrategy = { kind: 'none' };
-      }
-      group = {
-        param,
-        levtype: mars.levtype ?? '',
-        units: (v.metadata?.units as string) ?? '',
-        levelStrategy,
-        entries: [],
-      };
-      map.set(param, group);
-    }
-    group.entries.push({ step, marsLevel, variable: v });
-  }
-
-  for (const group of map.values()) {
-    if (group.levelStrategy.kind === 'none') {
-      const levelSet = new Set<number>();
-      for (const e of group.entries) {
-        if (e.marsLevel != null) levelSet.add(e.marsLevel);
-      }
-      if (levelSet.size > 1) {
-        group.levelStrategy = {
-          kind: 'per-object',
-          levels: [...levelSet].sort((a, b) => a - b),
-        };
-      }
-    }
-    group.entries.sort((a, b) => {
-      const la = a.marsLevel ?? -Infinity;
-      const lb = b.marsLevel ?? -Infinity;
-      if (la !== lb) return la - lb;
-      return a.step - b.step;
-    });
-  }
-
-  return Array.from(map.values()).sort((a, b) => a.param.localeCompare(b.param));
-}
-
-// ── Helpers ─────────────────────────────────────────────────────────
-
-function getLevels(group: ParamGroup): number[] {
-  if (group.levelStrategy.kind === 'none') return [];
-  return group.levelStrategy.levels;
-}
-
-function getEntriesForLevel(group: ParamGroup, level: number | null): ParamEntry[] {
-  if (group.levelStrategy.kind === 'per-object' && level != null) {
-    return group.entries.filter((e) => e.marsLevel === level);
-  }
-  return group.entries;
-}
+import {
+  getEntriesForLevel,
+  getLevels,
+  groupByParam,
+  type ParamEntry,
+  type ParamGroup,
+} from './groupByParam';
 
 function levelUnit(levtype: string): string {
   if (levtype === 'pl') return ' hPa';

--- a/tensoscope/src/components/file-browser/__tests__/groupByParam.test.ts
+++ b/tensoscope/src/components/file-browser/__tests__/groupByParam.test.ts
@@ -1,0 +1,93 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+/**
+ * Regression tests for `groupByParam`.
+ *
+ * Before the param-type-coercion fix, a GRIB-derived file whose
+ * `mars.param` was an integer code (e.g. 167 for 2m temperature)
+ * crashed the sidebar at render time because the sort used
+ * `String.prototype.localeCompare` directly on what turned out to
+ * be a `number`.  The fix coerces the param value to a string both
+ * when keying the group map and when sorting the final output.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { groupByParam } from '../groupByParam';
+import type { ObjectInfo } from '../../../tensogram';
+
+function makeVar(
+  name: string,
+  shape: number[],
+  marsParam: string | number | undefined,
+  extra: Record<string, unknown> = {},
+): ObjectInfo {
+  return {
+    msgIndex: 0,
+    objIndex: 0,
+    name,
+    shape,
+    dtype: 'float32',
+    encoding: 'none',
+    compression: 'none',
+    metadata: {
+      mars: marsParam !== undefined ? { param: marsParam, step: 0, ...extra } : extra,
+    },
+  };
+}
+
+describe('groupByParam — param type coercion', () => {
+  it('does not crash when mars.param is an integer (GRIB code)', () => {
+    const vars: ObjectInfo[] = [
+      makeVar('2t', [100], 167),
+      makeVar('msl', [100], 2),
+      makeVar('t', [100], 130),
+    ];
+    const groups = groupByParam(vars, 100);
+    expect(groups).toHaveLength(3);
+    expect(groups.map((g) => g.param).sort()).toEqual(['130', '167', '2']);
+  });
+
+  it('still works when mars.param is a string (GRIB short name)', () => {
+    const vars: ObjectInfo[] = [
+      makeVar('2t', [100], '2t'),
+      makeVar('msl', [100], 'msl'),
+    ];
+    const groups = groupByParam(vars, 100);
+    expect(groups).toHaveLength(2);
+    expect(groups.map((g) => g.param).sort()).toEqual(['2t', 'msl']);
+  });
+
+  it('mixes integer and string params into the same sort', () => {
+    const vars: ObjectInfo[] = [
+      makeVar('x', [100], 167),
+      makeVar('y', [100], '2t'),
+      makeVar('z', [100], 130),
+    ];
+    const groups = groupByParam(vars, 100);
+    expect(new Set(groups.map((g) => g.param))).toEqual(new Set(['167', '2t', '130']));
+  });
+
+  it('falls back to variable.name when mars.param is absent', () => {
+    const vars: ObjectInfo[] = [
+      makeVar('alpha', [100], undefined),
+      makeVar('beta', [100], undefined),
+    ];
+    const groups = groupByParam(vars, 100);
+    expect(groups.map((g) => g.param).sort()).toEqual(['alpha', 'beta']);
+  });
+
+  it('groups objects with the same integer param together', () => {
+    const vars: ObjectInfo[] = [
+      makeVar('2t', [100], 167, { levtype: 'sfc', step: 0 }),
+      makeVar('2t', [100], 167, { levtype: 'sfc', step: 6 }),
+      makeVar('2t', [100], 167, { levtype: 'sfc', step: 12 }),
+    ];
+    const groups = groupByParam(vars, 100);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].entries).toHaveLength(3);
+    expect(groups[0].entries.map((e) => e.step)).toEqual([0, 6, 12]);
+  });
+});

--- a/tensoscope/src/components/file-browser/groupByParam.ts
+++ b/tensoscope/src/components/file-browser/groupByParam.ts
@@ -1,0 +1,142 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+/**
+ * Grouping logic for the field-selector sidebar.
+ *
+ * Lives alongside `FieldSelector.tsx` but in its own module so the
+ * component file can export only React components (keeps
+ * `react-refresh/only-export-components` happy) and so the grouping
+ * logic is straightforward to unit-test against synthetic
+ * `ObjectInfo` inputs.
+ */
+
+import type { ObjectInfo } from '../../tensogram';
+
+export interface MarsMetadata {
+  step?: number;
+  param?: string | number;
+  levtype?: string;
+  levelist?: number | string;
+  level?: number | string;
+  [key: string]: unknown;
+}
+
+export type LevelStrategy =
+  | { kind: 'none' }
+  | { kind: 'packed'; levels: number[]; dim: number }
+  | { kind: 'per-object'; levels: number[] };
+
+export interface ParamEntry {
+  step: number;
+  marsLevel: number | null;
+  variable: ObjectInfo;
+}
+
+export interface ParamGroup {
+  param: string;
+  levtype: string;
+  units: string;
+  levelStrategy: LevelStrategy;
+  entries: ParamEntry[];
+}
+
+export function getMars(v: ObjectInfo): MarsMetadata {
+  return (v.metadata?.mars as MarsMetadata) ?? {};
+}
+
+export function getMarsLevel(mars: MarsMetadata): number | null {
+  const raw = mars.levelist ?? mars.level;
+  if (raw == null) return null;
+  if (mars.levtype === 'sfc') return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+export function getPackedLevels(v: ObjectInfo, coordLength: number): number[] | null {
+  if (v.shape.length <= 1) return null;
+  const levelDimSize = v.shape.find((s) => s !== coordLength);
+  if (!levelDimSize || levelDimSize <= 1) return null;
+
+  const anemoi = v.metadata?.anemoi as Record<string, unknown> | undefined;
+  const levels = anemoi?.levels as number[] | undefined;
+  if (levels && levels.length === levelDimSize) return levels;
+
+  return Array.from({ length: levelDimSize }, (_, i) => i);
+}
+
+export function groupByParam(variables: ObjectInfo[], coordLength: number): ParamGroup[] {
+  const map = new Map<string, ParamGroup>();
+
+  for (const v of variables) {
+    const mars = getMars(v);
+    // mars.param may be a GRIB integer code (133, 167, ...) or a
+    // short string ("t", "2t", ...); coerce to string so the Map
+    // keying and the localeCompare sort below both work.
+    const paramRaw = mars.param ?? v.name;
+    const param = typeof paramRaw === 'string' ? paramRaw : String(paramRaw ?? '');
+    const step = Number(mars.step ?? 0);
+    const marsLevel = getMarsLevel(mars);
+
+    let group = map.get(param);
+    if (!group) {
+      const packed = getPackedLevels(v, coordLength);
+      let levelStrategy: LevelStrategy;
+      if (packed && packed.length > 1) {
+        const dim = v.shape.findIndex((s) => s !== coordLength);
+        levelStrategy = { kind: 'packed', levels: packed, dim: dim >= 0 ? dim : 1 };
+      } else {
+        levelStrategy = { kind: 'none' };
+      }
+      group = {
+        param,
+        levtype: mars.levtype ?? '',
+        units: (v.metadata?.units as string) ?? '',
+        levelStrategy,
+        entries: [],
+      };
+      map.set(param, group);
+    }
+    group.entries.push({ step, marsLevel, variable: v });
+  }
+
+  for (const group of map.values()) {
+    if (group.levelStrategy.kind === 'none') {
+      const levelSet = new Set<number>();
+      for (const e of group.entries) {
+        if (e.marsLevel != null) levelSet.add(e.marsLevel);
+      }
+      if (levelSet.size > 1) {
+        group.levelStrategy = {
+          kind: 'per-object',
+          levels: [...levelSet].sort((a, b) => a - b),
+        };
+      }
+    }
+    group.entries.sort((a, b) => {
+      const la = a.marsLevel ?? -Infinity;
+      const lb = b.marsLevel ?? -Infinity;
+      if (la !== lb) return la - lb;
+      return a.step - b.step;
+    });
+  }
+
+  return Array.from(map.values()).sort((a, b) => a.param.localeCompare(b.param));
+}
+
+export function getLevels(group: ParamGroup): number[] {
+  if (group.levelStrategy.kind === 'none') return [];
+  return group.levelStrategy.levels;
+}
+
+export function getEntriesForLevel(group: ParamGroup, level: number | null): ParamEntry[] {
+  if (group.levelStrategy.kind === 'per-object' && level != null) {
+    return group.entries.filter((e) => e.marsLevel === level);
+  }
+  return group.entries;
+}

--- a/tensoscope/src/components/map/autoStyles.ts
+++ b/tensoscope/src/components/map/autoStyles.ts
@@ -58,9 +58,14 @@ const STYLES: Record<string, AutoStyle> = {
 
 /**
  * Look up the default style for a MARS param.
+ *
+ * Accepts `string | number | undefined` because `mars.param` in
+ * GRIB-derived files is a numeric code (167, 130, …) while in
+ * tensogram-native files it's a short string ("2t", "t", …).
  * Returns undefined if no style is defined for this param.
  */
-export function getAutoStyle(param: string | undefined): AutoStyle | undefined {
-  if (!param) return undefined;
-  return STYLES[param.toLowerCase()] ?? STYLES[param];
+export function getAutoStyle(param: string | number | undefined): AutoStyle | undefined {
+  if (param === undefined || param === null) return undefined;
+  const key = typeof param === 'string' ? param : String(param);
+  return STYLES[key.toLowerCase()] ?? STYLES[key];
 }

--- a/tensoscope/src/store/__tests__/decideSliceDim.test.ts
+++ b/tensoscope/src/store/__tests__/decideSliceDim.test.ts
@@ -1,0 +1,76 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+/**
+ * Regression tests for `decideSliceDim`, the helper that picks the
+ * axis of a field to slice down to 2-D before rendering.
+ *
+ * Covers the cases flagged in Oracle's post-implementation review:
+ *
+ *  1. Truly 2-D gridded data with meshed coords — no slice
+ *     (the original "donut in the north" regression).
+ *  2. Packed vertical levels with meshed coords
+ *     `[N_lev, nLat, nLon]` with `coordLength = nLat*nLon` — slice
+ *     dim 0 (the regression Oracle flagged on the first guard).
+ *  3. Packed levels with a flattened spatial axis
+ *     `[N_lev, nSpatial]` with `coordLength = nSpatial` — the
+ *     classic case the original guard was designed for.
+ *  4. Shape + coord length that don't fit — no slice, best-effort.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { decideSliceDim } from '../useAppStore';
+
+describe('decideSliceDim', () => {
+  it('does not slice a 2-D gridded field that matches the full coord length', () => {
+    // shape [721, 1440], coord length = 721 * 1440 = 1_038_240 (meshed).
+    expect(decideSliceDim([721, 1440], 721 * 1440)).toBe(-1);
+  });
+
+  it('slices dim 0 for a packed [N_lev, nLat, nLon] field with meshed coords', () => {
+    // This is the Oracle-flagged regression: before the generalisation
+    // to the total-is-a-multiple rule, this case returned -1 and the
+    // renderer got the full 3-D tensor.
+    expect(decideSliceDim([37, 721, 1440], 721 * 1440)).toBe(0);
+  });
+
+  it('slices dim 0 for a packed [N_lev, nSpatial] field with 1-D coords', () => {
+    // Classic case the original Tensoscope guard was designed for.
+    expect(decideSliceDim([37, 1038240], 1038240)).toBe(0);
+  });
+
+  it('does not slice when coord length is zero', () => {
+    expect(decideSliceDim([721, 1440], 0)).toBe(-1);
+  });
+
+  it('does not slice 1-D data', () => {
+    // coord == total → no slice regardless of rank.
+    expect(decideSliceDim([1038240], 1038240)).toBe(-1);
+  });
+
+  it('returns -1 on an empty shape', () => {
+    expect(decideSliceDim([], 1000)).toBe(-1);
+  });
+
+  it('does not slice when total is less than coord length', () => {
+    // Degenerate: coords advertise a bigger grid than the data covers.
+    expect(decideSliceDim([100], 1000)).toBe(-1);
+  });
+
+  it('does not slice when total is not a multiple of coord length', () => {
+    // total = 13*1000 + 500, not divisible.  Shape and coords don't
+    // fit; decode best-effort and let the renderer fail loudly rather
+    // than silently picking a wrong slice.
+    expect(decideSliceDim([13500], 1000)).toBe(-1);
+  });
+
+  it('slices on large multiples (hypothetical 4-D ensemble)', () => {
+    // [nEnsemble, nLev, nLat, nLon] with meshed coords.  Picks dim 0
+    // (ensemble), which is consistent with "slice the outermost
+    // non-spatial dim" even for rank ≥ 4 — a latent feature, not
+    // wired into the UI today, but guaranteed not to crash.
+    expect(decideSliceDim([5, 37, 721, 1440], 721 * 1440)).toBe(0);
+  });
+});

--- a/tensoscope/src/store/__tests__/decideSliceDim.test.ts
+++ b/tensoscope/src/store/__tests__/decideSliceDim.test.ts
@@ -66,11 +66,15 @@ describe('decideSliceDim', () => {
     expect(decideSliceDim([13500], 1000)).toBe(-1);
   });
 
-  it('slices on large multiples (hypothetical 4-D ensemble)', () => {
-    // [nEnsemble, nLev, nLat, nLon] with meshed coords.  Picks dim 0
-    // (ensemble), which is consistent with "slice the outermost
-    // non-spatial dim" even for rank ≥ 4 — a latent feature, not
-    // wired into the UI today, but guaranteed not to crash.
+  it('picks dim 0 on rank-4 shapes but does not fully flatten them', () => {
+    // [nEnsemble, nLev, nLat, nLon] with meshed coords matches the
+    // "multiple-of-coord" rule so decideSliceDim returns 0.  But the
+    // caller only performs a single `decodeFieldSlice` — slicing dim 0
+    // at index 0 leaves a 3-D tensor [nLev, nLat, nLon] which still
+    // exceeds coordLength.  Full rank-4 support would require a
+    // recursive / iterative slice, tracked as a follow-up.  The
+    // current behaviour is: pick the outermost dim, best-effort on
+    // everything else.
     expect(decideSliceDim([5, 37, 721, 1440], 721 * 1440)).toBe(0);
   });
 });

--- a/tensoscope/src/store/__tests__/useAppStore.test.ts
+++ b/tensoscope/src/store/__tests__/useAppStore.test.ts
@@ -237,3 +237,109 @@ describe('useAppStore — initViewer does not reset colorScale', () => {
     expect(colorScale.paletteReversed).toBe(true);
   });
 });
+
+// Heterogeneous multi-message files (different grids per message) must
+// have their coordinates fetched per-message, not once at file open.
+// Regression guard for Copilot's comment on PR #85: the per-msgIdx
+// cache at the Tensoscope wrapper layer is only useful if the store
+// also fetches per-message rather than reusing msg-0 coords forever.
+describe('useAppStore — selectField fetches coords per message', () => {
+  const COORDS_MSG0 = {
+    lat: new Float32Array([10, 20, 30, 40]),
+    lon: new Float32Array([0, 10, 20, 30]),
+  };
+  const COORDS_MSG1 = {
+    lat: new Float32Array([50, 60]),
+    lon: new Float32Array([100, 110]),
+  };
+
+  beforeEach(() => {
+    resetStore();
+    vi.clearAllMocks();
+    mocks.buildIndex.mockResolvedValue({
+      source: 'multi.tgm',
+      messageCount: 2,
+      variables: [
+        { msgIndex: 0, objIndex: 0, name: 'a', shape: [4], dtype: 'f32', encoding: '', compression: '', metadata: {} },
+        { msgIndex: 1, objIndex: 0, name: 'b', shape: [4], dtype: 'f32', encoding: '', compression: '', metadata: {} },
+      ],
+      coordinates: [],
+    });
+    mocks.fetchCoordinates.mockImplementation(async (msgIdx: number) =>
+      msgIdx === 0 ? COORDS_MSG0 : COORDS_MSG1,
+    );
+    mocks.decodeField.mockResolvedValue(DECODED_FIELD);
+    // Both decode paths must succeed so selectField reaches the
+    // atomic final set; msg-1's shorter coords force the slice path.
+    mocks.decodeFieldSlice.mockResolvedValue({
+      data: new Float32Array([5, 6]),
+      shape: [2],
+      stats: { min: 5, max: 6, mean: 5.5, std: 0.5 },
+    });
+    mocks.fromFile.mockImplementation(async () => ({
+      buildIndex: mocks.buildIndex,
+      fetchCoordinates: mocks.fetchCoordinates,
+      decodeField: mocks.decodeField,
+      decodeFieldSlice: mocks.decodeFieldSlice,
+      close: mocks.close,
+    }));
+  });
+
+  it('calls fetchCoordinates with the selected msgIdx, not always 0', async () => {
+    await useAppStore.getState().openLocalFile(new File([], 'multi.tgm'));
+    mocks.fetchCoordinates.mockClear();
+
+    await useAppStore.getState().selectField(1, 0);
+
+    expect(mocks.fetchCoordinates).toHaveBeenCalledWith(1);
+    expect(mocks.fetchCoordinates).not.toHaveBeenCalledWith(0);
+  });
+
+  it('stores the selected message coords, not msg-0 stale coords', async () => {
+    await useAppStore.getState().openLocalFile(new File([], 'multi.tgm'));
+    // Auto-select took msg 0; coords should reflect msg 0.
+    expect(useAppStore.getState().coordinates?.lat).toEqual(COORDS_MSG0.lat);
+
+    await useAppStore.getState().selectField(1, 0);
+
+    expect(useAppStore.getState().coordinates?.lat).toEqual(COORDS_MSG1.lat);
+    expect(useAppStore.getState().coordinates?.lon).toEqual(COORDS_MSG1.lon);
+  });
+
+  it('initViewer does not eagerly fetch coords for msg 0', async () => {
+    // Shifted index: first variable lives on msg 3, not msg 0.  The
+    // old code pre-fetched msg 0 unconditionally, wasting work and
+    // seeding the store with wrong coords; after the fix selectField
+    // is the only caller.
+    mocks.buildIndex.mockResolvedValue({
+      source: 'shifted.tgm',
+      messageCount: 5,
+      variables: [
+        { msgIndex: 3, objIndex: 1, name: 'x', shape: [4], dtype: 'f32', encoding: '', compression: '', metadata: {} },
+      ],
+      coordinates: [],
+    });
+
+    await useAppStore.getState().openLocalFile(new File([], 'shifted.tgm'));
+
+    const calls = mocks.fetchCoordinates.mock.calls.map((c) => c[0]);
+    expect(calls).not.toContain(0);
+    expect(calls).toContain(3);
+  });
+
+  it('decideSliceDim uses the selected message coord length', async () => {
+    // msg 0 ships 4-point coords, msg 1 ships 2-point coords.  Both
+    // variables have shape [4].  On msg 1, total (4) is a multiple
+    // of coordLength (2) → decideSliceDim picks dim 0 → decodeFieldSlice
+    // is called; on msg 0 with coord length 4, total === coord length
+    // → no slice → decodeField is called.
+    await useAppStore.getState().openLocalFile(new File([], 'multi.tgm'));
+    expect(mocks.decodeField).toHaveBeenCalledTimes(1);
+    expect(mocks.decodeFieldSlice).not.toHaveBeenCalled();
+
+    await useAppStore.getState().selectField(1, 0);
+
+    expect(mocks.decodeFieldSlice).toHaveBeenCalledTimes(1);
+    expect(mocks.decodeFieldSlice).toHaveBeenLastCalledWith(1, 0, 0, 0);
+  });
+});

--- a/tensoscope/src/store/useAppStore.ts
+++ b/tensoscope/src/store/useAppStore.ts
@@ -150,9 +150,12 @@ export const useAppStore = create<AppState>((set, get) => ({
         result = await viewer.decodeField(msgIdx, objIdx);
       }
 
-      // Apply per-variable auto-style if available, otherwise use data range
+      // Apply per-variable auto-style if available, otherwise use data range.
+      // mars.param can be either a short string ("2t", "t", ...) or a
+      // GRIB integer code (167, 130, ...); getAutoStyle handles both.
       const mars = varInfo?.metadata?.mars as Record<string, unknown> | undefined;
-      const param = (mars?.param as string) ?? varInfo?.name;
+      const marsParam = mars?.param as string | number | undefined;
+      const param = marsParam ?? varInfo?.name;
       const style = getAutoStyle(param);
 
       set({

--- a/tensoscope/src/store/useAppStore.ts
+++ b/tensoscope/src/store/useAppStore.ts
@@ -85,17 +85,25 @@ const DEFAULT_COLOR_SCALE: ColorScaleConfig = {
   displayUnit: '',
 };
 
-/** Shared logic after a Tensoscope is created. */
+/**
+ * Shared logic after a Tensoscope is created.
+ *
+ * `coordinates` is left null here — `selectField` fetches the coords
+ * for the specific message it is decoding and sets them atomically
+ * with `fieldData`, so the store's coordinates slot consistently
+ * means "coords for the currently-decoded field".  Heterogeneous
+ * multi-message files (different grids per message) would otherwise
+ * keep msg-0's coords forever.
+ */
 async function initViewer(
   viewer: Tensoscope,
   set: (partial: Partial<AppState>) => void,
 ) {
   const index = await viewer.buildIndex();
-  const coords = await viewer.fetchCoordinates(0);
   set({
     viewer,
     fileIndex: index,
-    coordinates: coords,
+    coordinates: null,
     selectedObject: null,
     selectedLevel: null,
     fieldData: null,
@@ -148,17 +156,22 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
 
   selectField: async (msgIdx: number, objIdx: number) => {
-    const { viewer, fileIndex, coordinates, selectedLevel } = get();
+    const { viewer, fileIndex, selectedLevel } = get();
     if (!viewer || !fileIndex) return;
     set({ loading: true, error: null, selectedObject: { msgIdx, objIdx } });
     // Yield so React renders the loading state before the synchronous WASM decode blocks the thread.
     await new Promise<void>((resolve) => setTimeout(resolve, 0));
     try {
+      // Heterogeneous multi-message files may carry different grids per
+      // message; fetch the coords for the selected message so coordLength
+      // and downstream geolocation match the field we are about to decode.
+      // The wrapper's per-msgIdx cache makes repeat calls free.
+      const coords = await viewer.fetchCoordinates(msgIdx);
       const varInfo = fileIndex.variables.find(
         (v) => v.msgIndex === msgIdx && v.objIndex === objIdx,
       );
       const originalShape = varInfo?.shape ?? [];
-      const coordLength = coordinates?.lat.length ?? 0;
+      const coordLength = coords?.lat.length ?? 0;
 
       const sliceDim = decideSliceDim(originalShape, coordLength);
 
@@ -186,10 +199,13 @@ export const useAppStore = create<AppState>((set, get) => ({
       const param = marsParam ?? varInfo?.name;
       const style = getAutoStyle(param);
 
+      // Commit data and coords together so consumers never see a field
+      // decoded against one message paired with coords from another.
       set({
         fieldData: result.data,
         fieldShape: originalShape,
         fieldStats: result.stats,
+        coordinates: coords,
         colorScale: style
           ? { ...DEFAULT_COLOR_SCALE, palette: style.palette, min: style.min, max: style.max, logScale: false, nativeUnits: style.units, displayUnit: style.units }
           : { ...get().colorScale, min: result.stats.min, max: result.stats.max, nativeUnits: '', displayUnit: '' },

--- a/tensoscope/src/store/useAppStore.ts
+++ b/tensoscope/src/store/useAppStore.ts
@@ -6,6 +6,35 @@ import type { FileIndex, DecodedField, CoordinateData } from '../tensogram';
 import { getAutoStyle } from '../components/map/autoStyles';
 import type { CustomStop } from '../components/map/colormaps';
 
+/**
+ * Decide which axis of a field to slice down to 2-D before rendering.
+ *
+ * `coordLength` is the length of the per-point (meshgridded) lat array
+ * Tensoscope caches; it equals the flattened spatial grid size.
+ *
+ * Three cases, in order:
+ *
+ *  - `total === coordLength` — the field IS the spatial grid (e.g.
+ *    `[nLat, nLon]` meshed, or `[nSpatial]` already flattened).  No
+ *    slicing; the renderer consumes the full tensor.
+ *  - `total` is a positive integer multiple of `coordLength` — one
+ *    or more leading "level-like" dims stack the spatial grid.  Slice
+ *    dim 0 (matches both `[N_lev, nLat, nLon]` and `[N_lev, nSpatial]`).
+ *  - Otherwise — shape and coords do not fit together.  Decode the
+ *    full tensor as best-effort; rendering will fail further
+ *    downstream if the mismatch is real.
+ *
+ * Exported for unit testing.  @internal
+ */
+export function decideSliceDim(shape: readonly number[], coordLength: number): number {
+  if (coordLength <= 0 || shape.length === 0) return -1;
+  let total = 1;
+  for (const s of shape) total *= s;
+  if (total === coordLength) return -1;
+  if (total > coordLength && total % coordLength === 0) return 0;
+  return -1;
+}
+
 export interface FieldStats {
   min: number;
   max: number;
@@ -128,16 +157,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       const originalShape = varInfo?.shape ?? [];
       const coordLength = coordinates?.lat.length ?? 0;
 
-      // Level-slicing applies only when one dimension of `shape` matches
-      // the coordinate length — that's the marker of a `[levels, grid]`-shaped
-      // tensor where the non-matching dim is a stack of vertical levels.
-      // For truly 2-D gridded data `[nlat, nlon]` with meshgridded coords
-      // of length `nlat*nlon`, no dim matches and we want the full field
-      // rendered as-is (not sliced to a single row of pixels).
-      const hasSpatialDim = coordLength > 0 && originalShape.includes(coordLength);
-      const sliceDim = hasSpatialDim
-        ? originalShape.findIndex((s) => s !== coordLength)
-        : -1;
+      const sliceDim = decideSliceDim(originalShape, coordLength);
 
       let result: DecodedField;
       if (sliceDim >= 0) {

--- a/tensoscope/src/store/useAppStore.ts
+++ b/tensoscope/src/store/useAppStore.ts
@@ -128,24 +128,29 @@ export const useAppStore = create<AppState>((set, get) => ({
       const originalShape = varInfo?.shape ?? [];
       const coordLength = coordinates?.lat.length ?? 0;
 
+      // Level-slicing applies only when one dimension of `shape` matches
+      // the coordinate length — that's the marker of a `[levels, grid]`-shaped
+      // tensor where the non-matching dim is a stack of vertical levels.
+      // For truly 2-D gridded data `[nlat, nlon]` with meshgridded coords
+      // of length `nlat*nlon`, no dim matches and we want the full field
+      // rendered as-is (not sliced to a single row of pixels).
+      const hasSpatialDim = coordLength > 0 && originalShape.includes(coordLength);
+      const sliceDim = hasSpatialDim
+        ? originalShape.findIndex((s) => s !== coordLength)
+        : -1;
+
       let result: DecodedField;
-      if (originalShape.length > 1 && coordLength > 0) {
-        const sliceDim = originalShape.findIndex((s) => s !== coordLength);
-        if (sliceDim >= 0) {
-          // Resolve slice index from selectedLevel if possible
-          let sliceIdx = 0;
-          if (selectedLevel != null) {
-            const anemoi = varInfo?.metadata?.anemoi as Record<string, unknown> | undefined;
-            const levels = anemoi?.levels as number[] | undefined;
-            if (levels) {
-              const idx = levels.indexOf(selectedLevel);
-              if (idx >= 0) sliceIdx = idx;
-            }
+      if (sliceDim >= 0) {
+        let sliceIdx = 0;
+        if (selectedLevel != null) {
+          const anemoi = varInfo?.metadata?.anemoi as Record<string, unknown> | undefined;
+          const levels = anemoi?.levels as number[] | undefined;
+          if (levels) {
+            const idx = levels.indexOf(selectedLevel);
+            if (idx >= 0) sliceIdx = idx;
           }
-          result = await viewer.decodeFieldSlice(msgIdx, objIdx, sliceDim, sliceIdx);
-        } else {
-          result = await viewer.decodeField(msgIdx, objIdx);
         }
+        result = await viewer.decodeFieldSlice(msgIdx, objIdx, sliceDim, sliceIdx);
       } else {
         result = await viewer.decodeField(msgIdx, objIdx);
       }

--- a/tensoscope/src/tensogram/__tests__/expandAxes.test.ts
+++ b/tensoscope/src/tensogram/__tests__/expandAxes.test.ts
@@ -1,0 +1,98 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+/**
+ * Tests for `expandAxesIfRectangularGrid` — the helper that promotes
+ * 1-D `latitude` + `longitude` axes to per-point meshgridded arrays
+ * when a file ships a regular rectangular grid (the common
+ * GRIB / NetCDF layout).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { expandAxesIfRectangularGrid } from '../index';
+import type { ObjectInfo } from '../index';
+
+function makeVar(name: string, shape: number[]): ObjectInfo {
+  return {
+    msgIndex: 0,
+    objIndex: 0,
+    name,
+    shape,
+    dtype: 'float32',
+    encoding: 'none',
+    compression: 'none',
+    metadata: {},
+  };
+}
+
+describe('expandAxesIfRectangularGrid', () => {
+  it('meshgrids 1-D axes when a [nLat, nLon] variable exists', () => {
+    const lat = new Float32Array([90, 0, -90]);
+    const lon = new Float32Array([0, 90, 180, -90]);
+    const variables = [makeVar('2t', [3, 4])];
+
+    const result = expandAxesIfRectangularGrid(lat, lon, variables);
+    expect(result).not.toBeNull();
+    expect(result!.lat.length).toBe(12);
+    expect(result!.lon.length).toBe(12);
+
+    // Row 0 (lat=90): every lon column repeats that lat.
+    expect(Array.from(result!.lat.slice(0, 4))).toEqual([90, 90, 90, 90]);
+    expect(Array.from(result!.lon.slice(0, 4))).toEqual([0, 90, 180, -90]);
+
+    // Row 1 (lat=0): same lon columns, lat=0 throughout.
+    expect(Array.from(result!.lat.slice(4, 8))).toEqual([0, 0, 0, 0]);
+    expect(Array.from(result!.lon.slice(4, 8))).toEqual([0, 90, 180, -90]);
+
+    // Row 2 (lat=-90): final row.
+    expect(Array.from(result!.lat.slice(8, 12))).toEqual([-90, -90, -90, -90]);
+  });
+
+  it('returns null when no [nLat, nLon] variable exists', () => {
+    const lat = new Float32Array([90, 0, -90]);
+    const lon = new Float32Array([0, 90, 180, -90]);
+    const variables = [
+      makeVar('x', [5, 4]),
+      makeVar('y', [3, 5]),
+      makeVar('z', [10]),
+    ];
+    expect(expandAxesIfRectangularGrid(lat, lon, variables)).toBeNull();
+  });
+
+  it('returns null for already-meshgridded coords (no match)', () => {
+    // Simulates the `add_coords_meshed.py` output: coords already
+    // expanded to length nLat*nLon, and variables still shaped
+    // [nLat, nLon] — but no variable has shape
+    // [fullGridLength, nLon] so the grid-match search comes back
+    // empty.
+    const nLat = 4;
+    const nLon = 3;
+    const latFull = new Float32Array(nLat * nLon);
+    const lonFull = new Float32Array(nLat * nLon);
+    const variables = [makeVar('2t', [nLat, nLon])];
+    expect(expandAxesIfRectangularGrid(latFull, lonFull, variables)).toBeNull();
+  });
+
+  it('returns null for empty axes', () => {
+    expect(
+      expandAxesIfRectangularGrid(new Float32Array(), new Float32Array([1]), []),
+    ).toBeNull();
+    expect(
+      expandAxesIfRectangularGrid(new Float32Array([1]), new Float32Array(), []),
+    ).toBeNull();
+  });
+
+  it('picks the first matching variable and ignores 3-D ones', () => {
+    const lat = new Float32Array([1, 2]);
+    const lon = new Float32Array([10, 20, 30]);
+    const variables = [
+      makeVar('levels', [5, 2, 3]),
+      makeVar('2t', [2, 3]),
+    ];
+    const result = expandAxesIfRectangularGrid(lat, lon, variables);
+    expect(result).not.toBeNull();
+    expect(result!.lat.length).toBe(6);
+  });
+});

--- a/tensoscope/src/tensogram/__tests__/inferAxesFromMars.test.ts
+++ b/tensoscope/src/tensogram/__tests__/inferAxesFromMars.test.ts
@@ -97,13 +97,36 @@ describe('inferAxesFromMarsGrid', () => {
   });
 
   it('picks the first 2-D regular_ll variable and ignores the rest', () => {
-    const result = inferAxesFromMarsGrid([
-      makeVar([5, 10, 20], { grid: 'regular_ll' }),
+    const lat = new Float32Array([1, 2]);
+    const lon = new Float32Array([10, 20, 30]);
+    const variables = [
+      makeVar([5, 2, 3], { grid: 'regular_ll' }),
       makeVar([73, 144], { grid: 'regular_ll' }),
       makeVar([100, 200], { grid: 'regular_ll' }),
-    ]);
+    ];
+    const result = inferAxesFromMarsGrid(variables);
     expect(result).not.toBeNull();
     expect(result!.lat.length).toBe(73);
     expect(result!.lon.length).toBe(144);
+  });
+
+  it('falls back to defaults when mars.area contains a non-finite bigint', () => {
+    // Corrupt or absurd CBOR-encoded areas — a bigint that overflows a
+    // JS number via Number(v) — must not silently produce Infinity
+    // coordinates.  toNumber returns null in that case and the
+    // defaults kick in.
+    const hugeBigint = 1n << 2000n;
+    const result = inferAxesFromMarsGrid([
+      makeVar([10, 20], {
+        grid: 'regular_ll',
+        area: [hugeBigint, 0, -90, 360],
+      }),
+    ]);
+    expect(result).not.toBeNull();
+    // Defaults: north=90 (since the overflowing bigint failed toNumber).
+    expect(result!.lat[0]).toBe(90);
+    expect(Number.isFinite(result!.lat[0])).toBe(true);
+    expect(Number.isFinite(result!.lat[result!.lat.length - 1])).toBe(true);
+    expect(Number.isFinite(result!.lon[0])).toBe(true);
   });
 });

--- a/tensoscope/src/tensogram/__tests__/inferAxesFromMars.test.ts
+++ b/tensoscope/src/tensogram/__tests__/inferAxesFromMars.test.ts
@@ -1,0 +1,109 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+/**
+ * Tests for `inferAxesFromMarsGrid` — the helper that synthesises 1-D
+ * latitude + longitude axes from `mars.grid = "regular_ll"` + the
+ * variable's shape, for GRIB-derived files that ship no explicit
+ * coordinate objects.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { inferAxesFromMarsGrid } from '../index';
+import type { ObjectInfo } from '../index';
+
+function makeVar(shape: number[], mars: Record<string, unknown>): ObjectInfo {
+  return {
+    msgIndex: 0,
+    objIndex: 0,
+    name: 't',
+    shape,
+    dtype: 'float32',
+    encoding: 'none',
+    compression: 'none',
+    metadata: { mars },
+  };
+}
+
+describe('inferAxesFromMarsGrid', () => {
+  it('infers 721×1440 global quarter-degree lat/lon from regular_ll', () => {
+    const result = inferAxesFromMarsGrid([
+      makeVar([721, 1440], { grid: 'regular_ll', param: 167 }),
+    ]);
+    expect(result).not.toBeNull();
+    expect(result!.lat.length).toBe(721);
+    expect(result!.lon.length).toBe(1440);
+    expect(result!.lat[0]).toBe(90);
+    expect(result!.lat[720]).toBe(-90);
+    expect(result!.lat[360]).toBeCloseTo(0, 5);
+    expect(result!.lon[0]).toBe(0);
+    expect(result!.lon[1439]).toBeCloseTo(359.75, 3);
+  });
+
+  it('honours mars.area [north, west, south, east] for regional grids', () => {
+    const result = inferAxesFromMarsGrid([
+      makeVar([100, 200], {
+        grid: 'regular_ll',
+        area: [60, -30, 20, 70],
+      }),
+    ]);
+    expect(result).not.toBeNull();
+    expect(result!.lat[0]).toBe(60);
+    expect(result!.lat[99]).toBeCloseTo(20, 5);
+    expect(result!.lon[0]).toBe(-30);
+    expect(result!.lon[199]).toBeCloseTo(70, 5);
+  });
+
+  it('uses endpoint-exclusive longitude when area wraps a full circle', () => {
+    const result = inferAxesFromMarsGrid([
+      makeVar([90, 180], { grid: 'regular_ll' }),
+    ]);
+    expect(result).not.toBeNull();
+    // 360 / 180 = 2°, last sample at 358°, not 360° (which would
+    // alias with 0°).
+    expect(result!.lon[0]).toBe(0);
+    expect(result!.lon[179]).toBeCloseTo(358, 3);
+  });
+
+  it('returns null for unsupported grid kinds', () => {
+    expect(
+      inferAxesFromMarsGrid([
+        makeVar([100, 200], { grid: 'reduced_gg' }),
+      ]),
+    ).toBeNull();
+    expect(
+      inferAxesFromMarsGrid([makeVar([100, 200], { grid: 'N320' })]),
+    ).toBeNull();
+    expect(
+      inferAxesFromMarsGrid([makeVar([100, 200], { grid: 'O96' })]),
+    ).toBeNull();
+  });
+
+  it('returns null when no variable has mars.grid', () => {
+    expect(
+      inferAxesFromMarsGrid([makeVar([100, 200], { param: 167 })]),
+    ).toBeNull();
+  });
+
+  it('returns null when the only matching variable is not 2-D', () => {
+    expect(
+      inferAxesFromMarsGrid([
+        makeVar([10, 100, 200], { grid: 'regular_ll' }),
+        makeVar([500], { grid: 'regular_ll' }),
+      ]),
+    ).toBeNull();
+  });
+
+  it('picks the first 2-D regular_ll variable and ignores the rest', () => {
+    const result = inferAxesFromMarsGrid([
+      makeVar([5, 10, 20], { grid: 'regular_ll' }),
+      makeVar([73, 144], { grid: 'regular_ll' }),
+      makeVar([100, 200], { grid: 'regular_ll' }),
+    ]);
+    expect(result).not.toBeNull();
+    expect(result!.lat.length).toBe(73);
+    expect(result!.lon.length).toBe(144);
+  });
+});

--- a/tensoscope/src/tensogram/index.ts
+++ b/tensoscope/src/tensogram/index.ts
@@ -266,10 +266,22 @@ export class Tensoscope {
     const lonInfo = index.coordinates.find(
       (c) => c.msgIndex === msgIdx && LON_NAMES.has(c.name.toLowerCase()),
     );
-    if (!latInfo || !lonInfo) return null;
 
-    const latAxis = (await this.decodeField(latInfo.msgIndex, latInfo.objIndex)).data;
-    const lonAxis = (await this.decodeField(lonInfo.msgIndex, lonInfo.objIndex)).data;
+    let latAxis: Float32Array | null = null;
+    let lonAxis: Float32Array | null = null;
+    if (latInfo && lonInfo) {
+      latAxis = (await this.decodeField(latInfo.msgIndex, latInfo.objIndex)).data;
+      lonAxis = (await this.decodeField(lonInfo.msgIndex, lonInfo.objIndex)).data;
+    } else {
+      // Fallback: no explicit coordinate objects.  Try to infer axes
+      // from `mars.grid` + data shape.  This covers GRIB-derived
+      // files that ship only data, relying on the grid-kind metadata
+      // hint for geolocation.
+      const inferred = inferAxesFromMarsGrid(index.variables);
+      if (!inferred) return null;
+      latAxis = inferred.lat;
+      lonAxis = inferred.lon;
+    }
 
     const expanded = expandAxesIfRectangularGrid(latAxis, lonAxis, index.variables);
     this._coords = expanded ?? { lat: latAxis, lon: lonAxis };
@@ -361,6 +373,66 @@ export function expandAxesIfRectangularGrid(
     }
   }
   return { lat: latFull, lon: lonFull };
+}
+
+/**
+ * Infer 1-D latitude + longitude axes from `mars.grid` metadata + the
+ * variable's shape, for files that ship no explicit coordinate
+ * objects.  Currently supports `regular_ll` (the common
+ * constant-step global lat/lon grid); returns `null` for any other
+ * grid kind (`reduced_gg`, octahedral `O*`, Gaussian `N*`, etc.) —
+ * those require either a per-point lat/lon pair in the file or a
+ * grid-definition lookup that this thin viewer layer can't do
+ * standalone.
+ *
+ * Exported for unit-testing.  @internal
+ */
+export function inferAxesFromMarsGrid(
+  variables: readonly ObjectInfo[],
+): { lat: Float32Array; lon: Float32Array } | null {
+  for (const v of variables) {
+    if (v.shape.length !== 2) continue;
+    const mars = v.metadata?.mars as Record<string, unknown> | undefined;
+    if (!mars) continue;
+    const grid = mars.grid;
+    if (typeof grid !== 'string') continue;
+    const gridKind = grid.toLowerCase();
+    if (gridKind !== 'regular_ll') continue;
+
+    const [nLat, nLon] = v.shape;
+    // MARS "area": [north, west, south, east].  Default to a full
+    // global domain when absent — matches ECMWF operational data.
+    const area = Array.isArray(mars.area) ? (mars.area as unknown[]) : null;
+    const north = toNumber(area?.[0]) ?? 90;
+    const west = toNumber(area?.[1]) ?? 0;
+    const south = toNumber(area?.[2]) ?? -90;
+    const east = toNumber(area?.[3]) ?? 360;
+
+    const lat = new Float32Array(nLat);
+    for (let i = 0; i < nLat; i++) {
+      lat[i] = north + (i * (south - north)) / Math.max(nLat - 1, 1);
+    }
+
+    // Longitude endpoint handling: when the area spans a full 360°
+    // circle the last sample sits one step before `east` because
+    // east ≡ west (mod 360).  For partial longitudinal bands the
+    // last sample sits exactly at `east`.
+    const lon = new Float32Array(nLon);
+    const spansCircle = Math.abs(east - west) >= 360 - 1e-6;
+    const denom = spansCircle ? nLon : Math.max(nLon - 1, 1);
+    for (let j = 0; j < nLon; j++) {
+      lon[j] = west + (j * (east - west)) / denom;
+    }
+    return { lat, lon };
+  }
+  return null;
+}
+
+/** Convert a CborValue to a plain number when possible. */
+function toNumber(v: unknown): number | null {
+  if (typeof v === 'number' && Number.isFinite(v)) return v;
+  if (typeof v === 'bigint') return Number(v);
+  return null;
 }
 
 /** Slice a flat array along one dimension of a multi-dimensional shape. */

--- a/tensoscope/src/tensogram/index.ts
+++ b/tensoscope/src/tensogram/index.ts
@@ -269,6 +269,12 @@ export class Tensoscope {
 
     let latAxis: Float32Array | null = null;
     let lonAxis: Float32Array | null = null;
+    // Scope inference + expansion to the variables of the requested
+    // message.  Heterogeneous multi-message files may have different
+    // grids in different messages and should not pick up an axis from
+    // some other message.
+    const msgVariables = index.variables.filter((v) => v.msgIndex === msgIdx);
+
     if (latInfo && lonInfo) {
       latAxis = (await this.decodeField(latInfo.msgIndex, latInfo.objIndex)).data;
       lonAxis = (await this.decodeField(lonInfo.msgIndex, lonInfo.objIndex)).data;
@@ -277,13 +283,13 @@ export class Tensoscope {
       // from `mars.grid` + data shape.  This covers GRIB-derived
       // files that ship only data, relying on the grid-kind metadata
       // hint for geolocation.
-      const inferred = inferAxesFromMarsGrid(index.variables);
+      const inferred = inferAxesFromMarsGrid(msgVariables);
       if (!inferred) return null;
       latAxis = inferred.lat;
       lonAxis = inferred.lon;
     }
 
-    const expanded = expandAxesIfRectangularGrid(latAxis, lonAxis, index.variables);
+    const expanded = expandAxesIfRectangularGrid(latAxis, lonAxis, msgVariables);
     this._coords = expanded ?? { lat: latAxis, lon: lonAxis };
     return this._coords;
   }

--- a/tensoscope/src/tensogram/index.ts
+++ b/tensoscope/src/tensogram/index.ts
@@ -240,7 +240,22 @@ export class Tensoscope {
 
   // ── Coordinates ───────────────────────────────────────────────────────
 
-  /** Decode and cache lat/lon coordinate arrays for a message. */
+  /**
+   * Decode and cache lat/lon coordinate arrays for a message.
+   *
+   * When a file ships 1-D latitude + longitude axes and one or more
+   * data variables shaped `[nLat, nLon]` (the natural
+   * regular-rectangular-grid layout for GRIB / NetCDF climate data),
+   * the renderer's downstream worker wants per-point coordinates —
+   * one `(lat, lon)` pair per data cell.  We detect that layout here
+   * and expand the axes into a full meshgrid so callers never have
+   * to worry about it.
+   *
+   * If the file already ships per-point coords (lat and lon of
+   * length `nLat * nLon`, as produced by
+   * `examples/.../add_coords_meshed.py`), the expansion is a no-op
+   * and we return the file's coords as-is.
+   */
   async fetchCoordinates(msgIdx: number): Promise<CoordinateData | null> {
     if (this._coords) return this._coords;
 
@@ -253,9 +268,11 @@ export class Tensoscope {
     );
     if (!latInfo || !lonInfo) return null;
 
-    const lat = (await this.decodeField(latInfo.msgIndex, latInfo.objIndex)).data;
-    const lon = (await this.decodeField(lonInfo.msgIndex, lonInfo.objIndex)).data;
-    this._coords = { lat, lon };
+    const latAxis = (await this.decodeField(latInfo.msgIndex, latInfo.objIndex)).data;
+    const lonAxis = (await this.decodeField(lonInfo.msgIndex, lonInfo.objIndex)).data;
+
+    const expanded = expandAxesIfRectangularGrid(latAxis, lonAxis, index.variables);
+    this._coords = expanded ?? { lat: latAxis, lon: lonAxis };
     return this._coords;
   }
 
@@ -303,6 +320,47 @@ function computeStats(data: Float32Array): FieldStats {
     mean,
     std: Math.sqrt(Math.max(0, variance)),
   };
+}
+
+/**
+ * Detect a regular rectangular grid and expand 1-D lat/lon axes to
+ * per-point arrays.  Exported for unit testing.
+ *
+ * Returns `null` when no expansion is needed — either because a
+ * matching `[nLat, nLon]` variable is not present, or because the
+ * coords are already full-length.
+ *
+ * @internal
+ */
+export function expandAxesIfRectangularGrid(
+  lat: Float32Array,
+  lon: Float32Array,
+  variables: readonly ObjectInfo[],
+): CoordinateData | null {
+  const nLat = lat.length;
+  const nLon = lon.length;
+  if (nLat === 0 || nLon === 0) return null;
+  // When the file already ships meshgridded coords (lat.length === full
+  // grid size), no data variable will have shape [lat.length, nLon] —
+  // the `gridMatch` search below then returns undefined, which is
+  // exactly the no-op answer we want.  No extra guard needed here.
+  const gridMatch = variables.find(
+    (v) => v.shape.length === 2 && v.shape[0] === nLat && v.shape[1] === nLon,
+  );
+  if (!gridMatch) return null;
+
+  const n = nLat * nLon;
+  const latFull = new Float32Array(n);
+  const lonFull = new Float32Array(n);
+  for (let i = 0; i < nLat; i++) {
+    const base = i * nLon;
+    const latVal = lat[i];
+    for (let j = 0; j < nLon; j++) {
+      latFull[base + j] = latVal;
+      lonFull[base + j] = lon[j];
+    }
+  }
+  return { lat: latFull, lon: lonFull };
 }
 
 /** Slice a flat array along one dimension of a multi-dimensional shape. */

--- a/tensoscope/src/tensogram/index.ts
+++ b/tensoscope/src/tensogram/index.ts
@@ -97,7 +97,14 @@ export class Tensoscope {
   private file: TensogramFile;
   private _source: string;
   private _index: FileIndex | null = null;
-  private _coords: CoordinateData | null = null;
+  /**
+   * Per-message coordinate cache.  Heterogeneous multi-message files
+   * may carry different grids in different messages; keying by
+   * `msgIdx` lets each call to {@link fetchCoordinates} return the
+   * coordinates for that specific message without silently reusing
+   * message 0's geometry.
+   */
+  private readonly _coords = new Map<number, CoordinateData>();
 
   private constructor(file: TensogramFile, source: string) {
     this.file = file;
@@ -257,7 +264,8 @@ export class Tensoscope {
    * and we return the file's coords as-is.
    */
   async fetchCoordinates(msgIdx: number): Promise<CoordinateData | null> {
-    if (this._coords) return this._coords;
+    const cached = this._coords.get(msgIdx);
+    if (cached) return cached;
 
     const index = await this.buildIndex();
     const latInfo = index.coordinates.find(
@@ -267,14 +275,14 @@ export class Tensoscope {
       (c) => c.msgIndex === msgIdx && LON_NAMES.has(c.name.toLowerCase()),
     );
 
-    let latAxis: Float32Array | null = null;
-    let lonAxis: Float32Array | null = null;
     // Scope inference + expansion to the variables of the requested
     // message.  Heterogeneous multi-message files may have different
     // grids in different messages and should not pick up an axis from
     // some other message.
     const msgVariables = index.variables.filter((v) => v.msgIndex === msgIdx);
 
+    let latAxis: Float32Array;
+    let lonAxis: Float32Array;
     if (latInfo && lonInfo) {
       latAxis = (await this.decodeField(latInfo.msgIndex, latInfo.objIndex)).data;
       lonAxis = (await this.decodeField(lonInfo.msgIndex, lonInfo.objIndex)).data;
@@ -290,8 +298,9 @@ export class Tensoscope {
     }
 
     const expanded = expandAxesIfRectangularGrid(latAxis, lonAxis, msgVariables);
-    this._coords = expanded ?? { lat: latAxis, lon: lonAxis };
-    return this._coords;
+    const coords = expanded ?? { lat: latAxis, lon: lonAxis };
+    this._coords.set(msgIdx, coords);
+    return coords;
   }
 
   close(): void {
@@ -434,10 +443,21 @@ export function inferAxesFromMarsGrid(
   return null;
 }
 
-/** Convert a CborValue to a plain number when possible. */
+/**
+ * Convert a CborValue to a plain finite number when possible.
+ *
+ * Guards against `bigint` values that overflow a `number` — converting
+ * a very large `bigint` via `Number(v)` silently returns `Infinity`,
+ * which would then propagate into generated lat/lon arrays and
+ * destroy the grid.  Return `null` on overflow so the caller falls
+ * back to a safe default.
+ */
 function toNumber(v: unknown): number | null {
   if (typeof v === 'number' && Number.isFinite(v)) return v;
-  if (typeof v === 'bigint') return Number(v);
+  if (typeof v === 'bigint') {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : null;
+  }
   return null;
 }
 


### PR DESCRIPTION
## Summary

Four related bugs/gaps that together prevent GRIB-derived `.tgm`
files from rendering in Tensoscope.  All four surface on the same
kind of file — a multi-variable ECMWF operational forecast — and are
fixed here together so realistic files work without any Python-side
preprocessing.

## Bug 1: `TypeError: a.param.localeCompare is not a function`

Opening crashed the sidebar because `mars.param` is a GRIB integer
code (`167`, `130`, `260360`, …) rather than a short string.

Fixed by coercing at the map-keying + sort boundary and widening
`getAutoStyle` to accept `string | number | undefined`.
`FieldSelector.tsx` split: a new `groupByParam.ts` module holds the
grouping logic so the component file stays pure-component (keeps
`react-refresh/only-export-components` happy) and the grouping is
easy to test against synthetic inputs.

## Bug 2: "donut in the north" on every field click

After the crash was gone, every clicked field drew only a thin ring
near the north pole.  `useAppStore.selectField` called the
level-slicing path whenever data was multi-dim and coordinates
existed — returning one latitude row.

Fixed with a new `decideSliceDim(shape, coordLength)` helper using a
total-is-a-multiple rule:

- `total === coordLength` → no slice (2-D meshed grid or flattened nSpatial)
- `total % coordLength === 0 && total > coordLength` → slice dim 0 (covers
  both `[N_lev, nLat, nLon]` and `[N_lev, nSpatial]`)
- otherwise → no slice, best-effort

This correctly handles both truly 2-D gridded data (user's file)
AND the classic packed-level layout (Oracle flagged the earlier,
tighter guard regressed that case).

## Bug 3: 1-D lat/lon axes didn't render at all

The regrid worker expects per-point coords
(`lat.length == lon.length == data.length`).  Files shipping 1-D
`latitude` + `longitude` axes + 2-D `[nLat, nLon]` data — the
standard rectangular-grid layout — previously required a
Python-side meshgrid before they would render.

Fixed by having `fetchCoordinates` auto-detect the layout: when it
sees 1-D axes of length `nLat`/`nLon` and a data variable shaped
`[nLat, nLon]`, it expands them into a full meshgrid before caching.
Already-meshed files pass through unchanged.  Exposed as
`expandAxesIfRectangularGrid` for unit testing.

## Bug 4: GRIB files with no coordinate objects at all

Files straight out of MARS/GRIB often ship no explicit coordinate
objects — only `mars.grid = "regular_ll"` as a metadata hint on each
data variable.  Previously Tensoscope returned null from
`fetchCoordinates` on such files and drew a blank map.

Fixed by adding `inferAxesFromMarsGrid` as a fallback inside
`fetchCoordinates`: when no `latitude`/`longitude` objects are
found, it walks the data variables looking for 2-D shapes with
`mars.grid == 'regular_ll'` and synthesises the axes from:

- shape `[nLat, nLon]`
- `mars.area` `[north, west, south, east]` (default `[90, 0, -90, 360]`)
- endpoint-exclusive longitude when the area wraps a full 360° circle

The synthetic 1-D axes then flow through the Bug-3 fix
(`expandAxesIfRectangularGrid`) to produce the per-point coords the
regrid worker wants.

Unsupported grid kinds (`reduced_gg`, octahedral `O*`, Gaussian `N*`)
return null — their geometry isn't inferrable from shape alone;
they'd need per-point lat/lon arrays in the file or a GRIB grid-
definition lookup that sits outside this thin viewer layer.

## Robustness

- **Multi-message safety.** Coordinate inference + meshgrid expansion
  are now scoped to the requested `msgIdx` via a filtered
  `msgVariables` list, so heterogeneous multi-message files don't
  pick up an axis from the wrong message.  The coord cache is
  per-message (`Map<number, CoordinateData>`), so later messages can
  carry different grids without silently reusing message 0's
  geometry.
- **Overflow-safe `toNumber`.** CBOR-encoded `mars.area` values may
  arrive as `bigint`s; converting via `Number(v)` silently returns
  `Infinity` for very large values.  The helper now returns `null`
  on non-finite results so the caller falls back to the safe
  defaults instead of propagating `Infinity` into the grid.

## Tests

26 new unit tests across four focused suites:

- `groupByParam.test.ts` — 5 tests (integer / string / mixed param
  types, fallback to `variable.name`, multi-step grouping)
- `expandAxes.test.ts` — 5 tests (meshgrid output, missing-variable
  no-op, already-meshed no-op, empty-axis edge cases, 3-D-variable
  filter)
- `inferAxesFromMars.test.ts` — 8 tests (global + regional
  `regular_ll`, full-circle endpoint rule, rejection of unsupported
  grid kinds, missing `mars.grid`, non-2-D variables, first-matching-
  variable selection, `bigint`-overflow fallback)
- `decideSliceDim.test.ts` — 9 tests (2-D meshed no-slice,
  packed-level `[N_lev, nLat, nLon]` slice, classic `[N_lev, nSpatial]`
  slice, rank-4 behaviour, degenerate / mismatched / zero-coord inputs)

All 39 Tensoscope tests pass (13 pre-existing + 26 new).
`npm run build` clean.

## End-to-end verification

A real 164-variable ECMWF April-2026 forecast renders in Tensoscope
in all three supply shapes:

1. **Meshed coordinates shipped in the file** — works (Bug 1 + Bug 2)
2. **1-D axes shipped in the file** — works (+ Bug 3)
3. **Nothing shipped, only `mars.grid = \"regular_ll\"`** — works
   (+ Bug 4) — the original unmodified file

All three produce a global temperature / moisture / wind field with
the expected cold-poles-warm-tropics pattern.  No Python
preprocessing needed.

## Review history

- Oracle round 1: flagged one blocker (packed-level slicing
  regression) + 2 follow-ups (msgIdx scoping, rank-4 test
  overstatement).  All three addressed.
- Copilot: flagged 5 comments — 2 were already addressed in-branch
  (msgIdx scoping), 2 were new and are now fixed (per-message cache,
  `toNumber` Infinity guard), and 1 was a test-count correction in
  this description.

## Grid-kind support matrix (after this PR)

| Grid | Renders? |
|---|:---:|
| `regular_ll` with meshed coord objects | ✅ |
| `regular_ll` with 1-D axis coord objects | ✅ |
| `regular_ll` with no coord objects, only `mars.grid` | ✅ |
| `reduced_gg`, octahedral `O*`, Gaussian `N*` | ❌ (needs per-point coords in the file; tracked as follow-up) |

## Known follow-ups (not in this PR)

- `reduced_gg` / octahedral / Gaussian grid support (needs converter-
  side work in `tensogram-grib` to emit per-point coords).
- Rank-4+ tensor flattening in `selectField` (current behaviour slices
  outermost dim once, leaves rank-3 tensor for rank-4 input).
- Raw `JSON.stringify(metadata)` in `MetadataPanel` /
  `FieldSelector` throws on `bigint` fields — pre-existing,
  unrelated to GRIB rendering.
- Numeric `mars.param` still displays as `object_<idx>` in
  `resolveName` fallback — cosmetic polish.

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-85
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->