### PR TITLE
test(python): bind discarded expressions to _ in pytest.raises blocks

### DIFF
--- a/python/tests/test_async.py
+++ b/python/tests/test_async.py
@@ -65,7 +65,7 @@ class TestAsyncOpen:
     @pytest.mark.asyncio
     async def test_open_nonexistent(self):
         with pytest.raises(OSError, match=r"[Nn]o such|not found"):
-            await tensogram.AsyncTensogramFile.open("/nonexistent/path.tgm")
+            _ = await tensogram.AsyncTensogramFile.open("/nonexistent/path.tgm")
 
     @pytest.mark.asyncio
     async def test_repr(self, tgm_path):
@@ -209,9 +209,7 @@ class TestAsyncGather:
             f.file_decode_object(2, 0),
         )
         for i, r in enumerate(results):
-            np.testing.assert_allclose(
-                r["data"], np.full(10, float(i), dtype=np.float32)
-            )
+            np.testing.assert_allclose(r["data"], np.full(10, float(i), dtype=np.float32))
 
     @pytest.mark.asyncio
     async def test_gather_mixed_operations(self, tgm_path):
@@ -233,9 +231,7 @@ class TestAsyncGather:
         )
         for i, (meta, objects) in enumerate(messages):
             assert meta.version == 3
-            np.testing.assert_allclose(
-                objects[0][1], np.full(10, float(i), dtype=np.float32)
-            )
+            np.testing.assert_allclose(objects[0][1], np.full(10, float(i), dtype=np.float32))
 
 
 class TestAsyncParity:
@@ -277,31 +273,31 @@ class TestAsyncErrors:
     async def test_decode_message_out_of_range(self, tgm_path):
         f = await tensogram.AsyncTensogramFile.open(tgm_path)
         with pytest.raises((ValueError, RuntimeError)):
-            await f.decode_message(999)
+            _ = await f.decode_message(999)
 
     @pytest.mark.asyncio
     async def test_file_decode_object_out_of_range(self, tgm_path):
         f = await tensogram.AsyncTensogramFile.open(tgm_path)
         with pytest.raises((ValueError, RuntimeError)):
-            await f.file_decode_object(999, 0)
+            _ = await f.file_decode_object(999, 0)
 
     @pytest.mark.asyncio
     async def test_file_decode_metadata_out_of_range(self, tgm_path):
         f = await tensogram.AsyncTensogramFile.open(tgm_path)
         with pytest.raises((ValueError, RuntimeError)):
-            await f.file_decode_metadata(999)
+            _ = await f.file_decode_metadata(999)
 
     @pytest.mark.asyncio
     async def test_file_decode_descriptors_out_of_range(self, tgm_path):
         f = await tensogram.AsyncTensogramFile.open(tgm_path)
         with pytest.raises((ValueError, RuntimeError)):
-            await f.file_decode_descriptors(999)
+            _ = await f.file_decode_descriptors(999)
 
     @pytest.mark.asyncio
     async def test_read_message_out_of_range(self, tgm_path):
         f = await tensogram.AsyncTensogramFile.open(tgm_path)
         with pytest.raises((ValueError, RuntimeError)):
-            await f.read_message(999)
+            _ = await f.read_message(999)
 
     @pytest.mark.asyncio
     async def test_decode_message_verify_hash_mismatch(self, tmp_path):
@@ -313,7 +309,7 @@ class TestAsyncErrors:
             fh.write(corrupt)
         f = await tensogram.AsyncTensogramFile.open(path)
         with pytest.raises((ValueError, RuntimeError)):
-            await f.decode_message(0, verify_hash=True)
+            _ = await f.decode_message(0, verify_hash=True)
 
     @pytest.mark.asyncio
     async def test_open_remote_bad_storage_options(self, serve_tgm_bytes):
@@ -335,7 +331,7 @@ class TestAsyncErrors:
         task = asyncio.ensure_future(fut)
         task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
-            await task
+            _ = await task
 
         result = await f.file_decode_object(1, 0)
         np.testing.assert_allclose(result["data"], np.ones(10, dtype=np.float32))
@@ -403,7 +399,7 @@ class TestAsyncDecodeRange:
     async def test_file_decode_range_out_of_range(self, tgm_path):
         f = await tensogram.AsyncTensogramFile.open(tgm_path)
         with pytest.raises((ValueError, RuntimeError)):
