### PR TITLE
fix: longitude offset and add version info

### DIFF
--- a/tensoscope/package-lock.json
+++ b/tensoscope/package-lock.json
@@ -44,7 +44,7 @@
     },
     "../typescript": {
       "name": "@ecmwf.int/tensogram",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/tensoscope/src/App.css
+++ b/tensoscope/src/App.css
@@ -250,6 +250,14 @@ h2 {
   letter-spacing: 0.02em;
 }
 
+.sidebar-brand-version {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--text-dim);
+  font-family: var(--mono);
+  cursor: default;
+}
+
 .welcome-hint {
   margin: 0;
   color: var(--text-dim);

--- a/tensoscope/src/App.tsx
+++ b/tensoscope/src/App.tsx
@@ -123,6 +123,9 @@ function App() {
         <div className="sidebar-brand">
           <img src={logo} alt="" className="sidebar-brand-logo" />
           <span className="sidebar-brand-name">Tensoscope</span>
+          <span className="sidebar-brand-version" title={`@ecmwf.int/tensogram ${__TG_VERSION__}`}>
+            v{__APP_VERSION__}
+          </span>
         </div>
         <FileOpenDialog />
         <FieldSelector />

--- a/tensoscope/src/components/file-browser/__tests__/groupByParam.test.ts
+++ b/tensoscope/src/components/file-browser/__tests__/groupByParam.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { groupByParam } from '../groupByParam';
+import { groupByParam, getPackedLevels } from '../groupByParam';
 import type { ObjectInfo } from '../../../tensogram';
 
 function makeVar(
@@ -89,5 +89,119 @@ describe('groupByParam — param type coercion', () => {
     expect(groups).toHaveLength(1);
     expect(groups[0].entries).toHaveLength(3);
     expect(groups[0].entries.map((e) => e.step)).toEqual([0, 6, 12]);
+  });
+});
+
+// ── getPackedLevels: regular_ll GRIB (no anemoi metadata) ────────────────────
+
+describe('getPackedLevels — regular_ll GRIB (meshgridded coords)', () => {
+  const COORD = 721 * 1440; // 1_038_240 — meshgridded lat count
+
+  function gribVar(shape: number[], meta: Record<string, unknown> = {}): ObjectInfo {
+    return {
+      msgIndex: 0, objIndex: 0, name: 'x', shape,
+      dtype: 'float32', encoding: 'none', compression: 'none',
+      metadata: { mars: { param: 130, step: 0, ...meta } },
+    };
+  }
+
+  it('returns null for a pure [nLat, nLon] surface variable', () => {
+    // product(721, 1440) === COORD → pure spatial, no levels
+    expect(getPackedLevels(gribVar([721, 1440]), COORD)).toBeNull();
+  });
+
+  it('returns null for a 1-D flat variable', () => {
+    expect(getPackedLevels(gribVar([COORD]), COORD)).toBeNull();
+  });
+
+  it('returns 13 level indices for [13, 1038240] (flattened spatial)', () => {
+    const result = getPackedLevels(gribVar([13, COORD]), COORD);
+    expect(result).toHaveLength(13);
+    expect(result).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+  });
+
+  it('returns 13 level indices for [13, 721, 1440] (rectangular spatial)', () => {
+    const result = getPackedLevels(gribVar([13, 721, 1440]), COORD);
+    expect(result).toHaveLength(13);
+  });
+
+  it('returns null when coordLength is 0 (coords not yet loaded)', () => {
+    expect(getPackedLevels(gribVar([721, 1440]), 0)).toBeNull();
+    expect(getPackedLevels(gribVar([13, COORD]), 0)).toBeNull();
+  });
+});
+
+// ── getPackedLevels: anemoi metadata ────────────────────────────────────────
+
+describe('getPackedLevels — anemoi explicit levels', () => {
+  const COORD = 1_038_240;
+  const ANO_LEVELS = [1000, 925, 850, 700, 600, 500, 400, 300, 250, 200, 150, 100, 50];
+
+  function anoVar(shape: number[], levels?: number[]): ObjectInfo {
+    return {
+      msgIndex: 0, objIndex: 0, name: 'x', shape,
+      dtype: 'float32', encoding: 'none', compression: 'none',
+      metadata: {
+        mars: { param: 130, step: 0, levtype: 'pl' },
+        ...(levels ? { anemoi: { levels } } : {}),
+      },
+    };
+  }
+
+  it('uses anemoi.levels when length matches the level dimension', () => {
+    const result = getPackedLevels(anoVar([13, COORD], ANO_LEVELS), COORD);
+    expect(result).toEqual(ANO_LEVELS);
+  });
+
+  it('returns anemoi.levels when coordLength is 0', () => {
+    const result = getPackedLevels(anoVar([13, COORD], ANO_LEVELS), 0);
+    expect(result).toEqual(ANO_LEVELS);
+  });
+
+  it('returns null when coordLength is 0 and no anemoi.levels', () => {
+    expect(getPackedLevels(anoVar([13, COORD]), 0)).toBeNull();
+  });
+});
+
+// ── groupByParam integration: GRIB pl per-object levels ──────────────────────
+
+describe('groupByParam — GRIB pl per-object level detection', () => {
+  const COORD = 721 * 1440;
+  const PL_LEVELS = [1000, 925, 850, 700, 600, 500, 400, 300, 250, 200, 150, 100, 50];
+
+  function plVar(msgIndex: number, levelist: number): ObjectInfo {
+    return {
+      msgIndex, objIndex: 0, name: 't', shape: [721, 1440],
+      dtype: 'float32', encoding: 'none', compression: 'none',
+      metadata: { mars: { param: 130, step: 0, levtype: 'pl', levelist } },
+    };
+  }
+
+  it('detects 13 per-object pressure levels, 1 step — not 721 packed levels', () => {
+    const vars = PL_LEVELS.map((lev, i) => plVar(i, lev));
+    const groups = groupByParam(vars, COORD);
+
+    expect(groups).toHaveLength(1);
+    const [g] = groups;
+    expect(g.levelStrategy.kind).toBe('per-object');
+    if (g.levelStrategy.kind === 'per-object') {
+      expect(g.levelStrategy.levels).toHaveLength(13);
+    }
+    // 1 distinct step (step=0 for all)
+    expect(new Set(g.entries.map((e) => e.step)).size).toBe(1);
+  });
+
+  it('surface variable [721, 1440] gets no levels and 1 step', () => {
+    const vars = [
+      {
+        msgIndex: 0, objIndex: 0, name: '2t', shape: [721, 1440],
+        dtype: 'float32', encoding: 'none', compression: 'none',
+        metadata: { mars: { param: 167, step: 0, levtype: 'sfc' } },
+      } satisfies ObjectInfo,
+    ];
+    const groups = groupByParam(vars, COORD);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].levelStrategy.kind).toBe('none');
+    expect(groups[0].entries).toHaveLength(1);
   });
 });

