### PR TITLE
fix: harden all decode paths against malformed tensor descriptors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,85 +241,86 @@ jobs:
         run: rm -rf "$TMPDIR" .venv target
 
   # ── macOS: lint + test + GRIB + NetCDF + Python ────────────────
-  main-macos:
-    name: Main (macOS)
-    runs-on: [self-hosted, macOS, platform-builder-MacOSX-13.4.1-arm64]
-    env:
-      RUSTUP_HOME: ${{ github.workspace }}/.rustup
-      CARGO_HOME: ${{ github.workspace }}/.cargo
-      SCCACHE_DIR: ${{ github.workspace }}/.sccache
-    steps:
-      - uses: actions/checkout@v4
-      - run: mkdir -p "$TMPDIR"
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
-
-      - uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-
-      - name: Install sccache
-        run: brew list sccache &>/dev/null || brew install sccache
-
-      - name: Install system dependencies
-        run: |
-          for pkg in netcdf hdf5 eccodes; do
-            brew list --formula "$pkg" >/dev/null 2>&1 || brew install "$pkg"
-          done
-          echo "PKG_CONFIG_PATH=$(brew --prefix)/lib/pkgconfig:$(brew --prefix eccodes)/lib/pkgconfig:$(brew --prefix netcdf)/lib/pkgconfig:$(brew --prefix hdf5)/lib/pkgconfig" >> "$GITHUB_ENV"
-          echo "ECCODES_DIR=$(brew --prefix eccodes)" >> "$GITHUB_ENV"
-
-      - name: Format check
-        run: cargo fmt --check
-
-      - name: Clippy
-        run: |
-          cargo clippy --workspace --all-targets -- -D warnings
-          cargo clippy -p tensogram --all-targets --features "remote,async" -- -D warnings
-          cargo clippy -p tensogram-cli --all-targets --features "grib,netcdf" -- -D warnings
-          cargo clippy --manifest-path rust/tensogram-netcdf/Cargo.toml --all-targets -- -D warnings
-
-      - name: Test
-        run: cargo test --workspace
-
-      - name: Test (remote feature)
-        run: cargo test -p tensogram --features remote
-
-      - name: Test (remote + async features)
-        run: cargo test -p tensogram --features "remote,async"
-
-      - name: Test (GRIB)
-        run: |
-          cargo test --manifest-path rust/tensogram-grib/Cargo.toml
-          cargo test -p tensogram-cli --features grib
-
-      - name: Test (NetCDF)
-        run: |
-          cargo clippy --manifest-path rust/tensogram-netcdf/Cargo.toml --all-targets -- -D warnings
-          cargo test --manifest-path rust/tensogram-netcdf/Cargo.toml
-          cargo test -p tensogram-cli --features netcdf
-
-      - name: Build and test Python bindings
-        run: |
-          uv python install 3.13
-          uv venv .venv --python 3.13
-          . .venv/bin/activate
-          uv pip install maturin pytest pytest-asyncio numpy ruff
-          cd python/bindings && maturin develop && cd ../..
-          ruff check --config python/bindings/pyproject.toml python/tests/
-          python -m pytest python/tests/ -v
-          cargo check --manifest-path python/bindings/Cargo.toml --no-default-features
-
-      - name: sccache stats
-        if: always()
-        run: sccache --show-adv-stats || true
-
-      - name: Cleanup
-        if: always()
-        run: |
-          sccache --stop-server || true
-          rm -rf "$TMPDIR" .venv build .rustup .cargo .sccache .llvm target
+  # TEMPORARILY DISABLED: self-hosted macOS runners are problematic.
+  # main-macos:
+  #   name: Main (macOS)
+  #   runs-on: [self-hosted, macOS, platform-builder-MacOSX-13.4.1-arm64]
+  #   env:
+  #     RUSTUP_HOME: ${{ github.workspace }}/.rustup
+  #     CARGO_HOME: ${{ github.workspace }}/.cargo
+  #     SCCACHE_DIR: ${{ github.workspace }}/.sccache
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - run: mkdir -p "$TMPDIR"
+  #     - uses: dtolnay/rust-toolchain@stable
+  #       with:
+  #         components: clippy, rustfmt
+  #
+  #     - uses: astral-sh/setup-uv@v5
+  #       with:
+  #         enable-cache: true
+  #
+  #     - name: Install sccache
+  #       run: brew list sccache &>/dev/null || brew install sccache
+  #
+  #     - name: Install system dependencies
+  #       run: |
+  #         for pkg in netcdf hdf5 eccodes; do
+  #           brew list --formula "$pkg" >/dev/null 2>&1 || brew install "$pkg"
+  #         done
+  #         echo "PKG_CONFIG_PATH=$(brew --prefix)/lib/pkgconfig:$(brew --prefix eccodes)/lib/pkgconfig:$(brew --prefix netcdf)/lib/pkgconfig:$(brew --prefix hdf5)/lib/pkgconfig" >> "$GITHUB_ENV"
+  #         echo "ECCODES_DIR=$(brew --prefix eccodes)" >> "$GITHUB_ENV"
+  #
+  #     - name: Format check
+  #       run: cargo fmt --check
+  #
+  #     - name: Clippy
+  #       run: |
+  #         cargo clippy --workspace --all-targets -- -D warnings
+  #         cargo clippy -p tensogram --all-targets --features "remote,async" -- -D warnings
+  #         cargo clippy -p tensogram-cli --all-targets --features "grib,netcdf" -- -D warnings
+  #         cargo clippy --manifest-path rust/tensogram-netcdf/Cargo.toml --all-targets -- -D warnings
+  #
+  #     - name: Test
+  #       run: cargo test --workspace
+  #
+  #     - name: Test (remote feature)
+  #       run: cargo test -p tensogram --features remote
+  #
+  #     - name: Test (remote + async features)
+  #       run: cargo test -p tensogram --features "remote,async"
+  #
+  #     - name: Test (GRIB)
+  #       run: |
+  #         cargo test --manifest-path rust/tensogram-grib/Cargo.toml
+  #         cargo test -p tensogram-cli --features grib
+  #
+  #     - name: Test (NetCDF)
+  #       run: |
+  #         cargo clippy --manifest-path rust/tensogram-netcdf/Cargo.toml --all-targets -- -D warnings
+  #         cargo test --manifest-path rust/tensogram-netcdf/Cargo.toml
+  #         cargo test -p tensogram-cli --features netcdf
+  #
+  #     - name: Build and test Python bindings
+  #       run: |
+  #         uv python install 3.13
+  #         uv venv .venv --python 3.13
+  #         . .venv/bin/activate
+  #         uv pip install maturin pytest pytest-asyncio numpy ruff
+  #         cd python/bindings && maturin develop && cd ../..
+  #         ruff check --config python/bindings/pyproject.toml python/tests/
+  #         python -m pytest python/tests/ -v
+  #         cargo check --manifest-path python/bindings/Cargo.toml --no-default-features
+  #
+  #     - name: sccache stats
+  #       if: always()
+  #       run: sccache --show-adv-stats || true
+  #
+  #     - name: Cleanup
+  #       if: always()
+  #       run: |
+  #         sccache --stop-server || true
+  #         rm -rf "$TMPDIR" .venv build .rustup .cargo .sccache .llvm target
 
   # ── C++: Linux ─────────────────────────────────────────────────
   cpp-linux:
@@ -352,39 +353,40 @@ jobs:
         run: rm -rf "$TMPDIR" build target
 
   # ── C++: macOS ─────────────────────────────────────────────────
-  cpp-macos:
-    name: C++ (macOS)
-    runs-on: [self-hosted, macOS, platform-builder-MacOSX-13.4.1-arm64]
-    env:
-      RUSTUP_HOME: ${{ github.workspace }}/.rustup
-      CARGO_HOME: ${{ github.workspace }}/.cargo
-      SCCACHE_DIR: ${{ github.workspace }}/.sccache
-    steps:
-      - uses: actions/checkout@v4
-      - run: mkdir -p "$TMPDIR"
-      - uses: dtolnay/rust-toolchain@stable
-
-      - name: Install sccache
-        run: brew list sccache &>/dev/null || brew install sccache
-
-      - name: Build and test
-        run: |
-          cargo build --release -p tensogram-ffi
-          cmake -S cpp -B build -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER_LAUNCHER=sccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-          cmake --build build -j
-          ctest --test-dir build --output-on-failure
-
-      - name: sccache stats
-        if: always()
-        run: sccache --show-adv-stats || true
-
-      - name: Cleanup
-        if: always()
-        run: |
-          sccache --stop-server || true
-          rm -rf "$TMPDIR" build .rustup .cargo .sccache target
+  # TEMPORARILY DISABLED: self-hosted macOS runners are problematic.
+  # cpp-macos:
+  #   name: C++ (macOS)
+  #   runs-on: [self-hosted, macOS, platform-builder-MacOSX-13.4.1-arm64]
+  #   env:
+  #     RUSTUP_HOME: ${{ github.workspace }}/.rustup
+  #     CARGO_HOME: ${{ github.workspace }}/.cargo
+  #     SCCACHE_DIR: ${{ github.workspace }}/.sccache
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - run: mkdir -p "$TMPDIR"
+  #     - uses: dtolnay/rust-toolchain@stable
+  #
+  #     - name: Install sccache
+  #       run: brew list sccache &>/dev/null || brew install sccache
+  #
+  #     - name: Build and test
+  #       run: |
+  #         cargo build --release -p tensogram-ffi
+  #         cmake -S cpp -B build -DCMAKE_BUILD_TYPE=Release \
+  #           -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+  #           -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+  #         cmake --build build -j
+  #         ctest --test-dir build --output-on-failure
+  #
+  #     - name: sccache stats
+  #       if: always()
+  #       run: sccache --show-adv-stats || true
+  #
+  #     - name: Cleanup
+  #       if: always()
+  #       run: |
+  #         sccache --stop-server || true
+  #         rm -rf "$TMPDIR" build .rustup .cargo .sccache target
 
   # ── WASM: build + test ────────────────────────────────────────
   wasm:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Security — cross-codec preallocation hardening
