### PR TITLE
feat(streaming): add finish_and_reset() for multi-message sequences

### DIFF
--- a/plans/DONE.md
+++ b/plans/DONE.md
@@ -30,6 +30,26 @@
 
 ---
 
+## `finish_and_reset()` on `StreamingEncoder` for multi-message sequences
+
+The `StreamingEncoder` acquired two new methods that finalise the current
+message and atomically reset the encoder for the next one, avoiding the
+overhead of constructing a fresh `StreamingEncoder` between messages.
+
+| Component | What changed |
+|-----------|--------------|
+| `rust/tensogram/src/streaming.rs` | `write_footer_frames_and_postamble(&mut self)` private helper extracted from `finish()`; shared by `finish()`, `finish_with_backfill()`, and the new methods. `write_preamble_and_header()` private free function extracted from `new()` so `reset_message_state()` can restart the encoder without re-running construction logic. |
+| `rust/tensogram/src/streaming.rs` | `impl StreamingEncoder<Cursor<Vec<u8>>>` specialised block adds `finish_and_reset() -> Result<Vec<u8>>` (streaming mode, `total_length = 0`) and `finish_and_reset_with_backfill() -> Result<Vec<u8>>` (back-fills both preamble and postamble lengths, satisfying §7 backward-locatability). `reset_message_state()` private helper clears per-message bookkeeping and writes the fresh preamble + header. |
+| `python/bindings/src/lib.rs` | `PyStreamingEncoder` gains `finish_and_reset()` and `finish_and_reset_backfilled()` methods. Unlike `finish()` / `finish_backfilled()` (which exhaust `self.inner`), these operate on `self.inner.as_mut()` and leave the encoder valid. |
+| `python/tests/test_streaming_encoder_finish_and_reset.py` | New test module: decode correctness, streaming-mode zero lengths, backfill lengths, multiple resets, encoder still usable after reset, exhaust-after-finish error, empty message, multi-object message, concatenation + scan, global-meta preserved across resets. |
+| `rust/tensogram/src/streaming.rs` tests | Eight new unit tests: decode correctness, zero lengths, backfill lengths, five-message loop, encoder usable after reset then finish(), dangling preceder error, concatenation scannable, empty message. |
+
+The public API change is additive — existing `finish()` / `finish_backfilled()` semantics are
+unchanged.  The internal refactor (shared `write_footer_frames_and_postamble` helper) is
+behaviour-preserving: verified by the full existing test suite.
+
+---
+
 ## Remote bidirectional walker — pipelined and on by default
 
 The remote backend now uses a pipelined bidirectional walker out of

--- a/plans/IDEAS.md
+++ b/plans/IDEAS.md
@@ -74,27 +74,6 @@ implement until promoted to `TODO.md`.
   `(file_path, msg_index, obj_index)`.  The same pattern applied to in-memory wire bytes covers
   the in-process / over-the-wire case.
 
-- [ ] **`finish_and_reset()` on `StreamingEncoder` for multi-message sequences**
-
-  The current `StreamingEncoder` is one-shot: `finish()` (or `finish_backfilled()`) finalises the
-  message and returns its bytes, after which the encoder is spent.  Producing a sequence of messages
-  — e.g. one tensogram message per model field in a loop — therefore requires constructing a new
-  `StreamingEncoder` for every iteration, which carries non-trivial allocation overhead and makes
-  the intent less readable.
-
-  A `finish_and_reset()` method would finalise the current message (returning its bytes exactly as
-  `finish()` does) and then atomically reset the encoder's internal cursor so the same object can
-  immediately start accumulating the next message.  Semantics are identical to:
-
-  ```python
-  bytes = enc.finish()
-  enc = tensogram.StreamingEncoder(...)   # expensive re-init
-  ```
-
-  but without the re-allocation.  The method is useful standalone (any multi-message file writer)
-  and is the natural primitive for workflow engines that intercept message boundaries to decide
-  when to forward data to downstream consumers.
-
 - [ ] **`message_to_bytes(msg: Message) -> bytes` convenience function**
 
   A canonical public function to obtain wire bytes from any `Message`, regardless of how it was

