### PR TITLE
fix: emit mars.area from tensogram-grib so regular_ll grids render correctly in Tensoscope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,11 @@ convention and guessed the wrong one.
   dateline-crossing regional subdomains).  Non-`regular_ll` grids
   (`reduced_gg`, octahedral `O*`, Gaussian `N*`) are unchanged.
 - **Tensoscope** reads `mars.area` when present.  For legacy files
-  without it, the inference fallback default flipped from
-  `[0, 360]` to `[-180, 180]` (a documented compatibility bridge)
-  with a one-shot `console.warn` explaining how to re-convert for
-  accurate geometry.
+  without it, the inference fallback is now formalised as a named
+  `DEFAULT_REGULAR_LL_AREA` constant (the `[-180, 180]` dateline-
+  first default already landed in #86) and emits a one-shot
+  `console.warn` the first time the fallback fires, explaining
+  how to re-convert for accurate geometry.
 
 ## [0.18.1] - 2026-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,33 @@
 All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Fixed — `regular_ll` longitude convention
+
+GRIB-derived `.tgm` files from ECMWF open-data (where the grid scans
+from the dateline eastwards, `longitudeOfFirstGridPointInDegrees =
+180`) rendered 180° off in Tensoscope — Sahara appeared where the
+Pacific should be and vice versa.  Root cause: the converter lifted
+only the ecCodes `mars` namespace, which does not include the grid's
+corner coordinates, so the viewer had to guess the longitude
+convention and guessed the wrong one.
+
+- **`tensogram-grib`** now lifts the four `regular_ll` corner-point
+  keys from the `geography` namespace and emits a canonical
+  `mars.area = [N, W, S, E]` alongside `mars.grid`.  A new pure
+  helper `compute_regular_ll_area` handles the one unambiguous
+  normalisation (full-global dateline-first → `west = -180`) and
+  refuses everything else it cannot express as a monotone
+  `[N, W, S, E]` tuple (non-standard scan modes,
+  dateline-crossing regional subdomains).  Non-`regular_ll` grids
+  (`reduced_gg`, octahedral `O*`, Gaussian `N*`) are unchanged.
+- **Tensoscope** reads `mars.area` when present.  For legacy files
+  without it, the inference fallback default flipped from
+  `[0, 360]` to `[-180, 180]` (a documented compatibility bridge)
+  with a one-shot `console.warn` explaining how to re-convert for
+  accurate geometry.
+
 ## [0.18.1] - 2026-04-23
 
 ### Added — Tensoscope: render GRIB-derived `.tgm` files without preprocessing

--- a/docs/src/grib/metadata-mapping.md
+++ b/docs/src/grib/metadata-mapping.md
@@ -39,17 +39,52 @@ The importer reads the following MARS namespace keys from each GRIB message usin
 | `stepUnits` | Step units | `1` (hours) |
 
 ### Spatial
-| GRIB Key | Description | Example |
-|----------|-------------|---------|
-| `gridType` | Grid type | `"regular_ll"` |
-| `Ni`, `Nj` | Grid dimensions | `360`, `181` |
-| `numberOfPoints` | Total grid points | `65160` |
-| `latitudeOfFirstGridPointInDegrees` | First latitude | `90.0` |
-| `longitudeOfFirstGridPointInDegrees` | First longitude | `0.0` |
-| `latitudeOfLastGridPointInDegrees` | Last latitude | `-90.0` |
-| `longitudeOfLastGridPointInDegrees` | Last longitude | `359.0` |
-| `iDirectionIncrementInDegrees` | Longitude step | `1.0` |
-| `jDirectionIncrementInDegrees` | Latitude step | `1.0` |
+
+The grid type is read from outside the MARS namespace and stored as
+`mars.grid` as a convenience (not a standard MARS key):
+
+| GRIB Key | Stored as | Description | Example |
+|----------|-----------|-------------|---------|
+| `gridType` | `mars.grid` | Grid type | `"regular_ll"` |
+
+For `regular_ll` grids with standard scan mode (`iScansNegatively = 0`,
+`jScansPositively = 0`), the four corner-point keys from the ecCodes
+`geography` namespace are also lifted into a canonical
+`mars.area = [N, W, S, E]`:
+
+| ecCodes key | Role | Example (0.25° global, dateline-first) |
+|----------|------|---------|
+| `latitudeOfFirstGridPointInDegrees` | → `N` | `90.0` |
+| `longitudeOfFirstGridPointInDegrees` | → `W` (see normalisation) | raw `180.0` → `-180.0` |
+| `latitudeOfLastGridPointInDegrees` | → `S` | `-90.0` |
+| `longitudeOfLastGridPointInDegrees` | → `E` | `179.75` |
+
+**Full-global dateline-first normalisation.**  ECMWF open-data GRIB
+encodes full-global grids as `longitudeOfFirstGridPointInDegrees =
+180` (first point at the dateline, scanning eastwards through
+Greenwich).  The MARS-area convention wants a monotone `W ≤ E` range,
+so the importer subtracts `360` from the raw `W` when the grid
+provably spans a full circle (`Ni × iDirectionIncrementInDegrees ≈
+360`), yielding `[-180, 179.75]` instead of the raw `[180, 179.75]`.
+This is the only normalisation applied; everything else passes
+through unchanged.  See `rust/tensogram-grib/src/area.rs` for the
+pure helper and its test matrix.
+
+**When `mars.area` is NOT emitted.**  The converter refuses (and omits
+`mars.area`) when any of the following holds — non-standard scan
+(`iScansNegatively != 0` or `jScansPositively != 0`, or either key
+missing from the GRIB), missing or NaN corner keys, `Ni < 2`,
+`i_direction_increment <= 0`, degenerate `W == E` or `N == S`,
+inverted latitudes (`lat_first < lat_last`), or a dateline-crossing
+regional subdomain that cannot be expressed as a monotone `[W, E]`.
+Non-`regular_ll` grids (`reduced_gg`, octahedral `O*`, Gaussian
+`N*`) never get a `mars.area`: their geography cannot be captured as
+four corners.
+
+The full raw geography namespace (including `Ni`, `Nj`,
+`numberOfPoints`, `iDirectionIncrementInDegrees`, etc.) is lifted
+into `base[i]["grib"]["geography"]` only when the converter is
+called with `preserve_all_keys=true`.
 
 ### Other
 | GRIB Key | Description | Example |

--- a/plans/DONE.md
+++ b/plans/DONE.md
@@ -655,6 +655,17 @@ comparison against ecCodes.
 - Honours shared `PipelineArgs` via the `apply_pipeline` helper, so
   `--encoding/--bits/--filter/--compression/--compression-level`
   produce descriptors byte-identical to `convert-netcdf`.
+- For `regular_ll` grids with standard scan mode, lifts the four
+  corner-point keys from the `geography` namespace into a canonical
+  `mars.area = [N, W, S, E]` via the pure helper
+  `compute_regular_ll_area` (module `area.rs`).  The only normalisation
+  applied is the full-global dateline-first case (raw ecCodes
+  `lon_first = 180, lon_last = 179.75` on a 0.25° grid, as used by
+  ECMWF open-data) which is shifted to `west = -180, east = 179.75`;
+  non-standard scan, dateline-crossing regional subdomains,
+  non-`regular_ll` grids, and degenerate inputs are all rejected (no
+  `mars.area` emitted), leaving downstream consumers free to either
+  fall back to a compat default or refuse to render.
 
 ## `tensogram-xarray`
 
@@ -742,6 +753,20 @@ comparison against ecCodes.
   marching-squares algorithm is required.
 - **State.** Zustand store (`useAppStore.ts`) owns selected file, field,
   step, and colour scale.
+- **Coordinate inference.** For GRIB-derived files that ship no
+  explicit latitude / longitude coordinate objects,
+  `inferAxesFromMarsGrid` synthesises 1-D axes from
+  `mars.grid = "regular_ll"` + `mars.area` (emitted by
+  `tensogram-grib` for supported grids) or, failing that, from a
+  documented compatibility-bridge default — `[N=90, W=-180, S=-90,
+  E=180]`, chosen to match the ECMWF open-data dateline-first
+  convention that is the common source of such files.  A one-shot
+  `console.warn` fires when the bridge default is used so the
+  provenance gap is visible.  `expandAxesIfRectangularGrid`
+  meshgrids the 1-D axes into per-point arrays for the regrid
+  worker.  Non-`regular_ll` grids (`reduced_gg`, octahedral `O*`,
+  Gaussian `N*`) return `null` — their geometry cannot be inferred
+  from shape alone.
 - **Deployment.** nginx Docker image; `BASE_PATH` env var for subpath
   deployments. Makefile targets: `build`, `push`, `run`, `stop`.
 

--- a/python/tests/test_convert_grib.py
+++ b/python/tests/test_convert_grib.py
@@ -117,6 +117,29 @@ def test_convert_grib_mars_keys_present() -> None:
 
 
 @requires_grib
+def test_convert_grib_emits_mars_area_for_regular_ll() -> None:
+    """``regular_ll`` files carry a canonical ``mars.area = [N, W, S, E]``.
+
+    The Tensoscope viewer consumes this tuple to place data on a map.
+    Without it, Tensoscope renders ECMWF open-data files 180° off —
+    this test pins the converter-side fix (see
+    ``rust/tensogram-grib/src/area.rs``).
+
+    Bundled fixtures are all dateline-first full-global scans, so the
+    normalisation path turns raw ``lon_first = 180`` into ``W = -180``.
+    """
+    messages = tensogram.convert_grib(str(_testdata("2t.grib2")))
+    meta = tensogram.decode_metadata(messages[0])
+    mars = meta.base[0].get("mars")
+    assert isinstance(mars, dict)
+    assert "area" in mars, "regular_ll fixture must emit mars.area"
+    area = mars["area"]
+    assert isinstance(area, list), f"mars.area must be a list, got {type(area).__name__}"
+    assert len(area) == 4, f"mars.area must have 4 elements, got {len(area)}"
+    assert area == [90.0, -180.0, -90.0, 179.75]
+
+
+@requires_grib
 def test_preserve_all_keys_populates_grib_namespace() -> None:
     """``preserve_all_keys=True`` lifts non-MARS namespaces into ``base[i]["grib"]``."""
     messages = tensogram.convert_grib(

--- a/rust/tensogram-grib/src/area.rs
+++ b/rust/tensogram-grib/src/area.rs
@@ -1,0 +1,327 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+//! Canonical `[N, W, S, E]` area computation for `regular_ll` GRIB grids.
+//!
+//! The Tensoscope viewer and downstream xarray/zarr readers consume
+//! `mars.area = [N, W, S, E]`.  This module turns the raw ecCodes
+//! `geography` corner keys (`latitudeOfFirstGridPointInDegrees` etc.)
+//! into that tuple.
+//!
+//! Only one normalisation is applied: a full-global dateline-first scan
+//! (`lon_first = 180, lon_last = 179.75` on a 0.25° grid, as used by
+//! ECMWF open-data) is shifted to `west = -180` so the axis is monotone
+//! in `[-180, +E]`.
+//!
+//! # Why refuse instead of guess for other `west > east` cases?
+//!
+//! A dateline-crossing regional subdomain — e.g. `(lon_first = 170,
+//! lon_last = -170, Ni = 80)` — cannot be represented as a single
+//! monotone axis in either `[-180, 180]` or `[0, 360]`.  The Tensoscope
+//! regrid worker normalises `lon > 180 → lon − 360` but does not handle
+//! `lon < -180`, so a naive `lon_first -= 360` there produces a wrapped
+//! axis the worker mis-bins.  The only correct answer for such grids is
+//! per-point lat/lon emission, which is out of scope for this pass.
+//! Returning `None` lets the caller either fall back to a compat default
+//! (legacy-file bridge) or skip emitting `mars.area`, rather than produce
+//! a silently-wrong area that renders nicely but is half a world off.
+
+/// Inputs required to compute the canonical area of a `regular_ll` grid.
+///
+/// Field names mirror the ecCodes `geography` namespace key names
+/// one-for-one so the call site in `converter.rs` is a trivial shuffle.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct RegularLlGeometry {
+    pub(crate) lat_first: f64,
+    pub(crate) lon_first: f64,
+    pub(crate) lat_last: f64,
+    pub(crate) lon_last: f64,
+    pub(crate) i_scans_negatively: i64,
+    pub(crate) j_scans_positively: i64,
+    pub(crate) ni: i64,
+    pub(crate) i_direction_increment: f64,
+}
+
+/// Compute `[north, west, south, east]` from a `regular_ll` grid's
+/// geometry keys.  See the module docstring for the `west > east` rule.
+///
+/// Returns `Some([N, W, S, E])` exactly when all of:
+/// - all four corner values + the increment are finite,
+/// - `i_scans_negatively == 0` and `j_scans_positively == 0`,
+/// - `ni >= 2` and `i_direction_increment > 0`,
+/// - after optional normalisation, `north > south` and `west < east`.
+pub(crate) fn compute_regular_ll_area(g: RegularLlGeometry) -> Option<[f64; 4]> {
+    if g.i_scans_negatively != 0 || g.j_scans_positively != 0 {
+        return None;
+    }
+    if !g.lat_first.is_finite()
+        || !g.lon_first.is_finite()
+        || !g.lat_last.is_finite()
+        || !g.lon_last.is_finite()
+        || !g.i_direction_increment.is_finite()
+    {
+        return None;
+    }
+    if g.ni < 2 || g.i_direction_increment <= 0.0 {
+        return None;
+    }
+
+    let north = g.lat_first;
+    let south = g.lat_last;
+    let mut west = g.lon_first;
+    let east = g.lon_last;
+
+    // Antimeridian-crossing branch: only the full-global dateline-first
+    // case has an unambiguous [-180, E] representation — regional subdomains
+    // that cross the dateline need per-point coords, not an [N,W,S,E] tuple.
+    // We also require that the shifted span matches the sample spacing
+    // (`east − west_shifted ≈ (ni − 1) × inc`) so a file with inconsistent
+    // corner metadata (e.g. `w=10, e=5` with `ni=360, inc=1`) is refused
+    // even though `ni × inc ≈ 360` alone might have accepted it.
+    if west > east {
+        if !is_full_global_i(g.ni, g.i_direction_increment) {
+            return None;
+        }
+        let shifted_span = east - (west - 360.0);
+        let expected_span = (g.ni - 1) as f64 * g.i_direction_increment;
+        if (shifted_span - expected_span).abs() >= 0.5 * g.i_direction_increment {
+            return None;
+        }
+        west -= 360.0;
+    }
+
+    if north <= south || west >= east {
+        return None;
+    }
+
+    Some([north, west, south, east])
+}
+
+/// True when `ni × i_direction_increment` covers a full 360° circle,
+/// within a half-increment tolerance.  The tolerance accommodates f64
+/// round-off for non-representable increments like `0.1` (where
+/// `3600 × 0.1 = 360.00000000000006` on IEEE-754).
+fn is_full_global_i(ni: i64, i_direction_increment: f64) -> bool {
+    let span = (ni as f64) * i_direction_increment;
+    (span - 360.0).abs() < 0.5 * i_direction_increment
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn quarter_degree_global(lon_first: f64, lon_last: f64) -> RegularLlGeometry {
+        RegularLlGeometry {
+            lat_first: 90.0,
+            lat_last: -90.0,
+            lon_first,
+            lon_last,
+            i_scans_negatively: 0,
+            j_scans_positively: 0,
+            ni: 1440,
+            i_direction_increment: 0.25,
+        }
+    }
+
+    #[test]
+    fn dateline_first_global_normalises() {
+        assert_eq!(
+            compute_regular_ll_area(quarter_degree_global(180.0, 179.75)),
+            Some([90.0, -180.0, -90.0, 179.75]),
+        );
+    }
+
+    #[test]
+    fn greenwich_first_global_no_normalise() {
+        assert_eq!(
+            compute_regular_ll_area(quarter_degree_global(0.0, 359.75)),
+            Some([90.0, 0.0, -90.0, 359.75]),
+        );
+    }
+
+    #[test]
+    fn half_degree_grid_also_normalises() {
+        let g = RegularLlGeometry {
+            lat_first: 90.0,
+            lat_last: -90.0,
+            lon_first: 180.0,
+            lon_last: 179.5,
+            i_scans_negatively: 0,
+            j_scans_positively: 0,
+            ni: 720,
+            i_direction_increment: 0.5,
+        };
+        assert_eq!(
+            compute_regular_ll_area(g),
+            Some([90.0, -180.0, -90.0, 179.5]),
+        );
+    }
+
+    #[test]
+    fn tenth_degree_grid_tolerates_f64_roundoff() {
+        let g = RegularLlGeometry {
+            lat_first: 90.0,
+            lat_last: -90.0,
+            lon_first: 180.0,
+            lon_last: 179.9,
+            i_scans_negatively: 0,
+            j_scans_positively: 0,
+            ni: 3600,
+            i_direction_increment: 0.1,
+        };
+        let area = compute_regular_ll_area(g).expect("0.1° global must succeed");
+        assert!((area[1] - (-180.0)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn greenwich_first_subdomain_passes_through() {
+        let g = RegularLlGeometry {
+            lat_first: 70.0,
+            lat_last: 30.0,
+            lon_first: -30.0,
+            lon_last: 50.0,
+            i_scans_negatively: 0,
+            j_scans_positively: 0,
+            ni: 321,
+            i_direction_increment: 0.25,
+        };
+        assert_eq!(compute_regular_ll_area(g), Some([70.0, -30.0, 30.0, 50.0]));
+    }
+
+    #[test]
+    fn dateline_crossing_regional_bails() {
+        // W > E with Ni × inc = 20.25° ≠ 360° — narrow-rule refuses.
+        let g = RegularLlGeometry {
+            lat_first: 60.0,
+            lat_last: -60.0,
+            lon_first: 170.0,
+            lon_last: -170.0,
+            i_scans_negatively: 0,
+            j_scans_positively: 0,
+            ni: 81,
+            i_direction_increment: 0.25,
+        };
+        assert_eq!(compute_regular_ll_area(g), None);
+    }
+
+    #[test]
+    fn inconsistent_endpoints_bail_even_when_full_global_in_ni() {
+        // Pathological metadata that the `ni × inc ≈ 360` check alone
+        // would have accepted: the endpoint-consistency guard rejects it.
+        // `w=10, e=5, ni=360, inc=1` — after shift `w=-350`, shifted-span
+        // would be 355°, expected `(ni-1)*inc = 359°`.  Mismatch > half an
+        // increment → bail.
+        let g = RegularLlGeometry {
+            lat_first: 90.0,
+            lat_last: -90.0,
+            lon_first: 10.0,
+            lon_last: 5.0,
+            i_scans_negatively: 0,
+            j_scans_positively: 0,
+            ni: 360,
+            i_direction_increment: 1.0,
+        };
+        assert_eq!(compute_regular_ll_area(g), None);
+    }
+
+    #[test]
+    fn non_standard_i_scan_bails() {
+        let mut g = quarter_degree_global(180.0, 179.75);
+        g.i_scans_negatively = 1;
+        assert_eq!(compute_regular_ll_area(g), None);
+    }
+
+    #[test]
+    fn non_standard_j_scan_bails() {
+        let mut g = quarter_degree_global(180.0, 179.75);
+        g.j_scans_positively = 1;
+        assert_eq!(compute_regular_ll_area(g), None);
+    }
+
+    #[test]
+    fn nan_lat_bails() {
+        let mut g = quarter_degree_global(180.0, 179.75);
+        g.lat_first = f64::NAN;
+        assert_eq!(compute_regular_ll_area(g), None);
+    }
+
+    #[test]
+    fn nan_lon_bails() {
+        let mut g = quarter_degree_global(180.0, 179.75);
+        g.lon_last = f64::NAN;
+        assert_eq!(compute_regular_ll_area(g), None);
+    }
+
+    #[test]
+    fn infinite_increment_bails() {
+        let mut g = quarter_degree_global(180.0, 179.75);
+        g.i_direction_increment = f64::INFINITY;
+        assert_eq!(compute_regular_ll_area(g), None);
+    }
+
+    #[test]
+    fn zero_increment_bails() {
+        let mut g = quarter_degree_global(180.0, 179.75);
+        g.i_direction_increment = 0.0;
+        assert_eq!(compute_regular_ll_area(g), None);
+    }
+
+    #[test]
+    fn negative_increment_bails() {
+        let mut g = quarter_degree_global(180.0, 179.75);
+        g.i_direction_increment = -0.25;
+        assert_eq!(compute_regular_ll_area(g), None);
+    }
+
+    #[test]
+    fn single_column_grid_bails() {
+        let mut g = quarter_degree_global(0.0, 0.0);
+        g.ni = 1;
+        assert_eq!(compute_regular_ll_area(g), None);
+    }
+
+    #[test]
+    fn degenerate_west_equals_east_bails() {
+        assert_eq!(
+            compute_regular_ll_area(quarter_degree_global(10.0, 10.0)),
+            None,
+        );
+    }
+
+    #[test]
+    fn degenerate_north_equals_south_bails() {
+        let mut g = quarter_degree_global(0.0, 359.75);
+        g.lat_first = 45.0;
+        g.lat_last = 45.0;
+        assert_eq!(compute_regular_ll_area(g), None);
+    }
+
+    #[test]
+    fn inverted_latitudes_bail() {
+        // Standard scan (jScansPositively = 0) requires lat_first > lat_last.
+        let mut g = quarter_degree_global(0.0, 359.75);
+        g.lat_first = -90.0;
+        g.lat_last = 90.0;
+        assert_eq!(compute_regular_ll_area(g), None);
+    }
+
+    #[test]
+    fn full_global_test_accepts_exact_and_roundoff() {
+        assert!(is_full_global_i(1440, 0.25));
+        assert!(is_full_global_i(720, 0.5));
+        assert!(is_full_global_i(360, 1.0));
+        assert!(is_full_global_i(3600, 0.1));
+    }
+
+    #[test]
+    fn full_global_test_rejects_regional() {
+        assert!(!is_full_global_i(81, 0.25));
+        assert!(!is_full_global_i(720, 0.25));
+        assert!(!is_full_global_i(719, 0.5));
+    }
+}

--- a/rust/tensogram-grib/src/converter.rs
+++ b/rust/tensogram-grib/src/converter.rs
@@ -143,11 +143,12 @@ fn extract_messages<D: Debug>(
         }
 
         // For regular_ll grids, also lift the geography corner keys into
-        // `mars.area = [N, W, S, E]` (via `compute_regular_ll_area`).  This
-        // is what the Tensoscope viewer consumes to place data on the map;
-        // without it the viewer has to fall back to a guessed default
-        // convention, which misrenders ECMWF open-data (dateline-first)
-        // files by 180°.
+        // `mars.area = [N, W, S, E]` (via `compute_regular_ll_area`).  The
+        // Tensoscope viewer consumes this to place data on the map; without
+        // it the geometry is ambiguous, and the viewer's compat-bridge
+        // default will misrender any file whose scan convention differs
+        // from its default (e.g. Greenwich-first files under a dateline-
+        // first default, or vice versa).
         if grid_type.as_deref() == Some("regular_ll") {
             let geo = RegularLlGeometry {
                 lat_first: msg

--- a/rust/tensogram-grib/src/converter.rs
+++ b/rust/tensogram-grib/src/converter.rs
@@ -17,6 +17,7 @@ use tensogram::pipeline::apply_pipeline;
 use tensogram::types::{ByteOrder, DataObjectDescriptor, GlobalMetadata};
 use tensogram::{DataPipeline, Dtype, EncodeOptions, encode};
 
+use crate::area::{RegularLlGeometry, compute_regular_ll_area};
 use crate::error::GribError;
 use crate::metadata::{GribKeySet, extract_all_namespace_keys, extract_mars_keys};
 
@@ -135,9 +136,45 @@ fn extract_messages<D: Debug>(
 
         // gridType is outside the MARS namespace — read it separately
         // and store as "grid" within the mars key set.
-        if let Ok(grid_type) = KeyRead::<String>::read_key(&msg, "gridType") {
+        let grid_type: Option<String> = KeyRead::<String>::read_key(&msg, "gridType").ok();
+        if let Some(gt) = &grid_type {
             keys.keys
-                .insert("grid".to_string(), CborValue::Text(grid_type));
+                .insert("grid".to_string(), CborValue::Text(gt.clone()));
+        }
+
+        // For regular_ll grids, also lift the geography corner keys into
+        // `mars.area = [N, W, S, E]` (via `compute_regular_ll_area`).  This
+        // is what the Tensoscope viewer consumes to place data on the map;
+        // without it the viewer has to fall back to a guessed default
+        // convention, which misrenders ECMWF open-data (dateline-first)
+        // files by 180°.
+        if grid_type.as_deref() == Some("regular_ll") {
+            let geo = RegularLlGeometry {
+                lat_first: msg
+                    .read_key("latitudeOfFirstGridPointInDegrees")
+                    .unwrap_or(f64::NAN),
+                lon_first: msg
+                    .read_key("longitudeOfFirstGridPointInDegrees")
+                    .unwrap_or(f64::NAN),
+                lat_last: msg
+                    .read_key("latitudeOfLastGridPointInDegrees")
+                    .unwrap_or(f64::NAN),
+                lon_last: msg
+                    .read_key("longitudeOfLastGridPointInDegrees")
+                    .unwrap_or(f64::NAN),
+                i_scans_negatively: msg.read_key("iScansNegatively").unwrap_or(-1),
+                j_scans_positively: msg.read_key("jScansPositively").unwrap_or(-1),
+                ni: msg.read_key("Ni").unwrap_or(0),
+                i_direction_increment: msg
+                    .read_key("iDirectionIncrementInDegrees")
+                    .unwrap_or(f64::NAN),
+            };
+            if let Some(area) = compute_regular_ll_area(geo) {
+                keys.keys.insert(
+                    "area".to_string(),
+                    CborValue::Array(area.into_iter().map(CborValue::Float).collect()),
+                );
+            }
         }
 
         // Optionally extract all non-mars namespace keys.

--- a/rust/tensogram-grib/src/lib.rs
+++ b/rust/tensogram-grib/src/lib.rs
@@ -20,6 +20,7 @@
 //! apt install libeccodes-dev # Debian/Ubuntu
 //! ```
 
+pub mod area;
 pub mod converter;
 pub mod error;
 pub mod metadata;

--- a/rust/tensogram-grib/src/lib.rs
+++ b/rust/tensogram-grib/src/lib.rs
@@ -20,7 +20,7 @@
 //! apt install libeccodes-dev # Debian/Ubuntu
 //! ```
 
-pub mod area;
+mod area;
 pub mod converter;
 pub mod error;
 pub mod metadata;

--- a/rust/tensogram-grib/tests/integration.rs
+++ b/rust/tensogram-grib/tests/integration.rs
@@ -661,3 +661,94 @@ fn test_empty_grib_file_error() {
     // ecCodes should find no messages or return an error
     assert!(result.is_err(), "empty/invalid GRIB file should fail");
 }
+
+// ──────────────────────────────────────────────────────────────────────
+// 18. test_mars_area_regular_ll_emitted (+ friends)
+// ──────────────────────────────────────────────────────────────────────
+
+/// Unpack `mars.area` into `[f64; 4]`.  Returns `None` if the CBOR shape
+/// doesn't match the 4-float array contract emitted by
+/// `compute_regular_ll_area` — which is itself a test-worthy invariant.
+fn mars_area_as_f64s(mars: &CborValue) -> Option<[f64; 4]> {
+    let CborValue::Array(items) = cbor_map_get(mars, "area")? else {
+        return None;
+    };
+    if items.len() != 4 {
+        return None;
+    }
+    let mut out = [0.0; 4];
+    for (i, item) in items.iter().enumerate() {
+        let CborValue::Float(f) = item else {
+            return None;
+        };
+        out[i] = *f;
+    }
+    Some(out)
+}
+
+/// Every bundled regular_ll fixture must emit the same canonical
+/// `mars.area`.  They are all 0.25° global dateline-first scans
+/// (`longitudeOfFirstGridPointInDegrees = 180`,
+/// `longitudeOfLastGridPointInDegrees = 179.75`), which
+/// `compute_regular_ll_area` normalises to `W = -180`.
+#[test]
+fn test_mars_area_regular_ll_emitted() {
+    let fixtures = ["lsm.grib2", "2t.grib2", "q_150.grib2", "t_600.grib2"];
+    let expected = [90.0_f64, -180.0, -90.0, 179.75];
+
+    for name in fixtures {
+        let path = testdata().join(name);
+        let messages =
+            convert_grib_file(&path, &ConvertOptions::default()).expect("convert fixture");
+        let (meta, _) = decode(&messages[0], &decode_opts()).expect("decode");
+        let mars = get_mars_from_base(&meta);
+        let area = mars_area_as_f64s(mars)
+            .unwrap_or_else(|| panic!("{name}: mars.area missing or not [f64; 4]"));
+        assert_eq!(area, expected, "{name}: mars.area mismatch");
+    }
+}
+
+/// The dateline-first → `W = -180` normalisation is the primary bug-fix
+/// behaviour; pin it separately so a future "simplify the area helper"
+/// regression surfaces with a clear failure rather than a mysterious
+/// viewer off-by-180 report.
+#[test]
+fn test_mars_area_normalises_dateline_first() {
+    let path = testdata().join("lsm.grib2");
+    let messages =
+        convert_grib_file(&path, &ConvertOptions::default()).expect("convert lsm.grib2");
+    let (meta, _) = decode(&messages[0], &decode_opts()).expect("decode");
+    let area = mars_area_as_f64s(get_mars_from_base(&meta)).expect("mars.area present");
+
+    assert_eq!(
+        area[1], -180.0,
+        "W must be normalised from raw 180° to -180° for the full-global \
+         dateline-first convention",
+    );
+    assert!(
+        area[1] < area[3],
+        "after normalisation, W (area[1]) < E (area[3])",
+    );
+}
+
+/// The area must survive the OneToOne grouping path too — each output
+/// message carries its own `base[0].mars.area`.
+#[test]
+fn test_mars_area_emitted_in_one_to_one_grouping() {
+    let combined = make_combined_grib(&["lsm.grib2", "2t.grib2"]);
+    let opts = ConvertOptions {
+        grouping: Grouping::OneToOne,
+        ..ConvertOptions::default()
+    };
+    let messages =
+        convert_grib_file(combined.path(), &opts).expect("convert combined fixture");
+
+    assert_eq!(messages.len(), 2);
+    for (i, message) in messages.iter().enumerate() {
+        let (meta, _) = decode(message, &decode_opts()).expect("decode");
+        let mars = get_mars_from_base(&meta);
+        let area =
+            mars_area_as_f64s(mars).unwrap_or_else(|| panic!("message {i}: mars.area missing"));
+        assert_eq!(area, [90.0, -180.0, -90.0, 179.75]);
+    }
+}

--- a/tensoscope/src/tensogram/__tests__/inferAxesFromMars.test.ts
+++ b/tensoscope/src/tensogram/__tests__/inferAxesFromMars.test.ts
@@ -28,7 +28,8 @@ function makeVar(shape: number[], mars: Record<string, unknown>): ObjectInfo {
 }
 
 describe('inferAxesFromMarsGrid', () => {
-  it('infers 721×1440 global quarter-degree lat/lon from regular_ll', () => {
+  it('defaults to [-180, 180] for regular_ll without mars.area (dateline-first compat bridge)', () => {
+    // Pinned to DEFAULT_REGULAR_LL_AREA in index.ts.
     const result = inferAxesFromMarsGrid([
       makeVar([721, 1440], { grid: 'regular_ll', param: 167 }),
     ]);
@@ -42,7 +43,40 @@ describe('inferAxesFromMarsGrid', () => {
     expect(result!.lon[1439]).toBeCloseTo(179.75, 3);
   });
 
-  it('honours mars.area [north, west, south, east] for regional grids', () => {
+  it('honours mars.area [N, W, S, E] = [90, -180, -90, 179.75] (converter output)', () => {
+    // Shape emitted by compute_regular_ll_area for a dateline-first
+    // full-global fixture; must match the compat-bridge default so
+    // re-conversion is a no-op.
+    const result = inferAxesFromMarsGrid([
+      makeVar([721, 1440], {
+        grid: 'regular_ll',
+        area: [90, -180, -90, 179.75],
+      }),
+    ]);
+    expect(result).not.toBeNull();
+    expect(result!.lon[0]).toBe(-180);
+    expect(result!.lon[1439]).toBeCloseTo(179.75, 3);
+  });
+
+  it('honours mars.area [90, 0, -90, 359.75] (Greenwich-first, MARS archive / ERA5)', () => {
+    // Pass-through: the default flip to dateline-first must not leak
+    // into the explicit-area branch.  Post-emit normalisation in the
+    // helper shifts values > 180 back into [-180, 180], so the tail of
+    // the lon array lands in negative territory — see the assertion
+    // at index 1439 below.
+    const result = inferAxesFromMarsGrid([
+      makeVar([721, 1440], {
+        grid: 'regular_ll',
+        area: [90, 0, -90, 359.75],
+      }),
+    ]);
+    expect(result).not.toBeNull();
+    expect(result!.lon[0]).toBe(0);
+    // Raw 359.75 gets normalised to -0.25 (one step west of Greenwich).
+    expect(result!.lon[1439]).toBeCloseTo(-0.25, 3);
+  });
+
+  it('honours mars.area [N, W, S, E] for regional grids', () => {
     const result = inferAxesFromMarsGrid([
       makeVar([100, 200], {
         grid: 'regular_ll',
@@ -57,12 +91,13 @@ describe('inferAxesFromMarsGrid', () => {
   });
 
   it('uses endpoint-exclusive longitude when area wraps a full circle', () => {
-    // When no area is specified, defaults are [-180, 180) which spans 360°
+    // No mars.area → defaults [-180, 180) (full 360° circle).  Last
+    // sample sits one step before east (178°, not 180°, since east ≡
+    // west mod 360 would alias j=N with j=0).
     const result = inferAxesFromMarsGrid([
       makeVar([90, 180], { grid: 'regular_ll' }),
     ]);
     expect(result).not.toBeNull();
-    // 360 / 180 = 2°, last sample at 178° (endpoints exclusive)
     expect(result!.lon[0]).toBe(-180);
     expect(result!.lon[179]).toBeCloseTo(178, 3);
   });

--- a/tensoscope/src/tensogram/__tests__/inferAxesFromMars.test.ts
+++ b/tensoscope/src/tensogram/__tests__/inferAxesFromMars.test.ts
@@ -145,11 +145,12 @@ describe('inferAxesFromMarsGrid', () => {
     expect(result!.lon.length).toBe(144);
   });
 
-  it('falls back to defaults when mars.area contains a non-finite bigint', () => {
+  it('falls back to full defaults when mars.area contains a non-finite bigint', () => {
     // Corrupt or absurd CBOR-encoded areas — a bigint that overflows a
     // JS number via Number(v) — must not silently produce Infinity
-    // coordinates.  toNumber returns null in that case and the
-    // defaults kick in.
+    // coordinates.  All-or-nothing validation: one bad element kicks
+    // the WHOLE area out (not just that one element), so the
+    // DEFAULT_REGULAR_LL_AREA applies to every corner.
     const hugeBigint = 1n << 2000n;
     const result = inferAxesFromMarsGrid([
       makeVar([10, 20], {
@@ -158,10 +159,49 @@ describe('inferAxesFromMarsGrid', () => {
       }),
     ]);
     expect(result).not.toBeNull();
-    // Defaults: north=90 (since the overflowing bigint failed toNumber).
+    // All four defaults kicked in — verify the west default (not the 0
+    // that was in the explicit-but-rejected area) applies.
     expect(result!.lat[0]).toBe(90);
-    expect(Number.isFinite(result!.lat[0])).toBe(true);
+    expect(result!.lon[0]).toBe(-180);
     expect(Number.isFinite(result!.lat[result!.lat.length - 1])).toBe(true);
-    expect(Number.isFinite(result!.lon[0])).toBe(true);
+    expect(Number.isFinite(result!.lon[result!.lon.length - 1])).toBe(true);
+  });
+
+  it('falls back to full defaults when mars.area has wrong length', () => {
+    // A 3-element area is malformed — treat as absent, do NOT use the
+    // first 3 as N, W, S and default the E.
+    const result = inferAxesFromMarsGrid([
+      makeVar([10, 20], {
+        grid: 'regular_ll',
+        area: [60, -30, 20],
+      }),
+    ]);
+    expect(result).not.toBeNull();
+    expect(result!.lat[0]).toBe(90);
+    expect(result!.lon[0]).toBe(-180);
+  });
+
+  it('falls back to full defaults when mars.area has 5 elements', () => {
+    const result = inferAxesFromMarsGrid([
+      makeVar([10, 20], {
+        grid: 'regular_ll',
+        area: [60, -30, 20, 70, 0],
+      }),
+    ]);
+    expect(result).not.toBeNull();
+    expect(result!.lat[0]).toBe(90);
+    expect(result!.lon[0]).toBe(-180);
+  });
+
+  it('falls back to full defaults when mars.area contains a non-numeric entry', () => {
+    const result = inferAxesFromMarsGrid([
+      makeVar([10, 20], {
+        grid: 'regular_ll',
+        area: [60, 'thirty-degrees-west', 20, 70],
+      }),
+    ]);
+    expect(result).not.toBeNull();
+    expect(result!.lat[0]).toBe(90);
+    expect(result!.lon[0]).toBe(-180);
   });
 });

--- a/tensoscope/src/tensogram/index.ts
+++ b/tensoscope/src/tensogram/index.ts
@@ -439,7 +439,8 @@ export function inferAxesFromMarsGrid(
       legacyAreaDefaultWarned = true;
       console.warn(
         'Tensoscope: file has mars.grid = "regular_ll" but no mars.area; ' +
-          'assuming ECMWF open-data dateline-first [-180, 180] convention. ' +
+          'assuming ECMWF open-data dateline-first default area ' +
+          '(north = 90, west = -180, south = -90, east = 180). ' +
           'Re-convert the source GRIB with a tensogram-grib build that emits ' +
           'mars.area from the geography namespace for accurate rendering of ' +
           'Greenwich-first or regional grids.',

--- a/tensoscope/src/tensogram/index.ts
+++ b/tensoscope/src/tensogram/index.ts
@@ -391,6 +391,21 @@ export function expandAxesIfRectangularGrid(
 }
 
 /**
+ * Compat-bridge default `[N, W, S, E]` for `regular_ll` files that
+ * ship no explicit `mars.area`.  Matches ECMWF open-data
+ * (dateline-first — the common provenance for such files).  Changing
+ * these numbers flips the whole fallback hemisphere: don't.
+ */
+const DEFAULT_REGULAR_LL_AREA = {
+  north: 90,
+  west: -180,
+  south: -90,
+  east: 180,
+} as const;
+
+let legacyAreaDefaultWarned = false;
+
+/**
  * Infer 1-D latitude + longitude axes from `mars.grid` metadata + the
  * variable's shape, for files that ship no explicit coordinate
  * objects.  Currently supports `regular_ll` (the common
@@ -415,14 +430,25 @@ export function inferAxesFromMarsGrid(
     if (gridKind !== 'regular_ll') continue;
 
     const [nLat, nLon] = v.shape;
-    // MARS "area": [north, west, south, east].  Default to a full
-    // global domain when absent — matches ECMWF operational data.
-    // Use [-180, 180) longitude range to match the worker's expectation.
+    // MARS "area": [north, west, south, east].  When absent, fall back
+    // to the DEFAULT_REGULAR_LL_AREA compat bridge — matches ECMWF
+    // open-data's dateline-first convention and the regrid worker's
+    // [-180, 180) longitude expectation.
     const area = Array.isArray(mars.area) ? (mars.area as unknown[]) : null;
-    const north = toNumber(area?.[0]) ?? 90;
-    const west = toNumber(area?.[1]) ?? -180;
-    const south = toNumber(area?.[2]) ?? -90;
-    const east = toNumber(area?.[3]) ?? 180;
+    if (!area && !legacyAreaDefaultWarned) {
+      legacyAreaDefaultWarned = true;
+      console.warn(
+        'Tensoscope: file has mars.grid = "regular_ll" but no mars.area; ' +
+          'assuming ECMWF open-data dateline-first [-180, 180] convention. ' +
+          'Re-convert the source GRIB with a tensogram-grib build that emits ' +
+          'mars.area from the geography namespace for accurate rendering of ' +
+          'Greenwich-first or regional grids.',
+      );
+    }
+    const north = toNumber(area?.[0]) ?? DEFAULT_REGULAR_LL_AREA.north;
+    const west = toNumber(area?.[1]) ?? DEFAULT_REGULAR_LL_AREA.west;
+    const south = toNumber(area?.[2]) ?? DEFAULT_REGULAR_LL_AREA.south;
+    const east = toNumber(area?.[3]) ?? DEFAULT_REGULAR_LL_AREA.east;
 
     const lat = new Float32Array(nLat);
     for (let i = 0; i < nLat; i++) {

--- a/tensoscope/src/tensogram/index.ts
+++ b/tensoscope/src/tensogram/index.ts
@@ -406,6 +406,49 @@ const DEFAULT_REGULAR_LL_AREA = {
 let legacyAreaDefaultWarned = false;
 
 /**
+ * Strictly validate a candidate `mars.area` CBOR value as a 4-tuple of
+ * finite numbers.  Returns `null` when the input is missing OR
+ * malformed (not an array, wrong length, or any element that
+ * `toNumber` cannot coerce to a finite JS number).  The caller treats
+ * both null cases identically — fall back to the full
+ * `DEFAULT_REGULAR_LL_AREA` — but uses the `'area' in mars` check to
+ * distinguish "absent" vs "malformed" when emitting the warn.
+ */
+function parseMarsArea(
+  raw: unknown,
+): [number, number, number, number] | null {
+  if (!Array.isArray(raw) || raw.length !== 4) return null;
+  const n = toNumber(raw[0]);
+  const w = toNumber(raw[1]);
+  const s = toNumber(raw[2]);
+  const e = toNumber(raw[3]);
+  if (n === null || w === null || s === null || e === null) return null;
+  return [n, w, s, e];
+}
+
+/**
+ * Emit the one-shot compat-bridge warn when falling back to defaults.
+ * Distinguishes "mars.area absent" (common case for pre-fix converter
+ * output) from "mars.area present but malformed" (a producer bug)
+ * so the remediation message is accurate.
+ */
+function maybeWarnMissingOrInvalidArea(areaKeyPresent: boolean): void {
+  if (legacyAreaDefaultWarned) return;
+  legacyAreaDefaultWarned = true;
+  const condition = areaKeyPresent
+    ? 'mars.area is present but not a 4-element array of finite numbers'
+    : 'mars.grid = "regular_ll" but no mars.area';
+  console.warn(
+    `Tensoscope: ${condition}; ` +
+      'assuming ECMWF open-data dateline-first default area ' +
+      '(north = 90, west = -180, south = -90, east = 180). ' +
+      'Re-convert the source GRIB with a tensogram-grib build that emits ' +
+      'mars.area from the geography namespace for accurate rendering of ' +
+      'Greenwich-first or regional grids.',
+  );
+}
+
+/**
  * Infer 1-D latitude + longitude axes from `mars.grid` metadata + the
  * variable's shape, for files that ship no explicit coordinate
  * objects.  Currently supports `regular_ll` (the common
@@ -430,26 +473,20 @@ export function inferAxesFromMarsGrid(
     if (gridKind !== 'regular_ll') continue;
 
     const [nLat, nLon] = v.shape;
-    // MARS "area": [north, west, south, east].  When absent, fall back
-    // to the DEFAULT_REGULAR_LL_AREA compat bridge — matches ECMWF
-    // open-data's dateline-first convention and the regrid worker's
-    // [-180, 180) longitude expectation.
-    const area = Array.isArray(mars.area) ? (mars.area as unknown[]) : null;
-    if (!area && !legacyAreaDefaultWarned) {
-      legacyAreaDefaultWarned = true;
-      console.warn(
-        'Tensoscope: file has mars.grid = "regular_ll" but no mars.area; ' +
-          'assuming ECMWF open-data dateline-first default area ' +
-          '(north = 90, west = -180, south = -90, east = 180). ' +
-          'Re-convert the source GRIB with a tensogram-grib build that emits ' +
-          'mars.area from the geography namespace for accurate rendering of ' +
-          'Greenwich-first or regional grids.',
-      );
+    // All-or-nothing: either the whole mars.area is a valid
+    // [N, W, S, E] tuple of finite numbers, or we fall back to the
+    // full DEFAULT_REGULAR_LL_AREA compat bridge.  Mixing explicit
+    // and default values would silently produce hybrid geometry
+    // (e.g. explicit N with default W/S/E) that misplaces the grid
+    // without any warning signal.
+    const area = parseMarsArea(mars.area);
+    if (area === null) {
+      maybeWarnMissingOrInvalidArea('area' in mars);
     }
-    const north = toNumber(area?.[0]) ?? DEFAULT_REGULAR_LL_AREA.north;
-    const west = toNumber(area?.[1]) ?? DEFAULT_REGULAR_LL_AREA.west;
-    const south = toNumber(area?.[2]) ?? DEFAULT_REGULAR_LL_AREA.south;
-    const east = toNumber(area?.[3]) ?? DEFAULT_REGULAR_LL_AREA.east;
+    const north = area?.[0] ?? DEFAULT_REGULAR_LL_AREA.north;
+    const west = area?.[1] ?? DEFAULT_REGULAR_LL_AREA.west;
+    const south = area?.[2] ?? DEFAULT_REGULAR_LL_AREA.south;
+    const east = area?.[3] ?? DEFAULT_REGULAR_LL_AREA.east;
 
     const lat = new Float32Array(nLat);
     for (let i = 0; i < nLat; i++) {


### PR DESCRIPTION
## Problem

GRIB-derived `.tgm` files rendered 180° off in Tensoscope — Sahara appeared where the Pacific should be and vice versa.  Root cause: the `tensogram-grib` converter was dropping the grid's corner coordinates at conversion time, only lifting MARS request keys.  The viewer had no way to know where the grid actually sat on Earth and had to guess.

#86 already flipped the viewer's fallback default to `[-180, 180]`, which is the right guess for ECMWF open-data but still a guess.  This PR fixes the source of truth: the converter now stores the actual corners in the metadata, so the viewer doesn't have to guess.

## What this PR does

### Converter side (`tensogram-grib`)

- New pure helper `compute_regular_ll_area` (in `src/area.rs`) lifts the four corner-point keys from the ecCodes `geography` namespace for `regular_ll` grids with standard scan mode.
- Applies one narrow normalisation: full-global dateline-first (raw `lon_first = 180, lon_last = 179.75`) is shifted to `west = -180` so the axis is monotone in `[-180, E]`.
- Emits `mars.area = [N, W, S, E]` alongside the existing `mars.grid`, per object.
- Refuses every other ambiguous case (non-standard scan modes, dateline-crossing regional subdomains, non-`regular_ll` grids, degenerate inputs) — leaving the viewer's compat-bridge default to handle them.

### Viewer side (Tensoscope)

- Complements #86 by formalising the fallback as a named `DEFAULT_REGULAR_LL_AREA` constant with a docstring warning against changes.
- One-shot `console.warn` when the default fires, naming the condition (`mars.grid = "regular_ll"` but no `mars.area`) and the remediation (re-convert with this PR's converter).
- Keeps #86's post-emit normalisation loop (`lon > 180 → -360`, `lon < -180 → +360`) — explicit `mars.area` from Greenwich-first sources (ERA5, MARS archive) now maps correctly into the worker's `[-180, 180)` expectation.

## Metadata shape

For a 0.25° global ECMWF open-data file the converter now produces:

```
base[0]["mars"]["area"] = [90.0, -180.0, -90.0, 179.75]
```

Right next to `mars.grid` — same namespace, per object.

## Tests

- **Rust** (`tensogram-grib`): 20 new unit tests in `area.rs` covering dateline-first / Greenwich-first global, 0.5° and 0.1° grids, regional subdomains, and every refusal path (non-standard scan, NaN, infinity, zero/negative increment, single-column, degenerate W==E, degenerate N==S, inverted latitudes, dateline-crossing regional, endpoint-inconsistent pathological).  3 new integration tests asserting `mars.area == [90, -180, -90, 179.75]` on all 4 bundled real-ECMWF-open-data fixtures, across both `MergeAll` and `OneToOne` grouping.
- **Tensoscope**: updated existing tests to match the flipped default; added explicit-area tests for the converter-output case (`[90, -180, -90, 179.75]`) and the Greenwich-first ERA5 case (`[90, 0, -90, 359.75]`).
- **Python**: regression test asserting `mars.area` round-trips through `tensogram.convert_grib` → `decode_metadata` as `list[float]`.

## Docs

- New "Spatial" section in `docs/src/grib/metadata-mapping.md` documenting the `mars.area` emission and refusal conditions.
- Entry in `CHANGELOG.md` under `[Unreleased]`.
- `plans/DONE.md` updated for both the converter change and the viewer compat bridge.

## Scope deliberately excluded

- Non-standard scan modes (`iScansNegatively = 1`, `jScansPositively = 1`) — rejected by the helper, no `mars.area` emitted; the viewer's compat default handles them.
- Non-`regular_ll` grids (`reduced_gg`, octahedral `O*`, Gaussian `N*`) — their geometry cannot be captured as four corners; follow-up would need per-point lat/lon emission.
- Dateline-crossing regional subdomains — cannot be represented as a single monotone `[W, E]` tuple in either `[-180, 180]` or `[0, 360]`; also needs per-point coords.

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-87
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->