### PR TITLE
feat(tensoscope): mobile responsiveness — bottom sheet layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ python/bindings/python/tensogram/tensogram*.so
 # TODO do we want to have uv.locks ignored?
 **/uv.lock
 examples/jupyter/tensogram_jupyter_examples.egg-info/
+.worktrees/

--- a/tensoscope/src/App.css
+++ b/tensoscope/src/App.css
@@ -821,7 +821,7 @@ h2 {
     min-width: 0;
     max-width: none;
     height: var(--sheet-height, 28px);
-    overflow-y: hidden;
+    overflow-y: auto;
     overflow-x: hidden;
     z-index: 100;
     border-right: none;

--- a/tensoscope/src/App.css
+++ b/tensoscope/src/App.css
@@ -746,6 +746,11 @@ h2 {
   background: var(--accent);
 }
 
+/* Hidden on desktop, shown inside the sheet on mobile */
+.sheet-drag-handle {
+  display: none;
+}
+
 /* ── Projection Picker ── */
 /* ── Map Controls Bar (top-left) ── */
 .map-controls-bar {
@@ -794,4 +799,66 @@ h2 {
   background: rgba(255, 255, 255, 0.14);
   color: #fff;
   font-weight: 500;
+}
+
+/* ── Mobile layout (≤767px): sidebar becomes a bottom sheet ── */
+@media (max-width: 767px) {
+  .app-layout {
+    display: block;
+  }
+
+  .map-area {
+    height: 100svh;
+    flex: none;
+  }
+
+  .sidebar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    width: auto;
+    min-width: 0;
+    max-width: none;
+    height: var(--sheet-height, 28px);
+    overflow-y: hidden;
+    overflow-x: hidden;
+    z-index: 100;
+    border-right: none;
+    border-top: 1px solid var(--border);
+    border-radius: 12px 12px 0 0;
+    transition: height 0.25s ease;
+    box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.4);
+  }
+
+  .sidebar-resize-handle {
+    display: none;
+  }
+
+  .animation-bar {
+    bottom: var(--sheet-height, 0px);
+    transition: bottom 0.25s ease;
+  }
+
+  .welcome-modal {
+    max-width: calc(100vw - 32px);
+  }
+
+  .sheet-drag-handle {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 28px;
+    cursor: grab;
+    flex-shrink: 0;
+    touch-action: none;
+  }
+
+  .sheet-drag-handle::before {
+    content: '';
+    width: 40px;
+    height: 4px;
+    background: var(--border);
+    border-radius: 2px;
+  }
 }

