### PR TITLE
chore(opencode): add YAML frontmatter to project commands

### DIFF
--- a/.prompts/address-pr-comments.md
+++ b/.prompts/address-pr-comments.md
@@ -1,3 +1,8 @@
+---
+description: Address all unresolved review comments on a GitHub PR and push fixes
+agent: build
+---
+
 # Address Pull Request Comments
 
 Review and resolve all feedback on a GitHub pull request.

--- a/.prompts/doc-fact-check.md
+++ b/.prompts/doc-fact-check.md
@@ -1,3 +1,8 @@
+---
+description: Run docs code examples and verify prose claims against the codebase
+agent: build
+---
+
 # Documentation Fact-Check
 
 Run code examples in the docs and verify prose claims against the actual codebase.

--- a/.prompts/improve-code-coverage.md
+++ b/.prompts/improve-code-coverage.md
@@ -1,3 +1,8 @@
+---
+description: Measure coverage and fill gaps until every package is at >=95%
+agent: build
+---
+
 # Improve Code Coverage
 
 Perform a comprehensive code coverage analysis and fill gaps to reach 95%+ coverage.

--- a/.prompts/improve-edge-cases.md
+++ b/.prompts/improve-edge-cases.md
@@ -1,3 +1,8 @@
+---
+description: Systematic edge-case audit and patching across the codebase
+agent: build
+---
+
 # Improve Edge Case Handling
 
 Perform a systematic edge case audit across the codebase.

--- a/.prompts/improve-error-handling.md
+++ b/.prompts/improve-error-handling.md
@@ -1,3 +1,8 @@
+---
+description: Audit error paths across Rust / Python / C++ / FFI and tighten up
+agent: build
+---
+
 # Improve Error Handling
 
 Perform a comprehensive error handling audit across the entire codebase.

--- a/.prompts/make-further-pass.md
+++ b/.prompts/make-further-pass.md
@@ -1,3 +1,8 @@
+---
+description: "Run a strictness-graded quality review pass — usage: /make-further-pass <pass-number>"
+agent: build
+---
+
 # Further Pass Review
 
 Perform a quality review pass over the codebase or the specified area.

--- a/.prompts/make-release.md
+++ b/.prompts/make-release.md
@@ -1,3 +1,8 @@
+---
+description: "Cut a new release — usage: /make-release <X.Y.Z>"
+agent: build
+---
+
 # Make Release
 
 Create a new release of Tensogram.

--- a/.prompts/prepare-make-pr.md
+++ b/.prompts/prepare-make-pr.md
@@ -1,3 +1,8 @@
+---
+description: Run pre-flight checks then commit, push and open the PR
+agent: build
+---
+
 # Prepare and Create Pull Request
 
 Final preparation check and PR creation workflow.


### PR DESCRIPTION
## Summary

Project commands under `.prompts/` (symlinked from `.opencode/commands/`)
were missing YAML frontmatter, so opencode discovered them but
presented no description in the TUI autocomplete — making them hard
to identify and effectively unusable.

This adds `description:` and `agent: build` frontmatter to each of the
8 project commands.

## Before

```
/address-pr-comments
/doc-fact-check
/improve-code-coverage
/improve-edge-cases
/improve-error-handling
/make-further-pass
/make-release
/prepare-make-pr
```

(visible but with no description text)

## After

```
/address-pr-comments       — Address all unresolved review comments on a GitHub PR and push fixes
/doc-fact-check            — Run docs code examples and verify prose claims against the codebase
/improve-code-coverage     — Measure coverage and fill gaps until every package is at >=95%
/improve-edge-cases        — Systematic edge-case audit and patching across the codebase
/improve-error-handling    — Audit error paths across Rust / Python / C++ / FFI and tighten up
/make-further-pass         — Run a strictness-graded quality review pass — usage: /make-further-pass <pass-number>
/make-release              — Cut a new release — usage: /make-release <X.Y.Z>
/prepare-make-pr           — Run pre-flight checks then commit, push and open the PR
```

## Notes

- Command **content** (the prompt template) is unchanged — pure metadata addition.
- The `agent: build` field tells opencode to run the command under
  the build agent, matching the pattern used by the global
  `implement-branch-todo` command.
- `argumentHint` is not parsable from markdown frontmatter (only
  `description` / `agent` / `model` / `subtask` are), so for the two
  commands that take an argument (`make-further-pass` and
  `make-release`) the usage hint is embedded in the description string.
- Verified via `opencode debug config` that all 8 commands now
  surface with their descriptions in the resolved config.

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-96
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->