-            await f.file_decode_range(999, 0, [(0, 5)])
+            _ = await f.file_decode_range(999, 0, [(0, 5)])
 
     @pytest.mark.asyncio
     async def test_file_decode_range_matches_sync(self, tgm_path):
@@ -465,9 +461,7 @@ class TestAsyncIteration:
         assert len(messages) == 3
         for i, (meta, objects) in enumerate(messages):
             assert meta.version == 3
-            np.testing.assert_allclose(
-                objects[0][1], np.full(10, float(i), dtype=np.float32)
-            )
+            np.testing.assert_allclose(objects[0][1], np.full(10, float(i), dtype=np.float32))
 
     @pytest.mark.asyncio
     async def test_aiter_early_break(self, tgm_path):
@@ -506,9 +500,7 @@ class TestAsyncIteration:
         async for m in f:
             messages.append(m)
         assert len(messages) == 1
-        np.testing.assert_allclose(
-            messages[0][1][0][1], np.full(4, 99.0, dtype=np.float32)
-        )
+        np.testing.assert_allclose(messages[0][1][0][1], np.full(4, 99.0, dtype=np.float32))
 
     @pytest.mark.asyncio
     async def test_aiter_repr(self, tgm_path):
@@ -549,7 +541,7 @@ class TestAsyncIteration:
         for _ in range(3):
             await it.__anext__()
         with pytest.raises(StopAsyncIteration):
-            await it.__anext__()
+            _ = await it.__anext__()
 
     @pytest.mark.asyncio
     async def test_aiter_concurrent_iterators(self, tgm_path):
@@ -693,7 +685,7 @@ class TestAsyncBatchRange:
         url = serve_tgm_bytes(msg)
         f = await tensogram.AsyncTensogramFile.open(url)
         with pytest.raises((ValueError, RuntimeError)):
-            await f.file_decode_range_batch([999], 0, [(0, 5)], join=True)
+            _ = await f.file_decode_range_batch([999], 0, [(0, 5)], join=True)
 
 
 class TestAsyncBatchObject:
@@ -722,9 +714,7 @@ class TestAsyncBatchObject:
             assert "data" in r
             assert "metadata" in r
             assert "descriptor" in r
-            np.testing.assert_allclose(
-                r["data"], np.full(10, float(i), dtype=np.float32)
-            )
+            np.testing.assert_allclose(r["data"], np.full(10, float(i), dtype=np.float32))
 
     @pytest.mark.asyncio
     async def test_batch_matches_individual(self, serve_tgm_bytes):
@@ -763,7 +753,7 @@ class TestAsyncBatchObject:
         url = serve_tgm_bytes(msg)
         f = await tensogram.AsyncTensogramFile.open(url)
         with pytest.raises((ValueError, RuntimeError)):
-            await f.file_decode_object_batch([999], 0)
+            _ = await f.file_decode_object_batch([999], 0)
 
 
 class TestSyncBatchObject:
@@ -787,9 +777,7 @@ class TestSyncBatchObject:
         results = f.file_decode_object_batch([0, 1, 2], 0)
         assert len(results) == 3
         for i, r in enumerate(results):
-            np.testing.assert_allclose(
-                r["data"], np.full(10, float(i), dtype=np.float32)
-            )
+            np.testing.assert_allclose(r["data"], np.full(10, float(i), dtype=np.float32))
 
     def test_batch_matches_individual(self, serve_tgm_bytes):
         meta = {"version": 3, "base": [{}]}
@@ -883,13 +871,13 @@ class TestBatchLocalFileError:
     async def test_async_object_batch_raises_on_local(self, tgm_path):
         f = await tensogram.AsyncTensogramFile.open(tgm_path)
         with pytest.raises(OSError, match="remote backend"):
-            await f.file_decode_object_batch([0, 1], 0)
+            _ = await f.file_decode_object_batch([0, 1], 0)
 
     @pytest.mark.asyncio
     async def test_async_range_batch_raises_on_local(self, tgm_path):
         f = await tensogram.AsyncTensogramFile.open(tgm_path)
         with pytest.raises(OSError, match="remote backend"):