--- a/python/bindings/src/lib.rs
+++ b/python/bindings/src/lib.rs
@@ -1539,6 +1539,10 @@ fn compute_packing_params(
 ///   ``total_length``.  Required for fixtures or workloads that exercise
 ///   the bidirectional remote walker.
 ///
+/// To produce a sequence of messages from a single encoder, use
+/// :meth:`finish_and_reset` or :meth:`finish_and_reset_backfilled` instead
+/// of constructing a new encoder per message.
+///
 /// Example::
 ///
 ///     enc = tensogram.StreamingEncoder({})
@@ -1547,6 +1551,14 @@ fn compute_packing_params(
 ///     msg = enc.finish()              # streaming-mode (total_length=0)
 ///     # or
 ///     msg = enc.finish_backfilled()   # backfilled (full backward locatability)
+///
+/// Multi-message sequence without re-allocation::
+///
+///     enc = tensogram.StreamingEncoder({})
+///     for field in fields:
+///         enc.write_object(descriptor, data)
+///         wire_bytes = enc.finish_and_reset_backfilled()
+///         send(wire_bytes)
 #[pyclass(name = "StreamingEncoder")]
 struct PyStreamingEncoder {
     inner: Option<StreamingEncoder<std::io::Cursor<Vec<u8>>>>,
@@ -1694,6 +1706,54 @@ impl PyStreamingEncoder {
             .ok_or_else(|| PyRuntimeError::new_err("StreamingEncoder already finished"))?;
         let cursor = inner.finish_with_backfill().map_err(to_py_err)?;
         Ok(PyBytes::new(py, cursor.get_ref()))
+    }
+
+    /// Finalise the current message and immediately begin the next one.
+    ///
+    /// Returns the wire-format ``bytes`` of the completed message (streaming
+    /// mode: ``total_length = 0`` in both preamble and postamble, matching
+    /// the :meth:`finish` contract).
+    ///
+    /// The encoder's accumulated state is reset and a fresh preamble +
+    /// header metadata frame are written so this encoder object is
+    /// immediately ready for the next :meth:`write_object` call.
+    ///
+    /// This is semantically equivalent to::
+    ///
+    ///     msg = enc.finish()
+    ///     enc = tensogram.StreamingEncoder(...)   # expensive re-init
+    ///
+    /// but without the re-allocation of the encoder object.
+    ///
+    /// Raises ``RuntimeError`` if the encoder has already been exhausted
+    /// by :meth:`finish` or :meth:`finish_backfilled`.
+    fn finish_and_reset<'py>(&mut self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
+        let inner = self
+            .inner
+            .as_mut()
+            .ok_or_else(|| PyRuntimeError::new_err("StreamingEncoder already finished"))?;
+        let bytes = inner.finish_and_reset().map_err(to_py_err)?;
+        Ok(PyBytes::new(py, &bytes))
+    }
+
+    /// Finalise the current message with back-filled length fields and
+    /// immediately begin the next one.
+    ///
+    /// Like :meth:`finish_and_reset` but patches ``total_length`` in both
+    /// the preamble and postamble before returning the bytes, satisfying the
+    /// backward-locatability invariant from wire-format §7.  Use this when
+    /// the concatenated output must support the bidirectional remote walker
+    /// or O(1) backward scans.
+    ///
+    /// Raises ``RuntimeError`` if the encoder has already been exhausted
+    /// by :meth:`finish` or :meth:`finish_backfilled`.
+    fn finish_and_reset_backfilled<'py>(&mut self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
+        let inner = self
+            .inner
+            .as_mut()
+            .ok_or_else(|| PyRuntimeError::new_err("StreamingEncoder already finished"))?;
+        let bytes = inner.finish_and_reset_with_backfill().map_err(to_py_err)?;
+        Ok(PyBytes::new(py, &bytes))
     }
 }
 

--- a/python/tests/test_streaming_encoder_finish_and_reset.py
+++ b/python/tests/test_streaming_encoder_finish_and_reset.py
@@ -105,7 +105,7 @@ def test_finish_and_reset_then_finish() -> None:
     """Encoder remains valid for a final finish() after finish_and_reset()."""
     enc = tensogram.StreamingEncoder(_GLOBAL_META)
     enc.write_object(_DESCRIPTOR, _PAYLOAD)
-    _msg1 = enc.finish_and_reset()
+    enc.finish_and_reset()
 
     payload2 = _PAYLOAD + 10.0
     enc.write_object(_DESCRIPTOR, payload2)

