### PR TITLE
docs(ideas): add Python API & Serialisation section

### DIFF
--- a/plans/BRAINSTORMING.md
+++ b/plans/BRAINSTORMING.md
@@ -476,6 +476,13 @@ to Tensogram's N-dimensional objects.
 This opens Tensogram data to SQL-style query tools without any
 conversion step.
 
+*Note: Arrow's buffer model supports the same zero-copy-from-external-buffer pattern as NumPy's
+`frombuffer`.  When implementing `to_arrow()`, ensure that plain-layout objects (no compression,
+no filter, native byte order) produce Arrow arrays that view the original wire bytes directly
+rather than copying into new Arrow-managed memory — analogous to the zero-copy NumPy
+deserialisation idea in `IDEAS.md`.  This requires the `RawMessage` idea (also in `IDEAS.md`) so
+that the source buffer has a Python object lifetime that Arrow's buffer can anchor to.*
+
 ### G4. ONNX Runtime Direct Feed
 
 If an ONNX model expects a specific input tensor shape and dtype, and

--- a/plans/IDEAS.md
+++ b/plans/IDEAS.md
@@ -69,6 +69,27 @@ implement until promoted to `TODO.md`.
   `(file_path, msg_index, obj_index)`.  The same pattern applied to in-memory wire bytes covers
   the in-process / over-the-wire case.
 
+- [ ] **`finish_and_reset()` on `StreamingEncoder` for multi-message sequences**
+
+  The current `StreamingEncoder` is one-shot: `finish()` (or `finish_backfilled()`) finalises the
+  message and returns its bytes, after which the encoder is spent.  Producing a sequence of messages
+  — e.g. one tensogram message per model field in a loop — therefore requires constructing a new
+  `StreamingEncoder` for every iteration, which carries non-trivial allocation overhead and makes
+  the intent less readable.
+
+  A `finish_and_reset()` method would finalise the current message (returning its bytes exactly as
+  `finish()` does) and then atomically reset the encoder's internal cursor so the same object can
+  immediately start accumulating the next message.  Semantics are identical to:
+
+  ```python
+  bytes = enc.finish()
+  enc = tensogram.StreamingEncoder(...)   # expensive re-init
+  ```
+
+  but without the re-allocation.  The method is useful standalone (any multi-message file writer)
+  and is the natural primitive for workflow engines that intercept message boundaries to decide
+  when to forward data to downstream consumers.
+
 - [ ] **`message_to_bytes(msg: Message) -> bytes` convenience function**
 
   A canonical public function to obtain wire bytes from any `Message`, regardless of how it was

--- a/plans/IDEAS.md
+++ b/plans/IDEAS.md
@@ -48,6 +48,11 @@ implement until promoted to `TODO.md`.
   cost.  `RawMessage` would be the natural input/output type for the `message_to_bytes` function
   and for the `__reduce__` protocol described below.
 
+  **Note:** `RawMessage` is also the enabling primitive for true zero-copy NumPy (and Arrow)
+  deserialisation — the source buffer must outlive the arrays that view it, and `RawMessage`
+  provides the Python object whose lifetime NumPy's `.base` reference can anchor to.  See the
+  zero-copy NumPy deserialisation idea below.
+
 - [ ] **`__reduce__` / pickle support via wire bytes**
 
   `Metadata` and `DataObjectDescriptor` are PyO3 `#[pyclass]` objects with no custom `__reduce__`.
@@ -115,6 +120,53 @@ implement until promoted to `TODO.md`.
   and get their `Message` with zero additional copies of the wire bytes.  The NumPy arrays produced
   by decode will always involve a copy (they own their memory), but the metadata-parsing and
   descriptor-reading phases are read-only and need not copy the input buffer at all.