-            await f.file_decode_range_batch([0, 1], 0, [(0, 5)])
+            _ = await f.file_decode_range_batch([0, 1], 0, [(0, 5)])
 
 
 class TestAsyncPrefetchLayouts:
@@ -925,4 +913,4 @@ class TestAsyncPrefetchLayouts:
         url = serve_tgm_bytes(msg)
         f = await tensogram.AsyncTensogramFile.open(url)
         with pytest.raises((ValueError, RuntimeError)):
-            await f.prefetch_layouts([999])
+            _ = await f.prefetch_layouts([999])

--- a/python/tests/test_remote.py
+++ b/python/tests/test_remote.py
@@ -186,9 +186,7 @@ class TestBidirectionalKwarg:
         with tensogram.TensogramFile.open_remote(url) as f:
             assert f.message_count() == 1
 
-    def test_open_remote_bidirectional_false_opt_out_matches_bidirectional(
-        self, serve_tgm_bytes
-    ):
+    def test_open_remote_bidirectional_false_opt_out_matches_bidirectional(self, serve_tgm_bytes):
         msg1 = encode_test_message([4], fill=10.0)
         msg2 = encode_test_message([8], fill=20.0)
         msg3 = encode_test_message([16], fill=30.0)

--- a/python/tests/test_tensogram.py
+++ b/python/tests/test_tensogram.py
@@ -1297,9 +1297,9 @@ class TestEdgeCases:
 
         with tensogram.TensogramFile.open(path) as f:
             with pytest.raises(IndexError):
-                f[5]
+                _ = f[5]
             with pytest.raises(IndexError):
-                f[-2]
+                _ = f[-2]
 
     def test_file_slice_basic(self, tmp_path):
         """file[1:3] returns a list of two decoded messages."""
@@ -1392,7 +1392,7 @@ class TestEdgeCases:
             f.append(make_global_meta(3), [(make_descriptor([4], dtype="float32"), data)])
 
         with tensogram.TensogramFile.open(path) as f, pytest.raises(TypeError):
-            f["bad"]
+            _ = f["bad"]
 
     # ── Message namedtuple ──
 
@@ -1600,7 +1600,7 @@ class TestMetadataCoverage:
         msg = encode_simple(np.ones(4, dtype=np.float32))
         meta = tensogram.decode_metadata(msg)
         with pytest.raises(KeyError, match="nonexistent"):
-            meta["nonexistent"]
+            _ = meta["nonexistent"]
 
     def test_contains(self):
         """__contains__ checks both base entries and extra."""
@@ -1885,7 +1885,7 @@ class TestMetadataEdgeCases:
         msg = encode_simple(np.ones(4, dtype=np.float32))
         meta = tensogram.decode_metadata(msg)
         with pytest.raises(KeyError, match="_reserved_"):
-            meta["_reserved_"]
+            _ = meta["_reserved_"]
 
     def test_contains_reserved_false(self):
         """'_reserved_' in meta returns False (hidden from dict access)."""
@@ -2096,12 +2096,12 @@ class TestFileSliceCoverage:
     def test_index_out_of_range(self, sample_file):
         """file[100] raises IndexError."""
         with tensogram.TensogramFile.open(sample_file) as f, pytest.raises(IndexError):
-            f[100]
+            _ = f[100]
 
     def test_negative_out_of_range(self, sample_file):
         """file[-100] raises IndexError."""
         with tensogram.TensogramFile.open(sample_file) as f, pytest.raises(IndexError):
-            f[-100]
+            _ = f[-100]
 
     def test_slice_reverse(self, sample_file):
         """file[::-1] reverses all messages."""
@@ -2554,7 +2554,7 @@ class TestPyMetadataAccessCoverage:
         # Base entries contain _reserved_ from encoder, but
         # __getitem__ skips _reserved_ → should raise KeyError
         with pytest.raises(KeyError, match="_reserved_"):
-            meta["_reserved_"]
+            _ = meta["_reserved_"]
 
     def test_repr_format(self):
         """__repr__ includes version, base_len, and extra_keys."""


### PR DESCRIPTION
## Summary