--- a/python/tests/test_streaming_encoder_finish_and_reset.py
+++ b/python/tests/test_streaming_encoder_finish_and_reset.py
@@ -1,0 +1,230 @@
+# (C) Copyright 2026- ECMWF and individual contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation nor
+# does it submit to any jurisdiction.
+
+"""Tests for ``StreamingEncoder.finish_and_reset()`` and
+``StreamingEncoder.finish_and_reset_backfilled()``.
+
+These methods finalise the current message and immediately reset the encoder
+so that it can accumulate the next message without re-construction.
+"""
+
+from __future__ import annotations
+
+import struct
+
+import numpy as np
+import pytest
+import tensogram
+
+_DESCRIPTOR = {
+    "type": "ntensor",
+    "ndim": 1,
+    "shape": [4],
+    "dtype": "float32",
+    "encoding": "none",
+    "filter": "none",
+    "compression": "none",
+}
+_PAYLOAD = np.arange(4, dtype=np.float32)
+_GLOBAL_META = {"base": [{"name": "test"}]}
+
+
+def _preamble_total_length(message: bytes) -> int:
+    """Bytes 16..24 of the preamble carry total_length as big-endian u64."""
+    return struct.unpack(">Q", message[16:24])[0]
+
+
+def _postamble_total_length(message: bytes) -> int:
+    """The second u64 field of the postamble is the mirrored total_length."""
+    return struct.unpack(">Q", message[-16:-8])[0]
+
+
+# ── finish_and_reset (streaming mode, total_length=0) ────────────────────────
+
+
+def test_finish_and_reset_returns_decodable_message() -> None:
+    enc = tensogram.StreamingEncoder(_GLOBAL_META)
+    enc.write_object(_DESCRIPTOR, _PAYLOAD)
+    msg = enc.finish_and_reset()
+
+    decoded = tensogram.decode(msg)
+    assert len(decoded.objects) == 1
+    descriptor, data = decoded.objects[0]
+    assert descriptor.dtype == "float32"
+    assert list(descriptor.shape) == [4]
+    np.testing.assert_array_equal(data, _PAYLOAD)
+
+
+def test_finish_and_reset_streaming_mode_zero_lengths() -> None:
+    enc = tensogram.StreamingEncoder(_GLOBAL_META)
+    enc.write_object(_DESCRIPTOR, _PAYLOAD)
+    msg = enc.finish_and_reset()
+
+    assert _preamble_total_length(msg) == 0
+    assert _postamble_total_length(msg) == 0
+
+
+def test_finish_and_reset_encoder_still_usable() -> None:
+    """After finish_and_reset the encoder must accept new write_object calls."""
+    enc = tensogram.StreamingEncoder(_GLOBAL_META)
+    enc.write_object(_DESCRIPTOR, _PAYLOAD)
+    msg1 = enc.finish_and_reset()
+
+    payload2 = _PAYLOAD * 2
+    enc.write_object(_DESCRIPTOR, payload2)
+    msg2 = enc.finish_and_reset()
+
+    decoded1 = tensogram.decode(msg1)
+    np.testing.assert_array_equal(decoded1.objects[0][1], _PAYLOAD)
+
+    decoded2 = tensogram.decode(msg2)
+    np.testing.assert_array_equal(decoded2.objects[0][1], payload2)
+
+
+def test_finish_and_reset_multiple_resets() -> None:
+    """A single encoder can produce many messages via repeated resets."""
+    enc = tensogram.StreamingEncoder(_GLOBAL_META)
+    messages: list[tuple[bytes, np.ndarray]] = []
+    for i in range(5):
+        payload = _PAYLOAD + float(i)
+        enc.write_object(_DESCRIPTOR, payload)
+        messages.append((enc.finish_and_reset(), payload))
+
+    for msg, expected in messages:
+        decoded = tensogram.decode(msg)
+        assert len(decoded.objects) == 1
+        np.testing.assert_array_equal(decoded.objects[0][1], expected)
+
+
+def test_finish_and_reset_then_finish() -> None:
+    """Encoder remains valid for a final finish() after finish_and_reset()."""
+    enc = tensogram.StreamingEncoder(_GLOBAL_META)
+    enc.write_object(_DESCRIPTOR, _PAYLOAD)
+    _msg1 = enc.finish_and_reset()
+
+    payload2 = _PAYLOAD + 10.0
+    enc.write_object(_DESCRIPTOR, payload2)
+    msg2 = enc.finish()
+
+    decoded2 = tensogram.decode(msg2)
+    np.testing.assert_array_equal(decoded2.objects[0][1], payload2)
+
+
+def test_finish_and_reset_after_finish_raises() -> None:
+    """Calling finish_and_reset after finish() must raise RuntimeError."""
+    enc = tensogram.StreamingEncoder(_GLOBAL_META)
+    enc.write_object(_DESCRIPTOR, _PAYLOAD)
+    enc.finish()
+    with pytest.raises(RuntimeError):
+        enc.finish_and_reset()
+
+
+def test_finish_and_reset_empty_message_is_decodable() -> None:
+    """finish_and_reset with no objects must produce a valid empty message."""
+    enc = tensogram.StreamingEncoder(_GLOBAL_META)
+    msg = enc.finish_and_reset()
+
+    decoded = tensogram.decode(msg)
+    assert len(decoded.objects) == 0
+
+
+def test_finish_and_reset_multi_object_message() -> None:
+    """Messages with multiple objects round-trip correctly after reset."""
+    enc = tensogram.StreamingEncoder(_GLOBAL_META)
+    enc.write_object(_DESCRIPTOR, _PAYLOAD)
+    enc.write_object(_DESCRIPTOR, _PAYLOAD * 2)
+    msg = enc.finish_and_reset()
+
+    decoded = tensogram.decode(msg)
+    assert len(decoded.objects) == 2
+    np.testing.assert_array_equal(decoded.objects[0][1], _PAYLOAD)
+    np.testing.assert_array_equal(decoded.objects[1][1], _PAYLOAD * 2)
+
+
+# ── finish_and_reset_backfilled (total_length back-filled) ───────────────────
+
+
+def test_finish_and_reset_backfilled_writes_real_length_in_both_slots() -> None:
+    enc = tensogram.StreamingEncoder(_GLOBAL_META)
+    enc.write_object(_DESCRIPTOR, _PAYLOAD)
+    msg = enc.finish_and_reset_backfilled()
+
+    assert _preamble_total_length(msg) == len(msg)
+    assert _postamble_total_length(msg) == len(msg)
+
+
+def test_finish_and_reset_backfilled_decoder_round_trip() -> None:
+    enc = tensogram.StreamingEncoder(_GLOBAL_META)
+    enc.write_object(_DESCRIPTOR, _PAYLOAD)
+    msg = enc.finish_and_reset_backfilled()
+
+    decoded = tensogram.decode(msg)
+    assert len(decoded.objects) == 1
+    np.testing.assert_array_equal(decoded.objects[0][1], _PAYLOAD)
+
+
+def test_finish_and_reset_backfilled_concatenated_messages_scannable() -> None:
+    """Concatenation of backfilled messages must be scannable as separate messages."""
+    enc = tensogram.StreamingEncoder(_GLOBAL_META)
+    parts: list[bytes] = []
+    for i in range(3):
+        enc.write_object(_DESCRIPTOR, _PAYLOAD + float(i))
+        parts.append(enc.finish_and_reset_backfilled())
+
+    combined = b"".join(parts)
+    layouts = list(tensogram.scan(combined))
+
+    assert len(layouts) == 3
+
+    offset = 0
+    for i, part in enumerate(parts):
+        assert layouts[i] == (offset, len(part))
+        assert _postamble_total_length(combined[offset : offset + len(part)]) == len(part)
+        offset += len(part)
+
+
+def test_finish_and_reset_backfilled_then_finish_backfilled() -> None:
+    """Encoder works correctly when mixing finish_and_reset_backfilled and finish_backfilled."""
+    enc = tensogram.StreamingEncoder(_GLOBAL_META)
+    enc.write_object(_DESCRIPTOR, _PAYLOAD)
+    msg1 = enc.finish_and_reset_backfilled()
+
+    enc.write_object(_DESCRIPTOR, _PAYLOAD * 3)
+    msg2 = enc.finish_backfilled()
+
+    assert _preamble_total_length(msg1) == len(msg1)
+    assert _preamble_total_length(msg2) == len(msg2)
+
+    decoded1 = tensogram.decode(msg1)
+    decoded2 = tensogram.decode(msg2)
+    np.testing.assert_array_equal(decoded1.objects[0][1], _PAYLOAD)
+    np.testing.assert_array_equal(decoded2.objects[0][1], _PAYLOAD * 3)
+
+
+def test_finish_and_reset_backfilled_after_finish_backfilled_raises() -> None:
+    """finish_and_reset_backfilled after finish_backfilled must raise RuntimeError."""
+    enc = tensogram.StreamingEncoder(_GLOBAL_META)
+    enc.write_object(_DESCRIPTOR, _PAYLOAD)
+    enc.finish_backfilled()
+    with pytest.raises(RuntimeError):
+        enc.finish_and_reset_backfilled()
+
+
+def test_finish_and_reset_global_meta_preserved_across_resets() -> None:
+    """The global metadata supplied at construction must appear in every message."""
+    meta = {"base": [{"source": "test-suite"}]}
+    enc = tensogram.StreamingEncoder(meta)
+    messages: list[bytes] = []
+    for _ in range(3):
+        enc.write_object(_DESCRIPTOR, _PAYLOAD)
+        messages.append(enc.finish_and_reset_backfilled())
+
+    for msg in messages:
+        decoded = tensogram.decode(msg)
+        # The "source" key must be present in base[0] of every message.
+        assert decoded.metadata.base[0].get("source") == "test-suite"