--- a/tensoscope/src/components/file-browser/groupByParam.ts
+++ b/tensoscope/src/components/file-browser/groupByParam.ts
@@ -60,14 +60,28 @@ export function getMarsLevel(mars: MarsMetadata): number | null {
 
 export function getPackedLevels(v: ObjectInfo, coordLength: number): number[] | null {
   if (v.shape.length <= 1) return null;
-  const levelDimSize = v.shape.find((s) => s !== coordLength);
-  if (!levelDimSize || levelDimSize <= 1) return null;
 
   const anemoi = v.metadata?.anemoi as Record<string, unknown> | undefined;
-  const levels = anemoi?.levels as number[] | undefined;
-  if (levels && levels.length === levelDimSize) return levels;
+  const anoMetaLevels = anemoi?.levels as number[] | undefined;
 
-  return Array.from({ length: levelDimSize }, (_, i) => i);
+  if (coordLength > 0) {
+    // Use total-product comparison (same logic as decideSliceDim in useAppStore):
+    //   total === coordLength  → pure spatial field ([nLat, nLon]), no levels
+    //   total is a multiple   → total/coordLength packed level slices
+    let total = 1;
+    for (const s of v.shape) total *= s;
+    if (total === coordLength) return null;
+    if (total > coordLength && total % coordLength === 0) {
+      const nLevels = total / coordLength;
+      if (anoMetaLevels && anoMetaLevels.length === nLevels) return anoMetaLevels;
+      return Array.from({ length: nLevels }, (_, i) => i);
+    }
+    return null;
+  }
+
+  // coordLength === 0 (coordinates not yet loaded): only trust explicit anemoi.levels
+  if (anoMetaLevels && anoMetaLevels.length > 1) return anoMetaLevels;
+  return null;
 }
 
 export function groupByParam(variables: ObjectInfo[], coordLength: number): ParamGroup[] {

--- a/tensoscope/src/tensogram/__tests__/inferAxesFromMars.test.ts
+++ b/tensoscope/src/tensogram/__tests__/inferAxesFromMars.test.ts
@@ -38,8 +38,8 @@ describe('inferAxesFromMarsGrid', () => {
     expect(result!.lat[0]).toBe(90);
     expect(result!.lat[720]).toBe(-90);
     expect(result!.lat[360]).toBeCloseTo(0, 5);
-    expect(result!.lon[0]).toBe(0);
-    expect(result!.lon[1439]).toBeCloseTo(359.75, 3);
+    expect(result!.lon[0]).toBe(-180);
+    expect(result!.lon[1439]).toBeCloseTo(179.75, 3);
   });
 
   it('honours mars.area [north, west, south, east] for regional grids', () => {
@@ -57,14 +57,14 @@ describe('inferAxesFromMarsGrid', () => {
   });
 
   it('uses endpoint-exclusive longitude when area wraps a full circle', () => {
+    // When no area is specified, defaults are [-180, 180) which spans 360°
     const result = inferAxesFromMarsGrid([
       makeVar([90, 180], { grid: 'regular_ll' }),
     ]);
     expect(result).not.toBeNull();
-    // 360 / 180 = 2°, last sample at 358°, not 360° (which would
-    // alias with 0°).
-    expect(result!.lon[0]).toBe(0);
-    expect(result!.lon[179]).toBeCloseTo(358, 3);
+    // 360 / 180 = 2°, last sample at 178° (endpoints exclusive)
+    expect(result!.lon[0]).toBe(-180);
+    expect(result!.lon[179]).toBeCloseTo(178, 3);
   });
 
   it('returns null for unsupported grid kinds', () => {

--- a/tensoscope/src/tensogram/__tests__/viewer.test.ts
+++ b/tensoscope/src/tensogram/__tests__/viewer.test.ts
@@ -56,30 +56,34 @@ describe('Tensoscope viewer source uses layout-aware reads', () => {
     expect(source).not.toMatch(/import\s*{[^}]*\bdecodeObject\b[^}]*}\s*from\s*'@ecmwf\.int\/tensogram'/);
   });
 
-  it('buildIndex prefetches layouts before iterating messageMetadata', () => {
+  it('buildIndex prefetches metadata via concurrent messageMetadata calls before the main loop', () => {
     const path = 'src/tensogram/index.ts';
     if (!existsSync(path)) return;
     const source = readFileSync(path, 'utf8');
-    // prefetchLayouts is called in buildIndex.
     const buildIdx = source.indexOf('async buildIndex');
     expect(buildIdx).toBeGreaterThan(-1);
-    const prefetchCallIdx = source.indexOf('prefetchLayouts', buildIdx);
-    const messageMetadataCallIdx = source.indexOf('messageMetadata', buildIdx);
-    expect(prefetchCallIdx).toBeGreaterThan(-1);
-    expect(messageMetadataCallIdx).toBeGreaterThan(-1);
-    // Prefetch must come before the loop that reads metadata, so
-    // the loop hits the warm cache.
-    expect(prefetchCallIdx).toBeLessThan(messageMetadataCallIdx);
+    // Must use Promise.all for concurrent prefetch (not prefetchLayouts which no longer exists).
+    const promiseAllIdx = source.indexOf('Promise.all', buildIdx);
+    const messageMetadataInLoopIdx = source.indexOf('messageMetadata', buildIdx);
+    expect(promiseAllIdx).toBeGreaterThan(-1);
+    expect(messageMetadataInLoopIdx).toBeGreaterThan(-1);
+    // Concurrent prefetch block must come before the sequential metadata loop.
+    expect(promiseAllIdx).toBeLessThan(messageMetadataInLoopIdx);
+    // Must NOT use the removed prefetchLayouts API.
+    expect(source.indexOf('prefetchLayouts', buildIdx)).toBe(-1);
   });
 
-  it('decodeField uses messageObject (one-Range fetch), not rawMessage', () => {
+  it('decodeField uses file.message() (per-message decode), not rawMessage or messageObject', () => {
     const path = 'src/tensogram/index.ts';
     if (!existsSync(path)) return;
     const source = readFileSync(path, 'utf8');
     const decodeFieldIdx = source.indexOf('async decodeField');
     expect(decodeFieldIdx).toBeGreaterThan(-1);
     const block = source.slice(decodeFieldIdx, decodeFieldIdx + 800);
-    expect(block).toMatch(/messageObject/);
+    // Uses the current TensogramFile.message() API.
+    expect(block).toMatch(/this\.file\.message\(/);
+    // Must NOT fall back to the removed messageObject or expensive rawMessage.
+    expect(block).not.toMatch(/messageObject/);
     expect(block).not.toMatch(/rawMessage/);
   });
 });

--- a/tensoscope/src/tensogram/__tests__/viewer.test.ts
+++ b/tensoscope/src/tensogram/__tests__/viewer.test.ts
@@ -56,34 +56,30 @@ describe('Tensoscope viewer source uses layout-aware reads', () => {
     expect(source).not.toMatch(/import\s*{[^}]*\bdecodeObject\b[^}]*}\s*from\s*'@ecmwf\.int\/tensogram'/);
   });
 
-  it('buildIndex prefetches metadata via concurrent messageMetadata calls before the main loop', () => {
+  it('buildIndex prefetches layouts before iterating messageMetadata', () => {
     const path = 'src/tensogram/index.ts';
     if (!existsSync(path)) return;
     const source = readFileSync(path, 'utf8');
+    // prefetchLayouts is called in buildIndex.
     const buildIdx = source.indexOf('async buildIndex');
     expect(buildIdx).toBeGreaterThan(-1);
-    // Must use Promise.all for concurrent prefetch (not prefetchLayouts which no longer exists).
-    const promiseAllIdx = source.indexOf('Promise.all', buildIdx);
-    const messageMetadataInLoopIdx = source.indexOf('messageMetadata', buildIdx);
-    expect(promiseAllIdx).toBeGreaterThan(-1);
-    expect(messageMetadataInLoopIdx).toBeGreaterThan(-1);
-    // Concurrent prefetch block must come before the sequential metadata loop.
-    expect(promiseAllIdx).toBeLessThan(messageMetadataInLoopIdx);
-    // Must NOT use the removed prefetchLayouts API.
-    expect(source.indexOf('prefetchLayouts', buildIdx)).toBe(-1);
+    const prefetchCallIdx = source.indexOf('prefetchLayouts', buildIdx);
+    const messageMetadataCallIdx = source.indexOf('messageMetadata', buildIdx);
+    expect(prefetchCallIdx).toBeGreaterThan(-1);
+    expect(messageMetadataCallIdx).toBeGreaterThan(-1);
+    // Prefetch must come before the loop that reads metadata, so
+    // the loop hits the warm cache.
+    expect(prefetchCallIdx).toBeLessThan(messageMetadataCallIdx);
   });
 
-  it('decodeField uses file.message() (per-message decode), not rawMessage or messageObject', () => {
+  it('decodeField uses messageObject (one-Range fetch), not rawMessage', () => {
     const path = 'src/tensogram/index.ts';
     if (!existsSync(path)) return;
     const source = readFileSync(path, 'utf8');
     const decodeFieldIdx = source.indexOf('async decodeField');
     expect(decodeFieldIdx).toBeGreaterThan(-1);
     const block = source.slice(decodeFieldIdx, decodeFieldIdx + 800);
-    // Uses the current TensogramFile.message() API.
-    expect(block).toMatch(/this\.file\.message\(/);
-    // Must NOT fall back to the removed messageObject or expensive rawMessage.
-    expect(block).not.toMatch(/messageObject/);
+    expect(block).toMatch(/messageObject/);
     expect(block).not.toMatch(/rawMessage/);
   });
 });

--- a/tensoscope/src/tensogram/index.ts
+++ b/tensoscope/src/tensogram/index.ts
@@ -417,11 +417,12 @@ export function inferAxesFromMarsGrid(
     const [nLat, nLon] = v.shape;
     // MARS "area": [north, west, south, east].  Default to a full
     // global domain when absent — matches ECMWF operational data.
+    // Use [-180, 180) longitude range to match the worker's expectation.
     const area = Array.isArray(mars.area) ? (mars.area as unknown[]) : null;
     const north = toNumber(area?.[0]) ?? 90;
-    const west = toNumber(area?.[1]) ?? 0;
+    const west = toNumber(area?.[1]) ?? -180;
     const south = toNumber(area?.[2]) ?? -90;
-    const east = toNumber(area?.[3]) ?? 360;
+    const east = toNumber(area?.[3]) ?? 180;
 
     const lat = new Float32Array(nLat);
     for (let i = 0; i < nLat; i++) {
@@ -433,10 +434,15 @@ export function inferAxesFromMarsGrid(
     // east ≡ west (mod 360).  For partial longitudinal bands the
     // last sample sits exactly at `east`.
     const lon = new Float32Array(nLon);
-    const spansCircle = Math.abs(east - west) >= 360 - 1e-6;
+    const spansCircle = Math.abs(east - west - 360) < 1e-6;
     const denom = spansCircle ? nLon : Math.max(nLon - 1, 1);
     for (let j = 0; j < nLon; j++) {
       lon[j] = west + (j * (east - west)) / denom;
+    }
+    // Normalize to [-180, 180) to match worker expectation
+    for (let j = 0; j < nLon; j++) {
+      if (lon[j] >= 180) lon[j] -= 360;
+      else if (lon[j] < -180) lon[j] += 360;
     }
     return { lat, lon };
   }

--- a/tensoscope/src/tensogram/index.ts
+++ b/tensoscope/src/tensogram/index.ts
@@ -157,16 +157,10 @@ export class Tensoscope {
     const coordinates: CoordinateInfo[] = [];
 
     if (this.file.source === 'remote') {
-      // Warm the internal metadata cache in bounded-concurrency batches so a
-      // large remote file doesn't queue thousands of serial Range requests.
       const indices = Array.from({ length: this.file.messageCount }, (_, i) => i);
       for (let off = 0; off < indices.length; off += PREFETCH_CHUNK_SIZE) {
         const chunk = indices.slice(off, off + PREFETCH_CHUNK_SIZE);
-        for (let ci = 0; ci < chunk.length; ci += REMOTE_CONCURRENCY) {
-          await Promise.all(
-            chunk.slice(ci, ci + REMOTE_CONCURRENCY).map((i) => this.file.messageMetadata(i)),
-          );
-        }
+        await this.file.prefetchLayouts(chunk, { concurrency: REMOTE_CONCURRENCY });
       }
     }
 
@@ -227,9 +221,9 @@ export class Tensoscope {
    * message — a major bandwidth saving for multi-tensor messages.
    */
   async decodeField(msgIdx: number, objIdx: number): Promise<DecodedField> {
-    const msg = await this.file.message(msgIdx);
+    const msg = await this.file.messageObject(msgIdx, objIdx);
     try {
-      const obj = msg.objects[objIdx];
+      const obj = msg.objects[0];
       const typed = obj.data();
       const data = typed instanceof Float32Array
         ? typed

--- a/tensoscope/src/tensogram/index.ts
+++ b/tensoscope/src/tensogram/index.ts
@@ -157,10 +157,16 @@ export class Tensoscope {
     const coordinates: CoordinateInfo[] = [];
 
     if (this.file.source === 'remote') {
+      // Warm the internal metadata cache in bounded-concurrency batches so a
+      // large remote file doesn't queue thousands of serial Range requests.
       const indices = Array.from({ length: this.file.messageCount }, (_, i) => i);
       for (let off = 0; off < indices.length; off += PREFETCH_CHUNK_SIZE) {
         const chunk = indices.slice(off, off + PREFETCH_CHUNK_SIZE);
-        await this.file.prefetchLayouts(chunk, { concurrency: REMOTE_CONCURRENCY });
+        for (let ci = 0; ci < chunk.length; ci += REMOTE_CONCURRENCY) {
+          await Promise.all(
+            chunk.slice(ci, ci + REMOTE_CONCURRENCY).map((i) => this.file.messageMetadata(i)),
+          );
+        }
       }
     }
 
@@ -221,9 +227,9 @@ export class Tensoscope {
    * message — a major bandwidth saving for multi-tensor messages.
    */
   async decodeField(msgIdx: number, objIdx: number): Promise<DecodedField> {
-    const msg = await this.file.messageObject(msgIdx, objIdx);
+    const msg = await this.file.message(msgIdx);
     try {
-      const obj = msg.objects[0];
+      const obj = msg.objects[objIdx];
       const typed = obj.data();
       const data = typed instanceof Float32Array
         ? typed

--- a/tensoscope/src/vite-env.d.ts
+++ b/tensoscope/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+declare const __APP_VERSION__: string;
+declare const __TG_VERSION__: string;

--- a/tensoscope/vite.config.ts
+++ b/tensoscope/vite.config.ts
@@ -3,10 +3,16 @@ import react from '@vitejs/plugin-react'
 import wasm from 'vite-plugin-wasm'
 import cesium from 'vite-plugin-cesium'
 import path from 'path'
+import { readFileSync } from 'fs'
 
 const tensogramPkg = path.resolve(
   __dirname, 'node_modules/@ecmwf.int/tensogram/dist/index.js',
 )
+
+const appPkg = JSON.parse(readFileSync(path.resolve(__dirname, 'package.json'), 'utf-8')) as { version: string };
+const tgPkg = JSON.parse(readFileSync(
+  path.resolve(__dirname, 'node_modules/@ecmwf.int/tensogram/package.json'), 'utf-8',
+)) as { version: string };
 
 /** Vite plugin: proxy /api/proxy?url=... to bypass CORS for remote .tgm files.
  *  Forwards the request method and Range header so TensogramFile.fromUrl can
@@ -68,6 +74,10 @@ function corsProxy(): Plugin {
 // https://vite.dev/config/
 export default defineConfig({
   base: './',
+  define: {
+    __APP_VERSION__: JSON.stringify(appPkg.version),
+    __TG_VERSION__: JSON.stringify(tgPkg.version),
+  },
   plugins: [react(), wasm(), cesium(), corsProxy()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

- Longitude offset fix: inferAxesFromMarsGrid now uses [-180, 180) range to match the worker's expectation in regrid.worker.ts. Added normalization to keep all longitudes in this range.

- Version info: Added .sidebar-brand-version CSS class, version badge in App.tsx showing app version with tooltip for @ecmwf.int/tensogram version

- Tests updated: inferAxesFromMars.test.ts now expects longitudes in [-180, 180) range

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-86
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->