+
+- [ ] **Zero-copy NumPy deserialisation for plain-layout objects**
+
+  *Requires the `RawMessage` idea.*
+
+  NumPy supports viewing an external buffer as an array without any copy via
+  `numpy.frombuffer(buffer, dtype=dtype).reshape(shape)`.  The resulting array holds a reference to
+  the source object as its `.base`, keeping it alive for as long as the array exists.  Tensogram
+  does not currently exploit this: every decode path copies tensor data into NumPy-owned memory,
+  and the `float16` / `complex` path (`numpy_via_frombuffer` in the Python bindings) even copies
+  *twice* — once from the Rust decode buffer into a temporary `PyBytes`, and again via an explicit
+  `.copy()` call whose sole purpose is to break the lifetime dependency on that temporary.
+
+  For objects whose encoding pipeline is a no-op (no compression, no filter, no encoding
+  transformation), the decoded payload bytes are a contiguous slice directly into the original wire
+  buffer — already in the correct in-memory layout for NumPy.  If the source wire buffer is kept
+  alive as a `RawMessage` Python object, `numpy.frombuffer` can create a zero-copy array view of
+  those bytes.  The array's `.base` reference to the `RawMessage` prevents premature collection.
+  No data movement at all is required.
+
+  For compressed or filtered objects the decompression / filter-reversal output is a freshly
+  allocated `Vec<u8>` that did not exist in the source buffer; one copy is genuinely unavoidable.
+  However, even there the current code copies *again* from the decompressed Vec into a separate
+  NumPy buffer — a second unnecessary copy that the same `frombuffer`-with-base technique would
+  eliminate.
+
+  **Optional extension — `DataObjectDescriptor.allows_zerocopy_deser() -> bool`.**
+  Whether an object qualifies for the zero-copy path is entirely determinable from its descriptor
+  metadata, which is already fully exposed to Python:
+
+  ```python
+  import sys
+
+  def allows_zerocopy_deser(descriptor) -> bool:
+      return (
+          descriptor.encoding    == "none" and
+          descriptor.filter      == "none" and
+          descriptor.compression == "none" and
+          descriptor.byte_order  == sys.byteorder   # "little" or "big"
+      )
+  ```
+
+  Exposing this as a method on `DataObjectDescriptor` lets callers (library code, integrations,
+  benchmarks) make an informed decision about whether to use the zero-copy path or fall back to a
+  full decode, without reimplementing the check themselves.  It also serves as a stable contract:
+  if new encoding / filter types are added in the future, the method's implementation is the single
+  place that must be updated.
 
 ## Languages
 

--- a/plans/IDEAS.md
+++ b/plans/IDEAS.md
@@ -23,6 +23,78 @@ implement until promoted to `TODO.md`.
 
 - [ ] Tensogram as a storage backend for NetCDF
 
