### PR TITLE
refactor(tensogram): extract num_elements helper, split pipeline config resolver, mark error enums #[non_exhaustive]

### DIFF
--- a/rust/tensogram-encodings/src/compression/mod.rs
+++ b/rust/tensogram-encodings/src/compression/mod.rs
@@ -56,6 +56,7 @@ pub use self::zstd_pure::ZstdPureCompressor;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum CompressionError {
     #[error("szip error: {0}")]
     Szip(String),

--- a/rust/tensogram-encodings/src/pipeline.rs
+++ b/rust/tensogram-encodings/src/pipeline.rs
@@ -78,6 +78,7 @@ pub fn byteswap(data: &mut [u8], unit_size: usize) -> Result<(), PipelineError> 
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum PipelineError {
     #[error("encoding error: {0}")]
     Encoding(#[from] PackingError),

--- a/rust/tensogram/src/decode.rs
+++ b/rust/tensogram/src/decode.rs
@@ -473,13 +473,7 @@ pub fn decode_range_from_payload(
     // `tensogram validate --checksum` or call
     // `hash::verify_frame_hash` on the full frame directly.
 
-    let shape_product = desc
-        .shape
-        .iter()
-        .try_fold(1u64, |acc, &x| acc.checked_mul(x))
-        .ok_or_else(|| TensogramError::Metadata("shape product overflow".to_string()))?;
-    let num_elements = usize::try_from(shape_product)
-        .map_err(|_| TensogramError::Metadata("element count overflows usize".to_string()))?;
+    let num_elements = desc.num_elements()?;
     // Thread-budget dispatch for range decode.
     //
     // Each range is an independent decode call; parallelism is natural
@@ -585,13 +579,7 @@ fn decode_single_object_with_backend(
     // for programmatic per-frame verification.
     let _ = options.verify_hash;
 
-    let shape_product = desc
-        .shape
-        .iter()
-        .try_fold(1u64, |acc, &x| acc.checked_mul(x))
-        .ok_or_else(|| TensogramError::Metadata("shape product overflow".to_string()))?;
-    let num_elements = usize::try_from(shape_product)
-        .map_err(|_| TensogramError::Metadata("element count overflows usize".to_string()))?;
+    let num_elements = desc.num_elements()?;
     let config = build_pipeline_config_with_backend(
         desc,
         num_elements,

--- a/rust/tensogram/src/encode.rs
+++ b/rust/tensogram/src/encode.rs
@@ -738,7 +738,7 @@ fn resolve_filter(desc: &DataObjectDescriptor) -> Result<FilterType> {
     }
 }
 
-/// Resolve the compression backend from a descriptor, using the resolved
+/// Resolve the compression type from a descriptor, using the resolved
 /// encoding and filter for any codec that depends on them (szip bits_per_sample,
 /// blosc2 typesize).
 fn resolve_compression(

--- a/rust/tensogram/src/encode.rs
+++ b/rust/tensogram/src/encode.rs
@@ -248,13 +248,7 @@ fn encode_one_object(
         (std::borrow::Cow::Borrowed(data), MaskSet::empty(0))
     };
 
-    let shape_product = desc
-        .shape
-        .iter()
-        .try_fold(1u64, |acc, &x| acc.checked_mul(x))
-        .ok_or_else(|| TensogramError::Metadata("shape product overflow".to_string()))?;
-    let num_elements = usize::try_from(shape_product)
-        .map_err(|_| TensogramError::Metadata("element count overflows usize".to_string()))?;
+    let num_elements = desc.num_elements()?;
     let dtype = desc.dtype;
 
     // Build the descriptor we will emit on the wire.  For Raw mode this
@@ -703,20 +697,10 @@ pub(crate) fn build_pipeline_config(
     )
 }
 
-/// Build a pipeline config with an explicit compression backend override
-/// and an intra-codec thread budget.
-///
-/// `intra_codec_threads == 0` preserves the pre-threads behaviour and is
-/// what direct pipeline callers (benchmarks, external code) should use.
-pub(crate) fn build_pipeline_config_with_backend(
-    desc: &DataObjectDescriptor,
-    num_values: usize,
-    dtype: Dtype,
-    compression_backend: pipeline::CompressionBackend,
-    intra_codec_threads: u32,
-) -> Result<PipelineConfig> {
-    let encoding = match desc.encoding.as_str() {
-        "none" => EncodingType::None,
+/// Resolve the encoding type from a descriptor.
+fn resolve_encoding(desc: &DataObjectDescriptor, dtype: Dtype) -> Result<EncodingType> {
+    match desc.encoding.as_str() {
+        "none" => Ok(EncodingType::None),
         "simple_packing" => {
             // Strict float64 check.  A `byte_width() != 8` test would
             // also let `Int64` / `Uint64` / `Complex64` through, and
@@ -728,17 +712,18 @@ pub(crate) fn build_pipeline_config_with_backend(
                 )));
             }
             let params = extract_simple_packing_params(&desc.params)?;
-            EncodingType::SimplePacking(params)
+            Ok(EncodingType::SimplePacking(params))
         }
-        other => {
-            return Err(TensogramError::Encoding(format!(
-                "unknown encoding: {other}"
-            )));
-        }
-    };
+        other => Err(TensogramError::Encoding(format!(
+            "unknown encoding: {other}"
+        ))),
+    }
+}
 
-    let filter = match desc.filter.as_str() {
-        "none" => FilterType::None,
+/// Resolve the filter type from a descriptor.
+fn resolve_filter(desc: &DataObjectDescriptor) -> Result<FilterType> {
+    match desc.filter.as_str() {
+        "none" => Ok(FilterType::None),
         "shuffle" => {
             let element_size = usize::try_from(get_u64_param(
                 &desc.params,
@@ -747,13 +732,23 @@ pub(crate) fn build_pipeline_config_with_backend(
             .map_err(|_| {
                 TensogramError::Metadata("shuffle_element_size out of usize range".to_string())
             })?;
-            FilterType::Shuffle { element_size }
+            Ok(FilterType::Shuffle { element_size })
         }
-        other => return Err(TensogramError::Encoding(format!("unknown filter: {other}"))),
-    };
+        other => Err(TensogramError::Encoding(format!("unknown filter: {other}"))),
+    }
+}
 
-    let compression = match desc.compression.as_str() {
-        "none" => CompressionType::None,
+/// Resolve the compression backend from a descriptor, using the resolved
+/// encoding and filter for any codec that depends on them (szip bits_per_sample,
+/// blosc2 typesize).
+fn resolve_compression(
+    desc: &DataObjectDescriptor,
+    dtype: Dtype,
+    encoding: &EncodingType,
+    filter: &FilterType,
+) -> Result<CompressionType> {
+    match desc.compression.as_str() {
+        "none" => Ok(CompressionType::None),
         #[cfg(any(feature = "szip", feature = "szip-pure"))]
         "szip" => {
             let rsi = u32::try_from(get_u64_param(&desc.params, "szip_rsi")?)
@@ -764,17 +759,17 @@ pub(crate) fn build_pipeline_config_with_backend(
                 })?;
             let flags = u32::try_from(get_u64_param(&desc.params, "szip_flags")?)
                 .map_err(|_| TensogramError::Metadata("szip_flags out of u32 range".to_string()))?;
-            let bits_per_sample = match (&encoding, &filter) {
+            let bits_per_sample = match (encoding, filter) {
                 (EncodingType::SimplePacking(params), _) => params.bits_per_value,
                 (EncodingType::None, FilterType::Shuffle { .. }) => 8,
                 (EncodingType::None, FilterType::None) => (dtype.byte_width() * 8) as u32,
             };
-            CompressionType::Szip {
+            Ok(CompressionType::Szip {
                 rsi,
                 block_size,
                 flags,
                 bits_per_sample,
-            }
+            })
         }
         #[cfg(any(feature = "zstd", feature = "zstd-pure"))]
         "zstd" => {
@@ -782,10 +777,10 @@ pub(crate) fn build_pipeline_config_with_backend(
             let level = i32::try_from(level_i64).map_err(|_| {
                 TensogramError::Metadata(format!("zstd_level value {level_i64} out of i32 range"))
             })?;
-            CompressionType::Zstd { level }
+            Ok(CompressionType::Zstd { level })
         }
         #[cfg(feature = "lz4")]
-        "lz4" => CompressionType::Lz4,
+        "lz4" => Ok(CompressionType::Lz4),
         #[cfg(feature = "blosc2")]
         "blosc2" => {
             let codec_str = match desc.params.get("blosc2_codec") {
@@ -810,18 +805,18 @@ pub(crate) fn build_pipeline_config_with_backend(
                     "blosc2_clevel value {clevel_i64} out of i32 range"
                 ))
             })?;
-            let typesize = match (&encoding, &filter) {
+            let typesize = match (encoding, filter) {
                 (EncodingType::SimplePacking(params), _) => {
                     (params.bits_per_value as usize).div_ceil(8)
                 }
                 (EncodingType::None, FilterType::Shuffle { .. }) => 1,
                 (EncodingType::None, FilterType::None) => dtype.byte_width(),
             };
-            CompressionType::Blosc2 {
+            Ok(CompressionType::Blosc2 {
                 codec,
                 clevel,
                 typesize,
-            }
+            })
         }
         #[cfg(feature = "zfp")]
         "zfp" => {
@@ -855,7 +850,7 @@ pub(crate) fn build_pipeline_config_with_backend(
                     )));
                 }
             };
-            CompressionType::Zfp { mode }
+            Ok(CompressionType::Zfp { mode })
         }
         #[cfg(feature = "sz3")]
         "sz3" => {
@@ -878,7 +873,7 @@ pub(crate) fn build_pipeline_config_with_backend(
                     )));
                 }
             };
-            CompressionType::Sz3 { error_bound }
+            Ok(CompressionType::Sz3 { error_bound })
         }
         "rle" => {
             // Bitmask-only codec — see `plans/WIRE_FORMAT.md` §8.
@@ -888,7 +883,7 @@ pub(crate) fn build_pipeline_config_with_backend(
                     dtype
                 )));
             }
