### PR TITLE
ci: switch Linux wheel builds to quay manylinux_2_28 container

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -14,15 +14,19 @@ jobs:
   build-tensogram-linux:
     name: Build tensogram wheels (${{ matrix.label }})
     runs-on: ${{ matrix.runs-on }}
+    container:
+      image: quay.io/pypa/${{ matrix.manylinux }}_${{ matrix.arch }}
     strategy:
       matrix:
         include:
           - runs-on: ubuntu-24.04
             label: Linux x86_64
-            artifact-name: wheels-tensogram-linux-x86_64
+            manylinux: manylinux_2_28
+            arch: x86_64
           - runs-on: ubuntu-24.04-arm
             label: Linux aarch64
-            artifact-name: wheels-tensogram-linux-aarch64
+            manylinux: manylinux_2_28
+            arch: aarch64
     steps:
       - uses: actions/checkout@v4
         with:
@@ -35,8 +39,9 @@ jobs:
       # Install all supported CPython versions (including free-threaded) so
       # they are available to maturin via explicit --interpreter flags.
       # Maturin produces manylinux-tagged wheels automatically on Linux.
-      - name: Install supported CPython versions
+      - name: Install supported CPython versions and Clang
         run: |
+          dnf install -y clang-devel
           uv python install \
             3.11 3.12 3.13 3.14 \
             cpython-3.13+freethreaded cpython-3.14+freethreaded
@@ -48,11 +53,11 @@ jobs:
                    cpython-3.13+freethreaded cpython-3.14+freethreaded; do
             ARGS="$ARGS --interpreter $(uv python find $v)"
           done
-          make python-dist MATURIN_INTERP_ARGS="$ARGS"
+          make python-dist MATURIN_INTERP_ARGS="$ARGS" MATURIN_COMPAT=${{ matrix.manylinux }}
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifact-name }}
+          name: wheels-tensogram-linux-${{ matrix.arch }}
           path: python/bindings/dist/
 
   build-tensogram-macos:

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,10 @@ RUFF_CFG ?= python/bindings/pyproject.toml
 # Space-separated --interpreter flags passed to maturin build; defaults to
 # auto-discovery. Override in CI: MATURIN_INTERP_ARGS="--interpreter /path/to/py"
 MATURIN_INTERP_ARGS ?= --find-interpreter
+# Optional maturin --compatibility target (e.g. manylinux_2_28).
+# Passed as --compatibility <value> when non-empty.
+MATURIN_COMPAT ?=
+MATURIN_COMPAT_ARG = $(if $(MATURIN_COMPAT),--compatibility $(MATURIN_COMPAT))
 
 python-build: ## Build Python bindings via maturin (dev install into .venv)
 	if [ ! -d .venv ] ; then uv venv ; fi
@@ -65,7 +69,7 @@ python-build: ## Build Python bindings via maturin (dev install into .venv)
 
 python-dist: ## Build tensogram distributable wheels for the current platform
 	if [ ! -d .venv ] ; then uv venv ; fi
-	cd python/bindings && $(MATURIN) build --release --out dist $(MATURIN_INTERP_ARGS)
+	cd python/bindings && $(MATURIN) build --release --out dist $(MATURIN_INTERP_ARGS) $(MATURIN_COMPAT_ARG)
 
 python-dist-extras: ## Build distributable wheels for pure-Python extra packages
 	uv build python/tensogram-xarray --out-dir dist/extras


### PR DESCRIPTION
- Add MATURIN_COMPAT optional Makefile variable (default empty); expands to --compatibility <value> in the python-dist recipe.
- Add manylinux and arch fields to the Linux build matrix in publish-pypi.yml so the target appears explicitly in both the container image name (quay.io/pypa/manylinux_2_28_{arch}) and the maturin --compatibility flag.


<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-91
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->