### PR TITLE
[pypi publish] explicit macos target

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -87,6 +87,8 @@ jobs:
                    cpython-3.13+freethreaded cpython-3.14+freethreaded; do
             ARGS="$ARGS --interpreter $(uv python find $v)"
           done
+          # NOTE aligned macos target with https://github.com/ecmwf/python-develop-bundle
+          export MACOS_DEPLOYMENT_TARGET="13.0"
           make python-dist MATURIN_INTERP_ARGS="$ARGS"
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
we set explicit macos target, to be aligned with the rest of ecmwf binary stack. This is actually higher than the default value, but better to be explicit


<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-92
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->