--- a/rust/tensogram/src/streaming.rs
+++ b/rust/tensogram/src/streaming.rs
@@ -1939,7 +1939,7 @@ mod tests {
 
         let mut parts: Vec<Vec<u8>> = Vec::new();
         for i in 0u8..3 {
-            enc.write_object(&desc, &vec![i; 4 * 4]).unwrap();
+            enc.write_object(&desc, &[i; 16]).unwrap();
             parts.push(enc.finish_and_reset_with_backfill().unwrap());
         }
 

--- a/rust/tensogram/src/streaming.rs
+++ b/rust/tensogram/src/streaming.rs
@@ -123,41 +123,14 @@ impl<W: Write> StreamingEncoder<W> {
         let resolved = options.aggregate_hash.resolved_streaming()?;
         let emit_footer_hash = options.hashing && resolved.emits_footer();
 
-        let meta_cbor = metadata::global_metadata_to_cbor(global_meta)?;
-
-        // Streaming preamble: total_length=0 signals unknown length at write time.
-        // Always set PRECEDER_METADATA in streaming mode — the flag is advisory
-        // and decoders handle the absence of actual preceder frames gracefully.
-        let mut flags = MessageFlags::default();
-        flags.set(MessageFlags::HEADER_METADATA);
-        flags.set(MessageFlags::FOOTER_METADATA);
-        flags.set(MessageFlags::FOOTER_INDEX);
-        flags.set(MessageFlags::PRECEDER_METADATA);
-        if options.hashing {
-            // v3: HASHES_PRESENT signals per-frame inline hash slots
-            // are populated; set whenever hashing is enabled.
-            flags.set(MessageFlags::HASHES_PRESENT);
-            if emit_footer_hash {
-                flags.set(MessageFlags::FOOTER_HASHES);
-            }
-        }
-
-        let preamble = Preamble {
-            version: crate::wire::WIRE_VERSION,
-            flags,
-            reserved: 0,
-            total_length: 0,
-        };
-        let preamble_bytes = preamble_to_bytes(&preamble);
-        writer.write_all(&preamble_bytes)?;
-        let mut bytes_written = PREAMBLE_SIZE as u64;
-
-        // Write header metadata frame
-        let frame_bytes = build_frame(FrameType::HeaderMetadata, 1, 0, &meta_cbor, options.hashing);
-        writer.write_all(&frame_bytes)?;
-        bytes_written += frame_bytes.len() as u64;
-
-        write_padding(&mut writer, &mut bytes_written)?;
+        let mut bytes_written = 0u64;
+        write_preamble_and_header(
+            &mut writer,
+            &mut bytes_written,
+            global_meta,
+            options.hashing,
+            emit_footer_hash,
+        )?;
 
         // Snapshot the thread budget now so that mid-message changes to
         // TENSOGRAM_THREADS don't leak in between write_object calls —
@@ -430,6 +403,26 @@ impl<W: Write> StreamingEncoder<W> {
     /// Writes footer frames (payload metadata + hash + index) and the postamble.
     /// Consumes the encoder and returns the underlying writer.
     pub fn finish(mut self) -> Result<W> {
+        self.write_footer_frames_and_postamble()?;
+        self.writer.flush()?;
+        Ok(self.writer)
+    }
+
+    /// Write footer frames (metadata + optional hash + index) and the postamble
+    /// to the underlying writer.
+    ///
+    /// This is the shared inner implementation for [`finish`](Self::finish),
+    /// [`finish_with_backfill`](StreamingEncoder::finish_with_backfill), and
+    /// [`finish_and_reset`](StreamingEncoder::finish_and_reset).  It operates
+    /// on `&mut self` so that the specialized `finish_and_reset` variants can
+    /// reset the encoder state and write a new preamble without consuming the
+    /// encoder.
+    ///
+    /// After a successful call the accumulated per-message bookkeeping
+    /// (`object_offsets`, `object_lengths`) is consumed by the index frame
+    /// (via [`std::mem::take`]) and left empty; callers that reset the encoder
+    /// must also clear the remaining fields.
+    fn write_footer_frames_and_postamble(&mut self) -> Result<()> {
         if self.pending_preceder {
             return Err(TensogramError::Framing(
                 "dangling PrecederMetadata: finish called without a following write_object/write_object_pre_encoded"
@@ -500,10 +493,11 @@ impl<W: Write> StreamingEncoder<W> {
             write_padding(&mut self.writer, &mut self.bytes_written)?;
         }
 
-        // Footer index frame
+        // Footer index frame — `mem::take` moves the vecs out without cloning,
+        // leaving empty vecs in `self` (relevant for finish_and_reset callers).
         let index = IndexFrame {
-            offsets: self.object_offsets,
-            lengths: self.object_lengths,
+            offsets: std::mem::take(&mut self.object_offsets),
+            lengths: std::mem::take(&mut self.object_lengths),
         };
         let index_cbor = metadata::index_to_cbor(&index)?;
         let frame_bytes = build_frame(FrameType::FooterIndex, 1, 0, &index_cbor, self.hashing);
@@ -529,9 +523,7 @@ impl<W: Write> StreamingEncoder<W> {
         self.writer.write_all(&postamble_bytes)?;
         self.bytes_written += postamble_bytes.len() as u64;
 
-        self.writer.flush()?;
-
-        Ok(self.writer)
+        Ok(())
     }
 
     /// Returns the number of data objects written so far.
@@ -568,37 +560,194 @@ impl<W: Write + std::io::Seek> StreamingEncoder<W> {
     /// `write_all`, or `flush`.
     ///
     /// [`finish`]: StreamingEncoder::finish
-    pub fn finish_with_backfill(self) -> Result<W> {
+    pub fn finish_with_backfill(mut self) -> Result<W> {
         use std::io::SeekFrom;
-        // `finish()` consumes self and returns the inner writer;
-        // we then seek back to patch both length slots.
-        let mut writer = self.finish()?;
+        self.write_footer_frames_and_postamble()?;
 
         // Determine the current file position, which equals the full
-        // message length after finish() (finish() consumed self, so
-        // we re-derive via `stream_position`).
-        let end_pos = writer.stream_position()?;
+        // message length after the footer + postamble have been written.
+        let end_pos = self.writer.stream_position()?;
         let total_length = end_pos;
 
         // Back-fill the preamble's total_length (bytes 16..24).
-        writer.seek(SeekFrom::Start(16))?;
-        writer.write_all(&total_length.to_be_bytes())?;
+        self.writer.seek(SeekFrom::Start(16))?;
+        self.writer.write_all(&total_length.to_be_bytes())?;
 
         // Back-fill the postamble's total_length (second u64 field,
         // located at `end - 16 .. end - 8`; the trailing 8 bytes are
         // the END_MAGIC).
-        writer.seek(SeekFrom::Start(end_pos - 16))?;
-        writer.write_all(&total_length.to_be_bytes())?;
+        self.writer.seek(SeekFrom::Start(end_pos - 16))?;
+        self.writer.write_all(&total_length.to_be_bytes())?;
 
         // Seek back to EOF so the returned writer matches
         // `finish()`'s post-condition (cursor at the very end).
-        writer.seek(SeekFrom::Start(end_pos))?;
-        writer.flush()?;
-        Ok(writer)
+        self.writer.seek(SeekFrom::Start(end_pos))?;
+        self.writer.flush()?;
+        Ok(self.writer)
+    }
+}
+
+// ── In-memory cursor specialisation — finish_and_reset ───────────────────────
+
+impl StreamingEncoder<std::io::Cursor<Vec<u8>>> {
+    /// Finalise the current message and immediately begin the next one.
+    ///
+    /// Returns the wire bytes of the completed message (streaming mode:
+    /// `total_length = 0` in both preamble and postamble, matching the
+    /// [`finish`](StreamingEncoder::finish) contract).
+    ///
+    /// The encoder's accumulated per-message state is cleared and a fresh
+    /// preamble + header metadata frame are written so the same encoder
+    /// object is immediately ready for the next sequence of
+    /// [`write_object`](StreamingEncoder::write_object) calls.
+    ///
+    /// This is semantically equivalent to:
+    /// ```no_run
+    /// # use tensogram::streaming::StreamingEncoder;
+    /// # use tensogram::{GlobalMetadata, EncodeOptions};
+    /// # let meta = GlobalMetadata::default();
+    /// # let opts = EncodeOptions::default();
+    /// # let mut enc = StreamingEncoder::new(
+    /// #     std::io::Cursor::new(Vec::new()), &meta, &opts).unwrap();
+    /// let bytes: Vec<u8> = enc.finish().unwrap().into_inner();
+    /// enc = StreamingEncoder::new(
+    ///     std::io::Cursor::new(Vec::new()), &meta, &opts).unwrap();
+    /// ```
+    /// but without re-allocating the encoder object.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TensogramError::Framing`] if a
+    /// [`write_preceder`](StreamingEncoder::write_preceder) call has no
+    /// corresponding [`write_object`](StreamingEncoder::write_object)
+    /// (dangling preceder).
+    pub fn finish_and_reset(&mut self) -> Result<Vec<u8>> {
+        self.write_footer_frames_and_postamble()?;
+        self.writer.flush()?;
+        let finished_bytes = self.writer.get_ref().clone();
+        self.reset_message_state()?;
+        Ok(finished_bytes)
+    }
+
+    /// Finalise the current message with back-filled length fields and
+    /// immediately begin the next one.
+    ///
+    /// Like [`finish_and_reset`](Self::finish_and_reset) but patches
+    /// `total_length` in both the preamble (byte offset 16) and the
+    /// postamble (byte offset `end - 16`) before returning the bytes,
+    /// satisfying the backward-locatability invariant from wire-format §7.
+    ///
+    /// Readers can then O(1) backward-scan the concatenated output produced
+    /// by repeated `finish_and_reset_with_backfill` calls; use this variant
+    /// when the multi-message sequence must support the bidirectional remote
+    /// walker.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TensogramError::Framing`] if a
+    /// [`write_preceder`](StreamingEncoder::write_preceder) call has no
+    /// corresponding [`write_object`](StreamingEncoder::write_object)
+    /// (dangling preceder).
+    pub fn finish_and_reset_with_backfill(&mut self) -> Result<Vec<u8>> {
+        use std::io::{Seek, SeekFrom};
+        self.write_footer_frames_and_postamble()?;
+
+        // Back-fill total_length in preamble and postamble.
+        let end_pos = self.writer.stream_position()?;
+        let total_length = end_pos;
+        self.writer.seek(SeekFrom::Start(16))?;
+        self.writer.write_all(&total_length.to_be_bytes())?;
+        self.writer.seek(SeekFrom::Start(end_pos - 16))?;
+        self.writer.write_all(&total_length.to_be_bytes())?;
+        self.writer.seek(SeekFrom::Start(end_pos))?;
+        self.writer.flush()?;
+
+        let finished_bytes = self.writer.get_ref().clone();
+        self.reset_message_state()?;
+        Ok(finished_bytes)
+    }
+
+    /// Clear all per-message accumulated state and write a fresh preamble +
+    /// header metadata frame so the encoder is ready for the next message.
+    fn reset_message_state(&mut self) -> Result<()> {
+        // Replace the cursor with a fresh empty buffer.
+        self.writer = std::io::Cursor::new(Vec::new());
+        // Clear per-message bookkeeping.  object_offsets and object_lengths
+        // were already consumed by write_footer_frames_and_postamble via
+        // mem::take, but we clear them defensively.
+        self.object_offsets.clear();
+        self.object_lengths.clear();
+        self.hash_entries.clear();
+        self.completed_objects.clear();
+        self.pending_preceder = false;
+        self.preceder_payloads.clear();
+        self.bytes_written = 0;
+        // Snapshot fields that cannot be borrowed while self.writer is mutably
+        // borrowed by write_preamble_and_header.
+        let global_meta = self.global_meta.clone();
+        let hashing = self.hashing;
+        let emit_footer_hash_frame = self.emit_footer_hash_frame;
+        write_preamble_and_header(
+            &mut self.writer,
+            &mut self.bytes_written,
+            &global_meta,
+            hashing,
+            emit_footer_hash_frame,
+        )
     }
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Write the streaming-mode preamble (`total_length = 0`) and the
+/// `HeaderMetadata` frame to `writer`, updating `bytes_written` accordingly.
+///
+/// Extracted from [`StreamingEncoder::new`] so it can also be called by
+/// [`StreamingEncoder::reset_message_state`] to begin a fresh message after
+/// [`StreamingEncoder::finish_and_reset`].
+fn write_preamble_and_header<W: Write>(
+    writer: &mut W,
+    bytes_written: &mut u64,
+    global_meta: &GlobalMetadata,
+    hashing: bool,
+    emit_footer_hash_frame: bool,
+) -> Result<()> {
+    let meta_cbor = metadata::global_metadata_to_cbor(global_meta)?;
+
+    // Streaming preamble: total_length=0 signals unknown length at write time.
+    // Always set PRECEDER_METADATA in streaming mode — the flag is advisory
+    // and decoders handle the absence of actual preceder frames gracefully.
+    let mut flags = MessageFlags::default();
+    flags.set(MessageFlags::HEADER_METADATA);
+    flags.set(MessageFlags::FOOTER_METADATA);
+    flags.set(MessageFlags::FOOTER_INDEX);
+    flags.set(MessageFlags::PRECEDER_METADATA);
+    if hashing {
+        // v3: HASHES_PRESENT signals per-frame inline hash slots
+        // are populated; set whenever hashing is enabled.
+        flags.set(MessageFlags::HASHES_PRESENT);
+        if emit_footer_hash_frame {
+            flags.set(MessageFlags::FOOTER_HASHES);
+        }
+    }
+
+    let preamble = Preamble {
+        version: crate::wire::WIRE_VERSION,
+        flags,
+        reserved: 0,
+        total_length: 0,
+    };
+    let preamble_bytes = preamble_to_bytes(&preamble);
+    writer.write_all(&preamble_bytes)?;
+    *bytes_written += PREAMBLE_SIZE as u64;
+
+    let frame_bytes = build_frame(FrameType::HeaderMetadata, 1, 0, &meta_cbor, hashing);
+    writer.write_all(&frame_bytes)?;
+    *bytes_written += frame_bytes.len() as u64;
+
+    write_padding(writer, bytes_written)?;
+    Ok(())
+}
 
 fn preamble_to_bytes(preamble: &Preamble) -> Vec<u8> {
     let mut out = Vec::with_capacity(PREAMBLE_SIZE);
@@ -1609,5 +1758,228 @@ mod tests {
         };
         let res = StreamingEncoder::new(Vec::new(), &meta, &opts);
         assert!(res.is_ok(), "None must be accepted in streaming mode");
+    }
+
+    // ── finish_and_reset tests ────────────────────────────────────────────
+
+    #[test]
+    fn finish_and_reset_produces_independently_decodable_messages() {
+        let meta = GlobalMetadata::default();
+        let desc = make_descriptor(vec![4]);
+        let data1 = vec![1u8; 4 * 4];
+        let data2 = vec![2u8; 4 * 4];
+
+        let mut enc = StreamingEncoder::new(
+            std::io::Cursor::new(Vec::new()),
+            &meta,
+            &EncodeOptions::default(),
+        )
+        .unwrap();
+
+        enc.write_object(&desc, &data1).unwrap();
+        let msg1 = enc.finish_and_reset().unwrap();
+
+        enc.write_object(&desc, &data2).unwrap();
+        let msg2 = enc.finish_and_reset().unwrap();
+
+        let (_, objs1) = decode(&msg1, &DecodeOptions::default()).unwrap();
+        assert_eq!(objs1.len(), 1);
+        assert_eq!(objs1[0].1, data1, "message 1 payload mismatch");
+
+        let (_, objs2) = decode(&msg2, &DecodeOptions::default()).unwrap();
+        assert_eq!(objs2.len(), 1);
+        assert_eq!(objs2[0].1, data2, "message 2 payload mismatch");
+    }
+
+    #[test]
+    fn finish_and_reset_streaming_mode_zero_lengths() {
+        // finish_and_reset (without backfill) matches finish(): total_length = 0.
+        let meta = GlobalMetadata::default();
+        let desc = make_descriptor(vec![4]);
+        let data = vec![0u8; 4 * 4];
+
+        let mut enc = StreamingEncoder::new(
+            std::io::Cursor::new(Vec::new()),
+            &meta,
+            &EncodeOptions::default(),
+        )
+        .unwrap();
+        enc.write_object(&desc, &data).unwrap();
+        let msg = enc.finish_and_reset().unwrap();
+
+        let preamble_len = u64::from_be_bytes(msg[16..24].try_into().unwrap());
+        let postamble_len =
+            u64::from_be_bytes(msg[msg.len() - 16..msg.len() - 8].try_into().unwrap());
+        assert_eq!(
+            preamble_len, 0,
+            "streaming mode preamble total_length must be 0"
+        );
+        assert_eq!(
+            postamble_len, 0,
+            "streaming mode postamble total_length must be 0"
+        );
+    }
+
+    #[test]
+    fn finish_and_reset_with_backfill_fills_total_length() {
+        let meta = GlobalMetadata::default();
+        let desc = make_descriptor(vec![4]);
+        let data = vec![0u8; 4 * 4];
+
+        let mut enc = StreamingEncoder::new(
+            std::io::Cursor::new(Vec::new()),
+            &meta,
+            &EncodeOptions::default(),
+        )
+        .unwrap();
+        enc.write_object(&desc, &data).unwrap();
+        let msg = enc.finish_and_reset_with_backfill().unwrap();
+
+        let total = msg.len() as u64;
+        let preamble_len = u64::from_be_bytes(msg[16..24].try_into().unwrap());
+        let postamble_len =
+            u64::from_be_bytes(msg[msg.len() - 16..msg.len() - 8].try_into().unwrap());
+        assert_eq!(
+            preamble_len, total,
+            "backfilled preamble total_length must equal message length"
+        );
+        assert_eq!(
+            postamble_len, total,
+            "backfilled postamble total_length must equal message length"
+        );
+    }
+
+    #[test]
+    fn finish_and_reset_allows_multiple_resets() {
+        let meta = GlobalMetadata::default();
+        let desc = make_descriptor(vec![4]);
+
+        let mut enc = StreamingEncoder::new(
+            std::io::Cursor::new(Vec::new()),
+            &meta,
+            &EncodeOptions::default(),
+        )
+        .unwrap();
+
+        let mut messages = Vec::new();
+        for i in 0u8..5 {
+            let data = vec![i; 4 * 4];
+            enc.write_object(&desc, &data).unwrap();
+            messages.push((enc.finish_and_reset_with_backfill().unwrap(), data));
+        }
+
+        for (msg, expected_data) in &messages {
+            let (_, objs) = decode(msg, &DecodeOptions::default()).unwrap();
+            assert_eq!(objs.len(), 1);
+            assert_eq!(&objs[0].1, expected_data);
+        }
+    }
+
+    #[test]
+    fn finish_and_reset_encoder_still_usable_after_reset() {
+        // After finish_and_reset(), calling finish() on the same encoder must work.
+        let meta = GlobalMetadata::default();
+        let desc = make_descriptor(vec![4]);
+        let data1 = vec![10u8; 4 * 4];
+        let data2 = vec![20u8; 4 * 4];
+
+        let mut enc = StreamingEncoder::new(
+            std::io::Cursor::new(Vec::new()),
+            &meta,
+            &EncodeOptions::default(),
+        )
+        .unwrap();
+
+        enc.write_object(&desc, &data1).unwrap();
+        let _msg1 = enc.finish_and_reset().unwrap();
+
+        // enc is now reset; use finish() for the final message.
+        enc.write_object(&desc, &data2).unwrap();
+        let cursor = enc.finish().unwrap();
+        let (_, objs) = decode(cursor.get_ref(), &DecodeOptions::default()).unwrap();
+        assert_eq!(objs[0].1, data2);
+    }
+
+    #[test]
+    fn finish_and_reset_dangling_preceder_returns_error() {
+        let meta = GlobalMetadata::default();
+        let mut prec = BTreeMap::new();
+        prec.insert("key".to_string(), ciborium::Value::Text("val".to_string()));
+
+        let mut enc = StreamingEncoder::new(
+            std::io::Cursor::new(Vec::new()),
+            &meta,
+            &EncodeOptions::default(),
+        )
+        .unwrap();
+        enc.write_preceder(prec).unwrap();
+        // finish_and_reset without the corresponding write_object must fail.
+        let result = enc.finish_and_reset();
+        assert!(
+            result.is_err(),
+            "dangling preceder must cause finish_and_reset to fail"
+        );
+    }
+
+    #[test]
+    fn finish_and_reset_concatenated_messages_scannable() {
+        // Messages produced by finish_and_reset_with_backfill can be concatenated
+        // and scanned back as independent messages.
+        use crate::framing::scan;
+
+        let meta = GlobalMetadata::default();
+        let desc = make_descriptor(vec![4]);
+
+        let mut enc = StreamingEncoder::new(
+            std::io::Cursor::new(Vec::new()),
+            &meta,
+            &EncodeOptions::default(),
+        )
+        .unwrap();
+
+        let mut parts: Vec<Vec<u8>> = Vec::new();
+        for i in 0u8..3 {
+            enc.write_object(&desc, &vec![i; 4 * 4]).unwrap();
+            parts.push(enc.finish_and_reset_with_backfill().unwrap());
+        }
+
+        let combined: Vec<u8> = parts.iter().flatten().copied().collect();
+        let scanned = scan(&combined);
+        assert_eq!(
+            scanned.len(),
+            3,
+            "three concatenated messages must scan as three"
+        );
+
+        let mut offset = 0usize;
+        for (i, part) in parts.iter().enumerate() {
+            assert_eq!(
+                scanned[i],
+                (offset, part.len()),
+                "scan offset/length mismatch for message {i}"
+            );
+            offset += part.len();
+        }
+    }
+
+    #[test]
+    fn finish_and_reset_empty_message_is_decodable() {
+        // finish_and_reset with no objects must produce a valid empty message.
+        let meta = GlobalMetadata::default();
+
+        let mut enc = StreamingEncoder::new(
+            std::io::Cursor::new(Vec::new()),
+            &meta,
+            &EncodeOptions::default(),
+        )
+        .unwrap();
+
+        let msg = enc.finish_and_reset().unwrap();
+        let (_, objs) = decode(&msg, &DecodeOptions::default()).unwrap();
+        assert_eq!(
+            objs.len(),
+            0,
+            "empty message after finish_and_reset must decode to 0 objects"
+        );
     }
 }


### PR DESCRIPTION
StreamingEncoder gains two new methods on the in-memory cursor specialisation (StreamingEncoder<Cursor<Vec<u8>>>):

- finish_and_reset() — finalises the current message (streaming mode, total_length = 0, matching finish() semantics) and resets the encoder to immediately begin the next message.
- finish_and_reset_with_backfill() — same but back-fills total_length in both the preamble and postamble, satisfying the backward-locatability invariant from wire-format §7.

Both methods return Vec<u8> containing the completed message bytes.

Python bindings expose finish_and_reset() and finish_and_reset_backfilled() on StreamingEncoder.

Internal refactoring:
- write_preamble_and_header() extracted from new() as a private free function; shared with reset_message_state().
- write_footer_frames_and_postamble() extracted from finish() as a private &mut self method; shared by finish(), finish_with_backfill(), and the new reset variants.

Tests: 8 new Rust unit tests and 14 new Python tests covering decode correctness, length slots, multiple resets, empty messages, dangling preceder errors, concatenation + scan, and global-meta preservation.

## Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [ ] I have read the [Contributing Guide](CONTRIBUTING.md)
- [ ] My code follows the project's style guidelines (`cargo fmt`, `ruff format`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests pass (`cargo test --workspace`, `pytest`)
- [ ] I have updated documentation where necessary
- [ ] I have added examples if this introduces new public API

## Contributor Licence Agreement

By submitting this pull request, I confirm that my contribution is made under
the terms of the [Apache License 2.0](LICENSE) and that I have the right to
submit it under this licence. I agree to the terms of the
[ECMWF Contributor Licence Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).


<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-112
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->