--- a/tensoscope/src/App.tsx
+++ b/tensoscope/src/App.tsx
@@ -92,6 +92,7 @@ function App() {
   }, []);
 
   const onDragEnd = useCallback(() => {
+    if (!dragging.current) return;
     dragging.current = false;
     document.body.style.cursor = '';
     document.body.style.userSelect = '';

--- a/tensoscope/src/App.tsx
+++ b/tensoscope/src/App.tsx
@@ -109,11 +109,11 @@ function App() {
 
   const prevFileIndex = useRef<typeof fileIndex>(null);
   useEffect(() => {
-    if (prevFileIndex.current === null && fileIndex !== null) {
+    if (isMobile && prevFileIndex.current === null && fileIndex !== null) {
       setSheetState(s => s === 'collapsed' ? 'half' : s);
     }
     prevFileIndex.current = fileIndex;
-  }, [fileIndex]);
+  }, [fileIndex, isMobile]);
 
   const onSheetDragStart = useCallback((e: React.MouseEvent) => {
     sheetDragging.current = true;
@@ -141,11 +141,16 @@ function App() {
       const touch = e.changedTouches[0];
       setSheetState(snapSheet(sheetStartState.current, touch.clientY - sheetStartY.current));
     };
+    const onTouchCancel = () => {
+      sheetDragging.current = false;
+    };
     window.addEventListener('mouseup', onMouseUp);
     window.addEventListener('touchend', onTouchEnd);
+    window.addEventListener('touchcancel', onTouchCancel);
     return () => {
       window.removeEventListener('mouseup', onMouseUp);
       window.removeEventListener('touchend', onTouchEnd);
+      window.removeEventListener('touchcancel', onTouchCancel);
     };
   }, []);
 
@@ -171,7 +176,7 @@ function App() {
   return (
     <div
       className="app-layout"
-      style={{ '--sheet-height': sheetHeightCss(sheetState) } as React.CSSProperties}
+      style={isMobile ? { '--sheet-height': sheetHeightCss(sheetState) } as React.CSSProperties : undefined}
     >
       {!fileIndex && <WelcomeModal />}
       <aside className="sidebar" style={isMobile ? {} : { width: sidebarWidth }}>

--- a/tensoscope/src/App.tsx
+++ b/tensoscope/src/App.tsx
@@ -14,6 +14,9 @@ import { useAnimationSequence } from './components/animation/useAnimationSequenc
 import { useAnimationPlayer } from './components/animation/useAnimationPlayer';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import { useAppStore } from './store/useAppStore';
+import { useIsMobile } from './hooks/useIsMobile';
+import { snapSheet, sheetHeightCss } from './components/mobile/sheetSnap';
+import type { SheetState } from './components/mobile/sheetSnap';
 
 function App() {
   const {
@@ -62,10 +65,16 @@ function App() {
     onStepForward: () => player.setFrame(Math.min(frames.length - 1, player.currentFrameIndex + 1)),
   });
 
+  const isMobile = useIsMobile();
+  const [sheetState, setSheetState] = useState<SheetState>('collapsed');
+
   const [sidebarWidth, setSidebarWidth] = useState(380);
   const dragging = useRef(false);
   const startX = useRef(0);
   const startWidth = useRef(0);
+  const sheetDragging = useRef(false);
+  const sheetStartY = useRef(0);
+  const sheetStartState = useRef<SheetState>('collapsed');
 
   const onDragStart = useCallback((e: React.MouseEvent) => {
     dragging.current = true;
@@ -97,6 +106,48 @@ function App() {
     };
   }, [onDragMove, onDragEnd]);
 
+  const prevFileIndex = useRef<typeof fileIndex>(null);
+  useEffect(() => {
+    if (prevFileIndex.current === null && fileIndex !== null) {
+      setSheetState(s => s === 'collapsed' ? 'half' : s);
+    }
+    prevFileIndex.current = fileIndex;
+  }, [fileIndex]);
+
+  const onSheetDragStart = useCallback((e: React.MouseEvent) => {
+    sheetDragging.current = true;
+    sheetStartY.current = e.clientY;
+    sheetStartState.current = sheetState;
+    document.body.style.userSelect = 'none';
+  }, [sheetState]);
+
+  const onSheetTouchStart = useCallback((e: React.TouchEvent) => {
+    sheetDragging.current = true;
+    sheetStartY.current = e.touches[0].clientY;
+    sheetStartState.current = sheetState;
+  }, [sheetState]);
+
+  useEffect(() => {
+    const onMouseUp = (e: MouseEvent) => {
+      if (!sheetDragging.current) return;
+      sheetDragging.current = false;
+      document.body.style.userSelect = '';
+      setSheetState(snapSheet(sheetStartState.current, e.clientY - sheetStartY.current));
+    };
+    const onTouchEnd = (e: TouchEvent) => {
+      if (!sheetDragging.current) return;
+      sheetDragging.current = false;
+      const touch = e.changedTouches[0];
+      setSheetState(snapSheet(sheetStartState.current, touch.clientY - sheetStartY.current));
+    };
+    window.addEventListener('mouseup', onMouseUp);
+    window.addEventListener('touchend', onTouchEnd);
+    return () => {
+      window.removeEventListener('mouseup', onMouseUp);
+      window.removeEventListener('touchend', onTouchEnd);
+    };
+  }, []);
+
   // Find units for the selected variable -- prefer auto-style units, then metadata
   const selectedVar = selectedObject && fileIndex
     ? fileIndex.variables.find(
@@ -117,9 +168,17 @@ function App() {
   const units = (selectedVar?.metadata?.units as string) ?? marsParam;
 
   return (
-    <div className="app-layout">
+    <div
+      className="app-layout"
+      style={{ '--sheet-height': sheetHeightCss(sheetState) } as React.CSSProperties}
+    >
       {!fileIndex && <WelcomeModal />}
-      <aside className="sidebar" style={{ width: sidebarWidth }}>
+      <aside className="sidebar" style={isMobile ? {} : { width: sidebarWidth }}>
+        <div
+          className="sheet-drag-handle"
+          onMouseDown={onSheetDragStart}
+          onTouchStart={onSheetTouchStart}
+        />
         <div className="sidebar-brand">
           <img src={logo} alt="" className="sidebar-brand-logo" />
           <span className="sidebar-brand-name">Tensoscope</span>
@@ -144,6 +203,7 @@ function App() {
           </div>
         )}
         <MapView
+          colorScaleInitialMinimised={isMobile}
           data={fieldData}
           lat={coordinates?.lat ?? null}
           lon={coordinates?.lon ?? null}

--- a/tensoscope/src/components/map/ColorScaleControls.tsx
+++ b/tensoscope/src/components/map/ColorScaleControls.tsx
@@ -23,6 +23,7 @@ export interface ColorScaleControlsProps {
   onPaletteReversedChange: (v: boolean) => void;
   onCustomStopsChange: (stops: CustomStop[]) => void;
   onDisplayUnitChange: (unit: string) => void;
+  initialMinimised?: boolean;
 }
 
 // ── Shared styles ────────────────────────────────────────────────────────────
@@ -561,8 +562,9 @@ export function ColorScaleControls({
   onPaletteReversedChange,
   onCustomStopsChange,
   onDisplayUnitChange,
+  initialMinimised,
 }: ColorScaleControlsProps) {
-  const [minimised, setMinimised] = useState(false);
+  const [minimised, setMinimised] = useState(initialMinimised ?? false);
 
   const group = getUnitGroup(nativeUnits);
   const toDisplay = useMemo(

--- a/tensoscope/src/components/map/MapView.tsx
+++ b/tensoscope/src/components/map/MapView.tsx
@@ -140,7 +140,7 @@ export function MapView(props: MapViewProps) {
 
       {data && (
         <>
-          <div style={{ position: 'absolute', bottom: 'calc(var(--sheet-height, 0px) + 8px)', right: 16, zIndex: 10 }}>
+          <div style={{ position: 'absolute', bottom: 'calc(var(--sheet-height, 32px) + 8px)', right: 16, zIndex: 10 }}>
             <ColorBar
               min={colorMin}
               max={colorMax}

--- a/tensoscope/src/components/map/MapView.tsx
+++ b/tensoscope/src/components/map/MapView.tsx
@@ -34,6 +34,7 @@ export interface MapViewProps {
   nativeUnits: string;
   displayUnit: string;
   onDisplayUnitChange: (unit: string) => void;
+  colorScaleInitialMinimised?: boolean;
 }
 
 export function MapView(props: MapViewProps) {
@@ -45,6 +46,7 @@ export function MapView(props: MapViewProps) {
     onPaletteReversedChange, onCustomStopsChange,
     dataMin, dataMax,
     nativeUnits, displayUnit, onDisplayUnitChange,
+    colorScaleInitialMinimised,
   } = props;
 
   const [activePreset, setActivePreset] = useState<ProjectionPreset>(PROJECTION_PRESETS[0]);
@@ -138,7 +140,7 @@ export function MapView(props: MapViewProps) {
 
       {data && (
         <>
-          <div style={{ position: 'absolute', bottom: 40, right: 16, zIndex: 10 }}>
+          <div style={{ position: 'absolute', bottom: 'calc(var(--sheet-height, 0px) + 8px)', right: 16, zIndex: 10 }}>
             <ColorBar
               min={colorMin}
               max={colorMax}
@@ -168,6 +170,7 @@ export function MapView(props: MapViewProps) {
               onPaletteReversedChange={onPaletteReversedChange}
               onCustomStopsChange={onCustomStopsChange}
               onDisplayUnitChange={onDisplayUnitChange}
+              initialMinimised={colorScaleInitialMinimised}
             />
           </div>
         </>

--- a/tensoscope/src/components/mobile/__tests__/sheetSnap.test.ts
+++ b/tensoscope/src/components/mobile/__tests__/sheetSnap.test.ts
@@ -1,0 +1,63 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+import { describe, expect, it } from 'vitest';
+import { snapSheet, sheetHeightCss } from '../sheetSnap';
+
+describe('snapSheet', () => {
+  it('swipe up from collapsed past threshold snaps to half', () => {
+    expect(snapSheet('collapsed', -70)).toBe('half');
+  });
+
+  it('swipe up from half past threshold snaps to full', () => {
+    expect(snapSheet('half', -70)).toBe('full');
+  });
+
+  it('swipe down from full past threshold snaps to half', () => {
+    expect(snapSheet('full', 70)).toBe('half');
+  });
+
+  it('swipe down from half past threshold snaps to collapsed', () => {
+    expect(snapSheet('half', 70)).toBe('collapsed');
+  });
+
+  it('small upward delta below threshold returns same state', () => {
+    expect(snapSheet('half', -30)).toBe('half');
+  });
+
+  it('small downward delta below threshold returns same state', () => {
+    expect(snapSheet('half', 30)).toBe('half');
+  });
+
+  it('large upward delta from collapsed skips directly to full', () => {
+    expect(snapSheet('collapsed', -130)).toBe('full');
+  });
+
+  it('large downward delta from full skips directly to collapsed', () => {
+    expect(snapSheet('full', 130)).toBe('collapsed');
+  });
+
+  it('swipe up from full stays full', () => {
+    expect(snapSheet('full', -70)).toBe('full');
+  });
+
+  it('swipe down from collapsed stays collapsed', () => {
+    expect(snapSheet('collapsed', 70)).toBe('collapsed');
+  });
+});
+
+describe('sheetHeightCss', () => {
+  it('returns 28px for collapsed', () => {
+    expect(sheetHeightCss('collapsed')).toBe('28px');
+  });
+
+  it('returns 50svh for half', () => {
+    expect(sheetHeightCss('half')).toBe('50svh');
+  });
+
+  it('returns 90svh for full', () => {
+    expect(sheetHeightCss('full')).toBe('90svh');
+  });
+});

--- a/tensoscope/src/components/mobile/__tests__/sheetSnap.test.ts
+++ b/tensoscope/src/components/mobile/__tests__/sheetSnap.test.ts
@@ -31,6 +31,15 @@ describe('snapSheet', () => {
     expect(snapSheet('half', 30)).toBe('half');
   });
 
+  it('delta exactly at threshold (60) snaps', () => {
+    expect(snapSheet('half', 60)).toBe('collapsed');
+    expect(snapSheet('half', -60)).toBe('full');
+  });
+
+  it('delta of zero does not snap', () => {
+    expect(snapSheet('half', 0)).toBe('half');
+  });
+
   it('large upward delta from collapsed skips directly to full', () => {
     expect(snapSheet('collapsed', -130)).toBe('full');
   });

--- a/tensoscope/src/components/mobile/sheetSnap.ts
+++ b/tensoscope/src/components/mobile/sheetSnap.ts
@@ -1,0 +1,35 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+export type SheetState = 'collapsed' | 'half' | 'full';
+
+const THRESHOLD = 60;
+
+/**
+ * Given the current sheet state and the vertical drag delta in pixels
+ * (negative = upward / opening, positive = downward / closing), returns
+ * the next snap state. Deltas below THRESHOLD leave the state unchanged.
+ * Deltas beyond 2×THRESHOLD skip one level entirely.
+ */
+export function snapSheet(current: SheetState, deltaY: number): SheetState {
+  if (Math.abs(deltaY) < THRESHOLD) return current;
+
+  if (deltaY < 0) {
+    if (current === 'collapsed') return Math.abs(deltaY) > THRESHOLD * 2 ? 'full' : 'half';
+    if (current === 'half') return 'full';
+    return 'full';
+  }
+
+  if (current === 'full') return deltaY > THRESHOLD * 2 ? 'collapsed' : 'half';
+  if (current === 'half') return 'collapsed';
+  return 'collapsed';
+}
+
+/** Returns the CSS height value for a given sheet snap state. */
+export function sheetHeightCss(state: SheetState): string {
+  if (state === 'collapsed') return '28px';
+  if (state === 'half') return '50svh';
+  return '90svh';
+}

--- a/tensoscope/src/components/mobile/sheetSnap.ts
+++ b/tensoscope/src/components/mobile/sheetSnap.ts
@@ -19,7 +19,7 @@ export function snapSheet(current: SheetState, deltaY: number): SheetState {
   if (deltaY < 0) {
     if (current === 'collapsed') return Math.abs(deltaY) > THRESHOLD * 2 ? 'full' : 'half';
     if (current === 'half') return 'full';
-    return 'full';
+    return 'full'; // current === 'full', already at top
   }
 
   if (current === 'full') return deltaY > THRESHOLD * 2 ? 'collapsed' : 'half';

--- a/tensoscope/src/hooks/useIsMobile.ts
+++ b/tensoscope/src/hooks/useIsMobile.ts
@@ -9,10 +9,11 @@ const MOBILE_QUERY = '(max-width: 767px)';
 
 /** Returns true when the viewport is ≤767px wide and updates reactively. */
 export function useIsMobile(): boolean {
-  const [isMobile, setIsMobile] = useState(() => window.matchMedia(MOBILE_QUERY).matches);
+  const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
     const mq = window.matchMedia(MOBILE_QUERY);
+    setIsMobile(mq.matches);
     const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
     mq.addEventListener('change', handler);
     return () => mq.removeEventListener('change', handler);

--- a/tensoscope/src/hooks/useIsMobile.ts
+++ b/tensoscope/src/hooks/useIsMobile.ts
@@ -9,7 +9,7 @@ const MOBILE_QUERY = '(max-width: 767px)';
 
 /** Returns true when the viewport is ≤767px wide and updates reactively. */
 export function useIsMobile(): boolean {
-  const [isMobile, setIsMobile] = useState(false);
+  const [isMobile, setIsMobile] = useState(() => window.matchMedia(MOBILE_QUERY).matches);
 
   useEffect(() => {
     const mq = window.matchMedia(MOBILE_QUERY);

--- a/tensoscope/src/hooks/useIsMobile.ts
+++ b/tensoscope/src/hooks/useIsMobile.ts
@@ -1,0 +1,22 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+import { useState, useEffect } from 'react';
+
+const MOBILE_QUERY = '(max-width: 767px)';
+
+/** Returns true when the viewport is ≤767px wide and updates reactively. */
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(() => window.matchMedia(MOBILE_QUERY).matches);
+
+  useEffect(() => {
+    const mq = window.matchMedia(MOBILE_QUERY);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  return isMobile;
+}


### PR DESCRIPTION
## Summary

- Sidebar becomes a draggable bottom sheet on mobile (≤767px), leaving the desktop layout untouched
- Three snap states: `collapsed` (28px handle), `half` (50svh, auto-opens when a file is loaded), `full` (90svh)
- Colour bar and animation bar clear the sheet at all snap states via `--sheet-height` CSS custom property
- Colour scale controls start minimised on mobile; colour scale panel clamped to viewport width

## New files

- `tensoscope/src/components/mobile/sheetSnap.ts` — pure snap state machine (15 unit tests)
- `tensoscope/src/hooks/useIsMobile.ts` — reactive `window.matchMedia` hook

## Modified files

- `tensoscope/src/components/map/ColorScaleControls.tsx` — `initialMinimised?: boolean` prop
- `tensoscope/src/components/map/MapView.tsx` — `colorScaleInitialMinimised` prop; colour bar bottom uses `var(--sheet-height)`
- `tensoscope/src/App.css` — `@media (max-width: 767px)` block; `.sheet-drag-handle` base rule
- `tensoscope/src/App.tsx` — sheet state, drag handlers (touch + mouse), auto-open effect, `--sheet-height` CSS var

## Test plan

- [x] Dev server at 375px viewport: sheet shows 28px handle on load, snaps to 50% on file open, drags to full/collapsed
- [x] Colour bar and animation bar sit above the sheet at all snap states
- [x] Colour scale controls start minimised; tap to expand; panel does not overflow viewport width
- [x] Welcome modal fits on screen
- [x] Desktop at ≥768px: sidebar layout unchanged, resize handle works, colour controls start expanded
- [x] `npm test` — 84/84 passing

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-93
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->