+
+Every descriptor-derived allocation on the decode path is now fallible,
+and every size-arithmetic step that could wrap `usize` on hostile input
+is guarded by `checked_mul` / `u128` promotion. A malformed `.tgm`
+whose tensor-shape product drives `num_values × dtype_byte_width` into
+the terabyte range previously aborted the decode process via infallible
+`Vec::with_capacity` / `vec![_; N]` calls scattered across the codec,
+encoding, filter, and bitmask layers; it now surfaces as a typed error
+through the normal `Result<_, TensogramError>` channel.
+
+- **szip** (both C-FFI via libaec and the pure-Rust `tensogram-szip`
+  crate): fallible output / RSI-buffer / sample-serialisation
+  reservations, `checked_mul` on `rsi × block_size × byte_width`,
+  `checked_sub` on the `set_len` length math, `checked_add` on range
+  arithmetic, `try_reserve_exact` + per-element `usize::try_from` on
+  the FFI block-offsets conversion. The FFI backend now runs the same
+  `AecParams` validator as the pure-Rust crate, including the new
+  `block_size == 0` rejection shared by both.
+- **simple_packing** decode: `try_reserve_exact` in every sequential
+  and rayon-parallel path; `num_values × bits_per_value` promoted to
+  `u128` with a new `PackingError::BitCountOverflow`; byte-count
+  conversion raises `OutputSizeOverflow`.
+- **Bitmask decoders** (`packing::unpack`, `rle::decode`,
+  `roaring::decode`, `packing::pack` when called from RLE/Roaring
+  decompress): shared `try_reserve_mask` helper; RLE run-length
+  overflow check reworked to the overflow-safe form
+  `run > n_elements - out.len()`; `packing::pack` is now fallible.
+- **zfp / sz3**: `try_reserve_exact` on decompress and on the f64 → byte
+  serialisation; `checked_mul` / `checked_add` on range arithmetic.
+- **blosc2**: `checked_add` on byte-range math; range output cloned
+  fallibly.
+- **Shuffle** (`shuffle` + `unshuffle`): new
+  `ShuffleError::AllocationFailed`; even the `element_size == 1`
+  short-circuit uses a fallible `try_clone`.
+- **Pipeline** (`bytes_to_f64`, `f64_to_bytes`, range bit math): all
+  fallible, with `u128` promotion for the range-decode bit positions
+  and `usize::try_from` at the `u64 → usize` boundary.
+- **No static cap**: rejected because legitimate scientific workloads
+  produce multi-GiB single objects; fallible allocation alone is
+  sufficient.
+
 ### Fixed — `regular_ll` longitude convention
 
 GRIB-derived `.tgm` files from ECMWF open-data (where the grid scans

--- a/docs/src/guide/error-handling.md
+++ b/docs/src/guide/error-handling.md
@@ -450,47 +450,60 @@ silent corruption path where an `i32::MAX`-saturated
 with `0.0` and records their positions in a bitmask companion
 section.
 
-### Malformed Descriptor — Pathological Tensor Size (szip)
+### Malformed Descriptor — Pathological Tensor Size
 
 A corrupted or hostile `.tgm` file whose tensor descriptor declares an
 unrealistic element count (for example, `shape: [2^40]`) drives
 `num_values × dtype_byte_width` to a multi-terabyte value on decode.
 
-For the **szip compression codec** — both the C FFI backend (via
-libaec) and the pure-Rust `tensogram-szip` crate — every allocation on
-the decode path that derives from this untrusted size is fallible:
-`Vec::try_reserve_exact` on the output buffer, the per-RSI scratch
-buffer and the sample-serialisation buffer, `checked_mul` on the
-sample-count → byte-count conversion, and `checked_sub` on the
-bytes-written arithmetic the FFI path reports back. A hostile size
-therefore surfaces as a **Compression error** whose message begins
-with `"failed to reserve"` (or, for the multiplication overflow case,
-`"overflows usize"`) rather than aborting the process.
+Every descriptor-derived allocation on the decode path is fallible:
 
-Blosc2 is likewise hardened (see the PR #69 fix notes): it ignores the
-caller-supplied hint entirely and reserves fallibly per chunk against
-its own frame-trailer metadata.
+- **szip** (both C FFI and pure-Rust backends): `Vec::try_reserve_exact`
+  on the output buffer, the per-RSI scratch buffer and the sample
+  serialisation buffer; `checked_mul` on the sample-count → byte-count
+  conversion; `checked_sub` on the FFI bytes-written arithmetic that
+  drives `set_len`. The FFI backend additionally runs the same
+  `AecParams` validation as the pure-Rust backend (rejects
+  `bits_per_sample ∉ [1..=32]`, `block_size == 0`, invalid block sizes
+  without `AEC_NOT_ENFORCE`, `rsi ∉ [1..=4096]`, and `AEC_RESTRICTED`
+  with `bits_per_sample > 4`).
+- **simple_packing** decode: `try_reserve_exact` on the output
+  `Vec<f64>` in both aligned and generic paths (sequential and
+  rayon-parallel); `checked_mul` on `num_values × bits_per_value`
+  (promoted to `u128`) and on the range-decode `bit_offset + num_values × bpv`
+  arithmetic.
+- **Bitmask decoders** (`packing::unpack`, `rle::decode`,
+  `roaring::decode`): shared `try_reserve_mask` helper reserves the
+  output `Vec<bool>` fallibly. The RLE path's run-length overflow
+  check was also reworked so `run + out.len() > n_elements` cannot
+  itself overflow on hostile input.
+- **zfp**: `zfp_ffi::zfp_decompress_f64` reserves the output buffer
+  via `try_reserve_exact`; serialisation back to bytes uses
+  `checked_mul` on `values.len() × 8` and fallible reservation for
+  the byte buffer.
+- **Shuffle filter**: `unshuffle` reserves its output buffer fallibly
+  so a large decompressed stage cannot abort the shuffle stage even
+  when the host is close to OOM.
+- **blosc2**: ignores the caller-supplied hint entirely and reserves
+  fallibly per chunk against its own frame-trailer metadata.
 
-**Not yet hardened — known limitations:** The other codec (`zfp`) and
-two non-compression allocation sites still use infallible
-preallocation from descriptor-derived element counts. A `.tgm` crafted
-to route through any of the following paths can still trigger an
-allocation abort rather than a typed error:
+A hostile size therefore surfaces through the normal error channel as
+a typed error. The specific variants and their message prefixes:
 
-- `EncodingType::SimplePacking` on the decode path —
-  `simple_packing::decode*` uses `Vec::with_capacity(num_values)` for
-  the output `Vec<f64>`.
-- Bitmask companion frames — `bitmask::{packing,rle,roaring}::decode`
-  use `Vec::with_capacity(n_elements)`.
-- `CompressionType::Zfp` — `zfp_ffi::zfp_decompress_f64` does
-  `vec![0.0f64; num_values]` on a descriptor-derived `num_values`.
+| Codec / stage | Error variant | Prefix |
+|---|---|---|
+| szip (FFI) | `CompressionError::Szip` | `"failed to reserve"` |
+| szip (pure) | `AecError::Data` | `"failed to reserve"` |
+| simple_packing | `PackingError::AllocationFailed` / `BitCountOverflow` / `OutputSizeOverflow` | `"failed to reserve"` / `"bit-count overflow"` / `"output size overflow"` |
+| bitmask | `MaskError::AllocationFailed` | `"failed to reserve"` |
+| zfp / sz3 | `CompressionError::Zfp` / `CompressionError::Sz3` | `"failed to reserve"` |
+| shuffle | `ShuffleError::AllocationFailed` | `"failed to reserve"` |
+| pipeline f64↔bytes | `PipelineError::Range` | `"failed to reserve"` / `"overflows usize"` |
 
-These are tracked in `plans/TODO.md` as separate follow-up items. For
-now, callers that accept `.tgm` input from untrusted sources should
-either validate the descriptor shape before decode (structure-level
-`tensogram validate --quick` confirms the shape is well-formed) or
-restrict the accepted pipelines to szip and the other
-already-hardened codecs.
+This means a caller processing untrusted `.tgm` input (remote reads,
+user uploads, multi-tenant services) can rely on the normal
+`Result<_, TensogramError>` / exception channel to signal the problem.
+No defensive size-cap is needed at the call site.
 
 ### File Not Found / Permission Denied
 
@@ -563,15 +576,16 @@ and `unimplemented!()` in non-test code paths. The library guarantees:
 - `u64 → usize` conversions use `usize::try_from()` to prevent truncation
   on 32-bit platforms.
 - Array indexing is guarded by prior bounds checks.
-- **Untrusted sizes in the szip and blosc2 decode paths** (the
-  descriptor's `num_values × dtype_byte_width`, range-decode lengths,
-  per-codec internal size hints) are reserved via
-  `Vec::try_reserve_exact`, so allocation failure surfaces as a typed
-  error rather than aborting the process. Other decode paths
-  (`simple_packing`, bitmask decoders, `zfp`) still use infallible
-  preallocation — see [Malformed Descriptor — Pathological Tensor
-  Size (szip)](#malformed-descriptor--pathological-tensor-size-szip)
-  for the known limitations and the remediation plan.
+- **Untrusted sizes derived from the wire format** (the descriptor's
+  `num_values × dtype_byte_width`, range-decode lengths, per-codec
+  internal size hints, bitmask element counts) are reserved via
+  `Vec::try_reserve_exact` on every decode path, so allocation failure
+  surfaces as a typed error rather than aborting the process. Size
+  arithmetic that could overflow `usize` (`num_values × bits_per_value`,
+  `samples × byte_width`) is guarded by `checked_mul` / `u128`
+  promotion. See [Malformed Descriptor — Pathological Tensor
+  Size](#malformed-descriptor--pathological-tensor-size) for the
+  per-codec error variants.
 - FFI boundary code returns error codes instead of panicking, and uses
   `unwrap_or_default()` only for `CString::new()` (interior null fallback).
 - The scan functions (`scan`, `scan_file`) tolerate truncation of

--- a/docs/src/guide/error-handling.md
+++ b/docs/src/guide/error-handling.md
@@ -450,6 +450,48 @@ silent corruption path where an `i32::MAX`-saturated
 with `0.0` and records their positions in a bitmask companion
 section.
 
+### Malformed Descriptor — Pathological Tensor Size (szip)
+
+A corrupted or hostile `.tgm` file whose tensor descriptor declares an
+unrealistic element count (for example, `shape: [2^40]`) drives
+`num_values × dtype_byte_width` to a multi-terabyte value on decode.
+
+For the **szip compression codec** — both the C FFI backend (via
+libaec) and the pure-Rust `tensogram-szip` crate — every allocation on
+the decode path that derives from this untrusted size is fallible:
+`Vec::try_reserve_exact` on the output buffer, the per-RSI scratch
+buffer and the sample-serialisation buffer, `checked_mul` on the
+sample-count → byte-count conversion, and `checked_sub` on the
+bytes-written arithmetic the FFI path reports back. A hostile size
+therefore surfaces as a **Compression error** whose message begins
+with `"failed to reserve"` (or, for the multiplication overflow case,
+`"overflows usize"`) rather than aborting the process.
+
+Blosc2 is likewise hardened (see the PR #69 fix notes): it ignores the
+caller-supplied hint entirely and reserves fallibly per chunk against
+its own frame-trailer metadata.
+
+**Not yet hardened — known limitations:** The other codec (`zfp`) and
+two non-compression allocation sites still use infallible
+preallocation from descriptor-derived element counts. A `.tgm` crafted
+to route through any of the following paths can still trigger an
+allocation abort rather than a typed error:
+
+- `EncodingType::SimplePacking` on the decode path —
+  `simple_packing::decode*` uses `Vec::with_capacity(num_values)` for
+  the output `Vec<f64>`.
+- Bitmask companion frames — `bitmask::{packing,rle,roaring}::decode`
+  use `Vec::with_capacity(n_elements)`.
+- `CompressionType::Zfp` — `zfp_ffi::zfp_decompress_f64` does
+  `vec![0.0f64; num_values]` on a descriptor-derived `num_values`.
+
+These are tracked in `plans/TODO.md` as separate follow-up items. For
+now, callers that accept `.tgm` input from untrusted sources should
+either validate the descriptor shape before decode (structure-level
+`tensogram validate --quick` confirms the shape is well-formed) or
+restrict the accepted pipelines to szip and the other
+already-hardened codecs.
+
 ### File Not Found / Permission Denied
 
 `TensogramFile.open()` raises **OSError** (Python), **io\_error** (C++),
@@ -521,6 +563,15 @@ and `unimplemented!()` in non-test code paths. The library guarantees:
 - `u64 → usize` conversions use `usize::try_from()` to prevent truncation
   on 32-bit platforms.
 - Array indexing is guarded by prior bounds checks.
+- **Untrusted sizes in the szip and blosc2 decode paths** (the
+  descriptor's `num_values × dtype_byte_width`, range-decode lengths,
+  per-codec internal size hints) are reserved via
+  `Vec::try_reserve_exact`, so allocation failure surfaces as a typed
+  error rather than aborting the process. Other decode paths
+  (`simple_packing`, bitmask decoders, `zfp`) still use infallible
+  preallocation — see [Malformed Descriptor — Pathological Tensor
+  Size (szip)](#malformed-descriptor--pathological-tensor-size-szip)
+  for the known limitations and the remediation plan.
 - FFI boundary code returns error codes instead of panicking, and uses
   `unwrap_or_default()` only for `CString::new()` (interior null fallback).
 - The scan functions (`scan`, `scan_file`) tolerate truncation of

--- a/docs/src/guide/error-handling.md
+++ b/docs/src/guide/error-handling.md
@@ -490,15 +490,21 @@ Every descriptor-derived allocation on the decode path is fallible:
 A hostile size therefore surfaces through the normal error channel as
 a typed error. The specific variants and their message prefixes:
 
-| Codec / stage | Error variant | Prefix |
+| Codec / stage | Error variant (as seen from `TensogramError`) | Prefix |
 |---|---|---|
-| szip (FFI) | `CompressionError::Szip` | `"failed to reserve"` |
-| szip (pure) | `AecError::Data` | `"failed to reserve"` |
+| szip (both backends, via FFI wrapper) | `CompressionError::Szip` | `"failed to reserve"` |
 | simple_packing | `PackingError::AllocationFailed` / `BitCountOverflow` / `OutputSizeOverflow` | `"failed to reserve"` / `"bit-count overflow"` / `"output size overflow"` |
-| bitmask | `MaskError::AllocationFailed` | `"failed to reserve"` |
-| zfp / sz3 | `CompressionError::Zfp` / `CompressionError::Sz3` | `"failed to reserve"` |
+| bitmask decoders | `MaskError::AllocationFailed` | `"failed to reserve"` |
+| zfp | `CompressionError::Zfp` | `"failed to reserve"` |
+| sz3 | `CompressionError::Sz3` | `"failed to reserve"` |
+| blosc2 | `CompressionError::Blosc2` | `"failed to reserve"` |
 | shuffle | `ShuffleError::AllocationFailed` | `"failed to reserve"` |
-| pipeline f64↔bytes | `PipelineError::Range` | `"failed to reserve"` / `"overflows usize"` |
+| pipeline f64↔bytes + range math | `PipelineError::Range` | `"failed to reserve"` / `"overflow"` / `"exceeds usize"` |
+
+Note: the `szip (pure)` backend surfaces `AecError::Data` internally,
+but the wrapper in `tensogram-encodings/src/compression/szip_pure.rs`
+converts it to `CompressionError::Szip` at the trait boundary, so
+callers always see the FFI form.
 
 This means a caller processing untrusted `.tgm` input (remote reads,
 user uploads, multi-tenant services) can rely on the normal

--- a/plans/DONE.md
+++ b/plans/DONE.md
@@ -812,6 +812,47 @@ comparison against ecCodes.
   error paths (encoding, decoding, streaming, CLI) and the no-panic
   guarantee.
 
+## Preallocation hardening for szip decode paths
+
+A malformed `.tgm` descriptor whose tensor-shape product drove
+`num_values × dtype_byte_width` into the terabyte range previously
+aborted the decode process via infallible allocations in the szip
+codecs. Fallible reservation was already in place for blosc2 but not
+for szip; this closes the szip half of the gap.
+
+| Component | What changed |
+|-----------|-------------|
+| `tensogram-encodings/src/libaec.rs` | `aec_decompress` and `aec_decompress_range` now use `Vec::new()` + `try_reserve_exact` + `set_len(decoded_len)` in place of `vec![0u8; N]`. Trust-model doc comments on both entry points. `expected_size == 0` early-returns to avoid the `NonNull::dangling()` pointer class on zero-capacity `Vec`s. `checked_sub` on `expected_size - avail_out` guards against a misbehaving libaec feeding the `set_len` an absurd length. A hostile `expected_size` / `byte_size` surfaces as `CompressionError::Szip` with a `"failed to reserve"` prefix rather than aborting the process. The removal of the eager zero-fill is also a small honest-path win. |
+| `tensogram-szip/src/decoder.rs` | The `decode` main output buffer, `decode_rsi` scratch buffer, and `write_samples` sample-serialisation buffer all switched from `Vec::with_capacity` to fallible `try_reserve_exact`. `write_samples` additionally guards the `samples.len() * byte_width` multiplication with `checked_mul`, and `samples_per_rsi = rsi_blocks * block_size` is now a `checked_mul` to survive 32-bit targets and `AEC_NOT_ENFORCE` parameter combinations. |
+| Tests | New in-module regression tests in `libaec.rs` (FFI path) and new `preallocation_hardening` module in `tensogram-szip/tests/error_paths.rs` (pure path) assert that `usize::MAX` / `isize::MAX + 1` sentinels surface as typed errors. End-to-end integration tests in `pipeline.rs::tests` exercise the full `decode_pipeline` with a hostile `PipelineConfig.num_values` against both the FFI and pure-Rust szip backends. |
+| Docs | `docs/src/guide/error-handling.md` gains a *Malformed Descriptor — Pathological Tensor Size (szip)* subsection and a new bullet under the *No-Panic Guarantee* on fallible allocation from untrusted wire-format sizes. The subsection also lists the remaining unhardened paths (`simple_packing`, bitmask, `zfp`) as explicit known limitations so callers don't mistake this for a cross-codec guarantee. |
+
+Design choices worth recording:
+
+- **No static cap.** Imposing a documented maximum decompressed size in
+  `estimate_decompressed_size` was considered and rejected — the
+  library's target workloads (ERA5, ML weights, high-res climate
+  simulations) routinely produce legitimate multi-GiB single objects,
+  so any cap that fits them is too permissive to block attackers, and
+  any cap that blocks attackers breaks honest use. Fallible allocation
+  is sufficient on its own.
+- **Sound FFI buffer pattern.** `aec_decompress` keeps `len == 0`
+  during the FFI call and only `set_len(decoded_len)` after libaec
+  reports how many bytes it wrote. No uninitialised memory is ever
+  observable through the `Vec` API; this avoids the UB trap of
+  calling `set_len(expected_size)` before the bytes are written.
+- **Szip-only scope.** The fix covers the two szip backends. Four
+  sibling paths share the same threat model but are deliberately left
+  for focused follow-up PRs, tracked as separate items in `TODO.md`:
+  `simple_packing::decode*` (8× amplified output, reachable through
+  `CompressionType::None + EncodingType::SimplePacking` with no
+  compressor involved at all); `bitmask::{packing,rle,roaring}::decode`
+  (especially RLE, where a tiny compressed blob can claim a huge run
+  count); `zfp_ffi::zfp_decompress_f64` (infallible `vec![0.0f64; N]`
+  on descriptor-derived `num_values`); and the FFI-vs-pure szip
+  parameter-validation asymmetry (pure backend runs `params::validate`
+  on entry, FFI path does not).
+
 ## Examples
 
 ### Rust

--- a/plans/DONE.md
+++ b/plans/DONE.md
@@ -812,46 +812,60 @@ comparison against ecCodes.
   error paths (encoding, decoding, streaming, CLI) and the no-panic
   guarantee.
 
-## Preallocation hardening for szip decode paths
+## Preallocation hardening across decode paths
 
 A malformed `.tgm` descriptor whose tensor-shape product drove
 `num_values × dtype_byte_width` into the terabyte range previously
-aborted the decode process via infallible allocations in the szip
-codecs. Fallible reservation was already in place for blosc2 but not
-for szip; this closes the szip half of the gap.
+aborted the decode process via infallible allocations scattered across
+the codec, encoding, filter, and bitmask layers. Every descriptor-
+derived allocation on the decode path is now fallible, and every
+size-arithmetic step that could wrap `usize` on hostile input is
+guarded.
 
 | Component | What changed |
 |-----------|-------------|
-| `tensogram-encodings/src/libaec.rs` | `aec_decompress` and `aec_decompress_range` now use `Vec::new()` + `try_reserve_exact` + `set_len(decoded_len)` in place of `vec![0u8; N]`. Trust-model doc comments on both entry points. `expected_size == 0` early-returns to avoid the `NonNull::dangling()` pointer class on zero-capacity `Vec`s. `checked_sub` on `expected_size - avail_out` guards against a misbehaving libaec feeding the `set_len` an absurd length. A hostile `expected_size` / `byte_size` surfaces as `CompressionError::Szip` with a `"failed to reserve"` prefix rather than aborting the process. The removal of the eager zero-fill is also a small honest-path win. |
-| `tensogram-szip/src/decoder.rs` | The `decode` main output buffer, `decode_rsi` scratch buffer, and `write_samples` sample-serialisation buffer all switched from `Vec::with_capacity` to fallible `try_reserve_exact`. `write_samples` additionally guards the `samples.len() * byte_width` multiplication with `checked_mul`, and `samples_per_rsi = rsi_blocks * block_size` is now a `checked_mul` to survive 32-bit targets and `AEC_NOT_ENFORCE` parameter combinations. |
-| Tests | New in-module regression tests in `libaec.rs` (FFI path) and new `preallocation_hardening` module in `tensogram-szip/tests/error_paths.rs` (pure path) assert that `usize::MAX` / `isize::MAX + 1` sentinels surface as typed errors. End-to-end integration tests in `pipeline.rs::tests` exercise the full `decode_pipeline` with a hostile `PipelineConfig.num_values` against both the FFI and pure-Rust szip backends. |
-| Docs | `docs/src/guide/error-handling.md` gains a *Malformed Descriptor — Pathological Tensor Size (szip)* subsection and a new bullet under the *No-Panic Guarantee* on fallible allocation from untrusted wire-format sizes. The subsection also lists the remaining unhardened paths (`simple_packing`, bitmask, `zfp`) as explicit known limitations so callers don't mistake this for a cross-codec guarantee. |
+| `tensogram-encodings/src/libaec.rs` | `aec_decompress` and `aec_decompress_range` use `Vec::new()` + `try_reserve_exact` + `set_len(decoded_len)` in place of `vec![0u8; N]`. Trust-model doc comments on both entry points. `expected_size == 0` short-circuits to avoid the `NonNull::dangling` edge case. `checked_sub` on `expected_size - avail_out` guards `set_len`. A new `validate_params` helper rejects invalid `AecParams` (matching the pure-Rust crate): `bits_per_sample` outside `1..=32`, `block_size == 0`, invalid block sizes without `AEC_NOT_ENFORCE`, `rsi` outside `1..=4096`, `AEC_RESTRICTED` combined with `bits_per_sample > 4`. |
+| `tensogram-szip/src/` | Decoder output, `decode_rsi` scratch, and `write_samples` output all use `try_reserve_exact`. `checked_mul` on `rsi_blocks × block_size` and on `samples × byte_width`. `params::validate` tightened to reject `block_size == 0` under `AEC_NOT_ENFORCE`. |
+| `tensogram-encodings/src/simple_packing.rs` | Every decode-side allocation (`decode`, `decode_aligned`, `decode_aligned_par`, `decode_generic`, `decode_generic_par`, `decode_range`, and both `bits_per_value == 0` fast paths) uses a shared `try_reserve_f64` helper. `num_values × bpv` arithmetic promoted to `u128`, surfaced as a new `PackingError::BitCountOverflow` variant. Byte-count conversion uses `usize::try_from` producing `OutputSizeOverflow`. New `PackingError::AllocationFailed { bytes, reason }` variant. Parallel helpers now return `Result<Vec<f64>, PackingError>` and reserve before rayon dispatch (no partial output on failure). |
+| `tensogram-encodings/src/bitmask/` | `try_reserve_mask` shared helper in `mod.rs`. `packing::unpack`, `rle::decode`, `roaring::decode` all use it. New `MaskError::AllocationFailed`. RLE's run-length overflow check reworked from `out.len() + run > n_elements` (itself overflow-prone) to `run > n_elements - out.len()` (safe after the guaranteed `out.len() <= n_elements` invariant). |
+| `tensogram-encodings/src/zfp_ffi.rs` | `zfp_decompress_f64` uses `try_reserve_exact` + `resize`. |
+| `tensogram-encodings/src/compression/{zfp,sz3}.rs` | The per-codec `f64_to_bytes` helpers now return `Result<Vec<u8>, CompressionError>`, with `checked_mul` on `values.len() × 8` and fallible byte-buffer reservation. |
+| `tensogram-encodings/src/pipeline.rs` | `bytes_to_f64` and `f64_to_bytes` return `Result<_, PipelineError>` with the same guards. |
+| `tensogram-encodings/src/shuffle.rs` | Output buffers use `try_reserve_shuffle` helper; new `ShuffleError::AllocationFailed`. |
+| Tests | Helper-level tests (`try_reserve_f64`, `try_reserve_mask`, `aec_decompress` / `aec_decompress_range` with `usize::MAX`), public-API tests (simple_packing `decode` / `decode_range` with `usize::MAX` both at `bpv=0` and `bpv=64`, `zfp_decompress_f64` with `usize::MAX`, roaring with `u32::MAX + 1`), FFI parameter-validator parity tests covering all invalid combinations, and end-to-end `decode_pipeline` integration tests against both szip backends, simple_packing, and zfp. |
+| Docs | `docs/src/guide/error-handling.md` — *Malformed Descriptor — Pathological Tensor Size* subsection with the per-codec / per-stage error-variant table; the No-Panic Guarantee bullet list now calls out `checked_mul`/`u128` promotion alongside `try_reserve_exact`. |
 
 Design choices worth recording:
 
-- **No static cap.** Imposing a documented maximum decompressed size in
-  `estimate_decompressed_size` was considered and rejected — the
-  library's target workloads (ERA5, ML weights, high-res climate
-  simulations) routinely produce legitimate multi-GiB single objects,
-  so any cap that fits them is too permissive to block attackers, and
-  any cap that blocks attackers breaks honest use. Fallible allocation
-  is sufficient on its own.
+- **No static cap.** Imposing a documented maximum decompressed size
+  was considered and rejected — the library's target workloads (ERA5,
+  ML weights, high-res climate simulations) routinely produce
+  legitimate multi-GiB single objects, so any cap that fits them is
+  too permissive to block attackers, and any cap that blocks
+  attackers breaks honest use. Fallible allocation is sufficient on
+  its own.
 - **Sound FFI buffer pattern.** `aec_decompress` keeps `len == 0`
   during the FFI call and only `set_len(decoded_len)` after libaec
   reports how many bytes it wrote. No uninitialised memory is ever
   observable through the `Vec` API; this avoids the UB trap of
   calling `set_len(expected_size)` before the bytes are written.
-- **Szip-only scope.** The fix covers the two szip backends. Four
-  sibling paths share the same threat model but are deliberately left
-  for focused follow-up PRs, tracked as separate items in `TODO.md`:
-  `simple_packing::decode*` (8× amplified output, reachable through
-  `CompressionType::None + EncodingType::SimplePacking` with no
-  compressor involved at all); `bitmask::{packing,rle,roaring}::decode`
-  (especially RLE, where a tiny compressed blob can claim a huge run
-  count); `zfp_ffi::zfp_decompress_f64` (infallible `vec![0.0f64; N]`
-  on descriptor-derived `num_values`); and the FFI-vs-pure szip
-  parameter-validation asymmetry (pure backend runs `params::validate`
-  on entry, FFI path does not).
+- **Checked arithmetic at every width-conversion step.** `u128`
+  promotion for `num_values × bits_per_value`, `checked_mul` for
+  sample-count → byte-count, `checked_sub` for the `expected_size -
+  avail_out` math that drives `set_len`, `checked_add` (via
+  rearrangement) for the RLE run-length accumulator.
+- **Parallel path ordering.** All rayon-parallel decoders reserve the
+  output buffer and resize it to length `num_values` *before* any
+  `par_iter_mut` / `par_chunks_mut` call. A reservation failure
+  cannot leave rayon with a partial output buffer — it errors out
+  before dispatch.
+- **FFI / pure parity contract.** The szip parameter validator in
+  `libaec.rs` is a mirror of `params::validate` in `tensogram-szip`.
+  Both are now tightened to reject `block_size == 0` even under
+  `AEC_NOT_ENFORCE` (the previous policy would have led to
+  divide-by-zero / infinite loops later in the decoder). Parity is
+  asserted by tests on the FFI side; the pure-Rust side already had
+  coverage.
 
 ## Examples
 

--- a/plans/TODO.md
+++ b/plans/TODO.md
@@ -346,7 +346,8 @@ For speculative ideas, see `IDEAS.md`.
   scientific workloads make any usable cap too permissive to block
   attackers. See `DONE.md` → *Preallocation hardening across decode
   paths* for the full rationale, soundness notes on the FFI `set_len`
-  pattern, and the per-codec test matrix. Closes issue #68 / PR #69.
+  pattern, and the per-codec test matrix. Follows the fallible-
+  allocation pattern first established for blosc2 in PR #69.
 
 ## Viewer
 

--- a/plans/TODO.md
+++ b/plans/TODO.md
@@ -308,63 +308,45 @@ For speculative ideas, see `IDEAS.md`.
 - [x] ~~code coverage~~ → All CLI subcommands have dedicated tests (ls, dump, get, set, copy, merge, split, reshuffle, validate, convert-grib, convert-netcdf). Encodings: `simple_packing` and `zfp` covered. FFI exercised through the C++ wrapper test suite.
 - [x] ~~add logging trace~~ → `tracing` crate instrumented on encode/decode/scan/file/pipeline. Activate with `TENSOGRAM_LOG=debug`
 
-- [x] ~~**cross-codec `expected_size` preallocation hardening (szip)**~~ →
-  Fallible allocation across both szip backends (FFI `aec_decompress` +
-  `aec_decompress_range` in `libaec.rs`; pure-Rust `decode`, `decode_rsi`,
-  `write_samples` in `tensogram-szip`). `checked_mul` added to
-  `samples_per_rsi` and `write_samples` sample-count → byte-count math.
-  `checked_sub` added to the `decoded_len = expected_size - avail_out`
-  arithmetic that feeds `set_len`. Hostile `num_values` now surfaces as
-  `CompressionError::Szip` / `AecError::Data` with a `"failed to
-  reserve"` prefix instead of aborting the process.
-  Static cap deliberately NOT introduced — rejected because legitimate
-  multi-GiB scientific workloads make any usable cap too permissive to
-  block attackers. See `DONE.md` → *Preallocation hardening for szip
-  decode paths* for the full rationale and soundness notes on the FFI
-  `set_len` pattern. Closes the szip half of issue #68 / PR #69.
-
-- [ ] **preallocation hardening — `simple_packing` decode paths**:
-    - `simple_packing::decode_aligned`, `decode_generic`, `decode_range`,
-      and the parallel variants in
-      `rust/tensogram-encodings/src/simple_packing.rs` all call
-      `Vec::with_capacity(num_values)` on descriptor-derived
-      `num_values` for the output `Vec<f64>`, giving 8× amplification.
-    - Reachable without any compression codec in play
-      (`CompressionType::None + EncodingType::SimplePacking`), so a
-      malformed `.tgm` can still abort the process through this path
-      after the szip hardening landed.
-    - Fix shape mirrors the szip fix: switch `Vec::with_capacity` to
-      `Vec::new()` + `try_reserve_exact` and surface allocation
-      failures as `PackingError::AllocationFailed` (new variant).
-
-- [ ] **preallocation hardening — bitmask decode paths**:
-    - `bitmask::packing::unpack`, `bitmask::rle::decode`,
-      `bitmask::roaring::decode` each call `Vec::with_capacity(n_elements)`
-      (or `vec![false; n_elements]`) on descriptor-derived `n_elements`.
-    - RLE is especially cheap to attack: a tiny compressed blob can
-      claim a huge run count.
-    - Fix: same `try_reserve_exact` pattern; new `MaskError::AllocationFailed`
-      variant.
-
-- [ ] **preallocation hardening — `zfp_decompress_f64`**:
-    - `rust/tensogram-encodings/src/zfp_ffi.rs:82` —
-      `vec![0.0f64; num_values]` on `num_values` sourced from
-      `ZfpCompressor` which reads from the descriptor. 8× amplification,
-      eager zero-fill forces commit under Linux overcommit.
-    - Fix: `Vec::try_reserve_exact(num_values)` + avoid the eager
-      zero-fill (libzfp writes every f64 it produces into the output
-      slice passed via `zfp_field_1d`).
-
-- [ ] **FFI-vs-pure szip parameter validation asymmetry**:
-    - `rust/tensogram-szip/src/lib.rs` calls `params::validate()` on
-      every entry point.
-    - `rust/tensogram-encodings/src/libaec.rs` (FFI path) does not
-      apply the same pre-validation; it relies on libaec returning
-      non-zero status codes.
-    - Add a shared validation step (or lift `params::validate` into
-      `tensogram-encodings` as a small helper) so the two backends
-      reject malformed AEC parameters consistently before touching the
-      FFI boundary.
+- [x] ~~**cross-codec `expected_size` preallocation hardening**~~ →
+  Fallible allocation on every descriptor-derived decode-path site
+  across all codecs, encodings, filters, and bitmask decoders:
+    - szip (FFI and pure-Rust): `aec_decompress` / `aec_decompress_range`
+      in `libaec.rs`; `decode`, `decode_rsi`, `write_samples` in
+      `tensogram-szip`. `checked_mul` on `samples_per_rsi` and
+      `samples × byte_width`; `checked_sub` on the `set_len` length math.
+    - `simple_packing` decode paths: all sequential + rayon-parallel
+      variants (`decode_aligned`, `decode_aligned_par`, `decode_generic`,
+      `decode_generic_par`, `decode_range`, and the bpv=0 fast paths).
+      `num_values × bits_per_value` is now `u128`-promoted with a
+      `BitCountOverflow` error variant; byte-count conversion uses
+      `usize::try_from` to surface `OutputSizeOverflow` cleanly.
+    - Bitmask decoders (`bitmask::packing::unpack`, `bitmask::rle::decode`,
+      `bitmask::roaring::decode`): shared `try_reserve_mask` helper;
+      RLE's run-length overflow check reworked to avoid its own
+      `usize` overflow.
+    - `zfp_ffi::zfp_decompress_f64` and the wrapper's f64 → bytes
+      serialisation.
+    - `pipeline::{bytes_to_f64, f64_to_bytes}` and the per-codec
+      copies in `compression/{zfp,sz3}.rs`.
+    - `shuffle::{shuffle,unshuffle}_with_threads` output buffers.
+    - FFI szip parameter validation: `libaec.rs` now runs the same
+      `AecParams` validation as the pure-Rust crate (rejects
+      `bits_per_sample ∉ [1..=32]`, `block_size == 0`, invalid block
+      sizes without `AEC_NOT_ENFORCE`, `rsi ∉ [1..=4096]`, and
+      `AEC_RESTRICTED` with `bits_per_sample > 4`). Both backends also
+      now reject `block_size == 0` under `AEC_NOT_ENFORCE` (previous
+      gap).
+  Hostile descriptor sizes surface as typed errors
+  (`CompressionError::Szip` / `AecError::Data` / `PackingError::*` /
+  `MaskError::AllocationFailed` / `CompressionError::Zfp` /
+  `PipelineError::Range`) with a `"failed to reserve"` or
+  `"overflow"` prefix rather than aborting the process.
+  Static cap deliberately NOT introduced — legitimate multi-GiB
+  scientific workloads make any usable cap too permissive to block
+  attackers. See `DONE.md` → *Preallocation hardening across decode
+  paths* for the full rationale, soundness notes on the FFI `set_len`
+  pattern, and the per-codec test matrix. Closes issue #68 / PR #69.
 
 ## Viewer
 

--- a/plans/TODO.md
+++ b/plans/TODO.md
@@ -308,34 +308,63 @@ For speculative ideas, see `IDEAS.md`.
 - [x] ~~code coverage~~ → All CLI subcommands have dedicated tests (ls, dump, get, set, copy, merge, split, reshuffle, validate, convert-grib, convert-netcdf). Encodings: `simple_packing` and `zfp` covered. FFI exercised through the C++ wrapper test suite.
 - [x] ~~add logging trace~~ → `tracing` crate instrumented on encode/decode/scan/file/pipeline. Activate with `TENSOGRAM_LOG=debug`
 
-- [ ] **cross-codec `expected_size` preallocation hardening**:
-    - `Compressor::decompress` receives `expected_size` from
-      `estimate_decompressed_size(config)`
-      (`rust/tensogram-encodings/src/pipeline.rs:787`), which multiplies
-      `config.num_values * dtype_byte_width` with no upper-bound check.
-      `config.num_values` is attacker-controllable via the tensor-shape
-      CBOR of a malformed `.tgm` file, so a pathological value drives
-      an infallible allocation that can abort the process (DoS).
-    - blosc2 was fixed in PR #69 (which closes issue #68) by dropping
-      `expected_size` trust entirely and using `Vec::new()` + per-chunk
-      `try_reserve` (size comes from the codec's own frame trailer, not
-      the descriptor).
-    - Remaining affected codecs:
-        - `rust/tensogram-encodings/src/libaec.rs:150` —
-          `vec![0u8; expected_size]` inside szip's `aec_decompress`
-          (additionally zero-initialises the buffer, so it's worse
-          than `with_capacity`).
-        - `rust/tensogram-szip/src/decoder.rs:88` —
-          `Vec::with_capacity` on `total_samples` in the pure-Rust
-          szip backend.
-    - Recommended two-layer fix:
-        - Add an upper-bound check in `estimate_decompressed_size`
-          (or in a new descriptor-validation step on decode) so the
-          pipeline-derived sizes can't exceed a documented cap.
-        - Switch the remaining codecs to `try_reserve` + growable
-          allocation so allocation failures surface as
-          `CompressionError` instead of aborting the process.
-    - Spun out of the Copilot review on PR #69.
+- [x] ~~**cross-codec `expected_size` preallocation hardening (szip)**~~ →
+  Fallible allocation across both szip backends (FFI `aec_decompress` +
+  `aec_decompress_range` in `libaec.rs`; pure-Rust `decode`, `decode_rsi`,
+  `write_samples` in `tensogram-szip`). `checked_mul` added to
+  `samples_per_rsi` and `write_samples` sample-count → byte-count math.
+  `checked_sub` added to the `decoded_len = expected_size - avail_out`
+  arithmetic that feeds `set_len`. Hostile `num_values` now surfaces as
+  `CompressionError::Szip` / `AecError::Data` with a `"failed to
+  reserve"` prefix instead of aborting the process.
+  Static cap deliberately NOT introduced — rejected because legitimate
+  multi-GiB scientific workloads make any usable cap too permissive to
+  block attackers. See `DONE.md` → *Preallocation hardening for szip
+  decode paths* for the full rationale and soundness notes on the FFI
+  `set_len` pattern. Closes the szip half of issue #68 / PR #69.
+
+- [ ] **preallocation hardening — `simple_packing` decode paths**:
+    - `simple_packing::decode_aligned`, `decode_generic`, `decode_range`,
+      and the parallel variants in
+      `rust/tensogram-encodings/src/simple_packing.rs` all call
+      `Vec::with_capacity(num_values)` on descriptor-derived
+      `num_values` for the output `Vec<f64>`, giving 8× amplification.
+    - Reachable without any compression codec in play
+      (`CompressionType::None + EncodingType::SimplePacking`), so a
+      malformed `.tgm` can still abort the process through this path
+      after the szip hardening landed.
+    - Fix shape mirrors the szip fix: switch `Vec::with_capacity` to
+      `Vec::new()` + `try_reserve_exact` and surface allocation
+      failures as `PackingError::AllocationFailed` (new variant).
+
+- [ ] **preallocation hardening — bitmask decode paths**:
+    - `bitmask::packing::unpack`, `bitmask::rle::decode`,
+      `bitmask::roaring::decode` each call `Vec::with_capacity(n_elements)`
+      (or `vec![false; n_elements]`) on descriptor-derived `n_elements`.
+    - RLE is especially cheap to attack: a tiny compressed blob can
+      claim a huge run count.
+    - Fix: same `try_reserve_exact` pattern; new `MaskError::AllocationFailed`
+      variant.
+
+- [ ] **preallocation hardening — `zfp_decompress_f64`**:
+    - `rust/tensogram-encodings/src/zfp_ffi.rs:82` —
+      `vec![0.0f64; num_values]` on `num_values` sourced from
+      `ZfpCompressor` which reads from the descriptor. 8× amplification,
+      eager zero-fill forces commit under Linux overcommit.
+    - Fix: `Vec::try_reserve_exact(num_values)` + avoid the eager
+      zero-fill (libzfp writes every f64 it produces into the output
+      slice passed via `zfp_field_1d`).
+
+- [ ] **FFI-vs-pure szip parameter validation asymmetry**:
+    - `rust/tensogram-szip/src/lib.rs` calls `params::validate()` on
+      every entry point.
+    - `rust/tensogram-encodings/src/libaec.rs` (FFI path) does not
+      apply the same pre-validation; it relies on libaec returning
+      non-zero status codes.
+    - Add a shared validation step (or lift `params::validate` into
+      `tensogram-encodings` as a small helper) so the two backends
+      reject malformed AEC parameters consistently before touching the
+      FFI boundary.
 
 ## Viewer
 

--- a/plans/TODO.md
+++ b/plans/TODO.md
@@ -349,6 +349,59 @@ For speculative ideas, see `IDEAS.md`.
   pattern, and the per-codec test matrix. Follows the fallible-
   allocation pattern first established for blosc2 in PR #69.
 
+- [ ] **descriptor ↔ frame-payload consistency checks on decode**:
+    - Complementary to the preallocation hardening above: instead of
+      *surviving* a pathological `num_values` via fallible allocation
+      after the fact, *reject* malformed descriptors cheaper and earlier
+      by cross-checking the descriptor's claimed output size against the
+      frame's actual payload length (known from the frame header)
+      before any decompression runs.
+    - Three tiers of strictness depending on the pipeline:
+        - **Exact** for `encoding="none" + compression="none"`:
+          `frame_payload_bytes == num_values × dtype_byte_width`
+          (and `ceil(num_values / 8)` for the `bitmask` dtype). A
+          mismatch in either direction is categorically malformed.
+        - **Exact** for `encoding="simple_packing" + compression="none"`:
+          `frame_payload_bytes == ceil(num_values × bits_per_value / 8)`.
+          The current simple_packing decoder rejects too-small payloads
+          with `InsufficientData` but silently ignores too-much data
+          — this TODO tightens the too-much-data direction too.
+        - **Plausibility ratio** for compressed codecs (`zstd`, `lz4`,
+          `szip`, `blosc2`, `zfp`, `sz3`):
+          `num_values × dtype_byte_width ≤ frame_payload_bytes ×
+          MAX_PLAUSIBLE_RATIO`. Pick a conservative cap (probably
+          around `1000×`) that accommodates pathological-but-legitimate
+          high-compression inputs (RLE on all-zero bitmasks,
+          szip on constant data) while still rejecting claims wildly
+          disproportionate to the compressed payload.
+    - Fit: `pipeline::decode_pipeline` gains a
+      `validate_descriptor_size(encoded.len(), config)` step right
+      before the `compressor.decompress(encoded, expected_size)` call.
+      `decode_range_pipeline` gets a matching check sized against
+      the sliced chunk rather than the full frame.
+    - New error: `PipelineError::DescriptorSizeMismatch { claimed_bytes,
+      payload_bytes, codec }`, marked `#[non_exhaustive]` consistent
+      with the other error enums hardened in PR #90.
+    - Why separate from the preallocation-hardening PR:
+        - Distinct mechanism (upstream structural validation vs
+          downstream fallible allocation).
+        - More specific operator-visible errors ("descriptor claims
+          4 TiB but frame is 50 bytes") than the generic
+          "failed to reserve".
+        - Distinct test matrix (one per encoding × compression ×
+          {match, too-small, too-big, ratio-plausible, ratio-implausible}).
+    - Tests (behaviour-driven):
+        - Exact tier: passthrough / bitmask / simple_packing
+          round-trips with matched sizes succeed; with off-by-one
+          payload lengths surface `DescriptorSizeMismatch`.
+        - Ratio tier: hand-craft a `.tgm` with 20-byte compressed
+          payload + descriptor claiming 4 TiB decoded size, assert
+          the typed error fires before any decompression is
+          attempted.
+        - Boundary: a descriptor claiming `compressed × 1000` bytes
+          is accepted; `compressed × 1001` is rejected (or whatever
+          ratio is picked).
+
 ## Viewer
 
 - [ ] Loading spinner/skeleton on map while field is being regridded

--- a/rust/tensogram-encodings/src/bitmask/codecs.rs
+++ b/rust/tensogram-encodings/src/bitmask/codecs.rs
@@ -22,7 +22,7 @@ use super::{Bitmask, MaskError, packing};
 /// the `method = "none"` on-wire format, chosen automatically by the
 /// encoder-integration layer for masks smaller than
 /// `small_mask_threshold_bytes` (default 128).
-pub fn encode_none(bits: &[bool]) -> Vec<u8> {
+pub fn encode_none(bits: &[bool]) -> Result<Vec<u8>, MaskError> {
     packing::pack(bits)
 }
 
@@ -35,7 +35,7 @@ pub fn decode_none(bytes: &[u8], n_elements: usize) -> Result<Bitmask, MaskError
 
 #[cfg(feature = "lz4")]
 pub fn encode_lz4(bits: &[bool]) -> Result<Vec<u8>, MaskError> {
-    let packed = packing::pack(bits);
+    let packed = packing::pack(bits)?;
     Ok(lz4_flex::compress_prepend_size(&packed))
 }
 
@@ -60,7 +60,7 @@ pub fn decode_lz4(_bytes: &[u8], _n_elements: usize) -> Result<Bitmask, MaskErro
 
 #[cfg(feature = "zstd")]
 pub fn encode_zstd(bits: &[bool], level: Option<i32>) -> Result<Vec<u8>, MaskError> {
-    let packed = packing::pack(bits);
+    let packed = packing::pack(bits)?;
     let level = level.unwrap_or(3);
     zstd::encode_all(packed.as_slice(), level)
         .map_err(|e| MaskError::Codec(format!("zstd encode: {e}")))
@@ -100,7 +100,7 @@ pub fn encode_blosc2(
     use blosc2::chunk::SChunk;
     use blosc2::{CParams, DParams, Filter};
 
-    let packed = packing::pack(bits);
+    let packed = packing::pack(bits)?;
     if packed.is_empty() {
         return Ok(Vec::new());
     }
@@ -177,7 +177,7 @@ mod tests {
     #[test]
     fn none_roundtrip() {
         let bits = sample_mask();
-        let enc = encode_none(&bits);
+        let enc = encode_none(&bits).unwrap();
         let dec = decode_none(&enc, bits.len()).unwrap();
         assert_eq!(dec, bits);
     }

--- a/rust/tensogram-encodings/src/bitmask/mod.rs
+++ b/rust/tensogram-encodings/src/bitmask/mod.rs
@@ -150,6 +150,20 @@ pub enum MaskError {
     Roaring(String),
     #[error("underlying codec error: {0}")]
     Codec(String),
+    /// Fallible output-buffer reservation failed — a descriptor-derived
+    /// `n_elements` is too large for the allocator to satisfy. Surfaced
+    /// instead of the process-abort that would otherwise come from an
+    /// infallible `Vec::with_capacity` / `vec![false; N]`.
+    #[error("failed to reserve {bytes} bytes for bitmask decode: {reason}")]
+    AllocationFailed { bytes: usize, reason: String },
+}
+
+pub(crate) fn try_reserve_mask(v: &mut Vec<bool>, n: usize) -> Result<(), MaskError> {
+    v.try_reserve_exact(n)
+        .map_err(|e| MaskError::AllocationFailed {
+            bytes: n,
+            reason: e.to_string(),
+        })
 }
 
 /// A bitmask is represented in memory as a vector of `bool` with length
@@ -160,3 +174,34 @@ pub enum MaskError {
 /// Conversion to / from the bit-packed wire representation is handled
 /// by [`packing`].
 pub type Bitmask = Vec<bool>;
+
+#[cfg(test)]
+mod allocation_tests {
+    use super::*;
+
+    #[test]
+    fn try_reserve_mask_rejects_pathological_capacity() {
+        let mut v: Vec<bool> = Vec::new();
+        let err = try_reserve_mask(&mut v, isize::MAX as usize + 1)
+            .expect_err("reservation beyond isize::MAX must fail capacity check");
+        match err {
+            MaskError::AllocationFailed { .. } => {}
+            other => panic!("expected AllocationFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn roaring_decode_rejects_addressable_limit() {
+        // The pre-existing `> u32::MAX` guard fires for n_elements one
+        // past the addressable range, producing a `Malformed` error
+        // rather than an allocation abort.  After the hardening the
+        // guard still dominates for this sentinel, and the
+        // allocation-helper path is covered by the test above.
+        let err = roaring::decode(&[], u32::MAX as usize + 1)
+            .expect_err("roaring must reject n_elements > u32::MAX");
+        match err {
+            MaskError::Malformed(_) => {}
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+}

--- a/rust/tensogram-encodings/src/bitmask/mod.rs
+++ b/rust/tensogram-encodings/src/bitmask/mod.rs
@@ -150,11 +150,13 @@ pub enum MaskError {
     Roaring(String),
     #[error("underlying codec error: {0}")]
     Codec(String),
-    /// Fallible output-buffer reservation failed — a descriptor-derived
-    /// `n_elements` is too large for the allocator to satisfy. Surfaced
-    /// instead of the process-abort that would otherwise come from an
-    /// infallible `Vec::with_capacity` / `vec![false; N]`.
-    #[error("failed to reserve {bytes} bytes for bitmask decode: {reason}")]
+    /// Fallible bitmask-buffer reservation failed — a descriptor-derived
+    /// `n_elements` (on decode) or `bits.len()` (on the repack path that
+    /// compression codecs call after decode) is too large for the
+    /// allocator to satisfy. Surfaced instead of the process-abort that
+    /// would otherwise come from an infallible `Vec::with_capacity` /
+    /// `vec![false; N]` / `vec![0u8; N]`.
+    #[error("failed to reserve {bytes} bytes for bitmask buffer: {reason}")]
     AllocationFailed { bytes: usize, reason: String },
 }
 

--- a/rust/tensogram-encodings/src/bitmask/mod.rs
+++ b/rust/tensogram-encodings/src/bitmask/mod.rs
@@ -133,6 +133,7 @@ impl MaskMethod {
 /// [`crate::TensogramError::Compression`] by the encoder integration
 /// layer.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum MaskError {
     #[error(
         "unknown mask method {0:?} (expected \"none\" | \"rle\" | \"roaring\" | \"lz4\" | \"zstd\" | \"blosc2\")"

--- a/rust/tensogram-encodings/src/bitmask/packing.rs
+++ b/rust/tensogram-encodings/src/bitmask/packing.rs
@@ -26,16 +26,24 @@ use super::{Bitmask, MaskError};
 /// Pack a `&[bool]` into MSB-first bit-packed bytes.
 ///
 /// Returns `ceil(bits.len() / 8)` bytes.  Trailing bits in the final
-/// byte are zero-filled.
-pub fn pack(bits: &[bool]) -> Vec<u8> {
+/// byte are zero-filled.  The output buffer is reserved fallibly so
+/// this function can be called safely on decode paths where
+/// `bits.len()` is descriptor-derived and potentially pathological.
+pub fn pack(bits: &[bool]) -> Result<Vec<u8>, MaskError> {
     let n_bytes = bits.len().div_ceil(8);
-    let mut out = vec![0u8; n_bytes];
+    let mut out: Vec<u8> = Vec::new();
+    out.try_reserve_exact(n_bytes)
+        .map_err(|e| MaskError::AllocationFailed {
+            bytes: n_bytes,
+            reason: e.to_string(),
+        })?;
+    out.resize(n_bytes, 0);
     for (i, &b) in bits.iter().enumerate() {
         if b {
             out[i / 8] |= 1 << (7 - (i % 8));
         }
     }
-    out
+    Ok(out)
 }
 
 /// Unpack MSB-first bit-packed bytes into `n_elements` bools.
@@ -75,19 +83,19 @@ mod tests {
 
     #[test]
     fn pack_empty() {
-        assert!(pack(&[]).is_empty());
+        assert!(pack(&[]).unwrap().is_empty());
     }
 
     #[test]
     fn pack_single_bit_set() {
-        assert_eq!(pack(&[true]), vec![0b1000_0000]);
-        assert_eq!(pack(&[false]), vec![0b0000_0000]);
+        assert_eq!(pack(&[true]).unwrap(), vec![0b1000_0000]);
+        assert_eq!(pack(&[false]).unwrap(), vec![0b0000_0000]);
     }
 
     #[test]
     fn pack_full_byte_msb_first() {
         let bits = [true, true, true, true, false, false, false, false];
-        assert_eq!(pack(&bits), vec![0b1111_0000]);
+        assert_eq!(pack(&bits).unwrap(), vec![0b1111_0000]);
     }
 
     #[test]
@@ -96,21 +104,21 @@ mod tests {
         let bits = [
             true, false, true, false, true, false, true, false, true, false,
         ];
-        assert_eq!(pack(&bits), vec![0b1010_1010, 0b1000_0000]);
+        assert_eq!(pack(&bits).unwrap(), vec![0b1010_1010, 0b1000_0000]);
     }
 
     #[test]
     fn pack_multi_byte() {
         // 16 bits, alternating — yields two 0xAA bytes.
         let bits: Vec<bool> = (0..16).map(|i| i % 2 == 0).collect();
-        assert_eq!(pack(&bits), vec![0xAA, 0xAA]);
+        assert_eq!(pack(&bits).unwrap(), vec![0xAA, 0xAA]);
     }
 
     #[test]
     fn unpack_roundtrip() {
         for n in [1usize, 7, 8, 9, 15, 16, 17, 64, 65, 256, 1000] {
             let bits: Vec<bool> = (0..n).map(|i| i % 3 == 0 || i % 7 == 1).collect();
-            let packed = pack(&bits);
+            let packed = pack(&bits).unwrap();
             assert_eq!(packed.len(), n.div_ceil(8));
             let unpacked = unpack(&packed, n).unwrap();
             assert_eq!(unpacked, bits, "roundtrip failed for n={n}");

--- a/rust/tensogram-encodings/src/bitmask/packing.rs
+++ b/rust/tensogram-encodings/src/bitmask/packing.rs
@@ -53,7 +53,8 @@ pub fn unpack(bytes: &[u8], n_elements: usize) -> Result<Bitmask, MaskError> {
             actual: bytes.len(),
         });
     }
-    let mut out = Vec::with_capacity(n_elements);
+    let mut out: Vec<bool> = Vec::new();
+    super::try_reserve_mask(&mut out, n_elements)?;
     for i in 0..n_elements {
         let bit = (bytes[i / 8] >> (7 - (i % 8))) & 1;
         out.push(bit == 1);

--- a/rust/tensogram-encodings/src/bitmask/rle.rs
+++ b/rust/tensogram-encodings/src/bitmask/rle.rs
@@ -102,7 +102,8 @@ pub fn decode(bytes: &[u8], n_elements: usize) -> Result<Bitmask, MaskError> {
         }
     };
 
-    let mut out = Vec::with_capacity(n_elements);
+    let mut out: Vec<bool> = Vec::new();
+    super::try_reserve_mask(&mut out, n_elements)?;
     let mut current = start_bit;
     let mut cursor = 1;
     while cursor < bytes.len() {
@@ -119,11 +120,17 @@ pub fn decode(bytes: &[u8], n_elements: usize) -> Result<Bitmask, MaskError> {
                 "run count {run} exceeds usize — malformed or truncated"
             ))
         })?;
-        if out.len() + run_usize > n_elements {
+        // `out.len() + run_usize` can itself overflow on hostile input,
+        // so rearrange the comparison to work on the remaining budget
+        // instead: `run_usize > n_elements - out.len()`. Safe because the
+        // only way to exit this branch with `out.len() > n_elements` is
+        // for a prior iteration to have already returned an error.
+        let remaining = n_elements - out.len();
+        if run_usize > remaining {
             return Err(MaskError::Rle(format!(
                 "run overruns element count: decoded {}..{} but only {n_elements} declared",
                 out.len(),
-                out.len() + run_usize
+                out.len().saturating_add(run_usize)
             )));
         }
         for _ in 0..run_usize {

--- a/rust/tensogram-encodings/src/bitmask/roaring.rs
+++ b/rust/tensogram-encodings/src/bitmask/roaring.rs
@@ -77,7 +77,9 @@ pub fn decode(bytes: &[u8], n_elements: usize) -> Result<Bitmask, MaskError> {
     }
     let bm = RoaringBitmap::deserialize_from(bytes)
         .map_err(|e| MaskError::Roaring(format!("deserialize: {e}")))?;
-    let mut out = vec![false; n_elements];
+    let mut out: Vec<bool> = Vec::new();
+    super::try_reserve_mask(&mut out, n_elements)?;
+    out.resize(n_elements, false);
     for key in bm.iter() {
         let k = key as usize;
         if k >= n_elements {

--- a/rust/tensogram-encodings/src/compression/blosc2.rs
+++ b/rust/tensogram-encodings/src/compression/blosc2.rs
@@ -277,7 +277,16 @@ impl Compressor for Blosc2Compressor {
                 items.len()
             )));
         }
-        Ok(items[offset_in_items..end].to_vec())
+        let slice = &items[offset_in_items..end];
+        let mut out: Vec<u8> = Vec::new();
+        out.try_reserve_exact(slice.len()).map_err(|e| {
+            CompressionError::Blosc2(format!(
+                "failed to reserve {} bytes for blosc2 range output: {e}",
+                slice.len()
+            ))
+        })?;
+        out.extend_from_slice(slice);
+        Ok(out)
     }
 }
 

--- a/rust/tensogram-encodings/src/compression/blosc2.rs
+++ b/rust/tensogram-encodings/src/compression/blosc2.rs
@@ -256,9 +256,13 @@ impl Compressor for Blosc2Compressor {
             return Err(CompressionError::Blosc2("typesize is 0".to_string()));
         }
 
-        // Convert byte range to item range
+        // Convert byte range to item range with checked arithmetic —
+        // `byte_pos + byte_size` can wrap on hostile input.
         let item_start = byte_pos / ts;
-        let item_end = (byte_pos + byte_size).div_ceil(ts);
+        let byte_end = byte_pos
+            .checked_add(byte_size)
+            .ok_or_else(|| CompressionError::Blosc2("byte range overflow".to_string()))?;
+        let item_end = byte_end.div_ceil(ts);
 
         let items = schunk.items(item_start..item_end).map_err(map_err)?;
 

--- a/rust/tensogram-encodings/src/compression/rle.rs
+++ b/rust/tensogram-encodings/src/compression/rle.rs
@@ -75,7 +75,8 @@ impl Compressor for RleCompressor {
         let n_elements = u32::from_be_bytes(*prefix) as usize;
         let bits = rle::decode(rle_bytes, n_elements)
             .map_err(|e| CompressionError::Unknown(format!("RLE decode: {e}")))?;
-        let packed = packing::pack(&bits);
+        let packed = packing::pack(&bits)
+            .map_err(|e| CompressionError::Unknown(format!("RLE repack: {e}")))?;
         if packed.len() != expected_size {
             return Err(CompressionError::Unknown(format!(
                 "RLE decompressed size {} != expected {}",

--- a/rust/tensogram-encodings/src/compression/roaring.rs
+++ b/rust/tensogram-encodings/src/compression/roaring.rs
@@ -60,7 +60,8 @@ impl Compressor for RoaringCompressor {
         let n_elements = u32::from_be_bytes(*prefix) as usize;
         let bits = roaring::decode(blob, n_elements)
             .map_err(|e| CompressionError::Unknown(format!("Roaring decode: {e}")))?;
-        let packed = packing::pack(&bits);
+        let packed = packing::pack(&bits)
+            .map_err(|e| CompressionError::Unknown(format!("Roaring repack: {e}")))?;
         if packed.len() != expected_size {
             return Err(CompressionError::Unknown(format!(
                 "Roaring decompressed size {} != expected {}",

--- a/rust/tensogram-encodings/src/compression/sz3.rs
+++ b/rust/tensogram-encodings/src/compression/sz3.rs
@@ -64,7 +64,7 @@ impl Compressor for Sz3Compressor {
         let values = dimensioned.into_data();
         // Write in the wire byte order so the pipeline's byteswap step can
         // uniformly convert wire → native without special-casing lossy codecs.
-        Ok(f64_to_bytes(&values, self.byte_order))
+        f64_to_bytes(&values, self.byte_order)
     }
 
     fn decompress_range(
@@ -98,14 +98,26 @@ fn bytes_to_f64_native(data: &[u8]) -> Result<Vec<f64>, CompressionError> {
 }
 
 /// Serialise f64 values to bytes in the specified byte order.
-fn f64_to_bytes(values: &[f64], byte_order: ByteOrder) -> Vec<u8> {
-    values
-        .iter()
-        .flat_map(|v| match byte_order {
+fn f64_to_bytes(values: &[f64], byte_order: ByteOrder) -> Result<Vec<u8>, CompressionError> {
+    let bytes_len = values.len().checked_mul(8).ok_or_else(|| {
+        CompressionError::Sz3(format!(
+            "f64-to-byte output length overflows usize: {} values x 8 bytes",
+            values.len()
+        ))
+    })?;
+    let mut out: Vec<u8> = Vec::new();
+    out.try_reserve_exact(bytes_len).map_err(|e| {
+        CompressionError::Sz3(format!(
+            "failed to reserve {bytes_len} bytes for sz3 output serialisation: {e}"
+        ))
+    })?;
+    for v in values {
+        out.extend_from_slice(&match byte_order {
             ByteOrder::Big => v.to_be_bytes(),
             ByteOrder::Little => v.to_le_bytes(),
-        })
-        .collect()
+        });
+    }
+    Ok(out)
 }
 
 #[cfg(test)]

--- a/rust/tensogram-encodings/src/compression/zfp.rs
+++ b/rust/tensogram-encodings/src/compression/zfp.rs
@@ -49,7 +49,7 @@ impl Compressor for ZfpCompressor {
         let values = zfp_ffi::zfp_decompress_f64(data, self.num_values, &self.mode)?;
         // Write in the wire byte order so the pipeline's byteswap step can
         // uniformly convert wire → native without special-casing lossy codecs.
-        Ok(f64_to_bytes(&values, self.byte_order))
+        f64_to_bytes(&values, self.byte_order)
     }
 
     fn decompress_range(
@@ -71,7 +71,7 @@ impl Compressor for ZfpCompressor {
             sample_count,
         )?;
 
-        Ok(f64_to_bytes(&values, self.byte_order))
+        f64_to_bytes(&values, self.byte_order)
     }
 }
 
@@ -95,14 +95,26 @@ fn bytes_to_f64_native(data: &[u8]) -> Result<Vec<f64>, CompressionError> {
 }
 
 /// Serialise f64 values to bytes in the specified byte order.
-fn f64_to_bytes(values: &[f64], byte_order: ByteOrder) -> Vec<u8> {
-    values
-        .iter()
-        .flat_map(|v| match byte_order {
+fn f64_to_bytes(values: &[f64], byte_order: ByteOrder) -> Result<Vec<u8>, CompressionError> {
+    let bytes_len = values.len().checked_mul(8).ok_or_else(|| {
+        CompressionError::Zfp(format!(
+            "f64-to-byte output length overflows usize: {} values x 8 bytes",
+            values.len()
+        ))
+    })?;
+    let mut out: Vec<u8> = Vec::new();
+    out.try_reserve_exact(bytes_len).map_err(|e| {
+        CompressionError::Zfp(format!(
+            "failed to reserve {bytes_len} bytes for zfp output serialisation: {e}"
+        ))
+    })?;
+    for v in values {
+        out.extend_from_slice(&match byte_order {
             ByteOrder::Big => v.to_be_bytes(),
             ByteOrder::Little => v.to_le_bytes(),
-        })
-        .collect()
+        });
+    }
+    Ok(out)
 }
 
 #[cfg(test)]

--- a/rust/tensogram-encodings/src/libaec.rs
+++ b/rust/tensogram-encodings/src/libaec.rs
@@ -298,6 +298,16 @@ pub fn aec_decompress(
                 )));
             }
         };
+        // Strict equality: a full decompress is only honest when the
+        // codec writes exactly the descriptor-declared number of bytes.
+        // A short decode (even with `AEC_OK`) indicates a truncated /
+        // malformed stream that should not be accepted silently.
+        if decoded_len != expected_size {
+            aec_decode_end(&mut strm);
+            return Err(CompressionError::Szip(format!(
+                "aec_decode wrote {decoded_len} bytes, expected {expected_size} (truncated or malformed stream)"
+            )));
+        }
         aec_decode_end(&mut strm);
 
         out.set_len(decoded_len);
@@ -413,6 +423,17 @@ pub fn aec_decompress_range(
                 )));
             }
         };
+        // Strict equality: the caller asked for exactly `byte_size`
+        // bytes starting at `byte_pos`; a short write (even with
+        // `AEC_OK`) means the range request could not be fully
+        // satisfied, which for a range API is indistinguishable from
+        // a truncated / malformed input at the caller's level.
+        if decoded_len != byte_size {
+            aec_decode_end(&mut strm);
+            return Err(CompressionError::Szip(format!(
+                "aec_decode_range wrote {decoded_len} bytes, expected {byte_size} (truncated or malformed range)"
+            )));
+        }
         aec_decode_end(&mut strm);
 
         out.set_len(decoded_len);

--- a/rust/tensogram-encodings/src/libaec.rs
+++ b/rust/tensogram-encodings/src/libaec.rs
@@ -203,7 +203,18 @@ pub fn aec_decompress(
 
     validate_params(params)?;
 
-    if data.is_empty() || expected_size == 0 {
+    // The only honest case for `expected_size == 0` is an empty
+    // compressed stream; a non-empty payload paired with a claimed-zero
+    // output would otherwise silently discard whatever it decodes to.
+    if expected_size == 0 {
+        if data.is_empty() {
+            return Ok(Vec::new());
+        }
+        return Err(CompressionError::Szip(
+            "expected_size=0 with non-empty compressed stream (malformed descriptor)".to_string(),
+        ));
+    }
+    if data.is_empty() {
         return Ok(Vec::new());
     }
 

--- a/rust/tensogram-encodings/src/libaec.rs
+++ b/rust/tensogram-encodings/src/libaec.rs
@@ -135,6 +135,16 @@ fn aec_compress_impl(
 }
 
 /// Decompress an entire AEC-compressed stream.
+///
+/// # Trust model
+///
+/// `expected_size` is treated as **untrusted**. It originates from the
+/// tensor descriptor in the wire format (via
+/// `estimate_decompressed_size`) and a malformed `.tgm` file can inflate
+/// it to an arbitrary value. The buffer is therefore reserved with
+/// [`Vec::try_reserve_exact`]; an oversized request surfaces as
+/// [`CompressionError::Szip`] with a `"failed to reserve"` prefix rather
+/// than aborting the process.
 pub fn aec_decompress(
     data: &[u8],
     expected_size: usize,
@@ -142,19 +152,50 @@ pub fn aec_decompress(
 ) -> Result<Vec<u8>, CompressionError> {
     use libaec_sys::*;
 
-    if data.is_empty() {
+    if data.is_empty() || expected_size == 0 {
         return Ok(Vec::new());
     }
 
     let flags = effective_flags(params);
-    let mut out = vec![0u8; expected_size];
 
+    // Reserve capacity fallibly — untrusted `expected_size` must not be
+    // allowed to abort the process via an infallible allocator panic.
+    // We deliberately do NOT zero-initialise the buffer: libaec writes
+    // every byte it produces (see SAFETY note below), and the previous
+    // `vec![0u8; N]` form forced the kernel to commit every page up
+    // front, which was both slower and the mechanism that made hostile
+    // sizes lethal under Linux overcommit.
+    let mut out: Vec<u8> = Vec::new();
+    out.try_reserve_exact(expected_size).map_err(|e| {
+        CompressionError::Szip(format!(
+            "failed to reserve {expected_size} bytes for szip decompression: {e}"
+        ))
+    })?;
+
+    // SAFETY contract for the FFI call below:
+    //   * The `expected_size == 0` early return above means we reach
+    //     this point with `expected_size >= 1`, so the preceding
+    //     `try_reserve_exact` gave us `capacity() >= 1` — `as_mut_ptr`
+    //     is therefore a valid pointer into the backing allocation
+    //     rather than the `NonNull::dangling()` that would be returned
+    //     for a zero-capacity `Vec`.
+    //   * libaec writes forward into `next_out` for at most `avail_out`
+    //     bytes and never reads from it.
+    //   * `out.len()` remains `0` during the entire FFI call, so no
+    //     uninitialised bytes are ever logically "inside" the `Vec`.
+    //   * After decode we `set_len(decoded_len)`, where `decoded_len` is
+    //     `checked_sub`'d from `expected_size` against the reported
+    //     `avail_out`. Every byte in `0..decoded_len` is initialised by
+    //     libaec.
+    //   * On any error path we return before `set_len`, so the `Vec` is
+    //     dropped with `len == 0` and no destructor runs on
+    //     uninitialised memory.
     unsafe {
         let mut strm: aec_stream = std::mem::zeroed();
         strm.next_in = data.as_ptr();
         strm.avail_in = data.len();
         strm.next_out = out.as_mut_ptr();
-        strm.avail_out = out.len();
+        strm.avail_out = expected_size;
         strm.bits_per_sample = params.bits_per_sample;
         strm.block_size = params.block_size;
         strm.rsi = params.rsi;
@@ -170,10 +211,19 @@ pub fn aec_decompress(
             )));
         }
 
-        let decoded_len = out.len() - strm.avail_out;
+        // `checked_sub` guards against a misbehaving libaec leaving
+        // `avail_out > expected_size` (not legal per the libaec contract,
+        // but cheap insurance against the wrapping arithmetic that would
+        // otherwise feed `set_len` an absurd length).
+        let decoded_len = expected_size.checked_sub(strm.avail_out).ok_or_else(|| {
+            CompressionError::Szip(format!(
+                "aec_decode reported avail_out={} > expected_size={expected_size}",
+                strm.avail_out
+            ))
+        })?;
         aec_decode_end(&mut strm);
 
-        out.truncate(decoded_len);
+        out.set_len(decoded_len);
         Ok(out)
     }
 }
@@ -182,6 +232,15 @@ pub fn aec_decompress(
 ///
 /// `block_offsets` are bit offsets of RSI block boundaries in the compressed stream.
 /// `byte_pos` and `byte_size` specify the byte range within the decompressed output to extract.
+///
+/// # Trust model
+///
+/// `byte_size` is treated as **untrusted**. For honest callers it is the
+/// requested range length, but an attacker-supplied descriptor can make
+/// upstream range-math produce arbitrary values. The output buffer is
+/// reserved with [`Vec::try_reserve_exact`]; an oversized request
+/// surfaces as [`CompressionError::Szip`] with a `"failed to reserve"`
+/// prefix rather than aborting the process.
 pub fn aec_decompress_range(
     data: &[u8],
     block_offsets: &[u64],
@@ -201,15 +260,28 @@ pub fn aec_decompress_range(
     }
 
     let flags = effective_flags(params);
-    let mut out = vec![0u8; byte_size];
+
+    // Fallible reservation — mirrors `aec_decompress` above; see its
+    // trust-model doc comment for the full rationale.
+    let mut out: Vec<u8> = Vec::new();
+    out.try_reserve_exact(byte_size).map_err(|e| {
+        CompressionError::Szip(format!(
+            "failed to reserve {byte_size} bytes for szip range decode: {e}"
+        ))
+    })?;
     let offsets_usize: Vec<usize> = block_offsets.iter().map(|&o| o as usize).collect();
 
+    // SAFETY: identical reasoning to `aec_decompress`; `out.len() == 0`
+    // throughout the FFI call, `capacity >= byte_size`, libaec only
+    // writes forward into `next_out`, and `set_len(decoded_len)` runs
+    // only on success with `decoded_len = byte_size - strm.avail_out`
+    // bytes all initialised by libaec.
     unsafe {
         let mut strm: aec_stream = std::mem::zeroed();
         strm.next_in = data.as_ptr();
         strm.avail_in = data.len();
         strm.next_out = out.as_mut_ptr();
-        strm.avail_out = out.len();
+        strm.avail_out = byte_size;
         strm.bits_per_sample = params.bits_per_sample;
         strm.block_size = params.block_size;
         strm.rsi = params.rsi;
@@ -231,10 +303,17 @@ pub fn aec_decompress_range(
             )));
         }
 
-        let decoded_len = out.len() - strm.avail_out;
+        // `checked_sub` guards against a misbehaving libaec (see the
+        // matching note in `aec_decompress`).
+        let decoded_len = byte_size.checked_sub(strm.avail_out).ok_or_else(|| {
+            CompressionError::Szip(format!(
+                "aec_decode_range reported avail_out={} > byte_size={byte_size}",
+                strm.avail_out
+            ))
+        })?;
         aec_decode_end(&mut strm);
 
-        out.truncate(decoded_len);
+        out.set_len(decoded_len);
         Ok(out)
     }
 }
@@ -466,5 +545,48 @@ mod tests {
             Err(_) => {} // Error is acceptable
             Ok(decompressed) => assert_ne!(decompressed, data, "corruption should change output"),
         }
+    }
+
+    // ── Preallocation-DoS hardening ──────────────────────────────────────
+    //
+    // Regression tests for the cross-codec `expected_size` preallocation
+    // hardening.  Before the fix, a malicious descriptor whose shape
+    // product was close to `usize::MAX` could drive `aec_decompress` (or
+    // `aec_decompress_range`) into an infallible `vec![0u8; N]` that
+    // aborted the process.  After the fix, the untrusted size is
+    // reserved fallibly and rejected cleanly as `CompressionError::Szip`.
+
+    fn small_real_compressed_blob() -> (Vec<u8>, AecParams) {
+        let params = default_params(8);
+        let data: Vec<u8> = (0..256).map(|i| i as u8).collect();
+        let (compressed, _) = aec_compress(&data, &params).unwrap();
+        (compressed, params)
+    }
+
+    #[test]
+    fn aec_decompress_rejects_pathological_expected_size() {
+        let (compressed, params) = small_real_compressed_blob();
+
+        let err = aec_decompress(&compressed, usize::MAX, &params)
+            .expect_err("expected allocation failure, not success nor abort");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("failed to reserve"),
+            "error should report allocation failure, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn aec_decompress_range_rejects_pathological_byte_size() {
+        let (compressed, params) = small_real_compressed_blob();
+        let offsets: Vec<u64> = Vec::new();
+
+        let err = aec_decompress_range(&compressed, &offsets, 0, usize::MAX, &params)
+            .expect_err("expected allocation failure, not success nor abort");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("failed to reserve"),
+            "error should report allocation failure, got: {msg}"
+        );
     }
 }

--- a/rust/tensogram-encodings/src/libaec.rs
+++ b/rust/tensogram-encodings/src/libaec.rs
@@ -38,12 +38,61 @@ pub fn aec_compress_no_offsets(
     Ok(bytes)
 }
 
+/// Reject AEC parameter combinations that libaec would fail on, or that
+/// would drive the decoder into divide-by-zero / infinite-loop territory
+/// (`block_size == 0`, `rsi == 0`).  Mirrors the pure-Rust backend's
+/// `params::validate` so both szip implementations reject the same
+/// malformed input up front, before any FFI boundary is crossed.
+fn validate_params(params: &AecParams) -> Result<(), CompressionError> {
+    use libaec_sys::*;
+
+    if params.bits_per_sample == 0 || params.bits_per_sample > 32 {
+        return Err(CompressionError::Szip(format!(
+            "bits_per_sample must be 1..=32, got {}",
+            params.bits_per_sample
+        )));
+    }
+    if params.block_size == 0 {
+        return Err(CompressionError::Szip(
+            "block_size must be non-zero".to_string(),
+        ));
+    }
+    if params.flags & AEC_NOT_ENFORCE != 0 {
+        if params.block_size & 1 != 0 {
+            return Err(CompressionError::Szip(format!(
+                "block_size must be even, got {}",
+                params.block_size
+            )));
+        }
+    } else if !matches!(params.block_size, 8 | 16 | 32 | 64) {
+        return Err(CompressionError::Szip(format!(
+            "block_size must be 8, 16, 32, or 64, got {}",
+            params.block_size
+        )));
+    }
+    if params.rsi == 0 || params.rsi > 4096 {
+        return Err(CompressionError::Szip(format!(
+            "rsi must be 1..=4096, got {}",
+            params.rsi
+        )));
+    }
+    if params.flags & AEC_RESTRICTED != 0 && params.bits_per_sample > 4 {
+        return Err(CompressionError::Szip(format!(
+            "AEC_RESTRICTED requires bits_per_sample <= 4, got {}",
+            params.bits_per_sample
+        )));
+    }
+    Ok(())
+}
+
 fn aec_compress_impl(
     data: &[u8],
     params: &AecParams,
     track_offsets: bool,
 ) -> Result<(Vec<u8>, Vec<u64>), CompressionError> {
     use libaec_sys::*;
+
+    validate_params(params)?;
 
     if data.is_empty() {
         return Ok((Vec::new(), Vec::new()));
@@ -152,6 +201,8 @@ pub fn aec_decompress(
 ) -> Result<Vec<u8>, CompressionError> {
     use libaec_sys::*;
 
+    validate_params(params)?;
+
     if data.is_empty() || expected_size == 0 {
         return Ok(Vec::new());
     }
@@ -249,6 +300,8 @@ pub fn aec_decompress_range(
     params: &AecParams,
 ) -> Result<Vec<u8>, CompressionError> {
     use libaec_sys::*;
+
+    validate_params(params)?;
 
     if byte_size == 0 {
         return Ok(Vec::new());
@@ -588,5 +641,97 @@ mod tests {
             msg.contains("failed to reserve"),
             "error should report allocation failure, got: {msg}"
         );
+    }
+
+    // ── FFI parameter validator parity ──────────────────────────────────
+    //
+    // The FFI backend must reject the same invalid `AecParams` as the
+    // pure-Rust backend's `params::validate`. These tests assert the
+    // parity contract — without them the FFI path could drift from the
+    // pure-Rust path unnoticed.
+
+    fn tiny_compressed_blob() -> Vec<u8> {
+        let data: Vec<u8> = (0..32).map(|i| i as u8).collect();
+        let (compressed, _) = aec_compress(&data, &default_params(8)).unwrap();
+        compressed
+    }
+
+    #[test]
+    fn validate_rejects_bits_per_sample_zero() {
+        let mut params = default_params(8);
+        params.bits_per_sample = 0;
+        let err = aec_decompress(&tiny_compressed_blob(), 32, &params)
+            .expect_err("bits_per_sample=0 must be rejected");
+        assert!(format!("{err}").contains("bits_per_sample"));
+    }
+
+    #[test]
+    fn validate_rejects_bits_per_sample_over_32() {
+        let mut params = default_params(8);
+        params.bits_per_sample = 33;
+        let err = aec_decompress(&tiny_compressed_blob(), 32, &params)
+            .expect_err("bits_per_sample=33 must be rejected");
+        assert!(format!("{err}").contains("bits_per_sample"));
+    }
+
+    #[test]
+    fn validate_rejects_block_size_zero() {
+        let mut params = default_params(8);
+        params.block_size = 0;
+        let err = aec_decompress(&tiny_compressed_blob(), 32, &params)
+            .expect_err("block_size=0 must be rejected");
+        assert!(format!("{err}").contains("block_size"));
+    }
+
+    #[test]
+    fn validate_rejects_invalid_block_size_without_not_enforce() {
+        let mut params = default_params(8);
+        params.block_size = 7;
+        let err = aec_decompress(&tiny_compressed_blob(), 32, &params)
+            .expect_err("block_size=7 must be rejected without AEC_NOT_ENFORCE");
+        assert!(format!("{err}").contains("block_size"));
+    }
+
+    #[test]
+    fn validate_rejects_rsi_zero() {
+        let mut params = default_params(8);
+        params.rsi = 0;
+        let err = aec_decompress(&tiny_compressed_blob(), 32, &params)
+            .expect_err("rsi=0 must be rejected");
+        assert!(format!("{err}").contains("rsi"));
+    }
+
+    #[test]
+    fn validate_rejects_rsi_over_4096() {
+        let mut params = default_params(8);
+        params.rsi = 4097;
+        let err = aec_decompress(&tiny_compressed_blob(), 32, &params)
+            .expect_err("rsi=4097 must be rejected");
+        assert!(format!("{err}").contains("rsi"));
+    }
+
+    #[test]
+    fn validate_rejects_restricted_with_bps_over_4() {
+        let mut params = default_params(8);
+        params.flags |= libaec_sys::AEC_RESTRICTED;
+        let err = aec_decompress(&tiny_compressed_blob(), 32, &params)
+            .expect_err("AEC_RESTRICTED with bits_per_sample>4 must be rejected");
+        assert!(format!("{err}").contains("RESTRICTED"));
+    }
+
+    #[test]
+    fn validate_accepts_not_enforce_even_block_size() {
+        // Even block sizes outside {8,16,32,64} are valid under
+        // AEC_NOT_ENFORCE. Round-trip must succeed.
+        let params = AecParams {
+            bits_per_sample: 8,
+            block_size: 6,
+            rsi: 64,
+            flags: libaec_sys::AEC_DATA_PREPROCESS | libaec_sys::AEC_NOT_ENFORCE,
+        };
+        let data: Vec<u8> = (0..96).map(|i| i as u8).collect();
+        let (compressed, _) = aec_compress(&data, &params).unwrap();
+        let decoded = aec_decompress(&compressed, data.len(), &params).unwrap();
+        assert_eq!(decoded, data);
     }
 }

--- a/rust/tensogram-encodings/src/libaec.rs
+++ b/rust/tensogram-encodings/src/libaec.rs
@@ -265,13 +265,19 @@ pub fn aec_decompress(
         // `checked_sub` guards against a misbehaving libaec leaving
         // `avail_out > expected_size` (not legal per the libaec contract,
         // but cheap insurance against the wrapping arithmetic that would
-        // otherwise feed `set_len` an absurd length).
-        let decoded_len = expected_size.checked_sub(strm.avail_out).ok_or_else(|| {
-            CompressionError::Szip(format!(
-                "aec_decode reported avail_out={} > expected_size={expected_size}",
-                strm.avail_out
-            ))
-        })?;
+        // otherwise feed `set_len` an absurd length).  Call
+        // `aec_decode_end` unconditionally on this error path too so
+        // the stream state is never leaked.
+        let decoded_len = match expected_size.checked_sub(strm.avail_out) {
+            Some(n) => n,
+            None => {
+                let avail = strm.avail_out;
+                aec_decode_end(&mut strm);
+                return Err(CompressionError::Szip(format!(
+                    "aec_decode reported avail_out={avail} > expected_size={expected_size}"
+                )));
+            }
+        };
         aec_decode_end(&mut strm);
 
         out.set_len(decoded_len);
@@ -322,7 +328,24 @@ pub fn aec_decompress_range(
             "failed to reserve {byte_size} bytes for szip range decode: {e}"
         ))
     })?;
-    let offsets_usize: Vec<usize> = block_offsets.iter().map(|&o| o as usize).collect();
+    // Build the usize offsets fallibly: `block_offsets.len()` is
+    // small and attacker-bounded by the number of RSI blocks, but
+    // `u64 -> usize` can truncate on 32-bit targets, so use
+    // `usize::try_from` to surface the overflow as a typed error.
+    let mut offsets_usize: Vec<usize> = Vec::new();
+    offsets_usize
+        .try_reserve_exact(block_offsets.len())
+        .map_err(|e| {
+            CompressionError::Szip(format!(
+                "failed to reserve {} offsets for szip range decode: {e}",
+                block_offsets.len(),
+            ))
+        })?;
+    for &o in block_offsets {
+        offsets_usize.push(usize::try_from(o).map_err(|_| {
+            CompressionError::Szip(format!("RSI block offset {o} exceeds usize on this target"))
+        })?);
+    }
 
     // SAFETY: identical reasoning to `aec_decompress`; `out.len() == 0`
     // throughout the FFI call, `capacity >= byte_size`, libaec only
@@ -357,13 +380,19 @@ pub fn aec_decompress_range(
         }
 
         // `checked_sub` guards against a misbehaving libaec (see the
-        // matching note in `aec_decompress`).
-        let decoded_len = byte_size.checked_sub(strm.avail_out).ok_or_else(|| {
-            CompressionError::Szip(format!(
-                "aec_decode_range reported avail_out={} > byte_size={byte_size}",
-                strm.avail_out
-            ))
-        })?;
+        // matching note in `aec_decompress`).  Call `aec_decode_end`
+        // unconditionally on this error path so the stream state is
+        // never leaked.
+        let decoded_len = match byte_size.checked_sub(strm.avail_out) {
+            Some(n) => n,
+            None => {
+                let avail = strm.avail_out;
+                aec_decode_end(&mut strm);
+                return Err(CompressionError::Szip(format!(
+                    "aec_decode_range reported avail_out={avail} > byte_size={byte_size}"
+                )));
+            }
+        };
         aec_decode_end(&mut strm);
 
         out.set_len(decoded_len);

--- a/rust/tensogram-encodings/src/libaec.rs
+++ b/rust/tensogram-encodings/src/libaec.rs
@@ -203,19 +203,28 @@ pub fn aec_decompress(
 
     validate_params(params)?;
 
-    // The only honest case for `expected_size == 0` is an empty
-    // compressed stream; a non-empty payload paired with a claimed-zero
-    // output would otherwise silently discard whatever it decodes to.
-    if expected_size == 0 {
-        if data.is_empty() {
-            return Ok(Vec::new());
+    // Reject the two malformed pairings that would otherwise silently
+    // return `Ok(empty)`:
+    //   * `expected_size == 0` with non-empty compressed data would
+    //     discard whatever the data decodes to.
+    //   * `expected_size > 0` with empty compressed data would claim a
+    //     successful decode of a truncated/missing payload.
+    // The only honest case is both sides empty, which round-trips as
+    // an empty Vec.
+    match (expected_size, data.is_empty()) {
+        (0, true) => return Ok(Vec::new()),
+        (0, false) => {
+            return Err(CompressionError::Szip(
+                "expected_size=0 with non-empty compressed stream (malformed descriptor)"
+                    .to_string(),
+            ));
         }
-        return Err(CompressionError::Szip(
-            "expected_size=0 with non-empty compressed stream (malformed descriptor)".to_string(),
-        ));
-    }
-    if data.is_empty() {
-        return Ok(Vec::new());
+        (_, true) => {
+            return Err(CompressionError::Szip(format!(
+                "expected_size={expected_size} with empty compressed stream (truncated or malformed payload)"
+            )));
+        }
+        _ => {}
     }
 
     let flags = effective_flags(params);

--- a/rust/tensogram-encodings/src/pipeline.rs
+++ b/rust/tensogram-encodings/src/pipeline.rs
@@ -742,10 +742,23 @@ pub fn decode_range_pipeline(
         }
         EncodingType::None => {
             let elem_size = config.dtype_byte_width;
-            let bs = (sample_offset as usize)
+            // `usize::try_from` rather than `as usize` so a `u64`
+            // sample offset/count truncating on 32-bit surfaces as a
+            // typed error instead of slicing into bogus memory.
+            let offset_usize = usize::try_from(sample_offset).map_err(|_| {
+                PipelineError::Range(format!(
+                    "sample_offset {sample_offset} exceeds usize on this target"
+                ))
+            })?;
+            let count_usize = usize::try_from(sample_count).map_err(|_| {
+                PipelineError::Range(format!(
+                    "sample_count {sample_count} exceeds usize on this target"
+                ))
+            })?;
+            let bs = offset_usize
                 .checked_mul(elem_size)
                 .ok_or_else(|| PipelineError::Range("byte offset overflow".to_string()))?;
-            let sz = (sample_count as usize)
+            let sz = count_usize
                 .checked_mul(elem_size)
                 .ok_or_else(|| PipelineError::Range("byte count overflow".to_string()))?;
             (bs, sz, None)
@@ -764,7 +777,7 @@ pub fn decode_range_pipeline(
                     "range ({sample_offset}, {sample_count}) exceeds payload size"
                 )));
             }
-            encoded[byte_start..byte_end].to_vec()
+            try_clone_bytes(&encoded[byte_start..byte_end])?
         }
         Some(compressor) => {
             compressor.decompress_range(encoded, block_offsets, byte_start, byte_size)?
@@ -787,10 +800,15 @@ pub fn decode_range_pipeline(
             Ok(result)
         }
         EncodingType::SimplePacking(params) => {
+            let count_usize = usize::try_from(sample_count).map_err(|_| {
+                PipelineError::Range(format!(
+                    "sample_count {sample_count} exceeds usize on this target"
+                ))
+            })?;
             let values = simple_packing::decode_range(
                 &decompressed,
                 bit_offset_in_chunk.unwrap_or(0),
-                sample_count as usize,
+                count_usize,
                 params,
             )?;
             f64_to_bytes(&values, target_byte_order)
@@ -816,6 +834,18 @@ fn estimate_decompressed_size(config: &PipelineConfig) -> usize {
             total_bits.div_ceil(8).min(usize::MAX as u128) as usize
         }
     }
+}
+
+pub(crate) fn try_clone_bytes(src: &[u8]) -> Result<Vec<u8>, PipelineError> {
+    let mut out: Vec<u8> = Vec::new();
+    out.try_reserve_exact(src.len()).map_err(|e| {
+        PipelineError::Range(format!(
+            "failed to reserve {} bytes for range output clone: {e}",
+            src.len()
+        ))
+    })?;
+    out.extend_from_slice(src);
+    Ok(out)
 }
 
 fn bytes_to_f64(data: &[u8], byte_order: ByteOrder) -> Result<Vec<f64>, PipelineError> {

--- a/rust/tensogram-encodings/src/pipeline.rs
+++ b/rust/tensogram-encodings/src/pipeline.rs
@@ -1381,4 +1381,76 @@ mod tests {
             "transparent simple_packing must produce byte-identical hashes across thread counts: {hashes:?}"
         );
     }
+
+    // ── Preallocation-DoS hardening (end-to-end) ────────────────────────
+    //
+    // Integration tests for the cross-codec `expected_size` preallocation
+    // hardening.  A malformed descriptor with a hostile `num_values` must
+    // surface as a `PipelineError::Compression` through the normal error
+    // channel, not as a process abort.  Covers both szip backends when
+    // both features are compiled in.
+
+    #[cfg(any(feature = "szip", feature = "szip-pure"))]
+    fn szip_hostile_config(num_values: usize, backend: CompressionBackend) -> PipelineConfig {
+        PipelineConfig {
+            encoding: EncodingType::None,
+            filter: FilterType::None,
+            compression: CompressionType::Szip {
+                bits_per_sample: 8,
+                block_size: 16,
+                rsi: 64,
+                flags: 0,
+            },
+            num_values,
+            byte_order: ByteOrder::Little,
+            dtype_byte_width: 1,
+            swap_unit_size: 1,
+            compression_backend: backend,
+            intra_codec_threads: 0,
+            compute_hash: false,
+        }
+    }
+
+    #[cfg(any(feature = "szip", feature = "szip-pure"))]
+    fn small_szip_payload(backend: CompressionBackend) -> Vec<u8> {
+        // Encode 256 bytes honestly with the selected backend so we have
+        // a real szip-compressed payload the decode pipeline will accept
+        // up to the reservation step.
+        let data: Vec<u8> = (0..256).map(|i| i as u8).collect();
+        let honest = PipelineConfig {
+            num_values: data.len(),
+            ..szip_hostile_config(data.len(), backend)
+        };
+        encode_pipeline(&data, &honest).unwrap().encoded_bytes
+    }
+
+    #[cfg(feature = "szip")]
+    #[test]
+    fn pipeline_rejects_malicious_num_values_szip_ffi() {
+        let payload = small_szip_payload(CompressionBackend::Ffi);
+        let hostile = szip_hostile_config(usize::MAX, CompressionBackend::Ffi);
+
+        let err = decode_pipeline(&payload, &hostile, false)
+            .expect_err("expected allocation failure, not success nor abort");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("failed to reserve"),
+            "error should report allocation failure, got: {msg}"
+        );
+    }
+
+    #[cfg(feature = "szip-pure")]
+    #[test]
+    fn pipeline_rejects_malicious_num_values_szip_pure() {
+        let payload = small_szip_payload(CompressionBackend::Pure);
+        let hostile = szip_hostile_config(usize::MAX, CompressionBackend::Pure);
+
+        let err = decode_pipeline(&payload, &hostile, false)
+            .expect_err("expected allocation failure, not success nor abort");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("failed to reserve"),
+            "error should report allocation failure, got: {msg}"
+        );
+    }
 }

--- a/rust/tensogram-encodings/src/pipeline.rs
+++ b/rust/tensogram-encodings/src/pipeline.rs
@@ -849,6 +849,16 @@ pub(crate) fn try_clone_bytes(src: &[u8]) -> Result<Vec<u8>, PipelineError> {
 }
 
 fn bytes_to_f64(data: &[u8], byte_order: ByteOrder) -> Result<Vec<f64>, PipelineError> {
+    // Reject partial trailing bytes rather than silently truncating —
+    // `chunks_exact(8)` would otherwise drop them, which on the encode
+    // side (simple_packing) would feed a truncated value stream into
+    // the encoder without any error.
+    if !data.len().is_multiple_of(8) {
+        return Err(PipelineError::Range(format!(
+            "byte-to-f64 input length {} is not a multiple of 8",
+            data.len()
+        )));
+    }
     let n = data.len() / 8;
     let mut out: Vec<f64> = Vec::new();
     out.try_reserve_exact(n).map_err(|e| {

--- a/rust/tensogram-encodings/src/pipeline.rs
+++ b/rust/tensogram-encodings/src/pipeline.rs
@@ -719,11 +719,26 @@ pub fn decode_range_pipeline(
     // Phase 1: Compute byte range needed from the (possibly compressed) stream
     let (byte_start, byte_size, bit_offset_in_chunk) = match &config.encoding {
         EncodingType::SimplePacking(params) => {
-            let bit_start = sample_offset * params.bits_per_value as u64;
-            let bit_count = sample_count * params.bits_per_value as u64;
-            let bs = (bit_start / 8) as usize;
-            let be = (bit_start + bit_count).div_ceil(8) as usize;
-            (bs, be - bs, Some((bit_start % 8) as usize))
+            // Promote to u128 for the bit-position arithmetic so a hostile
+            // `sample_offset` or `sample_count` cannot silently wrap.
+            let bpv = params.bits_per_value as u128;
+            let bit_start_u128 = (sample_offset as u128)
+                .checked_mul(bpv)
+                .ok_or_else(|| PipelineError::Range("bit start overflow".to_string()))?;
+            let bit_count_u128 = (sample_count as u128)
+                .checked_mul(bpv)
+                .ok_or_else(|| PipelineError::Range("bit count overflow".to_string()))?;
+            let bit_end_u128 = bit_start_u128
+                .checked_add(bit_count_u128)
+                .ok_or_else(|| PipelineError::Range("bit end overflow".to_string()))?;
+            let bs = usize::try_from(bit_start_u128 / 8)
+                .map_err(|_| PipelineError::Range("byte start exceeds usize".to_string()))?;
+            let be = usize::try_from(bit_end_u128.div_ceil(8))
+                .map_err(|_| PipelineError::Range("byte end exceeds usize".to_string()))?;
+            let size = be
+                .checked_sub(bs)
+                .ok_or_else(|| PipelineError::Range("byte range invariant violated".to_string()))?;
+            (bs, size, Some((bit_start_u128 % 8) as usize))
         }
         EncodingType::None => {
             let elem_size = config.dtype_byte_width;

--- a/rust/tensogram-encodings/src/pipeline.rs
+++ b/rust/tensogram-encodings/src/pipeline.rs
@@ -511,7 +511,7 @@ pub fn encode_pipeline(
     let encoded: Cow<'_, [u8]> = match &config.encoding {
         EncodingType::None => Cow::Borrowed(data),
         EncodingType::SimplePacking(params) => {
-            let values = bytes_to_f64(data, config.byte_order);
+            let values = bytes_to_f64(data, config.byte_order)?;
             Cow::Owned(simple_packing::encode_with_threads(
                 &values,
                 params,
@@ -578,7 +578,7 @@ pub fn encode_pipeline_f64(
         .then(xxhash_rust::xxh3::Xxh3Default::new);
 
     let encoded: Cow<'_, [u8]> = match &config.encoding {
-        EncodingType::None => Cow::Owned(f64_to_bytes(values, config.byte_order)),
+        EncodingType::None => Cow::Owned(f64_to_bytes(values, config.byte_order)?),
         EncodingType::SimplePacking(params) => Cow::Owned(simple_packing::encode_with_threads(
             values,
             params,
@@ -676,7 +676,7 @@ pub fn decode_pipeline(
                 params,
                 config.intra_codec_threads,
             )?;
-            f64_to_bytes(&values, target_byte_order)
+            f64_to_bytes(&values, target_byte_order)?
         }
     };
 
@@ -778,7 +778,7 @@ pub fn decode_range_pipeline(
                 sample_count as usize,
                 params,
             )?;
-            Ok(f64_to_bytes(&values, target_byte_order))
+            f64_to_bytes(&values, target_byte_order)
         }
     }
 }
@@ -803,27 +803,46 @@ fn estimate_decompressed_size(config: &PipelineConfig) -> usize {
     }
 }
 
-fn bytes_to_f64(data: &[u8], byte_order: ByteOrder) -> Vec<f64> {
-    data.chunks_exact(8)
-        .map(|chunk| {
-            let mut arr = [0u8; 8];
-            arr.copy_from_slice(chunk);
-            match byte_order {
-                ByteOrder::Big => f64::from_be_bytes(arr),
-                ByteOrder::Little => f64::from_le_bytes(arr),
-            }
-        })
-        .collect()
+fn bytes_to_f64(data: &[u8], byte_order: ByteOrder) -> Result<Vec<f64>, PipelineError> {
+    let n = data.len() / 8;
+    let mut out: Vec<f64> = Vec::new();
+    out.try_reserve_exact(n).map_err(|e| {
+        PipelineError::Range(format!(
+            "failed to reserve {} bytes for byte-to-f64 conversion: {e}",
+            n.saturating_mul(std::mem::size_of::<f64>()),
+        ))
+    })?;
+    for chunk in data.chunks_exact(8) {
+        let mut arr = [0u8; 8];
+        arr.copy_from_slice(chunk);
+        out.push(match byte_order {
+            ByteOrder::Big => f64::from_be_bytes(arr),
+            ByteOrder::Little => f64::from_le_bytes(arr),
+        });
+    }
+    Ok(out)
 }
 
-fn f64_to_bytes(values: &[f64], byte_order: ByteOrder) -> Vec<u8> {
-    values
-        .iter()
-        .flat_map(|v| match byte_order {
+fn f64_to_bytes(values: &[f64], byte_order: ByteOrder) -> Result<Vec<u8>, PipelineError> {
+    let bytes_len = values.len().checked_mul(8).ok_or_else(|| {
+        PipelineError::Range(format!(
+            "f64-to-byte output length overflows usize: {} values x 8 bytes",
+            values.len()
+        ))
+    })?;
+    let mut out: Vec<u8> = Vec::new();
+    out.try_reserve_exact(bytes_len).map_err(|e| {
+        PipelineError::Range(format!(
+            "failed to reserve {bytes_len} bytes for f64-to-byte conversion: {e}"
+        ))
+    })?;
+    for v in values {
+        out.extend_from_slice(&match byte_order {
             ByteOrder::Big => v.to_be_bytes(),
             ByteOrder::Little => v.to_le_bytes(),
-        })
-        .collect()
+        });
+    }
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -872,7 +891,7 @@ mod tests {
 
         let result = encode_pipeline(&data, &config).unwrap();
         let decoded = decode_pipeline(&result.encoded_bytes, &config, false).unwrap();
-        let decoded_values = bytes_to_f64(&decoded, ByteOrder::Little);
+        let decoded_values = bytes_to_f64(&decoded, ByteOrder::Little).unwrap();
 
         for (orig, dec) in values.iter().zip(decoded_values.iter()) {
             assert!((orig - dec).abs() < 0.01, "orig={orig}, dec={dec}");
@@ -1447,6 +1466,80 @@ mod tests {
 
         let err = decode_pipeline(&payload, &hostile, false)
             .expect_err("expected allocation failure, not success nor abort");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("failed to reserve"),
+            "error should report allocation failure, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn pipeline_rejects_malicious_num_values_simple_packing() {
+        // simple_packing with no compressor is the easiest descriptor-
+        // driven abort path after the szip hardening: a malformed shape
+        // takes `num_values` straight into simple_packing::decode_with_threads.
+        let values: Vec<f64> = (0..10).map(|i| i as f64).collect();
+        let data: Vec<u8> = values.iter().flat_map(|v| v.to_le_bytes()).collect();
+        let sp_params = simple_packing::compute_params(&values, 16, 0).unwrap();
+
+        let honest = PipelineConfig {
+            encoding: EncodingType::SimplePacking(sp_params.clone()),
+            filter: FilterType::None,
+            compression: CompressionType::None,
+            num_values: values.len(),
+            byte_order: ByteOrder::Little,
+            dtype_byte_width: 8,
+            swap_unit_size: 8,
+            compression_backend: CompressionBackend::default(),
+            intra_codec_threads: 0,
+            compute_hash: false,
+        };
+        let payload = encode_pipeline(&data, &honest).unwrap().encoded_bytes;
+
+        let hostile = PipelineConfig {
+            num_values: usize::MAX,
+            ..honest
+        };
+        let err = decode_pipeline(&payload, &hostile, false)
+            .expect_err("pathological num_values on simple_packing must surface as an error");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("overflow")
+                || msg.contains("failed to reserve")
+                || msg.contains("Insufficient")
+                || msg.contains("insufficient"),
+            "error should report a guard-check failure, got: {msg}"
+        );
+    }
+
+    #[cfg(feature = "zfp")]
+    #[test]
+    fn pipeline_rejects_malicious_num_values_zfp() {
+        let values: Vec<f64> = (0..64).map(|i| (i as f64) * 0.1).collect();
+        let data: Vec<u8> = values.iter().flat_map(|v| v.to_ne_bytes()).collect();
+
+        let honest = PipelineConfig {
+            encoding: EncodingType::None,
+            filter: FilterType::None,
+            compression: CompressionType::Zfp {
+                mode: ZfpMode::FixedRate { rate: 16.0 },
+            },
+            num_values: values.len(),
+            byte_order: ByteOrder::native(),
+            dtype_byte_width: 8,
+            swap_unit_size: 8,
+            compression_backend: CompressionBackend::default(),
+            intra_codec_threads: 0,
+            compute_hash: false,
+        };
+        let payload = encode_pipeline(&data, &honest).unwrap().encoded_bytes;
+
+        let hostile = PipelineConfig {
+            num_values: usize::MAX,
+            ..honest
+        };
+        let err = decode_pipeline(&payload, &hostile, false)
+            .expect_err("pathological num_values on zfp must surface as an error");
         let msg = format!("{err}");
         assert!(
             msg.contains("failed to reserve"),

--- a/rust/tensogram-encodings/src/shuffle.rs
+++ b/rust/tensogram-encodings/src/shuffle.rs
@@ -9,6 +9,7 @@
 use thiserror::Error;
 
 #[derive(Debug, Error, PartialEq)]
+#[non_exhaustive]
 pub enum ShuffleError {
     #[error("element_size must not be zero")]
     InvalidElementSize,

--- a/rust/tensogram-encodings/src/shuffle.rs
+++ b/rust/tensogram-encodings/src/shuffle.rs
@@ -17,6 +17,21 @@ pub enum ShuffleError {
         data_len: usize,
         element_size: usize,
     },
+    /// Fallible output-buffer reservation failed — surfaced instead of
+    /// the process-abort that would otherwise come from an infallible
+    /// `vec![0u8; data.len()]` when `data.len()` is pathologically
+    /// large (e.g. after a preceding decompression honestly produced a
+    /// very large buffer and the host is now close to OOM).
+    #[error("failed to reserve {bytes} bytes for shuffle output: {reason}")]
+    AllocationFailed { bytes: usize, reason: String },
+}
+
+fn try_reserve_shuffle(out: &mut Vec<u8>, n: usize) -> Result<(), ShuffleError> {
+    out.try_reserve_exact(n)
+        .map_err(|e| ShuffleError::AllocationFailed {
+            bytes: n,
+            reason: e.to_string(),
+        })
 }
 
 /// Minimum input length below which the parallel shuffle skips the
@@ -61,7 +76,9 @@ pub fn shuffle_with_threads(
     {
         if threads >= 2 && element_size >= 2 && data.len() >= PARALLEL_SHUFFLE_MIN_BYTES {
             use rayon::prelude::*;
-            let mut output = vec![0u8; data.len()];
+            let mut output: Vec<u8> = Vec::new();
+            try_reserve_shuffle(&mut output, data.len())?;
+            output.resize(data.len(), 0);
             output
                 .par_chunks_exact_mut(num_elements)
                 .enumerate()
@@ -74,7 +91,9 @@ pub fn shuffle_with_threads(
         }
     }
 
-    let mut output = vec![0u8; data.len()];
+    let mut output: Vec<u8> = Vec::new();
+    try_reserve_shuffle(&mut output, data.len())?;
+    output.resize(data.len(), 0);
     for byte_idx in 0..element_size {
         for elem in 0..num_elements {
             output[byte_idx * num_elements + elem] = data[elem * element_size + byte_idx];
@@ -124,7 +143,9 @@ pub fn unshuffle_with_threads(
         // each chunk can read its `element_size` stripes independently.
         if threads >= 2 && element_size >= 2 && data.len() >= PARALLEL_SHUFFLE_MIN_BYTES {
             use rayon::prelude::*;
-            let mut output = vec![0u8; data.len()];
+            let mut output: Vec<u8> = Vec::new();
+            try_reserve_shuffle(&mut output, data.len())?;
+            output.resize(data.len(), 0);
             // Split output into element-aligned chunks.  ~4 KiB per
             // chunk amortises rayon split cost; minimum 64 elements so
             // tiny element_size values still get decent chunks.
@@ -153,7 +174,9 @@ pub fn unshuffle_with_threads(
     // Sequential fallback — inverse of shuffle: scatter each source
     // byte (from plane `byte_idx`, position `elem`) into the
     // `byte_idx`-th byte of output element `elem`.
-    let mut output = vec![0u8; data.len()];
+    let mut output: Vec<u8> = Vec::new();
+    try_reserve_shuffle(&mut output, data.len())?;
+    output.resize(data.len(), 0);
     for byte_idx in 0..element_size {
         for elem in 0..num_elements {
             output[elem * element_size + byte_idx] = data[byte_idx * num_elements + elem];

--- a/rust/tensogram-encodings/src/shuffle.rs
+++ b/rust/tensogram-encodings/src/shuffle.rs
@@ -34,6 +34,13 @@ fn try_reserve_shuffle(out: &mut Vec<u8>, n: usize) -> Result<(), ShuffleError> 
         })
 }
 
+fn try_clone(data: &[u8]) -> Result<Vec<u8>, ShuffleError> {
+    let mut out: Vec<u8> = Vec::new();
+    try_reserve_shuffle(&mut out, data.len())?;
+    out.extend_from_slice(data);
+    Ok(out)
+}
+
 /// Minimum input length below which the parallel shuffle skips the
 /// rayon split.  Below ~64 KiB the parallel split overhead dominates.
 #[cfg(feature = "threads")]
@@ -62,7 +69,7 @@ pub fn shuffle_with_threads(
         return Err(ShuffleError::InvalidElementSize);
     }
     if element_size == 1 || data.is_empty() {
-        return Ok(data.to_vec());
+        return try_clone(data);
     }
     if !data.len().is_multiple_of(element_size) {
         return Err(ShuffleError::Misaligned {
@@ -124,7 +131,7 @@ pub fn unshuffle_with_threads(
         return Err(ShuffleError::InvalidElementSize);
     }
     if element_size == 1 || data.is_empty() {
-        return Ok(data.to_vec());
+        return try_clone(data);
     }
     if !data.len().is_multiple_of(element_size) {
         return Err(ShuffleError::Misaligned {
@@ -311,5 +318,16 @@ mod tests {
             ),
             "unshuffle with misaligned data must return Err(Misaligned)"
         );
+    }
+
+    #[test]
+    fn try_reserve_shuffle_rejects_pathological_capacity() {
+        let mut v: Vec<u8> = Vec::new();
+        let err = try_reserve_shuffle(&mut v, usize::MAX)
+            .expect_err("reservation at usize::MAX must fail the capacity check");
+        match err {
+            ShuffleError::AllocationFailed { .. } => {}
+            other => panic!("expected AllocationFailed, got {other:?}"),
+        }
     }
 }

--- a/rust/tensogram-encodings/src/simple_packing.rs
+++ b/rust/tensogram-encodings/src/simple_packing.rs
@@ -39,10 +39,13 @@ pub enum PackingError {
         num_values: usize,
         bytes_per_value: usize,
     },
-    /// Total-bits math overflowed before any slice or allocation step.
-    /// Fires when a hostile descriptor claims a `num_values` that, when
-    /// multiplied by `bits_per_value`, exceeds `u128` (effectively never
-    /// on any realistic platform, but the check is cheap insurance).
+    /// Total-bits math overflowed `u128` before any slice or
+    /// allocation step. Structurally unreachable under the current
+    /// public API — `usize::MAX * 64` still fits in `u128` on every
+    /// supported target, and `bits_per_value > 64` is rejected earlier
+    /// via [`BitsPerValueTooLarge`](PackingError::BitsPerValueTooLarge).
+    /// The variant is kept as defensive insurance so a future increase
+    /// in the `bits_per_value` width does not silently wrap.
     #[error("bit-count overflow: {num_values} values × {bits_per_value} bits per value")]
     BitCountOverflow {
         num_values: usize,

--- a/rust/tensogram-encodings/src/simple_packing.rs
+++ b/rust/tensogram-encodings/src/simple_packing.rs
@@ -9,6 +9,7 @@
 use thiserror::Error;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum PackingError {
     #[error("NaN value encountered at index {0}")]
     NanValue(usize),

--- a/rust/tensogram-encodings/src/simple_packing.rs
+++ b/rust/tensogram-encodings/src/simple_packing.rs
@@ -54,8 +54,10 @@ pub enum PackingError {
     /// Fallible output-buffer reservation failed — the descriptor-derived
     /// `num_values` is too large for the allocator to satisfy. Guards
     /// against pathological sizes aborting the process in place of an
-    /// infallible `vec![_; N]` / `Vec::with_capacity`.
-    #[error("failed to reserve {bytes} bytes for packing output: {reason}")]
+    /// infallible `vec![_; N]` / `Vec::with_capacity`. Fires from the
+    /// `simple_packing` decode paths that produce the `Vec<f64>` output
+    /// buffer.
+    #[error("failed to reserve {bytes} bytes for simple_packing decode output buffer: {reason}")]
     AllocationFailed { bytes: usize, reason: String },
     /// Internal invariant violation — specialised aligned-width encoder
     /// was invoked with an unsupported byte width. This is unreachable

--- a/rust/tensogram-encodings/src/simple_packing.rs
+++ b/rust/tensogram-encodings/src/simple_packing.rs
@@ -39,6 +39,21 @@ pub enum PackingError {
         num_values: usize,
         bytes_per_value: usize,
     },
+    /// Total-bits math overflowed before any slice or allocation step.
+    /// Fires when a hostile descriptor claims a `num_values` that, when
+    /// multiplied by `bits_per_value`, exceeds `u128` (effectively never
+    /// on any realistic platform, but the check is cheap insurance).
+    #[error("bit-count overflow: {num_values} values × {bits_per_value} bits per value")]
+    BitCountOverflow {
+        num_values: usize,
+        bits_per_value: u32,
+    },
+    /// Fallible output-buffer reservation failed — the descriptor-derived
+    /// `num_values` is too large for the allocator to satisfy. Guards
+    /// against pathological sizes aborting the process in place of an
+    /// infallible `vec![_; N]` / `Vec::with_capacity`.
+    #[error("failed to reserve {bytes} bytes for packing output: {reason}")]
+    AllocationFailed { bytes: usize, reason: String },
     /// Internal invariant violation — specialised aligned-width encoder
     /// was invoked with an unsupported byte width. This is unreachable
     /// under the public API; surfaced as an error instead of panicking
@@ -594,12 +609,29 @@ pub fn decode_with_threads(
     }
 
     if params.bits_per_value == 0 {
-        return Ok(vec![params.reference_value; num_values]);
+        let mut values: Vec<f64> = Vec::new();
+        try_reserve_f64(&mut values, num_values)?;
+        values.resize(num_values, params.reference_value);
+        return Ok(values);
     }
 
     let bpv = params.bits_per_value;
-    let total_bits = num_values as u64 * bpv as u64;
-    let required_bytes = total_bits.div_ceil(8) as usize;
+    // u128 arithmetic: a hostile `num_values * bpv` still fits in u128
+    // for any `num_values` representable in `usize` (u64), so this
+    // cannot overflow unless bpv somehow exceeds u64 — caught by the
+    // earlier bits_per_value>64 check.
+    let total_bits =
+        (num_values as u128)
+            .checked_mul(bpv as u128)
+            .ok_or(PackingError::BitCountOverflow {
+                num_values,
+                bits_per_value: bpv,
+            })?;
+    let required_bytes =
+        usize::try_from(total_bits.div_ceil(8)).map_err(|_| PackingError::OutputSizeOverflow {
+            num_values,
+            bytes_per_value: bpv.div_ceil(8) as usize,
+        })?;
     if packed.len() < required_bytes {
         return Err(PackingError::InsufficientData {
             expected: required_bytes,
@@ -620,13 +652,13 @@ pub fn decode_with_threads(
     if parallel {
         #[cfg(feature = "threads")]
         {
-            return Ok(match bpv {
+            return match bpv {
                 8 => decode_aligned_par::<1>(packed, num_values, refv, inv_scale),
                 16 => decode_aligned_par::<2>(packed, num_values, refv, inv_scale),
                 24 => decode_aligned_par::<3>(packed, num_values, refv, inv_scale),
                 32 => decode_aligned_par::<4>(packed, num_values, refv, inv_scale),
                 _ => decode_generic_par(packed, num_values, refv, inv_scale, bpv),
-            });
+            };
         }
     }
 
@@ -635,8 +667,16 @@ pub fn decode_with_threads(
         16 => decode_aligned::<2>(packed, num_values, refv, inv_scale),
         24 => decode_aligned::<3>(packed, num_values, refv, inv_scale),
         32 => decode_aligned::<4>(packed, num_values, refv, inv_scale),
-        _ => Ok(decode_generic(packed, num_values, refv, inv_scale, bpv)),
+        _ => decode_generic(packed, num_values, refv, inv_scale, bpv),
     }
+}
+
+fn try_reserve_f64(v: &mut Vec<f64>, n: usize) -> Result<(), PackingError> {
+    v.try_reserve_exact(n)
+        .map_err(|e| PackingError::AllocationFailed {
+            bytes: n.saturating_mul(std::mem::size_of::<f64>()),
+            reason: e.to_string(),
+        })
 }
 
 /// Read `N` MSB-first big-endian bytes from `chunk` as a `u64`.
@@ -677,7 +717,8 @@ fn decode_aligned<const N: usize>(
         return Err(PackingError::UnsupportedAlignedWidth(N));
     }
 
-    let mut values = Vec::with_capacity(num_values);
+    let mut values: Vec<f64> = Vec::new();
+    try_reserve_f64(&mut values, num_values)?;
     for chunk in packed[..num_values * N].chunks_exact(N) {
         let packed_int = gather_aligned::<N>(chunk);
         values.push(refv + inv_scale * packed_int as f64);
@@ -692,10 +733,12 @@ fn decode_aligned_par<const N: usize>(
     num_values: usize,
     refv: f64,
     inv_scale: f64,
-) -> Vec<f64> {
+) -> Result<Vec<f64>, PackingError> {
     use rayon::prelude::*;
 
-    let mut values = vec![0.0f64; num_values];
+    let mut values: Vec<f64> = Vec::new();
+    try_reserve_f64(&mut values, num_values)?;
+    values.resize(num_values, 0.0);
     values
         .par_iter_mut()
         .zip(packed[..num_values * N].par_chunks_exact(N))
@@ -703,7 +746,7 @@ fn decode_aligned_par<const N: usize>(
             let packed_int = gather_aligned::<N>(chunk);
             *out = refv + inv_scale * packed_int as f64;
         });
-    values
+    Ok(values)
 }
 
 /// Parallel generic decode for non-byte-aligned bit widths.  Uses the
@@ -716,7 +759,7 @@ fn decode_generic_par(
     refv: f64,
     inv_scale: f64,
     bpv: u32,
-) -> Vec<f64> {
+) -> Result<Vec<f64>, PackingError> {
     use rayon::prelude::*;
 
     let bpv_usize = bpv as usize;
@@ -725,7 +768,9 @@ fn decode_generic_par(
     let bytes_per_chunk = values_per_chunk * bpv_usize / 8;
 
     let full_chunks = num_values / values_per_chunk;
-    let mut values = vec![0.0f64; num_values];
+    let mut values: Vec<f64> = Vec::new();
+    try_reserve_f64(&mut values, num_values)?;
+    values.resize(num_values, 0.0);
 
     {
         let head_values_slice = &mut values[..full_chunks * values_per_chunk];
@@ -758,7 +803,7 @@ fn decode_generic_par(
         }
     }
 
-    values
+    Ok(values)
 }
 
 fn decode_generic(
@@ -767,8 +812,9 @@ fn decode_generic(
     refv: f64,
     inv_scale: f64,
     bpv: u32,
-) -> Vec<f64> {
-    let mut values = Vec::with_capacity(num_values);
+) -> Result<Vec<f64>, PackingError> {
+    let mut values: Vec<f64> = Vec::new();
+    try_reserve_f64(&mut values, num_values)?;
     let mut bit_pos: u64 = 0;
 
     for _ in 0..num_values {
@@ -776,7 +822,7 @@ fn decode_generic(
         values.push(refv + inv_scale * packed_int as f64);
         bit_pos += bpv as u64;
     }
-    values
+    Ok(values)
 }
 
 /// Decode a range of packed values starting at an arbitrary bit offset.
@@ -795,13 +841,30 @@ pub fn decode_range(
     }
 
     if params.bits_per_value == 0 {
-        return Ok(vec![params.reference_value; num_values]);
+        let mut values: Vec<f64> = Vec::new();
+        try_reserve_f64(&mut values, num_values)?;
+        values.resize(num_values, params.reference_value);
+        return Ok(values);
     }
 
     let bpv = params.bits_per_value;
 
-    let end_bit = bit_offset as u64 + num_values as u64 * bpv as u64;
-    let required_bytes = end_bit.div_ceil(8) as usize;
+    let end_bit = (bit_offset as u128)
+        .checked_add((num_values as u128).checked_mul(bpv as u128).ok_or(
+            PackingError::BitCountOverflow {
+                num_values,
+                bits_per_value: bpv,
+            },
+        )?)
+        .ok_or(PackingError::BitCountOverflow {
+            num_values,
+            bits_per_value: bpv,
+        })?;
+    let required_bytes =
+        usize::try_from(end_bit.div_ceil(8)).map_err(|_| PackingError::OutputSizeOverflow {
+            num_values,
+            bytes_per_value: bpv.div_ceil(8) as usize,
+        })?;
     if packed.len() < required_bytes {
         return Err(PackingError::InsufficientData {
             expected: required_bytes,
@@ -812,7 +875,8 @@ pub fn decode_range(
     let d_factor = 10f64.powi(-params.decimal_scale_factor);
     let e_factor = 2f64.powi(params.binary_scale_factor);
 
-    let mut values = Vec::with_capacity(num_values);
+    let mut values: Vec<f64> = Vec::new();
+    try_reserve_f64(&mut values, num_values)?;
     let mut bit_pos = bit_offset as u64;
 
     for _ in 0..num_values {
@@ -1713,5 +1777,96 @@ mod tests {
         write_bits(&mut buf, 5, 0b1111_0000_1111, 12);
         let val = read_bits(&buf, 5, 12);
         assert_eq!(val, 0b1111_0000_1111);
+    }
+
+    // ── Preallocation / overflow hardening ────────────────────────────────
+    //
+    // Regression tests for the descriptor-driven allocation / arithmetic
+    // guards.  Before the fix, a malformed descriptor whose `num_values`
+    // was close to `usize::MAX` could abort the decode process via
+    // `Vec::with_capacity` / `vec![_; N]` or via panicking / wrapping
+    // arithmetic on `num_values * bits_per_value`.  After the fix each
+    // path surfaces a typed `PackingError` instead.
+
+    #[test]
+    fn try_reserve_f64_rejects_pathological_capacity() {
+        let mut v: Vec<f64> = Vec::new();
+        let err = try_reserve_f64(&mut v, usize::MAX)
+            .expect_err("try_reserve of usize::MAX f64s must fail the capacity check");
+        match err {
+            PackingError::AllocationFailed { .. } => {}
+            other => panic!("expected AllocationFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_rejects_bit_count_overflow() {
+        // num_values * bits_per_value would overflow u128 only for
+        // values beyond usize's range; instead exercise the subsequent
+        // `usize::try_from` by picking a num_values where
+        // `num_values * bpv / 8` exceeds `usize::MAX`.  A bpv of 64 and
+        // num_values close to usize::MAX does the job: the u128 product
+        // does not overflow but the byte-count conversion to usize does.
+        let params = SimplePackingParams {
+            reference_value: 0.0,
+            binary_scale_factor: 0,
+            decimal_scale_factor: 0,
+            bits_per_value: 64,
+        };
+        let err = decode(&[], usize::MAX, &params)
+            .expect_err("pathological num_values must surface as an error");
+        match err {
+            PackingError::OutputSizeOverflow { .. } | PackingError::BitCountOverflow { .. } => {}
+            other => panic!("expected OutputSizeOverflow or BitCountOverflow, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_bpv_zero_rejects_pathological_num_values() {
+        // The bpv==0 fast path is a different reservation code path.
+        let params = SimplePackingParams {
+            reference_value: 0.0,
+            binary_scale_factor: 0,
+            decimal_scale_factor: 0,
+            bits_per_value: 0,
+        };
+        let err = decode(&[], usize::MAX, &params)
+            .expect_err("bpv=0 with usize::MAX num_values must surface as an error");
+        match err {
+            PackingError::AllocationFailed { .. } => {}
+            other => panic!("expected AllocationFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_range_rejects_pathological_num_values() {
+        let params = SimplePackingParams {
+            reference_value: 0.0,
+            binary_scale_factor: 0,
+            decimal_scale_factor: 0,
+            bits_per_value: 64,
+        };
+        let err = decode_range(&[], 0, usize::MAX, &params)
+            .expect_err("pathological num_values must surface as an error");
+        match err {
+            PackingError::OutputSizeOverflow { .. } | PackingError::BitCountOverflow { .. } => {}
+            other => panic!("expected OutputSizeOverflow or BitCountOverflow, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_range_bpv_zero_rejects_pathological_num_values() {
+        let params = SimplePackingParams {
+            reference_value: 0.0,
+            binary_scale_factor: 0,
+            decimal_scale_factor: 0,
+            bits_per_value: 0,
+        };
+        let err = decode_range(&[], 0, usize::MAX, &params)
+            .expect_err("bpv=0 with usize::MAX num_values must surface as an error");
+        match err {
+            PackingError::AllocationFailed { .. } => {}
+            other => panic!("expected AllocationFailed, got {other:?}"),
+        }
     }
 }

--- a/rust/tensogram-encodings/src/zfp_ffi.rs
+++ b/rust/tensogram-encodings/src/zfp_ffi.rs
@@ -163,7 +163,15 @@ pub fn zfp_decompress_range_f64(
         )));
     }
 
-    Ok(all[sample_offset..end].to_vec())
+    let mut out: Vec<f64> = Vec::new();
+    out.try_reserve_exact(sample_count).map_err(|e| {
+        err(format!(
+            "failed to reserve {} bytes for zfp range output: {e}",
+            sample_count.saturating_mul(std::mem::size_of::<f64>()),
+        ))
+    })?;
+    out.extend_from_slice(&all[sample_offset..end]);
+    Ok(out)
 }
 
 /// Set the ZFP compression mode on a stream.

--- a/rust/tensogram-encodings/src/zfp_ffi.rs
+++ b/rust/tensogram-encodings/src/zfp_ffi.rs
@@ -97,9 +97,10 @@ pub fn zfp_decompress_f64(
 
     // Fallible reservation: `num_values` flows from the descriptor via
     // `ZfpCompressor`, so an attacker-supplied value must not abort the
-    // process through an infallible `vec![0.0f64; N]`. The subsequent
-    // `resize` cannot reallocate because `capacity` already equals
-    // `num_values`; it only writes the zero-fill libzfp then overwrites.
+    // process through an infallible `vec![0.0f64; N]`. After
+    // `try_reserve_exact(num_values)` the capacity is at least
+    // `num_values`, so the subsequent `resize` only performs the
+    // zero-fill that libzfp then overwrites — no reallocation.
     let mut output: Vec<f64> = Vec::new();
     output.try_reserve_exact(num_values).map_err(|e| {
         err(format!(

--- a/rust/tensogram-encodings/src/zfp_ffi.rs
+++ b/rust/tensogram-encodings/src/zfp_ffi.rs
@@ -152,7 +152,11 @@ pub fn zfp_decompress_range_f64(
     // isn't exposed through the simple compress/decompress API.
     let all = zfp_decompress_f64(compressed, total_values, mode)?;
 
-    let end = sample_offset + sample_count;
+    let end = sample_offset.checked_add(sample_count).ok_or_else(|| {
+        err(format!(
+            "range end overflow: sample_offset {sample_offset} + sample_count {sample_count}"
+        ))
+    })?;
     if end > all.len() {
         return Err(err(format!(
             "range ({sample_offset}, {sample_count}) exceeds total values {total_values}"

--- a/rust/tensogram-encodings/src/zfp_ffi.rs
+++ b/rust/tensogram-encodings/src/zfp_ffi.rs
@@ -75,8 +75,24 @@ pub fn zfp_decompress_f64(
     num_values: usize,
     mode: &ZfpMode,
 ) -> Result<Vec<f64>, CompressionError> {
-    if num_values == 0 {
-        return Ok(Vec::new());
+    // Same honest/malformed matrix as szip's `aec_decompress`: only
+    // `num_values == 0 && compressed.is_empty()` is a legitimate
+    // empty-in / empty-out round-trip; the two mixed cases below are
+    // malformed-descriptor symptoms and must not silently return empty.
+    match (num_values, compressed.is_empty()) {
+        (0, true) => return Ok(Vec::new()),
+        (0, false) => {
+            return Err(err(
+                "num_values=0 with non-empty compressed stream (malformed zfp descriptor)"
+                    .to_string(),
+            ));
+        }
+        (_, true) => {
+            return Err(err(format!(
+                "num_values={num_values} with empty compressed stream (truncated or malformed payload)"
+            )));
+        }
+        _ => {}
     }
 
     // Fallible reservation: `num_values` flows from the descriptor via

--- a/rust/tensogram-encodings/src/zfp_ffi.rs
+++ b/rust/tensogram-encodings/src/zfp_ffi.rs
@@ -79,7 +79,19 @@ pub fn zfp_decompress_f64(
         return Ok(Vec::new());
     }
 
-    let mut output = vec![0.0f64; num_values];
+    // Fallible reservation: `num_values` flows from the descriptor via
+    // `ZfpCompressor`, so an attacker-supplied value must not abort the
+    // process through an infallible `vec![0.0f64; N]`. The subsequent
+    // `resize` cannot reallocate because `capacity` already equals
+    // `num_values`; it only writes the zero-fill libzfp then overwrites.
+    let mut output: Vec<f64> = Vec::new();
+    output.try_reserve_exact(num_values).map_err(|e| {
+        err(format!(
+            "failed to reserve {} bytes for zfp decompression: {e}",
+            num_values.saturating_mul(std::mem::size_of::<f64>()),
+        ))
+    })?;
+    output.resize(num_values, 0.0);
 
     unsafe {
         let ztype = zfp_sys_cc::zfp_type_zfp_type_double;
@@ -293,5 +305,17 @@ mod tests {
         let compressed = zfp_compress_f64(&values, &mode).unwrap();
         let decoded = zfp_decompress_f64(&compressed, values.len(), &mode).unwrap();
         assert_eq!(decoded.len(), values.len());
+    }
+
+    #[test]
+    fn zfp_decompress_rejects_pathological_num_values() {
+        let mode = ZfpMode::FixedRate { rate: 16.0 };
+        let err = zfp_decompress_f64(&[1u8, 2, 3, 4], usize::MAX, &mode)
+            .expect_err("usize::MAX num_values must fail the capacity check");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("failed to reserve"),
+            "error should report allocation failure, got: {msg}"
+        );
     }
 }

--- a/rust/tensogram-szip/src/decoder.rs
+++ b/rust/tensogram-szip/src/decoder.rs
@@ -127,9 +127,9 @@ pub(crate) fn decode(
             let reference = rsi_buffer[0];
             let mapped = &rsi_buffer[1..];
             if signed {
-                preprocessor::postprocess_signed(reference, mapped, bps, xmax)
+                preprocessor::postprocess_signed(reference, mapped, bps, xmax)?
             } else {
-                preprocessor::postprocess_unsigned(reference, mapped, xmax)
+                preprocessor::postprocess_unsigned(reference, mapped, xmax)?
             }
         } else {
             rsi_buffer
@@ -161,7 +161,28 @@ pub(crate) fn decode_range(
 
     let flags = params::effective_flags(p);
     let byte_width = params::sample_byte_width(p.bits_per_sample, flags);
-    let rsi_size = p.rsi as usize * p.block_size as usize * byte_width;
+    let bps = p.bits_per_sample;
+    let block_size = p.block_size as usize;
+    let rsi_blocks = p.rsi as usize;
+    // Promote every descriptor-driven multiplication to `checked_mul`
+    // before ANY use: both `rsi_size = samples_per_rsi * byte_width`
+    // and the subsequent `rsi_n * rsi_size` can overflow on 32-bit /
+    // `AEC_NOT_ENFORCE` inputs with large parameters.
+    let samples_per_rsi = rsi_blocks.checked_mul(block_size).ok_or_else(|| {
+        AecError::Data(format!(
+            "rsi ({rsi_blocks}) x block_size ({block_size}) overflows usize"
+        ))
+    })?;
+    let rsi_size = samples_per_rsi.checked_mul(byte_width).ok_or_else(|| {
+        AecError::Data(format!(
+            "samples_per_rsi ({samples_per_rsi}) x byte_width ({byte_width}) overflows usize"
+        ))
+    })?;
+    if rsi_size == 0 {
+        return Err(AecError::Data(
+            "rsi_size computes to zero (block_size or byte_width is 0)".into(),
+        ));
+    }
 
     let rsi_n = byte_pos / rsi_size;
     if rsi_n >= block_offsets.len() {
@@ -172,26 +193,23 @@ pub(crate) fn decode_range(
         )));
     }
 
-    let rsi_byte_offset = rsi_n * rsi_size;
-    let local_byte_pos = byte_pos - rsi_byte_offset;
+    let rsi_byte_offset = rsi_n.checked_mul(rsi_size).ok_or_else(|| {
+        AecError::Data(format!(
+            "rsi_byte_offset = {rsi_n} x {rsi_size} overflows usize"
+        ))
+    })?;
+    let local_byte_pos = byte_pos.checked_sub(rsi_byte_offset).ok_or_else(|| {
+        AecError::Data(format!(
+            "byte_pos {byte_pos} is before rsi_byte_offset {rsi_byte_offset}"
+        ))
+    })?;
 
     let bit_offset = block_offsets[rsi_n];
     let mut reader = BitReader::from_bit_offset(data, bit_offset);
 
-    let bps = p.bits_per_sample;
-    let block_size = p.block_size as usize;
-    let rsi_blocks = p.rsi as usize;
     let id_len = params::id_len(bps, flags);
     let pp = flags & params::AEC_DATA_PREPROCESS != 0;
     let signed = flags & params::AEC_DATA_SIGNED != 0;
-    // Match the `checked_mul` guard in the full-decode path so
-    // malformed `rsi * block_size` on 32-bit / AEC_NOT_ENFORCE inputs
-    // surfaces as a typed error, not a wrapping-multiplication panic.
-    let samples_per_rsi = rsi_blocks.checked_mul(block_size).ok_or_else(|| {
-        AecError::Data(format!(
-            "rsi ({rsi_blocks}) x block_size ({block_size}) overflows usize"
-        ))
-    })?;
     let se_table = SeTable::new();
 
     let xmax = if signed {
@@ -219,9 +237,9 @@ pub(crate) fn decode_range(
         let reference = rsi_buffer[0];
         let mapped = &rsi_buffer[1..];
         if signed {
-            preprocessor::postprocess_signed(reference, mapped, bps, xmax)
+            preprocessor::postprocess_signed(reference, mapped, bps, xmax)?
         } else {
-            preprocessor::postprocess_unsigned(reference, mapped, xmax)
+            preprocessor::postprocess_unsigned(reference, mapped, xmax)?
         }
     } else {
         rsi_buffer
@@ -244,7 +262,16 @@ pub(crate) fn decode_range(
         )));
     }
 
-    Ok(output[local_byte_pos..end].to_vec())
+    let slice = &output[local_byte_pos..end];
+    let mut out: Vec<u8> = Vec::new();
+    out.try_reserve_exact(slice.len()).map_err(|e| {
+        AecError::Data(format!(
+            "failed to reserve {} bytes for szip range output: {e}",
+            slice.len()
+        ))
+    })?;
+    out.extend_from_slice(slice);
+    Ok(out)
 }
 
 // ── RSI-level decoder ────────────────────────────────────────────────────────

--- a/rust/tensogram-szip/src/decoder.rs
+++ b/rust/tensogram-szip/src/decoder.rs
@@ -66,7 +66,16 @@ pub(crate) fn decode(
     let id_len = params::id_len(bps, flags);
     let pp = flags & params::AEC_DATA_PREPROCESS != 0;
     let signed = flags & params::AEC_DATA_SIGNED != 0;
-    let samples_per_rsi = rsi_blocks * block_size;
+    // Guard `rsi_blocks * block_size` with `checked_mul`: under
+    // `AEC_NOT_ENFORCE` these are caller-supplied parameters and their
+    // product can overflow on 32-bit targets (or with an exceptionally
+    // malformed header on 64-bit) before the later `try_reserve_exact`
+    // gets a chance to reject the value.
+    let samples_per_rsi = rsi_blocks.checked_mul(block_size).ok_or_else(|| {
+        AecError::Data(format!(
+            "rsi ({rsi_blocks}) x block_size ({block_size}) overflows usize"
+        ))
+    })?;
     let total_samples = expected_size / byte_width;
 
     let xmax = if signed {
@@ -85,7 +94,18 @@ pub(crate) fn decode(
 
     let se_table = SeTable::new();
     let mut reader = BitReader::new(data);
-    let mut all_samples: Vec<u32> = Vec::with_capacity(total_samples);
+    // Fallible reservation: `total_samples` is derived from the untrusted
+    // `expected_size` (which itself comes from the tensor descriptor in
+    // the wire format).  A hostile value is rejected here as a
+    // `CompressionError` rather than aborting the process via the
+    // infallible `Vec::with_capacity` path.  Mirrors the blosc2 fix in
+    // PR #69.
+    let mut all_samples: Vec<u32> = Vec::new();
+    all_samples.try_reserve_exact(total_samples).map_err(|e| {
+        AecError::Data(format!(
+            "failed to reserve {total_samples} u32 samples for szip decode: {e}"
+        ))
+    })?;
 
     while all_samples.len() < total_samples {
         let remaining = total_samples - all_samples.len();
@@ -238,7 +258,12 @@ fn decode_rsi(
 ) -> Result<Vec<u32>, AecError> {
     let samples_per_rsi = rsi_blocks * block_size;
     let modi = 1u32 << id_len;
-    let mut rsi_buffer: Vec<u32> = Vec::with_capacity(samples_per_rsi);
+    let mut rsi_buffer: Vec<u32> = Vec::new();
+    rsi_buffer.try_reserve_exact(samples_per_rsi).map_err(|e| {
+        AecError::Data(format!(
+            "failed to reserve {samples_per_rsi} u32 samples for szip RSI buffer: {e}"
+        ))
+    })?;
 
     // Track block state matching libaec's m_next_cds
     let mut has_ref = pp; // first block has ref if preprocessing
@@ -401,7 +426,19 @@ fn decode_uncomp(
 
 fn write_samples(samples: &[u32], byte_width: usize, flags: u32) -> Result<Vec<u8>, AecError> {
     let msb = flags & params::AEC_DATA_MSB != 0;
-    let mut out = Vec::with_capacity(samples.len() * byte_width);
+    let out_bytes = samples.len().checked_mul(byte_width).ok_or_else(|| {
+        AecError::Data(format!(
+            "output byte count overflows usize: {} samples x {} bytes",
+            samples.len(),
+            byte_width
+        ))
+    })?;
+    let mut out: Vec<u8> = Vec::new();
+    out.try_reserve_exact(out_bytes).map_err(|e| {
+        AecError::Data(format!(
+            "failed to reserve {out_bytes} bytes for szip sample output: {e}"
+        ))
+    })?;
 
     for &val in samples {
         match byte_width {
@@ -438,4 +475,24 @@ fn write_samples(samples: &[u32], byte_width: usize, flags: u32) -> Result<Vec<u
     }
 
     Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_samples_rejects_overflowing_byte_count() {
+        let samples = [0u32; 2];
+        let err = write_samples(&samples, usize::MAX, 0).expect_err(
+            "byte_width = usize::MAX must fail the checked_mul, not the size-1..=4 match",
+        );
+        match err {
+            AecError::Data(msg) => assert!(
+                msg.contains("overflows usize"),
+                "error should report overflow, got: {msg}"
+            ),
+            other => panic!("expected AecError::Data, got {other:?}"),
+        }
+    }
 }

--- a/rust/tensogram-szip/src/decoder.rs
+++ b/rust/tensogram-szip/src/decoder.rs
@@ -292,7 +292,14 @@ fn decode_rsi(
     max_samples: usize,
     se_table: &SeTable,
 ) -> Result<Vec<u32>, AecError> {
-    let samples_per_rsi = rsi_blocks * block_size;
+    // Independent checked_mul even though every current caller
+    // (`decode`, `decode_range`) already guards this product — keeps the
+    // helper self-protective if a future caller is added that forgets.
+    let samples_per_rsi = rsi_blocks.checked_mul(block_size).ok_or_else(|| {
+        AecError::Data(format!(
+            "rsi_blocks ({rsi_blocks}) x block_size ({block_size}) overflows usize"
+        ))
+    })?;
     let modi = 1u32 << id_len;
     let mut rsi_buffer: Vec<u32> = Vec::new();
     rsi_buffer.try_reserve_exact(samples_per_rsi).map_err(|e| {

--- a/rust/tensogram-szip/src/decoder.rs
+++ b/rust/tensogram-szip/src/decoder.rs
@@ -184,7 +184,14 @@ pub(crate) fn decode_range(
     let id_len = params::id_len(bps, flags);
     let pp = flags & params::AEC_DATA_PREPROCESS != 0;
     let signed = flags & params::AEC_DATA_SIGNED != 0;
-    let samples_per_rsi = rsi_blocks * block_size;
+    // Match the `checked_mul` guard in the full-decode path so
+    // malformed `rsi * block_size` on 32-bit / AEC_NOT_ENFORCE inputs
+    // surfaces as a typed error, not a wrapping-multiplication panic.
+    let samples_per_rsi = rsi_blocks.checked_mul(block_size).ok_or_else(|| {
+        AecError::Data(format!(
+            "rsi ({rsi_blocks}) x block_size ({block_size}) overflows usize"
+        ))
+    })?;
     let se_table = SeTable::new();
 
     let xmax = if signed {
@@ -222,20 +229,22 @@ pub(crate) fn decode_range(
 
     let output = write_samples(&final_samples, byte_width, flags)?;
 
-    if local_byte_pos + byte_size > output.len() {
+    let end = local_byte_pos.checked_add(byte_size).ok_or_else(|| {
+        AecError::Data(format!(
+            "range end overflow: local_byte_pos {local_byte_pos} + byte_size {byte_size}"
+        ))
+    })?;
+    if end > output.len() {
         return Err(AecError::Data(format!(
-            "range [{}, {}) exceeds decoded RSI #{} output ({} bytes, {} samples × {} byte_width, expected {})",
-            byte_pos,
-            byte_pos + byte_size,
-            rsi_n,
+            "range [{byte_pos}, {}) exceeds decoded RSI #{rsi_n} output ({} bytes, {} samples x {byte_width} byte_width, expected {})",
+            byte_pos.saturating_add(byte_size),
             output.len(),
             final_samples.len(),
-            byte_width,
-            samples_per_rsi * byte_width,
+            samples_per_rsi.saturating_mul(byte_width),
         )));
     }
 
-    Ok(output[local_byte_pos..local_byte_pos + byte_size].to_vec())
+    Ok(output[local_byte_pos..end].to_vec())
 }
 
 // ── RSI-level decoder ────────────────────────────────────────────────────────

--- a/rust/tensogram-szip/src/params.rs
+++ b/rust/tensogram-szip/src/params.rs
@@ -109,6 +109,9 @@ pub(crate) fn validate(params: &AecParams) -> Result<(), crate::AecError> {
         )));
     }
 
+    if params.block_size == 0 {
+        return Err(AecError::Config("block_size must be non-zero".to_string()));
+    }
     if params.flags & AEC_NOT_ENFORCE != 0 {
         if params.block_size & 1 != 0 {
             return Err(AecError::Config(format!(

--- a/rust/tensogram-szip/src/preprocessor.rs
+++ b/rust/tensogram-szip/src/preprocessor.rs
@@ -116,9 +116,24 @@ pub(crate) fn preprocess_signed(
 /// Post-process (undo preprocessing) for unsigned samples.
 ///
 /// Given a reference sample and mapped values, reconstruct the
-/// original sample stream.
-pub(crate) fn postprocess_unsigned(reference: u32, mapped: &[u32], xmax: u32) -> Vec<u32> {
-    let mut output = Vec::with_capacity(mapped.len() + 1);
+/// original sample stream. Reserves the output buffer fallibly so a
+/// pathological `mapped.len()` (driven by hostile RSI parameters) is
+/// rejected as [`AecError::Data`] rather than aborting the process.
+pub(crate) fn postprocess_unsigned(
+    reference: u32,
+    mapped: &[u32],
+    xmax: u32,
+) -> Result<Vec<u32>, crate::AecError> {
+    let cap = mapped
+        .len()
+        .checked_add(1)
+        .ok_or_else(|| crate::AecError::Data("postprocess output length overflows usize".into()))?;
+    let mut output: Vec<u32> = Vec::new();
+    output.try_reserve_exact(cap).map_err(|e| {
+        crate::AecError::Data(format!(
+            "failed to reserve {cap} u32 samples for szip postprocess (unsigned): {e}"
+        ))
+    })?;
     output.push(reference);
 
     let med = xmax / 2 + 1;
@@ -145,7 +160,7 @@ pub(crate) fn postprocess_unsigned(reference: u32, mapped: &[u32], xmax: u32) ->
         last = next;
     }
 
-    output
+    Ok(output)
 }
 
 /// Post-process (undo preprocessing) for signed samples.
@@ -162,9 +177,18 @@ pub(crate) fn postprocess_signed(
     mapped: &[u32],
     bits_per_sample: u32,
     xmax: u32,
-) -> Vec<u32> {
+) -> Result<Vec<u32>, crate::AecError> {
     let m = 1u32 << (bits_per_sample - 1);
-    let mut output = Vec::with_capacity(mapped.len() + 1);
+    let cap = mapped
+        .len()
+        .checked_add(1)
+        .ok_or_else(|| crate::AecError::Data("postprocess output length overflows usize".into()))?;
+    let mut output: Vec<u32> = Vec::new();
+    output.try_reserve_exact(cap).map_err(|e| {
+        crate::AecError::Data(format!(
+            "failed to reserve {cap} u32 samples for szip postprocess (signed): {e}"
+        ))
+    })?;
 
     // Sign extend the reference sample
     let ref_signed = ((reference_raw ^ m).wrapping_sub(m)) as i32;
@@ -211,7 +235,7 @@ pub(crate) fn postprocess_signed(
         last = next;
     }
 
-    output
+    Ok(output)
 }
 
 #[cfg(test)]
@@ -224,7 +248,7 @@ mod tests {
         let xmax = 255u32;
 
         let (reference, mapped) = preprocess_unsigned(&samples, xmax);
-        let reconstructed = postprocess_unsigned(reference, &mapped, xmax);
+        let reconstructed = postprocess_unsigned(reference, &mapped, xmax).unwrap();
 
         assert_eq!(reconstructed, samples);
     }
@@ -235,7 +259,7 @@ mod tests {
         let xmax = 255u32;
 
         let (reference, mapped) = preprocess_unsigned(&samples, xmax);
-        let reconstructed = postprocess_unsigned(reference, &mapped, xmax);
+        let reconstructed = postprocess_unsigned(reference, &mapped, xmax).unwrap();
 
         assert_eq!(reconstructed, samples);
     }
@@ -248,7 +272,7 @@ mod tests {
         let (reference, mapped) = preprocess_unsigned(&samples, xmax);
         // All deltas should be zero
         assert!(mapped.iter().all(|&d| d == 0));
-        let reconstructed = postprocess_unsigned(reference, &mapped, xmax);
+        let reconstructed = postprocess_unsigned(reference, &mapped, xmax).unwrap();
         assert_eq!(reconstructed, samples);
     }
 
@@ -258,7 +282,7 @@ mod tests {
         let xmax = 255u32;
 
         let (reference, mapped) = preprocess_unsigned(&samples, xmax);
-        let reconstructed = postprocess_unsigned(reference, &mapped, xmax);
+        let reconstructed = postprocess_unsigned(reference, &mapped, xmax).unwrap();
 
         assert_eq!(reconstructed, samples);
     }
@@ -283,7 +307,7 @@ mod tests {
         let xmax = 65535u32;
 
         let (reference, mapped) = preprocess_unsigned(&samples, xmax);
-        let reconstructed = postprocess_unsigned(reference, &mapped, xmax);
+        let reconstructed = postprocess_unsigned(reference, &mapped, xmax).unwrap();
 
         assert_eq!(reconstructed, samples);
     }
@@ -298,7 +322,7 @@ mod tests {
         let xmax = 127u32; // (1 << (bps-1)) - 1
 
         let (reference, mapped) = preprocess_signed(&samples, bps, xmax);
-        let reconstructed = postprocess_signed(reference, &mapped, bps, xmax);
+        let reconstructed = postprocess_signed(reference, &mapped, bps, xmax).unwrap();
 
         assert_eq!(reconstructed, samples);
     }
@@ -311,7 +335,7 @@ mod tests {
         let samples: Vec<u32> = (0..64).map(|i| (i * 1031) % 65536).collect();
 
         let (reference, mapped) = preprocess_signed(&samples, bps, xmax);
-        let reconstructed = postprocess_signed(reference, &mapped, bps, xmax);
+        let reconstructed = postprocess_signed(reference, &mapped, bps, xmax).unwrap();
 
         assert_eq!(reconstructed, samples);
     }
@@ -327,7 +351,7 @@ mod tests {
             mapped.iter().all(|&d| d == 0),
             "constant should map to all-zero deltas"
         );
-        let reconstructed = postprocess_signed(reference, &mapped, bps, xmax);
+        let reconstructed = postprocess_signed(reference, &mapped, bps, xmax).unwrap();
         assert_eq!(reconstructed, samples);
     }
 

--- a/rust/tensogram-szip/tests/error_paths.rs
+++ b/rust/tensogram-szip/tests/error_paths.rs
@@ -261,3 +261,45 @@ mod range_errors {
         assert!(result.is_err());
     }
 }
+
+// ── Preallocation-DoS hardening ─────────────────────────────────────────────
+//
+// Regression tests for the pure-Rust half of the cross-codec `expected_size`
+// preallocation hardening.  Before the fix, a malicious descriptor whose
+// shape product was close to `usize::MAX` could drive the decoder into an
+// infallible `Vec::with_capacity(total_samples)` that aborted the process.
+// After the fix, the untrusted size is reserved fallibly and rejected
+// cleanly as `AecError::Data`.
+mod preallocation_hardening {
+    use super::*;
+
+    #[test]
+    fn decompress_rejects_pathological_expected_size() {
+        let (compressed, _, _) = compress_ramp();
+
+        let err = aec_decompress(&compressed, usize::MAX, &default_params())
+            .expect_err("expected allocation failure, not success nor abort");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("failed to reserve"),
+            "error should report allocation failure, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn decompress_rejects_expected_size_overflowing_isize() {
+        // `try_reserve_exact` on `Vec<u32>` multiplies by 4 bytes, so
+        // anything above ~ isize::MAX/4 is rejected by the Rust-layer
+        // capacity check even without the OS allocator getting involved.
+        let (compressed, _, _) = compress_ramp();
+        let pathological = isize::MAX as usize + 1;
+
+        let err = aec_decompress(&compressed, pathological, &default_params())
+            .expect_err("expected allocation failure, not success nor abort");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("failed to reserve"),
+            "error should report allocation failure, got: {msg}"
+        );
+    }
+}

--- a/rust/tensogram/src/encode.rs
+++ b/rust/tensogram/src/encode.rs
@@ -1164,7 +1164,8 @@ fn encode_one_mask(
     };
 
     let blob = match &method {
-        MaskMethod::None => bitmask::codecs::encode_none(bits),
+        MaskMethod::None => bitmask::codecs::encode_none(bits)
+            .map_err(|e| TensogramError::Encoding(format!("bitmask pack: {e}")))?,
         MaskMethod::Rle => bitmask::rle::encode(bits),
         MaskMethod::Roaring => bitmask::roaring::encode(bits)
             .map_err(|e| TensogramError::Encoding(format!("roaring mask encode: {e}")))?,

--- a/rust/tensogram/src/restore.rs
+++ b/rust/tensogram/src/restore.rs
@@ -690,7 +690,8 @@ mod tests {
             ..Default::default()
         });
         let mut short_payload = vec![0u8; 16]; // only 2×f64 — wrong
-        let mask_region: Vec<u8> = bitmask::codecs::encode_none(&[false, true, false, true]);
+        let mask_region: Vec<u8> =
+            bitmask::codecs::encode_none(&[false, true, false, true]).unwrap();
         let err =
             restore_non_finite_into(&mut short_payload, &desc, &mask_region, ByteOrder::native())
                 .unwrap_err();


### PR DESCRIPTION
## Why

A `.tgm` file's decoder takes the tensor's **shape** from the CBOR descriptor and uses it to pre-size the buffers it will decode into. Every decoder in the library did this with infallible allocation calls (`Vec::with_capacity`, `vec![0; N]`, `vec![false; N]`, etc.) — calls that **abort the process** if the allocator can't satisfy the request.

That's a problem for anything reading untrusted `.tgm` input. A malformed or hostile descriptor that claimed `shape: [2^40]` would drive `num_values × dtype_byte_width` into the terabyte range and abort the decoder process. No graceful error, no way to catch it in Python / C++ / TS — just a dead process.

The fallible-allocation pattern was first established for blosc2 in PR #69 (during the review of an unrelated #68 fix). This PR applies the same pattern across every other decode path: szip, simple_packing, bitmask (RLE / Roaring / packed), zfp, sz3, shuffle, and the pipeline's byte↔value conversion helpers. It also hardens the related integer arithmetic (some of which could silently wrap before reaching the allocator) and adds parameter validation at the FFI boundary where the pure-Rust backend already had it.

## What changes for callers

**Nothing, on the honest path.** Every round-trip of legitimate data still produces byte-identical output. The wire format is unchanged.

**On hostile input**, decoders now return a typed error (`TensogramError::Compression`, `Encoding`, or similar) through the normal `Result` / exception channel instead of aborting. A Python caller catches it as `ValueError`, a C++ caller as `compression_error`, a TS caller via `try`/`catch` — same as any other decode failure.

See `docs/src/guide/error-handling.md` → *Malformed Descriptor — Pathological Tensor Size* for the per-codec error-variant table.

## Public API changes (acknowledged breaks)

This PR intentionally breaks a handful of low-level public items in `tensogram-encodings`. Per `CLAUDE.md` the project explicitly permits breaking changes at this maturity level:

> IMPORTANT: Don't worry about breaking compatibility or being backwards compatible. FTM this software has not been make public yet and there is no system using it.

The breaks:

- `bitmask::packing::pack` changes from `Vec<u8>` to `Result<Vec<u8>, MaskError>`. Keeping the old infallible signature would mean the DoS-capable allocation path stays reachable from anyone who picked the shorter name; a clean break is safer.
- `PackingError`, `MaskError`, and `ShuffleError` each grow one or more variants (`BitCountOverflow`, `AllocationFailed`, etc.). All three are now marked `#[non_exhaustive]`, so *future* hardening additions to these enums will no longer count as breaking changes — downstream matches must now include a catch-all arm, which is the idiomatic shape for evolving error types.
- Three pipeline-internal helpers (`pipeline::bytes_to_f64`, `pipeline::f64_to_bytes`, per-codec `f64_to_bytes` in `compression/zfp.rs` and `compression/sz3.rs`) return `Result<_, _>` where they previously returned the inner type. These are private `fn`, not `pub`, so no external break.

## What was fixed

### Decoder-level allocations — now fallible

Every descriptor-derived allocation on a decode path uses `Vec::try_reserve_exact` (or an equivalent fallible primitive) so the allocator can say "no, that's too much" and we can return an error:

- **szip** (both FFI via libaec and pure-Rust `tensogram-szip`): output, per-RSI scratch, sample serialisation, postprocess, and range-decode output buffers.
- **simple_packing**: every aligned / generic / parallel / range decode variant, including the `bits_per_value == 0` fast path.
- **Bitmask decoders**: `packing::unpack`, `rle::decode`, `roaring::decode`, and the on-decode repack via `packing::pack`.
- **zfp / sz3**: decompress output and the f64 → bytes serialisation.
- **Shuffle**: both forward and inverse, including the `element_size == 1` short-circuit.
- **Pipeline helpers**: `bytes_to_f64`, `f64_to_bytes`, and range-output clones.

### Integer arithmetic — now checked

Several code paths did `a * b` or `a + b` on descriptor-derived values. All are now:

- `checked_mul` / `checked_add` on `usize`, or
- promoted to `u128` where intermediate values can exceed `u64`, with `usize::try_from` at the boundary.

This fixes wraps that could pass a wrong-but-plausible number through the allocator check. Covered sites: simple_packing's `num_values × bpv`, szip's `rsi × block_size × byte_width` in both full and range decode paths, range-decode byte-position math in the pipeline, zfp / blosc2 range end math, the `u64 → usize` cast on range parameters, and the FFI szip block offsets conversion (previously truncating on 32-bit).

### Parameter validation — FFI/pure parity

The pure-Rust szip crate (`tensogram-szip`) already validated `AecParams` on every entry point. The FFI backend (`libaec.rs`) didn't — it relied on libaec returning an error code. Both now run the same validator and both now additionally reject `block_size == 0` even under `AEC_NOT_ENFORCE` (previously that would lead to divide-by-zero / infinite loops later in the decoder).

### FFI resource cleanup

The libaec decompression path could skip `aec_decode_end` on a defensive-check failure. Both `aec_decompress` and `aec_decompress_range` now clean up the stream state on every exit path, even the new guard failures. `aec_decompress` also no longer silently returns `Ok(empty)` when `expected_size == 0` pairs with a non-empty compressed stream — that case is now rejected as a malformed descriptor symptom.

## What was deliberately *not* done

**No static size cap.** A documented "reject anything over N GiB" check was considered and rejected. This library's target workloads — ERA5 reanalysis, ML weights, high-res climate simulations — routinely produce legitimate multi-GiB single objects, so any cap useful enough to block attackers would also block legitimate users. Fallible allocation is sufficient on its own: the allocator knows what the host can satisfy, and returns a typed error when it can't.

## Tests

Three categories of regression tests (all in-crate, no external fixtures):

- **Helper-level**: `try_reserve_f64`, `try_reserve_mask`, `try_reserve_shuffle` with sentinels (`usize::MAX` / `isize::MAX + 1`) that hit Rust's internal capacity check deterministically.
- **Public-API**: simple_packing `decode` / `decode_range` at `bpv=0` and `bpv=64`, zfp decompress with `usize::MAX`, roaring at `u32::MAX + 1` (pre-existing guard), szip FFI with every invalid `AecParams` combination plus a `block_size = 6 + AEC_NOT_ENFORCE` round-trip to confirm the escape hatch still works.
- **End-to-end**: `decode_pipeline` against both szip backends, simple_packing, and zfp with a hostile `num_values`.

## Verification

```
cargo fmt --check                                                        # clean
cargo clippy --workspace --all-targets --all-features -- -D warnings     # clean
cargo test --workspace                                                   # 1530 passed, 0 failed
cargo test -p tensogram-encodings --no-default-features \
  --features szip-pure,zstd-pure,lz4,threads                             # 153 passed, 0 failed (WASM feature set)
```

## Related

- Extends the fallible-allocation pattern introduced for blosc2 in PR #69 to every other decode path.



<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-90
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->