-            CompressionType::Rle
+            Ok(CompressionType::Rle)
         }
         "roaring" => {
             // Bitmask-only codec — see `plans/WIRE_FORMAT.md` §8.
@@ -898,14 +893,29 @@ pub(crate) fn build_pipeline_config_with_backend(
                     dtype
                 )));
             }
-            CompressionType::Roaring
+            Ok(CompressionType::Roaring)
         }
-        other => {
-            return Err(TensogramError::Encoding(format!(
-                "unknown compression: {other}"
-            )));
-        }
-    };
+        other => Err(TensogramError::Encoding(format!(
+            "unknown compression: {other}"
+        ))),
+    }
+}
+
+/// Build a pipeline config with an explicit compression backend override
+/// and an intra-codec thread budget.
+///
+/// `intra_codec_threads == 0` preserves the pre-threads behaviour and is
+/// what direct pipeline callers (benchmarks, external code) should use.
+pub(crate) fn build_pipeline_config_with_backend(
+    desc: &DataObjectDescriptor,
+    num_values: usize,
+    dtype: Dtype,
+    compression_backend: pipeline::CompressionBackend,
+    intra_codec_threads: u32,
+) -> Result<PipelineConfig> {
+    let encoding = resolve_encoding(desc, dtype)?;
+    let filter = resolve_filter(desc)?;
+    let compression = resolve_compression(desc, dtype, &encoding, &filter)?;
 
     Ok(PipelineConfig {
         encoding,

--- a/rust/tensogram/src/iter.rs
+++ b/rust/tensogram/src/iter.rs
@@ -144,24 +144,10 @@ impl Iterator for ObjectIter {
         // go through `validate --checksum`.
         let _ = (self.options.verify_hash, desc, payload_bytes);
 
-        let shape_product = match desc
-            .shape
-            .iter()
-            .try_fold(1u64, |acc, &x| acc.checked_mul(x))
-        {
-            Some(p) => p,
-            None => {
-                return Some(Err(crate::error::TensogramError::Metadata(
-                    "shape product overflow".to_string(),
-                )));
-            }
-        };
-        let num_elements = match usize::try_from(shape_product) {
+        let num_elements = match desc.num_elements() {
             Ok(n) => n,
-            Err(_) => {
-                return Some(Err(crate::error::TensogramError::Metadata(
-                    "element count overflows usize".to_string(),
-                )));
+            Err(e) => {
+                return Some(Err(crate::error::TensogramError::Metadata(e.to_string())));
             }
         };
 

--- a/rust/tensogram/src/iter.rs
+++ b/rust/tensogram/src/iter.rs
@@ -146,9 +146,7 @@ impl Iterator for ObjectIter {
 
         let num_elements = match desc.num_elements() {
             Ok(n) => n,
-            Err(e) => {
-                return Some(Err(crate::error::TensogramError::Metadata(e.to_string())));
-            }
+            Err(e) => return Some(Err(e)),
         };
 
         let config = match build_pipeline_config(desc, num_elements, desc.dtype) {

--- a/rust/tensogram/src/restore.rs
+++ b/rust/tensogram/src/restore.rs
@@ -120,13 +120,7 @@ fn each_mask_kind(
 }
 
 fn element_count(desc: &DataObjectDescriptor) -> Result<usize> {
-    let product = desc
-        .shape
-        .iter()
-        .try_fold(1u64, |acc, &x| acc.checked_mul(x))
-        .ok_or_else(|| TensogramError::Metadata("shape product overflow".to_string()))?;
-    usize::try_from(product)
-        .map_err(|_| TensogramError::Metadata("element count overflows usize".to_string()))
+    desc.num_elements()
 }
 
 /// Decompress one mask blob at `mask_region[md.offset - mask_region_base ..

--- a/rust/tensogram/src/streaming.rs
+++ b/rust/tensogram/src/streaming.rs
@@ -247,13 +247,7 @@ impl<W: Write> StreamingEncoder<W> {
     pub fn write_object(&mut self, desc: &DataObjectDescriptor, data: &[u8]) -> Result<()> {
         validate_object(desc, data.len())?;
 
-        let shape_product = desc
-            .shape
-            .iter()
-            .try_fold(1u64, |acc, &x| acc.checked_mul(x))
-            .ok_or_else(|| TensogramError::Metadata("shape product overflow".to_string()))?;
-        let num_elements = usize::try_from(shape_product)
-            .map_err(|_| TensogramError::Metadata("element count overflows usize".to_string()))?;
+        let num_elements = desc.num_elements()?;
 
         // Honour the intra-codec thread budget captured at construction.
         // Small-message threshold: if the payload is below the threshold,
@@ -360,13 +354,7 @@ impl<W: Write> StreamingEncoder<W> {
     ) -> Result<()> {
         validate_object(descriptor, pre_encoded_bytes.len())?;
 
-        let shape_product = descriptor
-            .shape
-            .iter()
-            .try_fold(1u64, |acc, &x| acc.checked_mul(x))
-            .ok_or_else(|| TensogramError::Metadata("shape product overflow".to_string()))?;
-        let num_elements = usize::try_from(shape_product)
-            .map_err(|_| TensogramError::Metadata("element count overflows usize".to_string()))?;
+        let num_elements = descriptor.num_elements()?;
 
         // Validate descriptor pipeline configuration without encoding.
         build_pipeline_config(descriptor, num_elements, descriptor.dtype)?;

--- a/rust/tensogram/src/types.rs
+++ b/rust/tensogram/src/types.rs
@@ -300,4 +300,87 @@ mod tests {
             assert_eq!(desc.byte_order, expected);
         }
     }
+
+    /// Build a minimal descriptor with the given shape; the other fields
+    /// are irrelevant to `num_elements()` because the method only inspects
+    /// `shape`.
+    fn descriptor_with_shape(shape: Vec<u64>) -> DataObjectDescriptor {
+        DataObjectDescriptor {
+            obj_type: "ntensor".to_string(),
+            ndim: shape.len() as u64,
+            shape,
+            strides: Vec::new(),
+            dtype: Dtype::Float32,
+            byte_order: ByteOrder::native(),
+            encoding: "none".to_string(),
+            filter: "none".to_string(),
+            compression: "none".to_string(),
+            masks: None,
+            params: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn num_elements_empty_shape_is_one() {
+        // Empty shape (scalar tensor, ndim=0) — by convention the
+        // empty product is 1.
+        let desc = descriptor_with_shape(vec![]);
+        assert_eq!(desc.num_elements().unwrap(), 1);
+    }
+
+    #[test]
+    fn num_elements_single_dim() {
+        let desc = descriptor_with_shape(vec![100]);
+        assert_eq!(desc.num_elements().unwrap(), 100);
+    }
+
+    #[test]
+    fn num_elements_multi_dim() {
+        let desc = descriptor_with_shape(vec![3, 4, 5]);
+        assert_eq!(desc.num_elements().unwrap(), 60);
+    }
+
+    #[test]
+    fn num_elements_zero_dim_yields_zero() {
+        // A dimension of zero produces a zero-element tensor; this is
+        // valid and must not error.
+        let desc = descriptor_with_shape(vec![10, 0, 5]);
+        assert_eq!(desc.num_elements().unwrap(), 0);
+    }
+
+    #[test]
+    fn num_elements_u64_overflow_is_metadata_error() {
+        // u64::MAX × 2 overflows checked_mul.
+        let desc = descriptor_with_shape(vec![u64::MAX, 2]);
+        let err = desc.num_elements().unwrap_err();
+        match err {
+            TensogramError::Metadata(msg) => {
+                assert!(
+                    msg.contains("shape product overflow"),
+                    "unexpected message: {msg}"
+                );
+            }
+            other => panic!("expected Metadata error, got: {other:?}"),
+        }
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    #[test]
+    fn num_elements_usize_overflow_is_metadata_error_on_32bit() {
+        // On 32-bit targets, a u64 product larger than usize::MAX
+        // surfaces the second error path.  On 64-bit targets the
+        // shape would have to be larger than `u64::MAX` to trigger
+        // this, which the previous test already covers.
+        let desc = descriptor_with_shape(vec![(usize::MAX as u64) + 1]);
+        let err = desc.num_elements().unwrap_err();
+        match err {
+            TensogramError::Metadata(msg) => {
+                assert!(
+                    msg.contains("element count overflows usize"),
+                    "unexpected message: {msg}"
+                );
+            }
+            other => panic!("expected Metadata error, got: {other:?}"),
+        }
+    }
 }

--- a/rust/tensogram/src/types.rs
+++ b/rust/tensogram/src/types.rs
@@ -10,6 +10,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 use crate::dtype::Dtype;
+use crate::error::Result;
+use crate::error::TensogramError;
 
 pub use tensogram_encodings::ByteOrder;
 
@@ -117,7 +119,6 @@ pub struct DataObjectDescriptor {
     /// no mask sections are present, and the frame is byte-compatible
     /// with an `NTensorFrame` emitted without the `allow_nan` /
     /// `allow_inf` opt-in.
-    ///
     /// Declared **before** `params` so that the flattened `params` map
     /// below does not absorb the `masks` key at deserialisation time.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -127,6 +128,24 @@ pub struct DataObjectDescriptor {
     /// szip_block_offsets, etc.). Stored as ciborium::Value for flexibility.
     #[serde(flatten)]
     pub params: BTreeMap<String, ciborium::Value>,
+}
+
+impl DataObjectDescriptor {
+    /// Compute the total number of elements implied by `shape`, validating
+    /// against u64 overflow and usize range.
+    ///
+    /// Returns the element count in `usize`, or an error when the product
+    /// overflows `u64` or cannot fit in `usize`.
+    #[inline]
+    pub fn num_elements(&self) -> Result<usize> {
+        let shape_product = self
+            .shape
+            .iter()
+            .try_fold(1u64, |acc, &x| acc.checked_mul(x))
+            .ok_or_else(|| TensogramError::Metadata("shape product overflow".to_string()))?;
+        usize::try_from(shape_product)
+            .map_err(|_| TensogramError::Metadata("element count overflows usize".to_string()))
+    }
 }
 
 /// Global message metadata (carried in header/footer metadata frames).


### PR DESCRIPTION
## Summary

Structural cleanup across `tensogram` and `tensogram-encodings`: deduplication, code splitting, and ABI safety.

> **Note: Source-breaking change.**  Adding `#[non_exhaustive]` to `PipelineError` and `CompressionError` is a deliberate source-breaking change for downstream code that exhaustively `match`es these enums.  The project is pre-public (Emerging maturity per ECMWF guidelines), so the breakage is acceptable; the change exists precisely to prevent recurring breakage every time a new variant is added.

### Added

- **`DataObjectDescriptor::num_elements()`** — new `#[inline]` method on `DataObjectDescriptor` that computes the total element count from `shape`, validating against u64 overflow and usize range. Replaces 7 duplicated blocks of identical code across `encode.rs`, `decode.rs`, `streaming.rs`, `iter.rs`, and `restore.rs`.
- **Unit tests for `num_elements()`** covering empty-shape, single-dim, multi-dim, zero-dim, u64-overflow, and (on 32-bit targets) usize-overflow paths.
- **`#[non_exhaustive]` on error enums** — `PipelineError` (tensogram-encodings) and `CompressionError` (tensogram-encodings) now marked `#[non_exhaustive]` to prevent downstream exhaustive match breakage when new variants are added.  See note above.

### Changed

- **Split `build_pipeline_config_with_backend` (216 lines → 12 lines composition)** — extracted into three focused functions:
  - `resolve_encoding()` — resolves `EncodingType` from descriptor (encoding string + simple_packing validation)
  - `resolve_filter()` — resolves `FilterType` from descriptor (none/shuffle)
  - `resolve_compression()` — resolves `CompressionType` from descriptor (all 8 codec variants with cfg-gated feature support)
- **`iter.rs::ObjectIter::next()`** — replaced inline shape-product boilerplate with `desc.num_elements()` and forwards the original error variant directly (no double-wrapping).

### Fixed

- **Private function visibility** — `resolve_encoding`, `resolve_filter`, `resolve_compression` are all `fn` (private), consistent with each other and the pattern used by other helpers in the same module (`validate_object`, `build_pipeline_config`, etc.).
- **Doc comment accuracy** — `resolve_compression` doc now says "compression type" rather than "compression backend" (the latter is a separate `CompressionBackend` concept passed in by callers).
- **Consistency** — all 7 call sites that previously computed `num_elements` inline now use `desc.num_elements()`.

## Files Changed

| File | Change |
|------|--------|
| `types.rs` | Added `DataObjectDescriptor::num_elements()` impl + unit tests |
| `encode.rs` | Split `build_pipeline_config_with_backend` into 3 helpers + composition |
| `decode.rs` | 2 call sites use `num_elements()` |
| `streaming.rs` | 2 call sites use `num_elements()` |
| `iter.rs` | 1 call site uses `num_elements()` |
| `restore.rs` | `element_count()` delegates to `num_elements()` |
| `pipeline.rs` | Added `#[non_exhaustive]` to `PipelineError` |
| `compression/mod.rs` | Added `#[non_exhaustive]` to `CompressionError` |

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (0 warnings)
- `cargo test --workspace` — all pass

## Notes

- Wire format and encoded output are unchanged; this is purely a source-level refactor.
- The three new `fn` helpers in `encode.rs` are private to the module; only `build_pipeline_config_with_backend` is `pub(crate)`.

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-107
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->