Fixes 9 CodeQL `py/ineffectual-statement` alerts in `python/tests/test_tensogram.py` and `python/tests/test_async.py` where bare-expression statements inside `with pytest.raises(...)` or `with contextlib.suppress(...)` blocks were the trigger for the expected exception. Assigning the result to `_` makes the discard explicit; behaviour is unchanged.

## Fixed

- **9 CodeQL `py/ineffectual-statement` alerts** in `test_tensogram.py` (8 sites) and `test_async.py` (1 site). Each `f[5]` / `meta["k"]` / `await task` etc. inside a `pytest.raises(...)` body is rewritten to `_ = f[5]` / `_ = meta["k"]` / `_ = await task`. The right-hand side is still evaluated and still raises the expected exception; the lint no longer fires because the statement now has an explicit effect (assignment to `_`).

## Changed

- **Sweep widened to all structurally-identical sites.** An AST scan over the test corpus found 23 sites total matching the same shape (single-statement bodies whose value is a `Subscript`, `Await`, `Attribute`, or `Name` inside `pytest.raises` / `contextlib.suppress`). All 23 are in this PR. Function-call bare expressions (`f.do_thing(args)`) were intentionally left alone — they are semantically side-effecting and not flagged by CodeQL or ruff `B018`.
- **Pre-existing ruff format drift in `test_async.py` and `test_remote.py` collapsed.** Six lines that ruff format wanted to refit on a single line were collapsed. This drift exists on `main` too (older ruff version produced wrapped lines that newer ruff considers should be one line). CI's `python/tests/` job runs `ruff check` only and not `ruff format --check`, which is why `main` is green there; `make python-fmt` would have failed without this cleanup.

## Why `_ = expr` and not the `pytest.raises(X, callable)` form

Three of the original sites use the combined `with TensogramFile.open(path) as f, pytest.raises(X):` form. The callable form does not compose with that without an awkward refactor or losing `match=...` ergonomics. `_ = expr` is the smallest, uniform change that satisfies the lint at every site.

## No behaviour change, no new tests

The existing `pytest.raises(X, match=Y)` calls already encode `(exception type, message regex)` as the spec — only the form of the trigger expression is changed. No test was added or weakened. AGENTS.md compliance: no `# noqa`, no `pyright: ignore`, no annotation suppression — the fix invalidates the lint's premise (statement has no effect) instead of suppressing the warning.

## Validation

Full clean rebuild (`cargo clean`, fresh `.venv`, fresh `node_modules`, fresh `wasm`, fresh `target`) then every gate run cold:

| Gate | Result |
|------|--------|
| `cargo fmt --check` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` (CI) | clean |
| `cargo clippy -p tensogram --all-targets --features "remote,async" -- -D warnings` (CI) | clean |
| `cargo test --workspace` | every result `ok`, 0 failures |
| `cargo test -p tensogram --features "remote,async"` | every result `ok`, 0 failures |
| `ruff check` `python/tests/` | clean |
| `ruff format --check` `python/tests/` | clean |
| `pytest python/tests/` | 568 passed, 30 skipped |
| `pytest python/tensogram-xarray/tests/` | 242 passed |
| `pytest python/tensogram-zarr/tests/` | 235 passed |
| `make ts-typecheck` | clean |
| `make ts-test` (vitest) | 402 / 402 |
| `mdbook build docs/` | clean |

### Note on `cargo clippy --all-features` on macOS

The strict `cargo clippy --workspace --all-targets --all-features -- -D warnings` documented in `AGENTS.md` does not currently build on macOS due to two third-party `-sys` crate environment gaps:

1. `tensogram-sz3-sys`'s `openmp` feature passes `-fopenmp` unconditionally to the C++ compiler, which Apple's stock clang does not accept.
2. `blosc2-rs-sys`'s cmake install attempts `/usr/local/include` (denied without sudo on macOS).

Both reproduce identically on `origin/main`. **CI does not exercise `--all-features`** (the `lint` job runs `make rust-lint` which uses default features and `--features "remote,async"`), and the macOS CI lane is currently disabled (`.github/workflows/ci.yml` lines 282-371). All gates CI does run are green on this branch. Worth a follow-up to either fix `tensogram-sz3-sys`'s build script for macOS Homebrew libomp or remove the `openmp` feature from the documented strict-lint command — out of scope for this PR.

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-105
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->