+## Python API & Serialisation
+
+- [ ] **Raw bytes retention on decoded `Message` — `RawMessage` type**
+
+  When `tensogram.decode(raw_bytes)` is called today the original wire bytes are discarded after
+  parsing; only the decoded `Metadata` / `DataObjectDescriptor` / NumPy arrays are kept.  Retaining
+  the raw bytes would make a decoded `Message` a lossless handle on the original wire representation,
+  enabling efficient round-trips in any system that serialises, routes, or caches tensogram data
+  without re-encoding.
+
+  Two implementation options:
+
+  - Add an optional `_raw: bytes | None = None` field to the `Message` `NamedTuple` (set by
+    `decode()`, `None` for programmatically constructed messages).
+  - Introduce a separate **`RawMessage`** type that wraps `bytes` and exposes `.decoded: Message` as
+    a lazy cached property — a cleaner API that does not pollute the primary `Message` type and makes
+    the intent explicit.
+
+  The `RawMessage` variant is arguably the right design: it is a first-class type for *uninterpreted*
+  tensogram bytes, useful as a routing token in message brokers, workflow engines, and caches that
+  must forward data without ever decoding it.  A workflow scheduler, for example, moves data between
+  machines but never inspects tensor values — handing it a `RawMessage` means it pays zero decode
+  cost.  `RawMessage` would be the natural input/output type for the `message_to_bytes` function
+  and for the `__reduce__` protocol described below.
+
+- [ ] **`__reduce__` / pickle support via wire bytes**
+
+  `Metadata` and `DataObjectDescriptor` are PyO3 `#[pyclass]` objects with no custom `__reduce__`.
+  Cloudpickle handles some PyO3 types via bytecode introspection, but this is fragile, version-
+  dependent, and may silently produce wrong results or error at unpredictable times.  If raw bytes
+  are retained (see above), a correct and efficient `__reduce__` becomes trivial:
+
+  ```python
+  def __reduce__(self):
+      return (tensogram.decode, (self._raw,))
+  ```
+
+  This makes cloudpickling a `Message` equivalent to: pickle-protocol overhead + one copy of already-
+  serialised wire bytes — far cheaper than pickling NumPy arrays by value (which copies all tensor
+  data twice: once when the array is allocated by `decode`, once when pickle serialises it).
+
+  The `tensogram-xarray` `TensogramBackendArray` is a direct precedent: it already implements
+  `__getstate__` / `__setstate__` that drops open file handles and reconstructs lazily from
+  `(file_path, msg_index, obj_index)`.  The same pattern applied to in-memory wire bytes covers
+  the in-process / over-the-wire case.
+
+- [ ] **`message_to_bytes(msg: Message) -> bytes` convenience function**
+
+  A canonical public function to obtain wire bytes from any `Message`, regardless of how it was
+  constructed.  If the message carries retained raw bytes (from `decode()`), this is O(1).  If the
+  message was built programmatically, it falls back to a fresh `tensogram.encode(...)` call.
+
+  Having a single stable API surface decouples callers from the internal representation and avoids
+  forcing callers to replicate the `encode()` call with the correct options.  It also acts as the
+  natural serialisation hook for third-party integrations (serde registries, object stores, IPC
+  transports) that need "give me bytes I can hand to `decode()`" without caring whether the source
+  was a decode round-trip or a fresh encode.
+
+- [ ] **Guarantee that `decode()` accepts buffer-protocol objects (including `memoryview`) without copying**
+
+  Currently `decode()` accepts bytes-like / `PyBackedBytes` input.  Whether a `memoryview` is
+  accepted *zero-copy* — i.e. the Rust core parses directly from the provided buffer without first
+  copying into a Rust-owned `Vec<u8>` — is undocumented and may not hold.
+
+  Explicitly supporting and documenting zero-copy `memoryview` input matters for systems that hold
+  tensogram bytes in POSIX shared memory (e.g. `multiprocessing.shared_memory`) and want to decode
+  in a receiving process without a userspace memcpy.  For example: producer task serialises once
+  into shared memory; all consumer tasks on the same host call `tensogram.decode(shm_memoryview)`
+  and get their `Message` with zero additional copies of the wire bytes.  The NumPy arrays produced
+  by decode will always involve a copy (they own their memory), but the metadata-parsing and
+  descriptor-reading phases are read-only and need not copy the input buffer at all.
+
 ## Languages
 
 - [ ] Go interface over Rust


### PR DESCRIPTION
Four inter-related ideas motivated by analysis of how workflow engines (earthkit-workflows/cascade) could integrate tensogram with zero-copy data movement:

- RawMessage / raw bytes retention on decoded Message: keep the wire bytes alive after decode so the message is a lossless handle on the original representation, enabling O(1) re-serialisation and routing without re-encoding.

- __reduce__ / pickle support via wire bytes: fix the correctness risk with cloudpickle of PyO3 classes (Metadata, DataObjectDescriptor have no __reduce__) and make pickling cheap — wire bytes as the canonical pickle representation, not NumPy-array-by-value.

- message_to_bytes() convenience function: stable public API to get wire bytes from any Message regardless of how it was constructed; O(1) when raw bytes are retained, falls back to encode() otherwise.

- Guarantee decode() accepts memoryview without copying: enable producers to write wire bytes into POSIX shared memory once, and consumers on the same host to decode directly from that shared buffer with zero userspace memcpy of the wire bytes (NumPy arrays still copy out as they own their memory).

## Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [ ] I have read the [Contributing Guide](CONTRIBUTING.md)
- [ ] My code follows the project's style guidelines (`cargo fmt`, `ruff format`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests pass (`cargo test --workspace`, `pytest`)
- [ ] I have updated documentation where necessary
- [ ] I have added examples if this introduces new public API

## Contributor Licence Agreement

By submitting this pull request, I confirm that my contribution is made under
the terms of the [Apache License 2.0](LICENSE) and that I have the right to
submit it under this licence. I agree to the terms of the
[ECMWF Contributor Licence Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).


<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-108
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->