### PR TITLE
feat(cpp-async): async C++ API for Tensogram (PRs 1-6 of plan)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -694,6 +694,15 @@ jobs:
         password: ${{ secrets.ECMWF_DOCKER_REGISTRY_ACCESS_TOKEN }}
     if: github.event_name == 'pull_request'
     timeout-minutes: 30
+    # Override the workflow-wide TMPDIR (which sits inside the workspace
+    # at $GITHUB_WORKSPACE/.tmp) for this job only.  cargo-mutants copies
+    # the workspace into a tempdir under TMPDIR; if TMPDIR is inside the
+    # workspace, the copy walks its own freshly-created tempdir and
+    # recurses until macOS / Linux PATH_MAX kicks in with
+    # "File name too long".  /tmp is outside the workspace and free of
+    # this trap.
+    env:
+      TMPDIR: /tmp
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,12 @@ jobs:
           cargo test --workspace
           cargo test -p tensogram --features remote
           cargo test -p tensogram --features "remote,async"
+          # The FFI's async tests file is `cfg(feature = "async")`, so
+          # `cargo test --workspace` (default features) compiles it to
+          # nothing.  Add an explicit pass with the async features so
+          # the dispatcher pool, streaming-encoder, and null-arg
+          # validation tests actually run in CI.
+          cargo test -p tensogram-ffi --features "async,async-remote"
 
       - name: sccache stats
         if: always()
@@ -335,6 +341,11 @@ jobs:
 
       - name: Test (remote + async features)
         run: cargo test -p tensogram --features "remote,async"
+
+      - name: Test (FFI async)
+        # FFI's async tests file is `cfg(feature = "async")`; default
+        # `cargo test --workspace` compiles it to nothing.
+        run: cargo test -p tensogram-ffi --features "async,async-remote"
 
       - name: Test (GRIB)
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added — Asynchronous C++ API
+
+A header-only asynchronous read/write surface for the C++ wrapper,
+sharing Tensogram's internal tokio runtime with no tokio types in the
+public API. Three opt-in frontends layer on one callback-based FFI
+core: `tensogram/async/callback.hpp` (C++17, always available),
+`tensogram/async/std_future.hpp` (C++17, `std::future<T>`), and
+`tensogram/async/coro.hpp` (C++20 `task<T>` + `co_await`, with an
+`async_for_each` message walker). The surface covers async file open,
+message count/read, decode (message / metadata / object), and a
+local-file streaming encoder for the producer side — all with
+cancellation tokens and per-call timeouts (`TGM_ERROR_CANCELLED` /
+`TGM_ERROR_TIMEOUT`). A contained multi-thread tokio runtime (default
+workers `min(num_cpus, 8)`) drives the work; a separate dispatcher pool
+runs user callbacks so a slow callback cannot starve I/O.
+
+`async_file::open_remote` reads `.tgm` files over an object store or a
+`file://` URL (`s3://`, `gs://`, `az://`, `https://`, `file://`) on all
+three frontends; enable it with the CMake `TENSOGRAM_ASYNC_REMOTE`
+option (FFI `async-remote` feature, which also turns on object_store's
+`fs` backend for `file://`). The async streaming encoder produces
+byte-identical output to the synchronous encoder, so async-written
+files round-trip through every binding.
+
+New caller examples `examples/cpp/19`–`24` and user guides
+`docs/src/guide/cpp-async.md` and
+`docs/src/guide/cpp-streaming-async.md`.
+
 ## [0.21.0] - 2026-04-29
 
 ### Added — Decode-time hash verification with per-frame `HASH_PRESENT` flag

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2298,8 +2298,11 @@ dependencies = [
  "ciborium",
  "serde",
  "serde_json",
+ "tempfile",
  "tensogram",
  "tensogram-encodings",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,6 +1439,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "walkdir",
  "wasm-bindgen-futures",
  "web-time",
 ]

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,8 @@ MUTANTS_ENV = \
 MUTANTS_FLAGS = \
 	--no-shuffle \
 	--jobserver-tasks $(MUTANTS_JOBS) \
-	--timeout-multiplier 3.0
+	--timeout-multiplier 3.0 \
+	--features async,async-remote
 
 mutants: mutants-install ## Full-workspace cargo-mutants sweep (long; use mutants-diff for PRs)
 	$(MUTANTS_ENV) cargo mutants $(MUTANTS_FLAGS)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Tensogram defines a binary message format, not strictly a file format. Multiple 
 - **File API** — `TensogramFile` for multi-message `.tgm` files: append, random-access read, iterate, and decode individual messages or objects
 - **Remote access** — read `.tgm` files directly from S3, GCS, Azure Blob, or HTTP via `object_store` integration (`open_remote`, `open_source`)
 - **Async API** — full async counterparts for file open, message read, decode, and iteration via tokio (`open_async`, `decode_message_async`, etc.)
+- **Async C++ API** — header-only asynchronous C++ frontends (callback, `std::future`, and C++20 coroutines) over the FFI async core, built for HPC streaming producer/consumer pipelines; includes cancellation/timeouts and remote reads (`open_remote`)
 - **Streaming encoder** — progressive encode/transmit without buffering the full message; preceder metadata frames enable consumer-side streaming decode
 - **Compression** — szip, zstd, lz4, blosc2, zfp, sz3 per data object; pure-Rust backends available (`szip-pure`, `zstd-pure`) for environments without C libraries
 - **Hash verified integrity** — xxHash xxh3-64 integrity check per frame
@@ -199,6 +200,12 @@ cmake --build build -j
 ctest --test-dir build --output-on-failure  # run C++ tests
 ```
 See `examples/cpp/` for encode/decode, metadata, file API, and iterator examples.
+
+The async surface is built by default (`-DTENSOGRAM_ASYNC=ON`). Examples
+`19`–`24` cover the callback, `std::future`, and C++20 coroutine
+frontends; add `-DTENSOGRAM_ASYNC_REMOTE=ON` to build the object-store
+read path (example `19`). See the [C++ Async API](docs/src/guide/cpp-async.md)
+and [C++ Async Streaming](docs/src/guide/cpp-streaming-async.md) guides.
 
 **Python bindings** (PyO3 + maturin, requires [uv](https://docs.astral.sh/uv/getting-started/installation/)):
 ```bash

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -6,10 +6,22 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # ---------------------------------------------------------------------------
-# Async surface (PR 4 of the cpp-async plan)
+# Async surface
 # ---------------------------------------------------------------------------
+# TENSOGRAM_ASYNC enables the header-only C++ async frontends and builds the
+# FFI with --features=async.  TENSOGRAM_ASYNC_REMOTE additionally enables the
+# object-store backend (s3://, gs://, az://, https:// and file://) by building
+# the FFI with --features=async-remote; it implies TENSOGRAM_ASYNC.
 option(TENSOGRAM_ASYNC "Build the async FFI surface and C++ frontends" ON)
-if(TENSOGRAM_ASYNC)
+option(TENSOGRAM_ASYNC_REMOTE
+    "Build the async object-store backend (implies TENSOGRAM_ASYNC)" OFF)
+if(TENSOGRAM_ASYNC_REMOTE AND NOT TENSOGRAM_ASYNC)
+    message(STATUS "TENSOGRAM_ASYNC_REMOTE=ON -> forcing TENSOGRAM_ASYNC=ON")
+    set(TENSOGRAM_ASYNC ON)
+endif()
+if(TENSOGRAM_ASYNC_REMOTE)
+    set(CARGO_FEATURES "--features=async-remote")
+elseif(TENSOGRAM_ASYNC)
     set(CARGO_FEATURES "--features=async")
 else()
     set(CARGO_FEATURES "")
@@ -64,6 +76,9 @@ if(TENSOGRAM_ASYNC)
     target_compile_definitions(tensogram INTERFACE TENSOGRAM_ASYNC=1)
     find_package(Threads REQUIRED)
     target_link_libraries(tensogram INTERFACE Threads::Threads)
+endif()
+if(TENSOGRAM_ASYNC_REMOTE)
+    target_compile_definitions(tensogram INTERFACE TENSOGRAM_ASYNC_REMOTE=1)
 endif()
 
 # Platform-specific system libraries required by the Rust static library

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -6,6 +6,16 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # ---------------------------------------------------------------------------
+# Async surface (PR 4 of the cpp-async plan)
+# ---------------------------------------------------------------------------
+option(TENSOGRAM_ASYNC "Build the async FFI surface and C++ frontends" ON)
+if(TENSOGRAM_ASYNC)
+    set(CARGO_FEATURES "--features=async")
+else()
+    set(CARGO_FEATURES "")
+endif()
+
+# ---------------------------------------------------------------------------
 # Build the Rust static library via cargo
 # ---------------------------------------------------------------------------
 set(CARGO_TARGET_DIR "${CMAKE_SOURCE_DIR}/../target")
@@ -28,7 +38,7 @@ set(RUST_LIB "${CARGO_TARGET_DIR}/release/libtensogram_ffi.a")
 add_custom_target(rust_lib ALL
     BYPRODUCTS "${RUST_LIB}"
     COMMAND ${CMAKE_COMMAND} -E env "CARGO_TARGET_DIR=${CARGO_TARGET_DIR}"
-            cargo build --release -p tensogram-ffi
+            cargo build --release -p tensogram-ffi ${CARGO_FEATURES}
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/.."
     COMMENT "Invoking cargo build -p tensogram-ffi (cargo decides freshness)"
 )
@@ -50,6 +60,11 @@ target_include_directories(tensogram INTERFACE
     "${CMAKE_SOURCE_DIR}/include"
     "${CMAKE_SOURCE_DIR}/../rust/tensogram-ffi")
 target_link_libraries(tensogram INTERFACE tensogram_ffi)
+if(TENSOGRAM_ASYNC)
+    target_compile_definitions(tensogram INTERFACE TENSOGRAM_ASYNC=1)
+    find_package(Threads REQUIRED)
+    target_link_libraries(tensogram INTERFACE Threads::Threads)
+endif()
 
 # Platform-specific system libraries required by the Rust static library
 if(APPLE)

--- a/cpp/include/tensogram.hpp
+++ b/cpp/include/tensogram.hpp
@@ -193,15 +193,17 @@ public:
 
 namespace detail {
 
-/// Throw the typed C++ exception that matches a non-OK C error code,
-/// using `message` as the exception text.
+/// Throw the typed C++ exception that matches a C error code, using
+/// `message` as the exception text.
 ///
-/// `TGM_ERROR_OK` is silently a no-op so callers can hand any code
-/// through without prior screening.  Used both by [`check()`] (which
-/// captures the FFI's thread-local last-error string) and by the
-/// async frontends (which capture the message inside completion
-/// handlers, before any other FFI call on the thread can clobber the
-/// last-error slot).
+/// This is `[[noreturn]]` and must be called with a *non-OK* code:
+/// `TGM_ERROR_OK` has no corresponding exception and falls through to
+/// the generic [`error`], so callers screen for OK first.  [`check()`]
+/// only calls this on a non-OK code, and the async frontends only on a
+/// failed `result`.  Used both by [`check()`] (which captures the FFI's
+/// thread-local last-error string) and by the async frontends (which
+/// capture the message inside completion handlers, before any other FFI
+/// call on the thread can clobber the last-error slot).
 [[noreturn]] inline void throw_for_code(tgm_error err, const std::string& message) {
     switch (err) {
         case TGM_ERROR_FRAMING:       throw framing_error(err, message);

--- a/cpp/include/tensogram.hpp
+++ b/cpp/include/tensogram.hpp
@@ -193,11 +193,16 @@ public:
 
 namespace detail {
 
-/// Check a C error code and throw the appropriate typed exception.
-inline void check(tgm_error err) {
-    if (err == TGM_ERROR_OK) return;
-    const char* msg = tgm_last_error();
-    std::string message = msg ? msg : tgm_error_string(err);
+/// Throw the typed C++ exception that matches a non-OK C error code,
+/// using `message` as the exception text.
+///
+/// `TGM_ERROR_OK` is silently a no-op so callers can hand any code
+/// through without prior screening.  Used both by [`check()`] (which
+/// captures the FFI's thread-local last-error string) and by the
+/// async frontends (which capture the message inside completion
+/// handlers, before any other FFI call on the thread can clobber the
+/// last-error slot).
+[[noreturn]] inline void throw_for_code(tgm_error err, const std::string& message) {
     switch (err) {
         case TGM_ERROR_FRAMING:       throw framing_error(err, message);
         case TGM_ERROR_METADATA:      throw metadata_error(err, message);
@@ -214,6 +219,14 @@ inline void check(tgm_error err) {
         case TGM_ERROR_END_OF_ITER:   throw error(err, message);
         default:                      throw error(err, message);
     }
+}
+
+/// Check a C error code and throw the appropriate typed exception.
+inline void check(tgm_error err) {
+    if (err == TGM_ERROR_OK) return;
+    const char* msg = tgm_last_error();
+    std::string message = msg ? msg : tgm_error_string(err);
+    throw_for_code(err, message);
 }
 
 /// Adapter that splits a vector of (pointer, length) pairs into parallel

--- a/cpp/include/tensogram.hpp
+++ b/cpp/include/tensogram.hpp
@@ -173,6 +173,20 @@ public:
     remote_error(tgm_error code, const std::string& msg) : error(code, msg) {}
 };
 
+/// Thrown when an async task exceeds its deadline.  See
+/// `plans/PLAN_CPP_ASYNC.md` §7.1.
+class timeout_error : public error {
+public:
+    timeout_error(tgm_error code, const std::string& msg) : error(code, msg) {}
+};
+
+/// Thrown when an async task is cancelled via its
+/// `cancellation_token`.  See `plans/PLAN_CPP_ASYNC.md` §7.2.
+class cancelled_error : public error {
+public:
+    cancelled_error(tgm_error code, const std::string& msg) : error(code, msg) {}
+};
+
 // ============================================================
 // detail — error checking helper
 // ============================================================
@@ -195,6 +209,8 @@ inline void check(tgm_error err) {
         case TGM_ERROR_MISSING_HASH:  throw missing_hash_error(err, message);
         case TGM_ERROR_INVALID_ARG:   throw invalid_arg_error(err, message);
         case TGM_ERROR_REMOTE:        throw remote_error(err, message);
+        case TGM_ERROR_TIMEOUT:       throw timeout_error(err, message);
+        case TGM_ERROR_CANCELLED:     throw cancelled_error(err, message);
         case TGM_ERROR_END_OF_ITER:   throw error(err, message);
         default:                      throw error(err, message);
     }
@@ -356,6 +372,14 @@ class buffer_iterator;
 class file_iterator;
 class object_iterator;
 class streaming_encoder;
+
+// Async-frontend bridge helpers (forward-declared for friend access).
+// Defined inline in `tensogram/async/callback.hpp` once the message
+// and metadata types are complete.
+namespace detail {
+    inline message message_from_raw(tgm_message_t* raw);
+    inline metadata metadata_from_raw(tgm_metadata_t* raw);
+}
 
 // Free functions (forward-declared for friend access)
 [[nodiscard]] inline message decode(const std::uint8_t* buf, std::size_t len,
@@ -556,6 +580,9 @@ private:
                                             std::size_t, const decode_options&);
     friend class file;
     friend class object_iterator;
+    // Async frontends (callback / coro / std_future) build a message
+    // from an FFI handle returned by tgm_async_task_join_message.
+    friend message tensogram::detail::message_from_raw(tgm_message_t*);
 
     struct deleter {
         void operator()(tgm_message_t* p) const noexcept { tgm_message_free(p); }
@@ -626,6 +653,9 @@ public:
 private:
     friend metadata tensogram::decode_metadata(const std::uint8_t*, std::size_t);
     friend class message;
+    // Async frontends construct a metadata wrapper from an FFI handle
+    // returned by tgm_async_task_join_metadata.
+    friend metadata tensogram::detail::metadata_from_raw(tgm_metadata_t*);
 
     struct deleter {
         void operator()(tgm_metadata_t* p) const noexcept { tgm_metadata_free(p); }

--- a/cpp/include/tensogram/async/callback.hpp
+++ b/cpp/include/tensogram/async/callback.hpp
@@ -267,6 +267,56 @@ public:
         register_async_file_completion(task, std::move(cb));
     }
 
+    /// Open a remote `.tgm` over S3 / GCS / Azure / HTTP asynchronously.
+    ///
+    /// `url` is an object-store URL (`s3://bucket/key.tgm`, `gs://…`,
+    /// `az://…`, `https://…`) or a `file://…` URL routed through the
+    /// same object-store backend.  `storage_options` carries backend
+    /// credentials / configuration as key→value pairs (e.g.
+    /// `{{"aws_region", "eu-west-1"}}`); pass an empty vector to rely
+    /// on ambient credentials (environment, instance role).
+    /// `bidirectional` selects the pipelined two-ended remote scan.
+    ///
+    /// Requires the FFI to be built with the `async-remote` Cargo
+    /// feature.  Without it the callback fires with `TGM_ERROR_REMOTE`
+    /// and a diagnostic naming the missing feature — the symbol is
+    /// always linkable, so this never becomes an undefined reference.
+    /// `timeout` is in milliseconds; pass `0` for no timeout.
+    static void open_remote(
+        const std::string& url,
+        const std::vector<std::pair<std::string, std::string>>& storage_options,
+        bool bidirectional,
+        std::function<void(result<async_file>)> cb,
+        cancellation_token* token = nullptr,
+        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) {
+        // The FFI copies every key/value string into an owned map
+        // before returning, so these `c_str()` views only need to
+        // stay valid across the synchronous launch call below.
+        std::vector<const char*> keys;
+        std::vector<const char*> values;
+        keys.reserve(storage_options.size());
+        values.reserve(storage_options.size());
+        for (const auto& [k, v] : storage_options) {
+            keys.push_back(k.c_str());
+            values.push_back(v.c_str());
+        }
+        tgm_async_task_t* task = nullptr;
+        tgm_error err = tgm_async_file_open_remote(
+            url.c_str(),
+            keys.empty() ? nullptr : keys.data(),
+            values.empty() ? nullptr : values.data(),
+            storage_options.size(),
+            bidirectional,
+            token ? token->raw() : nullptr,
+            static_cast<uint64_t>(timeout.count()),
+            &task);
+        if (err != TGM_ERROR_OK) {
+            cb(result<async_file>::err(err, detail::error_message_from_last()));
+            return;
+        }
+        register_async_file_completion(task, std::move(cb));
+    }
+
     /// Async message-count.
     void message_count(std::function<void(result<std::size_t>)> cb,
                        cancellation_token* token = nullptr,

--- a/cpp/include/tensogram/async/callback.hpp
+++ b/cpp/include/tensogram/async/callback.hpp
@@ -24,7 +24,6 @@
 #include "../../tensogram.hpp"
 
 #include <chrono>
-#include <cstring>
 #include <functional>
 #include <memory>
 #include <string>

--- a/cpp/include/tensogram/async/callback.hpp
+++ b/cpp/include/tensogram/async/callback.hpp
@@ -1,0 +1,516 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 ECMWF
+
+/// @file tensogram/async/callback.hpp
+/// @brief Callback-based asynchronous frontend (PR 4 of the cpp-async plan).
+///
+/// Header-only, C++17, always available wherever the FFI ships
+/// `--features async`.  The minimum-viable async surface that all
+/// other frontends (`coro.hpp`, `std_future.hpp`) layer on top of.
+///
+/// Plan: `plans/PLAN_CPP_ASYNC.md` §4.1.
+
+#ifndef TENSOGRAM_ASYNC_CALLBACK_HPP
+#define TENSOGRAM_ASYNC_CALLBACK_HPP
+
+#include "../../tensogram.hpp"
+
+#include <chrono>
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace tensogram::async_callback {
+
+// ============================================================
+// result<T> — never-throw discriminated union
+// ============================================================
+
+/// Lightweight success/error union for callback results.  Doesn't
+/// throw on construction or access; consumers check `.ok()` before
+/// reading `.value()`.
+template <typename T>
+class result {
+public:
+    static result<T> ok_value(T v) {
+        result<T> r;
+        r.ok_ = true;
+        r.value_ = std::make_unique<T>(std::move(v));
+        return r;
+    }
+    static result<T> err(tgm_error code, std::string msg) {
+        result<T> r;
+        r.ok_ = false;
+        r.code_ = code;
+        r.message_ = std::move(msg);
+        return r;
+    }
+
+    [[nodiscard]] bool ok() const noexcept { return ok_; }
+    [[nodiscard]] tgm_error code() const noexcept { return code_; }
+    [[nodiscard]] const std::string& message() const noexcept { return message_; }
+
+    /// Access the success value.  Caller must check `.ok()` first;
+    /// calling `.value()` on a failed result is undefined behaviour.
+    T& value() noexcept { return *value_; }
+    const T& value() const noexcept { return *value_; }
+
+    /// Move-out the success value.
+    T take() noexcept { return std::move(*value_); }
+
+private:
+    bool ok_ = false;
+    tgm_error code_ = TGM_ERROR_OK;
+    std::string message_;
+    std::unique_ptr<T> value_;
+};
+
+template <>
+class result<void> {
+public:
+    static result<void> ok_value() {
+        result<void> r;
+        r.ok_ = true;
+        return r;
+    }
+    static result<void> err(tgm_error code, std::string msg) {
+        result<void> r;
+        r.ok_ = false;
+        r.code_ = code;
+        r.message_ = std::move(msg);
+        return r;
+    }
+    [[nodiscard]] bool ok() const noexcept { return ok_; }
+    [[nodiscard]] tgm_error code() const noexcept { return code_; }
+    [[nodiscard]] const std::string& message() const noexcept { return message_; }
+private:
+    bool ok_ = false;
+    tgm_error code_ = TGM_ERROR_OK;
+    std::string message_;
+};
+
+// ============================================================
+// cancellation_token
+// ============================================================
+
+class cancellation_token {
+public:
+    cancellation_token()
+        : handle_(tgm_cancellation_token_create(),
+                  &tgm_cancellation_token_free) {}
+
+    void cancel() noexcept {
+        tgm_cancellation_token_cancel(handle_.get());
+    }
+    [[nodiscard]] bool cancelled() const noexcept {
+        return tgm_cancellation_token_is_cancelled(handle_.get());
+    }
+
+    cancellation_token(const cancellation_token&) = delete;
+    cancellation_token& operator=(const cancellation_token&) = delete;
+    cancellation_token(cancellation_token&&) noexcept = default;
+    cancellation_token& operator=(cancellation_token&&) noexcept = default;
+
+    /// Internal: raw handle for FFI plumbing.
+    [[nodiscard]] tgm_cancellation_token_t* raw() noexcept { return handle_.get(); }
+
+private:
+    using deleter_t = void (*)(tgm_cancellation_token_t*);
+    std::unique_ptr<tgm_cancellation_token_t, deleter_t> handle_;
+};
+
+// ============================================================
+// detail — task adapters
+// ============================================================
+
+namespace detail {
+
+/// Snapshot the FFI's thread-local last-error string into a `std::string`.
+///
+/// The completion threads each call this immediately after their join
+/// returns an error; the FFI's thread-local error slot is shared with
+/// any tgm_* call on the same OS thread, so the snapshot must happen
+/// before any other FFI call on that thread.
+inline std::string error_message_from_last() {
+    const char* m = tgm_last_error();
+    return m ? std::string(m) : std::string();
+}
+
+}  // namespace detail
+
+// ============================================================
+// async_file
+// ============================================================
+
+class async_file {
+public:
+    async_file(async_file&&) noexcept = default;
+    async_file& operator=(async_file&&) noexcept = default;
+    async_file(const async_file&) = delete;
+    async_file& operator=(const async_file&) = delete;
+
+    /// Open a local file asynchronously.  `cb` is invoked once when
+    /// the open completes (success or failure).
+    ///
+    /// `timeout` is in milliseconds; pass `0` for no timeout.
+    static void open(const std::string& path,
+                     std::function<void(result<async_file>)> cb,
+                     cancellation_token* token = nullptr,
+                     std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) {
+        tgm_async_task_t* task = nullptr;
+        tgm_error err = tgm_async_file_open(
+            path.c_str(),
+            token ? token->raw() : nullptr,
+            static_cast<uint64_t>(timeout.count()),
+            &task);
+        if (err != TGM_ERROR_OK) {
+            cb(result<async_file>::err(err, detail::error_message_from_last()));
+            return;
+        }
+        std::thread([task, cb = std::move(cb)]() mutable {
+            tgm_async_file_t* raw = nullptr;
+            tgm_error e = tgm_async_task_join_async_file(task, &raw);
+            if (e == TGM_ERROR_OK) {
+                cb(result<async_file>::ok_value(async_file(raw)));
+            } else {
+                cb(result<async_file>::err(e, detail::error_message_from_last()));
+            }
+            tgm_async_task_free(task);
+        }).detach();
+    }
+
+    /// Async message-count.
+    void message_count(std::function<void(result<std::size_t>)> cb,
+                       cancellation_token* token = nullptr,
+                       std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) const {
+        tgm_async_task_t* task = nullptr;
+        tgm_error err = tgm_async_file_message_count(
+            handle_.get(),
+            token ? token->raw() : nullptr,
+            static_cast<uint64_t>(timeout.count()),
+            &task);
+        if (err != TGM_ERROR_OK) {
+            cb(result<std::size_t>::err(err, detail::error_message_from_last()));
+            return;
+        }
+        std::thread([task, cb = std::move(cb)]() mutable {
+            uint64_t n = 0;
+            tgm_error e = tgm_async_task_join_size(task, &n);
+            if (e == TGM_ERROR_OK) {
+                cb(result<std::size_t>::ok_value(static_cast<std::size_t>(n)));
+            } else {
+                cb(result<std::size_t>::err(e, detail::error_message_from_last()));
+            }
+            tgm_async_task_free(task);
+        }).detach();
+    }
+
+    /// Async decode of message at `index`, returning a `tensogram::message`.
+    void decode_message(std::size_t index,
+                        std::function<void(result<tensogram::message>)> cb,
+                        cancellation_token* token = nullptr,
+                        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) const {
+        tgm_async_task_t* task = nullptr;
+        tgm_error err = tgm_async_file_decode_message(
+            handle_.get(), index,
+            true,   // native_byte_order
+            0,      // threads
+            true,   // restore_non_finite
+            false,  // verify_hash
+            token ? token->raw() : nullptr,
+            static_cast<uint64_t>(timeout.count()),
+            &task);
+        if (err != TGM_ERROR_OK) {
+            cb(result<tensogram::message>::err(err, detail::error_message_from_last()));
+            return;
+        }
+        std::thread([task, cb = std::move(cb)]() mutable {
+            tgm_message_t* raw = nullptr;
+            tgm_error e = tgm_async_task_join_message(task, &raw);
+            if (e == TGM_ERROR_OK) {
+                cb(result<tensogram::message>::ok_value(
+                    tensogram::detail::message_from_raw(raw)));
+            } else {
+                cb(result<tensogram::message>::err(e, detail::error_message_from_last()));
+            }
+            tgm_async_task_free(task);
+        }).detach();
+    }
+
+    /// Async decode of metadata only.
+    void decode_metadata(std::size_t index,
+                         std::function<void(result<tensogram::metadata>)> cb,
+                         cancellation_token* token = nullptr,
+                         std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) const {
+        tgm_async_task_t* task = nullptr;
+        tgm_error err = tgm_async_file_decode_metadata(
+            handle_.get(), index,
+            token ? token->raw() : nullptr,
+            static_cast<uint64_t>(timeout.count()),
+            &task);
+        if (err != TGM_ERROR_OK) {
+            cb(result<tensogram::metadata>::err(err, detail::error_message_from_last()));
+            return;
+        }
+        std::thread([task, cb = std::move(cb)]() mutable {
+            tgm_metadata_t* raw = nullptr;
+            tgm_error e = tgm_async_task_join_metadata(task, &raw);
+            if (e == TGM_ERROR_OK) {
+                cb(result<tensogram::metadata>::ok_value(
+                    tensogram::detail::metadata_from_raw(raw)));
+            } else {
+                cb(result<tensogram::metadata>::err(e, detail::error_message_from_last()));
+            }
+            tgm_async_task_free(task);
+        }).detach();
+    }
+
+    /// Async raw read of message bytes.
+    void read_message(std::size_t index,
+                      std::function<void(result<std::vector<std::uint8_t>>)> cb,
+                      cancellation_token* token = nullptr,
+                      std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) const {
+        tgm_async_task_t* task = nullptr;
+        tgm_error err = tgm_async_file_read_message(
+            handle_.get(), index,
+            token ? token->raw() : nullptr,
+            static_cast<uint64_t>(timeout.count()),
+            &task);
+        if (err != TGM_ERROR_OK) {
+            cb(result<std::vector<std::uint8_t>>::err(err, detail::error_message_from_last()));
+            return;
+        }
+        std::thread([task, cb = std::move(cb)]() mutable {
+            tgm_bytes_t b{nullptr, 0};
+            tgm_error e = tgm_async_task_join_bytes(task, &b);
+            if (e == TGM_ERROR_OK) {
+                std::vector<std::uint8_t> v(b.data, b.data + b.len);
+                tgm_bytes_free(b);
+                cb(result<std::vector<std::uint8_t>>::ok_value(std::move(v)));
+            } else {
+                cb(result<std::vector<std::uint8_t>>::err(e, detail::error_message_from_last()));
+            }
+            tgm_async_task_free(task);
+        }).detach();
+    }
+
+    /// Internal helper: raw FFI handle.  Reserved for the
+    /// other frontends.
+    [[nodiscard]] tgm_async_file_t* raw() const noexcept { return handle_.get(); }
+
+private:
+    using deleter_t = void (*)(tgm_async_file_t*);
+    std::unique_ptr<tgm_async_file_t, deleter_t> handle_;
+
+    explicit async_file(tgm_async_file_t* raw)
+        : handle_(raw, &tgm_async_file_close) {}
+};
+
+// ============================================================
+// async_streaming_encoder
+// ============================================================
+
+class async_streaming_encoder {
+public:
+    async_streaming_encoder(async_streaming_encoder&&) noexcept = default;
+    async_streaming_encoder& operator=(async_streaming_encoder&&) noexcept = default;
+    async_streaming_encoder(const async_streaming_encoder&) = delete;
+    async_streaming_encoder& operator=(const async_streaming_encoder&) = delete;
+
+    /// Create an async streaming encoder writing to a local file.
+    /// `cb` fires once with the constructed handle (or an error).
+    static void create(const std::string& path,
+                       const std::string& metadata_json,
+                       std::function<void(result<async_streaming_encoder>)> cb,
+                       const std::string& hash_algo = "xxh3",
+                       std::uint32_t threads = 0,
+                       cancellation_token* token = nullptr,
+                       std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) {
+        tgm_async_task_t* task = nullptr;
+        tgm_error err = tgm_async_streaming_encoder_create(
+            path.c_str(),
+            metadata_json.c_str(),
+            hash_algo.empty() ? nullptr : hash_algo.c_str(),
+            threads,
+            token ? token->raw() : nullptr,
+            static_cast<uint64_t>(timeout.count()),
+            &task);
+        if (err != TGM_ERROR_OK) {
+            cb(result<async_streaming_encoder>::err(err, detail::error_message_from_last()));
+            return;
+        }
+        std::thread([task, cb = std::move(cb)]() mutable {
+            tgm_async_streaming_encoder_t* raw = nullptr;
+            tgm_error e = tgm_async_task_join_async_streaming_encoder(task, &raw);
+            if (e == TGM_ERROR_OK) {
+                cb(result<async_streaming_encoder>::ok_value(
+                    async_streaming_encoder(raw)));
+            } else {
+                cb(result<async_streaming_encoder>::err(
+                    e, detail::error_message_from_last()));
+            }
+            tgm_async_task_free(task);
+        }).detach();
+    }
+
+    /// Async write of an encoded data object.  `cb` fires with void
+    /// success or an error.
+    void write_object(const std::string& descriptor_json,
+                      const std::uint8_t* data, std::size_t len,
+                      std::function<void(result<void>)> cb,
+                      cancellation_token* token = nullptr,
+                      std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) {
+        tgm_async_task_t* task = nullptr;
+        tgm_error err = tgm_async_streaming_encoder_write_object(
+            handle_.get(),
+            descriptor_json.c_str(),
+            data, len,
+            token ? token->raw() : nullptr,
+            static_cast<uint64_t>(timeout.count()),
+            &task);
+        launch_void_completion(task, err, std::move(cb));
+    }
+
+    /// Async write of a pre-encoded data object (descriptor must
+    /// describe the payload's encoding/compression accurately).
+    void write_pre_encoded(const std::string& descriptor_json,
+                           const std::uint8_t* data, std::size_t len,
+                           std::function<void(result<void>)> cb,
+                           cancellation_token* token = nullptr,
+                           std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) {
+        tgm_async_task_t* task = nullptr;
+        tgm_error err = tgm_async_streaming_encoder_write_pre_encoded(
+            handle_.get(),
+            descriptor_json.c_str(),
+            data, len,
+            token ? token->raw() : nullptr,
+            static_cast<uint64_t>(timeout.count()),
+            &task);
+        launch_void_completion(task, err, std::move(cb));
+    }
+
+    /// Async write of a `PrecederMetadata` frame.
+    void write_preceder(const std::string& metadata_json,
+                        std::function<void(result<void>)> cb,
+                        cancellation_token* token = nullptr,
+                        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) {
+        tgm_async_task_t* task = nullptr;
+        tgm_error err = tgm_async_streaming_encoder_write_preceder(
+            handle_.get(),
+            metadata_json.c_str(),
+            token ? token->raw() : nullptr,
+            static_cast<uint64_t>(timeout.count()),
+            &task);
+        launch_void_completion(task, err, std::move(cb));
+    }
+
+    /// Async finish — writes footer frames + postamble.  When
+    /// `backfill = true` (default) and the sink supports seek (local
+    /// files do), the preamble + postamble `total_length` slots are
+    /// patched.
+    void finish(std::function<void(result<void>)> cb,
+                bool backfill = true,
+                cancellation_token* token = nullptr,
+                std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) {
+        tgm_async_task_t* task = nullptr;
+        tgm_error err = tgm_async_streaming_encoder_finish(
+            handle_.get(),
+            backfill,
+            token ? token->raw() : nullptr,
+            static_cast<uint64_t>(timeout.count()),
+            &task);
+        launch_void_completion(task, err, std::move(cb));
+    }
+
+    /// Best-effort object-count snapshot.  Returns `static_cast<std::size_t>(-1)`
+    /// if the encoder is currently busy with another in-flight call.
+    [[nodiscard]] std::size_t object_count() const noexcept {
+        return tgm_async_streaming_encoder_object_count(handle_.get());
+    }
+
+private:
+    using deleter_t = void (*)(tgm_async_streaming_encoder_t*);
+    std::unique_ptr<tgm_async_streaming_encoder_t, deleter_t> handle_;
+
+    explicit async_streaming_encoder(tgm_async_streaming_encoder_t* raw)
+        : handle_(raw, &tgm_async_streaming_encoder_free) {}
+
+    static void launch_void_completion(tgm_async_task_t* task, tgm_error err,
+                                       std::function<void(result<void>)> cb) {
+        if (err != TGM_ERROR_OK) {
+            cb(result<void>::err(err, detail::error_message_from_last()));
+            return;
+        }
+        std::thread([task, cb_inner = std::move(cb)]() mutable {
+            tgm_error e = tgm_async_task_join_void(task);
+            if (e == TGM_ERROR_OK) {
+                cb_inner(result<void>::ok_value());
+            } else {
+                cb_inner(result<void>::err(e, detail::error_message_from_last()));
+            }
+            tgm_async_task_free(task);
+        }).detach();
+    }
+};
+
+// ============================================================
+// runtime — one-shot configuration
+// ============================================================
+
+/// Configure the FFI tokio runtime.  Must be called before any other
+/// async call; subsequent calls throw `invalid_arg_error`.
+///
+/// Pass `0` for any field to use the default.
+inline void runtime_configure(std::uint32_t workers = 0,
+                              std::uint32_t dispatcher_workers = 0,
+                              std::uint64_t multipart_part_size_bytes = 0) {
+    tgm_error e = tgm_runtime_configure(workers, dispatcher_workers,
+                                        multipart_part_size_bytes);
+    tensogram::detail::check(e);
+}
+
+/// Drain in-flight tasks and return the count that did not finish
+/// within `timeout`.
+inline std::uint64_t runtime_shutdown_blocking(std::chrono::milliseconds timeout) {
+    return tgm_runtime_shutdown_blocking(static_cast<uint64_t>(timeout.count()));
+}
+
+}  // namespace tensogram::async_callback
+
+// ============================================================
+// Helpers exposed back to ::tensogram for friend access
+// ============================================================
+
+namespace tensogram::detail {
+
+/// Construct a `tensogram::message` from a raw FFI handle.  Used by
+/// the async frontend to convert join results.  Uses the `message`'s
+/// private constructor through friend access.
+inline tensogram::message message_from_raw(tgm_message_t* raw) {
+    return tensogram::message(raw);
+}
+
+inline tensogram::metadata metadata_from_raw(tgm_metadata_t* raw) {
+    return tensogram::metadata(raw);
+}
+
+inline std::string error_string(tgm_error err) {
+    const char* s = tgm_error_string(err);
+    return s ? std::string(s) : std::string();
+}
+
+}  // namespace tensogram::detail
+
+#endif  // TENSOGRAM_ASYNC_CALLBACK_HPP

--- a/cpp/include/tensogram/async/callback.hpp
+++ b/cpp/include/tensogram/async/callback.hpp
@@ -21,6 +21,18 @@
 #ifndef TENSOGRAM_ASYNC_CALLBACK_HPP
 #define TENSOGRAM_ASYNC_CALLBACK_HPP
 
+// The async frontends call `tgm_async_*` symbols that exist only when the
+// FFI is built with the `async` Cargo feature.  CMake defines
+// `TENSOGRAM_ASYNC=1` on the `tensogram` target exactly when that build is
+// selected (`-DTENSOGRAM_ASYNC=ON`, the default).  Including an async
+// header in an async-disabled build would otherwise fail at link time with
+// undefined `tgm_async_*` references; fail fast with a clear message
+// instead.  (coro.hpp and std_future.hpp include this header, so the guard
+// covers the whole `async/` family.)
+#if !defined(TENSOGRAM_ASYNC)
+#  error "tensogram/async/*.hpp requires the async build: configure CMake with -DTENSOGRAM_ASYNC=ON (the default), or define TENSOGRAM_ASYNC if you build the FFI with --features=async by hand."
+#endif
+
 #include "../../tensogram.hpp"
 
 #include <chrono>

--- a/cpp/include/tensogram/async/callback.hpp
+++ b/cpp/include/tensogram/async/callback.hpp
@@ -28,7 +28,6 @@
 #include <functional>
 #include <memory>
 #include <string>
-#include <thread>
 #include <utility>
 #include <vector>
 
@@ -139,13 +138,75 @@ namespace detail {
 
 /// Snapshot the FFI's thread-local last-error string into a `std::string`.
 ///
-/// The completion threads each call this immediately after their join
-/// returns an error; the FFI's thread-local error slot is shared with
-/// any tgm_* call on the same OS thread, so the snapshot must happen
-/// before any other FFI call on that thread.
+/// The dispatcher worker calls this immediately after the join
+/// returns an error; the FFI's thread-local error slot is shared
+/// with any tgm_* call on the same OS thread, so the snapshot must
+/// happen before any other FFI call on that thread.
 inline std::string error_message_from_last() {
     const char* m = tgm_last_error();
     return m ? std::string(m) : std::string();
+}
+
+/// State held alive across the FFI completion callback.  When
+/// `tgm_async_task_set_completion` fires, the dispatcher worker
+/// invokes `trampoline(state)` which joins the task, packages the
+/// typed result, and hands it to the user's `cb`.  The state then
+/// frees the task handle and itself.
+template <typename T>
+struct completion_state {
+    std::function<void(result<T>)> cb;
+    tgm_async_task_t* task;
+};
+
+/// Trampoline: invoked by the FFI dispatcher pool when the task
+/// completes.  Templated on the result type and the typed-join
+/// function so we share the framing across every async entry point.
+template <typename T,
+          tgm_error (*JoinFn)(tgm_async_task_t*, T*)>
+inline void trampoline_join_value(void* userdata) noexcept {
+    auto* state = static_cast<completion_state<T>*>(userdata);
+    T raw{};
+    tgm_error e = JoinFn(state->task, &raw);
+    if (e == TGM_ERROR_OK) {
+        state->cb(result<T>::ok_value(std::move(raw)));
+    } else {
+        state->cb(result<T>::err(e, error_message_from_last()));
+    }
+    tgm_async_task_free(state->task);
+    delete state;
+}
+
+/// Trampoline for the void-result case (writes / finishes).
+inline void trampoline_join_void(void* userdata) noexcept {
+    auto* state = static_cast<completion_state<void>*>(userdata);
+    tgm_error e = tgm_async_task_join_void(state->task);
+    if (e == TGM_ERROR_OK) {
+        state->cb(result<void>::ok_value());
+    } else {
+        state->cb(result<void>::err(e, error_message_from_last()));
+    }
+    tgm_async_task_free(state->task);
+    delete state;
+}
+
+/// Register a completion callback on `task` that joins via `JoinFn`,
+/// converts the raw result via `Convert`, and invokes the user `cb`.
+/// Used for results that need post-join transformation
+/// (`tgm_async_file_t*` → `async_file`, `tgm_bytes_t` → vector).
+template <typename UserT, typename RawT,
+          tgm_error (*JoinFn)(tgm_async_task_t*, RawT*),
+          UserT (*Convert)(RawT&&)>
+inline void trampoline_join_convert(void* userdata) noexcept {
+    auto* state = static_cast<completion_state<UserT>*>(userdata);
+    RawT raw{};
+    tgm_error e = JoinFn(state->task, &raw);
+    if (e == TGM_ERROR_OK) {
+        state->cb(result<UserT>::ok_value(Convert(std::move(raw))));
+    } else {
+        state->cb(result<UserT>::err(e, error_message_from_last()));
+    }
+    tgm_async_task_free(state->task);
+    delete state;
 }
 
 }  // namespace detail
@@ -154,6 +215,31 @@ inline std::string error_message_from_last() {
 // async_file
 // ============================================================
 
+namespace detail {
+
+/// Trivial conversion helpers used by `trampoline_join_convert` so each
+/// async entry point can route raw FFI types into the user-facing C++
+/// types without bespoke trampolines.
+inline tensogram::message message_from_raw_handle(tgm_message_t*&& raw) {
+    return tensogram::detail::message_from_raw(raw);
+}
+
+inline tensogram::metadata metadata_from_raw_handle(tgm_metadata_t*&& raw) {
+    return tensogram::detail::metadata_from_raw(raw);
+}
+
+inline std::vector<std::uint8_t> bytes_to_vector(tgm_bytes_t&& b) {
+    std::vector<std::uint8_t> v(b.data, b.data + b.len);
+    tgm_bytes_free(b);
+    return v;
+}
+
+inline std::size_t size_to_size_t(std::uint64_t&& n) {
+    return static_cast<std::size_t>(n);
+}
+
+}  // namespace detail
+
 class async_file {
 public:
     async_file(async_file&&) noexcept = default;
@@ -161,8 +247,8 @@ public:
     async_file(const async_file&) = delete;
     async_file& operator=(const async_file&) = delete;
 
-    /// Open a local file asynchronously.  `cb` is invoked once when
-    /// the open completes (success or failure).
+    /// Open a local file asynchronously.  `cb` is invoked once on the
+    /// FFI dispatcher pool when the open completes.
     ///
     /// `timeout` is in milliseconds; pass `0` for no timeout.
     static void open(const std::string& path,
@@ -179,16 +265,7 @@ public:
             cb(result<async_file>::err(err, detail::error_message_from_last()));
             return;
         }
-        std::thread([task, cb = std::move(cb)]() mutable {
-            tgm_async_file_t* raw = nullptr;
-            tgm_error e = tgm_async_task_join_async_file(task, &raw);
-            if (e == TGM_ERROR_OK) {
-                cb(result<async_file>::ok_value(async_file(raw)));
-            } else {
-                cb(result<async_file>::err(e, detail::error_message_from_last()));
-            }
-            tgm_async_task_free(task);
-        }).detach();
+        register_async_file_completion(task, std::move(cb));
     }
 
     /// Async message-count.
@@ -205,16 +282,12 @@ public:
             cb(result<std::size_t>::err(err, detail::error_message_from_last()));
             return;
         }
-        std::thread([task, cb = std::move(cb)]() mutable {
-            uint64_t n = 0;
-            tgm_error e = tgm_async_task_join_size(task, &n);
-            if (e == TGM_ERROR_OK) {
-                cb(result<std::size_t>::ok_value(static_cast<std::size_t>(n)));
-            } else {
-                cb(result<std::size_t>::err(e, detail::error_message_from_last()));
-            }
-            tgm_async_task_free(task);
-        }).detach();
+        auto* state = new detail::completion_state<std::size_t>{std::move(cb), task};
+        tgm_async_task_set_completion(
+            task,
+            &detail::trampoline_join_convert<std::size_t, std::uint64_t,
+                &tgm_async_task_join_size, &detail::size_to_size_t>,
+            state);
     }
 
     /// Async decode of message at `index`, returning a `tensogram::message`.
@@ -236,17 +309,12 @@ public:
             cb(result<tensogram::message>::err(err, detail::error_message_from_last()));
             return;
         }
-        std::thread([task, cb = std::move(cb)]() mutable {
-            tgm_message_t* raw = nullptr;
-            tgm_error e = tgm_async_task_join_message(task, &raw);
-            if (e == TGM_ERROR_OK) {
-                cb(result<tensogram::message>::ok_value(
-                    tensogram::detail::message_from_raw(raw)));
-            } else {
-                cb(result<tensogram::message>::err(e, detail::error_message_from_last()));
-            }
-            tgm_async_task_free(task);
-        }).detach();
+        auto* state = new detail::completion_state<tensogram::message>{std::move(cb), task};
+        tgm_async_task_set_completion(
+            task,
+            &detail::trampoline_join_convert<tensogram::message, tgm_message_t*,
+                &tgm_async_task_join_message, &detail::message_from_raw_handle>,
+            state);
     }
 
     /// Async decode of metadata only.
@@ -264,17 +332,12 @@ public:
             cb(result<tensogram::metadata>::err(err, detail::error_message_from_last()));
             return;
         }
-        std::thread([task, cb = std::move(cb)]() mutable {
-            tgm_metadata_t* raw = nullptr;
-            tgm_error e = tgm_async_task_join_metadata(task, &raw);
-            if (e == TGM_ERROR_OK) {
-                cb(result<tensogram::metadata>::ok_value(
-                    tensogram::detail::metadata_from_raw(raw)));
-            } else {
-                cb(result<tensogram::metadata>::err(e, detail::error_message_from_last()));
-            }
-            tgm_async_task_free(task);
-        }).detach();
+        auto* state = new detail::completion_state<tensogram::metadata>{std::move(cb), task};
+        tgm_async_task_set_completion(
+            task,
+            &detail::trampoline_join_convert<tensogram::metadata, tgm_metadata_t*,
+                &tgm_async_task_join_metadata, &detail::metadata_from_raw_handle>,
+            state);
     }
 
     /// Async raw read of message bytes.
@@ -292,18 +355,13 @@ public:
             cb(result<std::vector<std::uint8_t>>::err(err, detail::error_message_from_last()));
             return;
         }
-        std::thread([task, cb = std::move(cb)]() mutable {
-            tgm_bytes_t b{nullptr, 0};
-            tgm_error e = tgm_async_task_join_bytes(task, &b);
-            if (e == TGM_ERROR_OK) {
-                std::vector<std::uint8_t> v(b.data, b.data + b.len);
-                tgm_bytes_free(b);
-                cb(result<std::vector<std::uint8_t>>::ok_value(std::move(v)));
-            } else {
-                cb(result<std::vector<std::uint8_t>>::err(e, detail::error_message_from_last()));
-            }
-            tgm_async_task_free(task);
-        }).detach();
+        auto* state = new detail::completion_state<std::vector<std::uint8_t>>{
+            std::move(cb), task};
+        tgm_async_task_set_completion(
+            task,
+            &detail::trampoline_join_convert<std::vector<std::uint8_t>, tgm_bytes_t,
+                &tgm_async_task_join_bytes, &detail::bytes_to_vector>,
+            state);
     }
 
     /// Internal helper: raw FFI handle.  Reserved for the
@@ -316,6 +374,34 @@ private:
 
     explicit async_file(tgm_async_file_t* raw)
         : handle_(raw, &tgm_async_file_close) {}
+
+    /// Inline-defined here so the trampoline can construct an
+    /// `async_file` from a raw FFI handle without exposing the
+    /// constructor publicly.
+    static void register_async_file_completion(
+        tgm_async_task_t* task,
+        std::function<void(result<async_file>)> cb) {
+        struct State {
+            std::function<void(result<async_file>)> cb;
+            tgm_async_task_t* task;
+        };
+        auto* state = new State{std::move(cb), task};
+        tgm_async_task_set_completion(
+            task,
+            [](void* userdata) noexcept {
+                auto* s = static_cast<State*>(userdata);
+                tgm_async_file_t* raw = nullptr;
+                tgm_error e = tgm_async_task_join_async_file(s->task, &raw);
+                if (e == TGM_ERROR_OK) {
+                    s->cb(result<async_file>::ok_value(async_file(raw)));
+                } else {
+                    s->cb(result<async_file>::err(e, detail::error_message_from_last()));
+                }
+                tgm_async_task_free(s->task);
+                delete s;
+            },
+            state);
+    }
 };
 
 // ============================================================
@@ -330,7 +416,8 @@ public:
     async_streaming_encoder& operator=(const async_streaming_encoder&) = delete;
 
     /// Create an async streaming encoder writing to a local file.
-    /// `cb` fires once with the constructed handle (or an error).
+    /// `cb` fires once on the FFI dispatcher pool with the
+    /// constructed handle (or an error).
     static void create(const std::string& path,
                        const std::string& metadata_json,
                        std::function<void(result<async_streaming_encoder>)> cb,
@@ -351,18 +438,28 @@ public:
             cb(result<async_streaming_encoder>::err(err, detail::error_message_from_last()));
             return;
         }
-        std::thread([task, cb = std::move(cb)]() mutable {
-            tgm_async_streaming_encoder_t* raw = nullptr;
-            tgm_error e = tgm_async_task_join_async_streaming_encoder(task, &raw);
-            if (e == TGM_ERROR_OK) {
-                cb(result<async_streaming_encoder>::ok_value(
-                    async_streaming_encoder(raw)));
-            } else {
-                cb(result<async_streaming_encoder>::err(
-                    e, detail::error_message_from_last()));
-            }
-            tgm_async_task_free(task);
-        }).detach();
+        struct State {
+            std::function<void(result<async_streaming_encoder>)> cb;
+            tgm_async_task_t* task;
+        };
+        auto* state = new State{std::move(cb), task};
+        tgm_async_task_set_completion(
+            task,
+            [](void* userdata) noexcept {
+                auto* s = static_cast<State*>(userdata);
+                tgm_async_streaming_encoder_t* raw = nullptr;
+                tgm_error e = tgm_async_task_join_async_streaming_encoder(s->task, &raw);
+                if (e == TGM_ERROR_OK) {
+                    s->cb(result<async_streaming_encoder>::ok_value(
+                        async_streaming_encoder(raw)));
+                } else {
+                    s->cb(result<async_streaming_encoder>::err(
+                        e, detail::error_message_from_last()));
+                }
+                tgm_async_task_free(s->task);
+                delete s;
+            },
+            state);
     }
 
     /// Async write of an encoded data object.  `cb` fires with void
@@ -453,15 +550,8 @@ private:
             cb(result<void>::err(err, detail::error_message_from_last()));
             return;
         }
-        std::thread([task, cb_inner = std::move(cb)]() mutable {
-            tgm_error e = tgm_async_task_join_void(task);
-            if (e == TGM_ERROR_OK) {
-                cb_inner(result<void>::ok_value());
-            } else {
-                cb_inner(result<void>::err(e, detail::error_message_from_last()));
-            }
-            tgm_async_task_free(task);
-        }).detach();
+        auto* state = new detail::completion_state<void>{std::move(cb), task};
+        tgm_async_task_set_completion(task, &detail::trampoline_join_void, state);
     }
 };
 

--- a/cpp/include/tensogram/async/callback.hpp
+++ b/cpp/include/tensogram/async/callback.hpp
@@ -530,8 +530,40 @@ public:
         launch_void_completion(task, err, std::move(cb));
     }
 
-    /// Best-effort object-count snapshot.  Returns `static_cast<std::size_t>(-1)`
-    /// if the encoder is currently busy with another in-flight call.
+    /// Outcome of `try_object_count`.  Distinguishes the four cases
+    /// the convenience accessor (`object_count`) collapses to a
+    /// single `static_cast<std::size_t>(-1)` sentinel.
+    enum class object_count_status {
+        ok = 0,           ///< `value` is the current object count.
+        null_handle = 1,  ///< Handle is null/invalid.
+        busy = 2,         ///< Encoder locked by another in-flight call.
+        finished = 3,     ///< `finish` already consumed the encoder.
+    };
+
+    /// Discriminated `try` accessor: returns both the status and (if
+    /// `status == ok`) the current count.  Use this in preference to
+    /// `object_count()` when you need to distinguish "0 written" from
+    /// "busy" or "finished".
+    struct object_count_result {
+        object_count_status status;
+        std::size_t value;
+    };
+
+    [[nodiscard]] object_count_result try_object_count() const noexcept {
+        std::size_t count = 0;
+        TgmObjectCountStatus s =
+            tgm_async_streaming_encoder_try_object_count(handle_.get(), &count);
+        return object_count_result{
+            static_cast<object_count_status>(static_cast<int>(s)),
+            count,
+        };
+    }
+
+    /// Best-effort object-count snapshot.  Returns
+    /// `static_cast<std::size_t>(-1)` if the handle is null, the
+    /// encoder is currently busy with another in-flight call, or
+    /// `finish` has already been called.  See `try_object_count`
+    /// for a typed version that distinguishes those cases.
     [[nodiscard]] std::size_t object_count() const noexcept {
         return tgm_async_streaming_encoder_object_count(handle_.get());
     }

--- a/cpp/include/tensogram/async/coro.hpp
+++ b/cpp/include/tensogram/async/coro.hpp
@@ -51,27 +51,9 @@ namespace tensogram::coro {
 
 namespace tac = tensogram::async_callback;
 
-namespace detail {
-
-inline void throw_for_error(tgm_error code, const std::string& message) {
-    switch (code) {
-        case TGM_ERROR_FRAMING:       throw tensogram::framing_error(code, message);
-        case TGM_ERROR_METADATA:      throw tensogram::metadata_error(code, message);
-        case TGM_ERROR_ENCODING:      throw tensogram::encoding_error(code, message);
-        case TGM_ERROR_COMPRESSION:   throw tensogram::compression_error(code, message);
-        case TGM_ERROR_OBJECT:        throw tensogram::object_error(code, message);
-        case TGM_ERROR_IO:            throw tensogram::io_error(code, message);
-        case TGM_ERROR_HASH_MISMATCH: throw tensogram::hash_mismatch_error(code, message);
-        case TGM_ERROR_MISSING_HASH:  throw tensogram::missing_hash_error(code, message);
-        case TGM_ERROR_INVALID_ARG:   throw tensogram::invalid_arg_error(code, message);
-        case TGM_ERROR_REMOTE:        throw tensogram::remote_error(code, message);
-        case TGM_ERROR_TIMEOUT:       throw tensogram::timeout_error(code, message);
-        case TGM_ERROR_CANCELLED:     throw tensogram::cancelled_error(code, message);
-        default:                      throw tensogram::error(code, message);
-    }
-}
-
-}  // namespace detail
+// `throw_for_error` lives in `tensogram::detail` so all async frontends
+// share a single typed-exception dispatch (single source of truth).
+// See `tensogram.hpp` → `detail::throw_for_code`.
 
 // ============================================================
 // awaiter<T> — wraps a callback-style async operation
@@ -106,7 +88,7 @@ public:
     T await_resume() {
         std::lock_guard lock(state_->mtx);
         if (state_->code != TGM_ERROR_OK) {
-            detail::throw_for_error(state_->code, state_->error_message);
+            tensogram::detail::throw_for_code(state_->code, state_->error_message);
         }
         return std::move(*state_->value);
     }
@@ -127,7 +109,7 @@ public:
             lock.lock();
         }
         if (state_->code != TGM_ERROR_OK) {
-            detail::throw_for_error(state_->code, state_->error_message);
+            tensogram::detail::throw_for_code(state_->code, state_->error_message);
         }
         return std::move(*state_->value);
     }
@@ -164,7 +146,7 @@ public:
     void await_resume() {
         std::lock_guard lock(state_->mtx);
         if (state_->code != TGM_ERROR_OK) {
-            detail::throw_for_error(state_->code, state_->error_message);
+            tensogram::detail::throw_for_code(state_->code, state_->error_message);
         }
     }
     void sync_get() {
@@ -175,7 +157,7 @@ public:
             lock.lock();
         }
         if (state_->code != TGM_ERROR_OK) {
-            detail::throw_for_error(state_->code, state_->error_message);
+            tensogram::detail::throw_for_code(state_->code, state_->error_message);
         }
     }
 

--- a/cpp/include/tensogram/async/coro.hpp
+++ b/cpp/include/tensogram/async/coro.hpp
@@ -1,0 +1,587 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 ECMWF
+
+/// @file tensogram/async/coro.hpp
+/// @brief C++20 coroutine frontend (PR 5 of the cpp-async plan).
+///
+/// Two types are provided:
+///
+///   * `task<T>` — a proper coroutine return type.  Users write
+///     `task<int> my_func() { co_return 42; }` and other functions
+///     can `co_await my_func()`.  Lazy: nothing happens until awaited.
+///
+///   * `awaiter<T>` — what the async I/O methods return.  Itself
+///     awaitable; suspends until the underlying FFI task resolves.
+///     Users typically don't construct these directly.
+///
+/// Plan: `plans/PLAN_CPP_ASYNC.md` §4.2.
+
+#ifndef TENSOGRAM_ASYNC_CORO_HPP
+#define TENSOGRAM_ASYNC_CORO_HPP
+
+#if __cplusplus < 202002L
+#  error "tensogram/async/coro.hpp requires C++20 (-std=c++20). Use tensogram/async/callback.hpp on C++17."
+#endif
+
+#include "callback.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <coroutine>
+#include <exception>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <thread>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace tensogram::coro {
+
+namespace tac = tensogram::async_callback;
+
+namespace detail {
+
+inline void throw_for_error(tgm_error code, const std::string& message) {
+    switch (code) {
+        case TGM_ERROR_FRAMING:       throw tensogram::framing_error(code, message);
+        case TGM_ERROR_METADATA:      throw tensogram::metadata_error(code, message);
+        case TGM_ERROR_ENCODING:      throw tensogram::encoding_error(code, message);
+        case TGM_ERROR_COMPRESSION:   throw tensogram::compression_error(code, message);
+        case TGM_ERROR_OBJECT:        throw tensogram::object_error(code, message);
+        case TGM_ERROR_IO:            throw tensogram::io_error(code, message);
+        case TGM_ERROR_HASH_MISMATCH: throw tensogram::hash_mismatch_error(code, message);
+        case TGM_ERROR_MISSING_HASH:  throw tensogram::missing_hash_error(code, message);
+        case TGM_ERROR_INVALID_ARG:   throw tensogram::invalid_arg_error(code, message);
+        case TGM_ERROR_REMOTE:        throw tensogram::remote_error(code, message);
+        case TGM_ERROR_TIMEOUT:       throw tensogram::timeout_error(code, message);
+        case TGM_ERROR_CANCELLED:     throw tensogram::cancelled_error(code, message);
+        default:                      throw tensogram::error(code, message);
+    }
+}
+
+}  // namespace detail
+
+// ============================================================
+// awaiter<T> — wraps a callback-style async operation
+// ============================================================
+
+template <typename T>
+class awaiter {
+public:
+    struct shared_state {
+        std::mutex mtx;
+        std::optional<T> value;
+        tgm_error code = TGM_ERROR_OK;
+        std::string error_message;
+        bool ready = false;
+        std::coroutine_handle<> awaiter_handle;
+    };
+
+    explicit awaiter(std::shared_ptr<shared_state> s) : state_(std::move(s)) {}
+
+    bool await_ready() const noexcept {
+        std::lock_guard lock(state_->mtx);
+        return state_->ready;
+    }
+    void await_suspend(std::coroutine_handle<> h) noexcept {
+        std::lock_guard lock(state_->mtx);
+        if (state_->ready) {
+            h.resume();
+        } else {
+            state_->awaiter_handle = h;
+        }
+    }
+    T await_resume() {
+        std::lock_guard lock(state_->mtx);
+        if (state_->code != TGM_ERROR_OK) {
+            detail::throw_for_error(state_->code, state_->error_message);
+        }
+        return std::move(*state_->value);
+    }
+
+    /// Synchronously block the calling thread until ready.  Used by
+    /// the block_on adapter and when_all when the value is needed
+    /// outside a coroutine.
+    T sync_get() {
+        std::unique_lock lock(state_->mtx);
+        // Wait via spin-yield since shared_state has no condvar; fine
+        // for top-level entry but we add a condvar for efficiency
+        // when polling many awaiters in when_all.
+        // We ship a separate condvar by promoting the awaiter to the
+        // block_on variant where needed.
+        while (!state_->ready) {
+            lock.unlock();
+            std::this_thread::yield();
+            lock.lock();
+        }
+        if (state_->code != TGM_ERROR_OK) {
+            detail::throw_for_error(state_->code, state_->error_message);
+        }
+        return std::move(*state_->value);
+    }
+
+private:
+    std::shared_ptr<shared_state> state_;
+};
+
+template <>
+class awaiter<void> {
+public:
+    struct shared_state {
+        std::mutex mtx;
+        tgm_error code = TGM_ERROR_OK;
+        std::string error_message;
+        bool ready = false;
+        std::coroutine_handle<> awaiter_handle;
+    };
+
+    explicit awaiter(std::shared_ptr<shared_state> s) : state_(std::move(s)) {}
+
+    bool await_ready() const noexcept {
+        std::lock_guard lock(state_->mtx);
+        return state_->ready;
+    }
+    void await_suspend(std::coroutine_handle<> h) noexcept {
+        std::lock_guard lock(state_->mtx);
+        if (state_->ready) {
+            h.resume();
+        } else {
+            state_->awaiter_handle = h;
+        }
+    }
+    void await_resume() {
+        std::lock_guard lock(state_->mtx);
+        if (state_->code != TGM_ERROR_OK) {
+            detail::throw_for_error(state_->code, state_->error_message);
+        }
+    }
+    void sync_get() {
+        std::unique_lock lock(state_->mtx);
+        while (!state_->ready) {
+            lock.unlock();
+            std::this_thread::yield();
+            lock.lock();
+        }
+        if (state_->code != TGM_ERROR_OK) {
+            detail::throw_for_error(state_->code, state_->error_message);
+        }
+    }
+
+private:
+    std::shared_ptr<shared_state> state_;
+};
+
+namespace detail {
+
+template <typename T, typename Launcher>
+inline awaiter<T> launch_awaiter(Launcher&& launch) {
+    auto state = std::make_shared<typename awaiter<T>::shared_state>();
+    auto state_capture = state;
+    launch([state_capture](tac::result<T> r) mutable {
+        std::coroutine_handle<> h_to_resume;
+        {
+            std::lock_guard lock(state_capture->mtx);
+            if (r.ok()) {
+                state_capture->value = r.take();
+            } else {
+                state_capture->code = r.code();
+                state_capture->error_message = r.message();
+            }
+            state_capture->ready = true;
+            h_to_resume = state_capture->awaiter_handle;
+            state_capture->awaiter_handle = nullptr;
+        }
+        if (h_to_resume) h_to_resume.resume();
+    });
+    return awaiter<T>(state);
+}
+
+template <typename Launcher>
+inline awaiter<void> launch_void_awaiter(Launcher&& launch) {
+    auto state = std::make_shared<awaiter<void>::shared_state>();
+    auto state_capture = state;
+    launch([state_capture](tac::result<void> r) mutable {
+        std::coroutine_handle<> h_to_resume;
+        {
+            std::lock_guard lock(state_capture->mtx);
+            if (!r.ok()) {
+                state_capture->code = r.code();
+                state_capture->error_message = r.message();
+            }
+            state_capture->ready = true;
+            h_to_resume = state_capture->awaiter_handle;
+            state_capture->awaiter_handle = nullptr;
+        }
+        if (h_to_resume) h_to_resume.resume();
+    });
+    return awaiter<void>(state);
+}
+
+}  // namespace detail
+
+// ============================================================
+// task<T> — coroutine return type
+// ============================================================
+
+template <typename T>
+struct task;
+
+namespace detail {
+
+template <typename T>
+struct task_promise_base {
+    std::mutex mtx;
+    std::condition_variable cv;
+    bool ready = false;
+    std::exception_ptr ex;
+    std::coroutine_handle<> continuation;
+
+    struct final_awaiter {
+        bool await_ready() noexcept { return false; }
+        template <typename Promise>
+        std::coroutine_handle<> await_suspend(std::coroutine_handle<Promise> h) noexcept {
+            auto& promise = h.promise();
+            std::coroutine_handle<> cont;
+            {
+                std::lock_guard lock(promise.mtx);
+                promise.ready = true;
+                cont = promise.continuation;
+            }
+            promise.cv.notify_all();
+            if (cont) return cont;
+            return std::noop_coroutine();
+        }
+        void await_resume() noexcept {}
+    };
+
+    std::suspend_always initial_suspend() noexcept { return {}; }
+    final_awaiter final_suspend() noexcept { return {}; }
+    void unhandled_exception() {
+        std::lock_guard lock(mtx);
+        ex = std::current_exception();
+    }
+};
+
+}  // namespace detail
+
+template <typename T>
+struct task {
+    struct promise_type : detail::task_promise_base<T> {
+        std::optional<T> value;
+        task get_return_object() {
+            return task{std::coroutine_handle<promise_type>::from_promise(*this)};
+        }
+        void return_value(T v) {
+            std::lock_guard lock(this->mtx);
+            value = std::move(v);
+        }
+    };
+
+    using handle_type = std::coroutine_handle<promise_type>;
+
+    explicit task(handle_type h) : handle_(h) {}
+    task(const task&) = delete;
+    task& operator=(const task&) = delete;
+    task(task&& other) noexcept : handle_(other.handle_) { other.handle_ = nullptr; }
+    task& operator=(task&& other) noexcept {
+        if (this != &other) {
+            if (handle_) handle_.destroy();
+            handle_ = other.handle_;
+            other.handle_ = nullptr;
+        }
+        return *this;
+    }
+    ~task() { if (handle_) handle_.destroy(); }
+
+    bool await_ready() const noexcept { return false; }
+
+    std::coroutine_handle<> await_suspend(std::coroutine_handle<> awaiter_h) {
+        auto& promise = handle_.promise();
+        std::lock_guard lock(promise.mtx);
+        if (promise.ready) return awaiter_h;
+        promise.continuation = awaiter_h;
+        return handle_;
+    }
+
+    T await_resume() {
+        auto& promise = handle_.promise();
+        if (promise.ex) std::rethrow_exception(promise.ex);
+        return std::move(*promise.value);
+    }
+
+    /// Synchronously run the task to completion on the calling thread.
+    T sync_run() {
+        // Run the coroutine to completion by resuming until ready.
+        // initial_suspend is suspend_always so we kick it off here.
+        handle_.resume();
+        auto& promise = handle_.promise();
+        std::unique_lock lock(promise.mtx);
+        promise.cv.wait(lock, [&] { return promise.ready; });
+        if (promise.ex) std::rethrow_exception(promise.ex);
+        return std::move(*promise.value);
+    }
+
+private:
+    handle_type handle_;
+};
+
+// task<void> specialization
+template <>
+struct task<void> {
+    struct promise_type : detail::task_promise_base<void> {
+        task get_return_object() {
+            return task{std::coroutine_handle<promise_type>::from_promise(*this)};
+        }
+        void return_void() {
+            std::lock_guard lock(this->mtx);
+        }
+    };
+
+    using handle_type = std::coroutine_handle<promise_type>;
+
+    explicit task(handle_type h) : handle_(h) {}
+    task(const task&) = delete;
+    task& operator=(const task&) = delete;
+    task(task&& other) noexcept : handle_(other.handle_) { other.handle_ = nullptr; }
+    task& operator=(task&& other) noexcept {
+        if (this != &other) {
+            if (handle_) handle_.destroy();
+            handle_ = other.handle_;
+            other.handle_ = nullptr;
+        }
+        return *this;
+    }
+    ~task() { if (handle_) handle_.destroy(); }
+
+    bool await_ready() const noexcept { return false; }
+    std::coroutine_handle<> await_suspend(std::coroutine_handle<> awaiter_h) {
+        auto& promise = handle_.promise();
+        std::lock_guard lock(promise.mtx);
+        if (promise.ready) return awaiter_h;
+        promise.continuation = awaiter_h;
+        return handle_;
+    }
+    void await_resume() {
+        auto& promise = handle_.promise();
+        if (promise.ex) std::rethrow_exception(promise.ex);
+    }
+
+    void sync_run() {
+        handle_.resume();
+        auto& promise = handle_.promise();
+        std::unique_lock lock(promise.mtx);
+        promise.cv.wait(lock, [&] { return promise.ready; });
+        if (promise.ex) std::rethrow_exception(promise.ex);
+    }
+
+private:
+    handle_type handle_;
+};
+
+/// Synchronously run a `task<T>` to completion on the calling thread.
+template <typename T>
+inline T block_on(task<T> t) {
+    return t.sync_run();
+}
+
+inline void block_on(task<void> t) {
+    t.sync_run();
+}
+
+// ============================================================
+// async_file — coroutine-friendly file handle
+// ============================================================
+
+class async_file {
+public:
+    [[nodiscard]] static awaiter<async_file> open(
+        const std::string& path,
+        tac::cancellation_token* token = nullptr,
+        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) {
+        return detail::launch_awaiter<async_file>([path, token, timeout](auto cb) {
+            tac::async_file::open(path,
+                [cb = std::move(cb)](tac::result<tac::async_file> r) mutable {
+                    if (r.ok()) {
+                        cb(tac::result<async_file>::ok_value(async_file(r.take())));
+                    } else {
+                        cb(tac::result<async_file>::err(r.code(), r.message()));
+                    }
+                }, token, timeout);
+        });
+    }
+
+    [[nodiscard]] awaiter<std::size_t> message_count(
+        tac::cancellation_token* token = nullptr,
+        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) const {
+        auto inner = inner_;
+        return detail::launch_awaiter<std::size_t>([inner, token, timeout](auto cb) {
+            inner->message_count(std::move(cb), token, timeout);
+        });
+    }
+
+    [[nodiscard]] awaiter<tensogram::message> decode_message(
+        std::size_t index,
+        tac::cancellation_token* token = nullptr,
+        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) const {
+        auto inner = inner_;
+        return detail::launch_awaiter<tensogram::message>([inner, index, token, timeout](auto cb) {
+            inner->decode_message(index, std::move(cb), token, timeout);
+        });
+    }
+
+    [[nodiscard]] awaiter<tensogram::metadata> decode_metadata(
+        std::size_t index,
+        tac::cancellation_token* token = nullptr,
+        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) const {
+        auto inner = inner_;
+        return detail::launch_awaiter<tensogram::metadata>(
+            [inner, index, token, timeout](auto cb) {
+                inner->decode_metadata(index, std::move(cb), token, timeout);
+            });
+    }
+
+    [[nodiscard]] awaiter<std::vector<std::uint8_t>> read_message(
+        std::size_t index,
+        tac::cancellation_token* token = nullptr,
+        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) const {
+        auto inner = inner_;
+        return detail::launch_awaiter<std::vector<std::uint8_t>>(
+            [inner, index, token, timeout](auto cb) {
+                inner->read_message(index, std::move(cb), token, timeout);
+            });
+    }
+
+    async_file(async_file&&) noexcept = default;
+    async_file& operator=(async_file&&) noexcept = default;
+    async_file(const async_file&) = delete;
+    async_file& operator=(const async_file&) = delete;
+
+private:
+    explicit async_file(tac::async_file inner)
+        : inner_(std::make_shared<tac::async_file>(std::move(inner))) {}
+    std::shared_ptr<tac::async_file> inner_;
+};
+
+// ============================================================
+// async_streaming_encoder
+// ============================================================
+
+class async_streaming_encoder {
+public:
+    [[nodiscard]] static awaiter<async_streaming_encoder> create(
+        const std::string& path,
+        const std::string& metadata_json,
+        const std::string& hash_algo = "xxh3",
+        std::uint32_t threads = 0,
+        tac::cancellation_token* token = nullptr,
+        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) {
+        return detail::launch_awaiter<async_streaming_encoder>(
+            [path, metadata_json, hash_algo, threads, token, timeout](auto cb) {
+                tac::async_streaming_encoder::create(path, metadata_json,
+                    [cb = std::move(cb)](tac::result<tac::async_streaming_encoder> r) mutable {
+                        if (r.ok()) {
+                            cb(tac::result<async_streaming_encoder>::ok_value(
+                                async_streaming_encoder(r.take())));
+                        } else {
+                            cb(tac::result<async_streaming_encoder>::err(r.code(), r.message()));
+                        }
+                    }, hash_algo, threads, token, timeout);
+            });
+    }
+
+    [[nodiscard]] awaiter<void> write_object(
+        const std::string& descriptor_json,
+        const std::uint8_t* data, std::size_t len,
+        tac::cancellation_token* token = nullptr,
+        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) {
+        auto inner = inner_;
+        return detail::launch_void_awaiter(
+            [inner, descriptor_json, data, len, token, timeout](auto cb) {
+                inner->write_object(descriptor_json, data, len, std::move(cb), token, timeout);
+            });
+    }
+
+    [[nodiscard]] awaiter<void> write_pre_encoded(
+        const std::string& descriptor_json,
+        const std::uint8_t* data, std::size_t len,
+        tac::cancellation_token* token = nullptr,
+        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) {
+        auto inner = inner_;
+        return detail::launch_void_awaiter(
+            [inner, descriptor_json, data, len, token, timeout](auto cb) {
+                inner->write_pre_encoded(descriptor_json, data, len, std::move(cb),
+                                         token, timeout);
+            });
+    }
+
+    [[nodiscard]] awaiter<void> write_preceder(
+        const std::string& metadata_json,
+        tac::cancellation_token* token = nullptr,
+        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) {
+        auto inner = inner_;
+        return detail::launch_void_awaiter(
+            [inner, metadata_json, token, timeout](auto cb) {
+                inner->write_preceder(metadata_json, std::move(cb), token, timeout);
+            });
+    }
+
+    [[nodiscard]] awaiter<void> finish(
+        bool backfill = true,
+        tac::cancellation_token* token = nullptr,
+        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) {
+        auto inner = inner_;
+        return detail::launch_void_awaiter([inner, backfill, token, timeout](auto cb) {
+            inner->finish(std::move(cb), backfill, token, timeout);
+        });
+    }
+
+    [[nodiscard]] std::size_t object_count() const noexcept {
+        return inner_->object_count();
+    }
+
+    async_streaming_encoder(async_streaming_encoder&&) noexcept = default;
+    async_streaming_encoder& operator=(async_streaming_encoder&&) noexcept = default;
+    async_streaming_encoder(const async_streaming_encoder&) = delete;
+    async_streaming_encoder& operator=(const async_streaming_encoder&) = delete;
+
+private:
+    explicit async_streaming_encoder(tac::async_streaming_encoder inner)
+        : inner_(std::make_shared<tac::async_streaming_encoder>(std::move(inner))) {}
+    std::shared_ptr<tac::async_streaming_encoder> inner_;
+};
+
+// ============================================================
+// async_for_each — drive a coroutine over every message in a file
+// ============================================================
+
+/// Apply `fn` to every decoded message in `file`.  `fn` is called with
+/// each `tensogram::message` in sequence; if `fn` returns `bool`,
+/// iteration stops on `false`.  See plan Q9.
+template <typename Fn>
+[[nodiscard]] inline task<void> async_for_each(async_file& file, Fn fn) {
+    std::size_t n = co_await file.message_count();
+    for (std::size_t i = 0; i < n; ++i) {
+        auto msg = co_await file.decode_message(i);
+        if constexpr (std::is_same_v<std::invoke_result_t<Fn, tensogram::message>, bool>) {
+            if (!fn(std::move(msg))) co_return;
+        } else {
+            fn(std::move(msg));
+        }
+    }
+}
+
+}  // namespace tensogram::coro
+
+#endif  // TENSOGRAM_ASYNC_CORO_HPP

--- a/cpp/include/tensogram/async/coro.hpp
+++ b/cpp/include/tensogram/async/coro.hpp
@@ -383,6 +383,29 @@ public:
         });
     }
 
+    /// Open a remote `.tgm` (S3 / GCS / Azure / HTTP / `file://`).
+    /// See `tensogram::async_callback::async_file::open_remote` for
+    /// the `storage_options` / `bidirectional` semantics and the
+    /// `async-remote` feature requirement.
+    [[nodiscard]] static awaiter<async_file> open_remote(
+        const std::string& url,
+        const std::vector<std::pair<std::string, std::string>>& storage_options,
+        bool bidirectional,
+        tac::cancellation_token* token = nullptr,
+        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) {
+        return detail::launch_awaiter<async_file>(
+            [url, storage_options, bidirectional, token, timeout](auto cb) {
+                tac::async_file::open_remote(url, storage_options, bidirectional,
+                    [cb = std::move(cb)](tac::result<tac::async_file> r) mutable {
+                        if (r.ok()) {
+                            cb(tac::result<async_file>::ok_value(async_file(r.take())));
+                        } else {
+                            cb(tac::result<async_file>::err(r.code(), r.message()));
+                        }
+                    }, token, timeout);
+            });
+    }
+
     [[nodiscard]] awaiter<std::size_t> message_count(
         tac::cancellation_token* token = nullptr,
         std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) const {

--- a/cpp/include/tensogram/async/coro.hpp
+++ b/cpp/include/tensogram/async/coro.hpp
@@ -77,16 +77,28 @@ public:
         std::lock_guard lock(state_->mtx);
         return state_->ready;
     }
-    void await_suspend(std::coroutine_handle<> h) noexcept {
+    /// Returns `false` to skip suspension when the producer has
+    /// already resolved the awaiter — that path used to call
+    /// `h.resume()` *while still holding* `state_->mtx`, which
+    /// deadlocked because the resumed coroutine immediately enters
+    /// `await_resume()` and tries to lock the same mutex.
+    /// The bool form lets us avoid suspending entirely; the resume
+    /// path then runs without any lock involvement.
+    bool await_suspend(std::coroutine_handle<> h) noexcept {
         std::lock_guard lock(state_->mtx);
         if (state_->ready) {
-            h.resume();
-        } else {
-            state_->awaiter_handle = h;
+            return false;  // skip suspension; await_resume runs next
         }
+        state_->awaiter_handle = h;
+        return true;
     }
     T await_resume() {
-        std::lock_guard lock(state_->mtx);
+        // Lock-free read: by the time await_resume runs, either we
+        // returned `false` from await_suspend (no other thread
+        // touches `state_` at this point), or `complete()` finished
+        // setting `ready = true` and `awaiter_handle = nullptr`
+        // before resuming us.  In both cases the fields below are
+        // safe to read without the mutex.
         if (state_->code != TGM_ERROR_OK) {
             tensogram::detail::throw_for_code(state_->code, state_->error_message);
         }
@@ -135,16 +147,18 @@ public:
         std::lock_guard lock(state_->mtx);
         return state_->ready;
     }
-    void await_suspend(std::coroutine_handle<> h) noexcept {
+    /// See `awaiter<T>::await_suspend` — the bool return avoids the
+    /// deadlock where resuming under the lock would re-enter
+    /// `await_resume()`'s lock attempt.
+    bool await_suspend(std::coroutine_handle<> h) noexcept {
         std::lock_guard lock(state_->mtx);
         if (state_->ready) {
-            h.resume();
-        } else {
-            state_->awaiter_handle = h;
+            return false;
         }
+        state_->awaiter_handle = h;
+        return true;
     }
     void await_resume() {
-        std::lock_guard lock(state_->mtx);
         if (state_->code != TGM_ERROR_OK) {
             tensogram::detail::throw_for_code(state_->code, state_->error_message);
         }

--- a/cpp/include/tensogram/async/coro.hpp
+++ b/cpp/include/tensogram/async/coro.hpp
@@ -508,6 +508,15 @@ public:
         });
     }
 
+    using object_count_status = tac::async_streaming_encoder::object_count_status;
+    using object_count_result = tac::async_streaming_encoder::object_count_result;
+
+    /// Discriminated try-accessor.  See
+    /// `tac::async_streaming_encoder::try_object_count`.
+    [[nodiscard]] object_count_result try_object_count() const noexcept {
+        return inner_->try_object_count();
+    }
+
     [[nodiscard]] std::size_t object_count() const noexcept {
         return inner_->object_count();
     }

--- a/cpp/include/tensogram/async/coro.hpp
+++ b/cpp/include/tensogram/async/coro.hpp
@@ -33,16 +33,13 @@
 
 #include "callback.hpp"
 
-#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <coroutine>
 #include <exception>
-#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
-#include <thread>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -105,27 +102,6 @@ public:
         return std::move(*state_->value);
     }
 
-    /// Synchronously block the calling thread until ready.  Used by
-    /// the block_on adapter and when_all when the value is needed
-    /// outside a coroutine.
-    T sync_get() {
-        std::unique_lock lock(state_->mtx);
-        // Wait via spin-yield since shared_state has no condvar; fine
-        // for top-level entry but we add a condvar for efficiency
-        // when polling many awaiters in when_all.
-        // We ship a separate condvar by promoting the awaiter to the
-        // block_on variant where needed.
-        while (!state_->ready) {
-            lock.unlock();
-            std::this_thread::yield();
-            lock.lock();
-        }
-        if (state_->code != TGM_ERROR_OK) {
-            tensogram::detail::throw_for_code(state_->code, state_->error_message);
-        }
-        return std::move(*state_->value);
-    }
-
 private:
     std::shared_ptr<shared_state> state_;
 };
@@ -159,17 +135,6 @@ public:
         return true;
     }
     void await_resume() {
-        if (state_->code != TGM_ERROR_OK) {
-            tensogram::detail::throw_for_code(state_->code, state_->error_message);
-        }
-    }
-    void sync_get() {
-        std::unique_lock lock(state_->mtx);
-        while (!state_->ready) {
-            lock.unlock();
-            std::this_thread::yield();
-            lock.lock();
-        }
         if (state_->code != TGM_ERROR_OK) {
             tensogram::detail::throw_for_code(state_->code, state_->error_message);
         }

--- a/cpp/include/tensogram/async/std_future.hpp
+++ b/cpp/include/tensogram/async/std_future.hpp
@@ -210,6 +210,15 @@ public:
         });
     }
 
+    using object_count_status = tac::async_streaming_encoder::object_count_status;
+    using object_count_result = tac::async_streaming_encoder::object_count_result;
+
+    /// Discriminated try-accessor.  See
+    /// `tac::async_streaming_encoder::try_object_count`.
+    [[nodiscard]] object_count_result try_object_count() const noexcept {
+        return inner_->try_object_count();
+    }
+
     [[nodiscard]] std::size_t object_count() const noexcept {
         return inner_->object_count();
     }

--- a/cpp/include/tensogram/async/std_future.hpp
+++ b/cpp/include/tensogram/async/std_future.hpp
@@ -1,0 +1,244 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 ECMWF
+
+/// @file tensogram/async/std_future.hpp
+/// @brief std::future<T> frontend (PR 5 of the cpp-async plan).
+///
+/// C++17 wrapper that returns `std::future<T>` from every async
+/// operation.  Internally backed by a `std::promise<T>` set inside a
+/// callback frontend completion handler.
+///
+/// Composition story is intentionally weak (no `.then`, no
+/// `when_all`).  Users wanting composition should use `coro.hpp` on
+/// C++20.  Plan: `plans/PLAN_CPP_ASYNC.md` §4.3.
+
+#ifndef TENSOGRAM_ASYNC_STD_FUTURE_HPP
+#define TENSOGRAM_ASYNC_STD_FUTURE_HPP
+
+#include "callback.hpp"
+
+#include <chrono>
+#include <future>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace tensogram::stdfuture {
+
+namespace tac = tensogram::async_callback;
+
+namespace detail {
+
+inline void throw_for_error(tgm_error code, const std::string& message) {
+    switch (code) {
+        case TGM_ERROR_FRAMING:       throw tensogram::framing_error(code, message);
+        case TGM_ERROR_METADATA:      throw tensogram::metadata_error(code, message);
+        case TGM_ERROR_ENCODING:      throw tensogram::encoding_error(code, message);
+        case TGM_ERROR_COMPRESSION:   throw tensogram::compression_error(code, message);
+        case TGM_ERROR_OBJECT:        throw tensogram::object_error(code, message);
+        case TGM_ERROR_IO:            throw tensogram::io_error(code, message);
+        case TGM_ERROR_HASH_MISMATCH: throw tensogram::hash_mismatch_error(code, message);
+        case TGM_ERROR_MISSING_HASH:  throw tensogram::missing_hash_error(code, message);
+        case TGM_ERROR_INVALID_ARG:   throw tensogram::invalid_arg_error(code, message);
+        case TGM_ERROR_REMOTE:        throw tensogram::remote_error(code, message);
+        case TGM_ERROR_TIMEOUT:       throw tensogram::timeout_error(code, message);
+        case TGM_ERROR_CANCELLED:     throw tensogram::cancelled_error(code, message);
+        default:                      throw tensogram::error(code, message);
+    }
+}
+
+template <typename T, typename Launcher>
+inline std::future<T> launch_future(Launcher&& launch) {
+    auto promise = std::make_shared<std::promise<T>>();
+    auto fut = promise->get_future();
+    launch([promise](tac::result<T> r) {
+        if (r.ok()) {
+            promise->set_value(r.take());
+        } else {
+            try {
+                throw_for_error(r.code(), r.message());
+            } catch (...) {
+                promise->set_exception(std::current_exception());
+            }
+        }
+    });
+    return fut;
+}
+
+template <typename Launcher>
+inline std::future<void> launch_void_future(Launcher&& launch) {
+    auto promise = std::make_shared<std::promise<void>>();
+    auto fut = promise->get_future();
+    launch([promise](tac::result<void> r) {
+        if (r.ok()) {
+            promise->set_value();
+        } else {
+            try {
+                throw_for_error(r.code(), r.message());
+            } catch (...) {
+                promise->set_exception(std::current_exception());
+            }
+        }
+    });
+    return fut;
+}
+
+}  // namespace detail
+
+class async_file {
+public:
+    [[nodiscard]] static std::future<async_file> open(
+        const std::string& path,
+        tac::cancellation_token* token = nullptr,
+        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) {
+        return detail::launch_future<async_file>([path, token, timeout](auto cb) {
+            tac::async_file::open(path,
+                [cb = std::move(cb)](tac::result<tac::async_file> r) mutable {
+                    if (r.ok()) {
+                        cb(tac::result<async_file>::ok_value(async_file(r.take())));
+                    } else {
+                        cb(tac::result<async_file>::err(r.code(), r.message()));
+                    }
+                }, token, timeout);
+        });
+    }
+
+    [[nodiscard]] std::future<std::size_t> message_count(
+        tac::cancellation_token* token = nullptr,
+        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) const {
+        return detail::launch_future<std::size_t>([this, token, timeout](auto cb) {
+            inner_->message_count(std::move(cb), token, timeout);
+        });
+    }
+
+    [[nodiscard]] std::future<tensogram::message> decode_message(
+        std::size_t index,
+        tac::cancellation_token* token = nullptr,
+        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) const {
+        return detail::launch_future<tensogram::message>([this, index, token, timeout](auto cb) {
+            inner_->decode_message(index, std::move(cb), token, timeout);
+        });
+    }
+
+    [[nodiscard]] std::future<tensogram::metadata> decode_metadata(
+        std::size_t index,
+        tac::cancellation_token* token = nullptr,
+        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) const {
+        return detail::launch_future<tensogram::metadata>([this, index, token, timeout](auto cb) {
+            inner_->decode_metadata(index, std::move(cb), token, timeout);
+        });
+    }
+
+    [[nodiscard]] std::future<std::vector<std::uint8_t>> read_message(
+        std::size_t index,
+        tac::cancellation_token* token = nullptr,
+        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) const {
+        return detail::launch_future<std::vector<std::uint8_t>>(
+            [this, index, token, timeout](auto cb) {
+                inner_->read_message(index, std::move(cb), token, timeout);
+            });
+    }
+
+    async_file(async_file&&) noexcept = default;
+    async_file& operator=(async_file&&) noexcept = default;
+    async_file(const async_file&) = delete;
+    async_file& operator=(const async_file&) = delete;
+
+private:
+    explicit async_file(tac::async_file inner)
+        : inner_(std::make_shared<tac::async_file>(std::move(inner))) {}
+    std::shared_ptr<tac::async_file> inner_;
+};
+
+class async_streaming_encoder {
+public:
+    [[nodiscard]] static std::future<async_streaming_encoder> create(
+        const std::string& path,
+        const std::string& metadata_json,
+        const std::string& hash_algo = "xxh3",
+        std::uint32_t threads = 0,
+        tac::cancellation_token* token = nullptr,
+        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) {
+        return detail::launch_future<async_streaming_encoder>(
+            [path, metadata_json, hash_algo, threads, token, timeout](auto cb) {
+                tac::async_streaming_encoder::create(path, metadata_json,
+                    [cb = std::move(cb)](tac::result<tac::async_streaming_encoder> r) mutable {
+                        if (r.ok()) {
+                            cb(tac::result<async_streaming_encoder>::ok_value(
+                                async_streaming_encoder(r.take())));
+                        } else {
+                            cb(tac::result<async_streaming_encoder>::err(r.code(), r.message()));
+                        }
+                    }, hash_algo, threads, token, timeout);
+            });
+    }
+
+    [[nodiscard]] std::future<void> write_object(
+        const std::string& descriptor_json,
+        const std::uint8_t* data, std::size_t len,
+        tac::cancellation_token* token = nullptr,
+        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) {
+        return detail::launch_void_future(
+            [this, descriptor_json, data, len, token, timeout](auto cb) {
+                inner_->write_object(descriptor_json, data, len, std::move(cb), token, timeout);
+            });
+    }
+
+    [[nodiscard]] std::future<void> write_pre_encoded(
+        const std::string& descriptor_json,
+        const std::uint8_t* data, std::size_t len,
+        tac::cancellation_token* token = nullptr,
+        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) {
+        return detail::launch_void_future(
+            [this, descriptor_json, data, len, token, timeout](auto cb) {
+                inner_->write_pre_encoded(descriptor_json, data, len, std::move(cb),
+                                          token, timeout);
+            });
+    }
+
+    [[nodiscard]] std::future<void> write_preceder(
+        const std::string& metadata_json,
+        tac::cancellation_token* token = nullptr,
+        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) {
+        return detail::launch_void_future(
+            [this, metadata_json, token, timeout](auto cb) {
+                inner_->write_preceder(metadata_json, std::move(cb), token, timeout);
+            });
+    }
+
+    [[nodiscard]] std::future<void> finish(
+        bool backfill = true,
+        tac::cancellation_token* token = nullptr,
+        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) {
+        return detail::launch_void_future([this, backfill, token, timeout](auto cb) {
+            inner_->finish(std::move(cb), backfill, token, timeout);
+        });
+    }
+
+    [[nodiscard]] std::size_t object_count() const noexcept {
+        return inner_->object_count();
+    }
+
+    async_streaming_encoder(async_streaming_encoder&&) noexcept = default;
+    async_streaming_encoder& operator=(async_streaming_encoder&&) noexcept = default;
+    async_streaming_encoder(const async_streaming_encoder&) = delete;
+    async_streaming_encoder& operator=(const async_streaming_encoder&) = delete;
+
+private:
+    explicit async_streaming_encoder(tac::async_streaming_encoder inner)
+        : inner_(std::make_shared<tac::async_streaming_encoder>(std::move(inner))) {}
+    std::shared_ptr<tac::async_streaming_encoder> inner_;
+};
+
+}  // namespace tensogram::stdfuture
+
+#endif  // TENSOGRAM_ASYNC_STD_FUTURE_HPP

--- a/cpp/include/tensogram/async/std_future.hpp
+++ b/cpp/include/tensogram/async/std_future.hpp
@@ -98,6 +98,31 @@ public:
         });
     }
 
+    /// Open a remote `.tgm` (S3 / GCS / Azure / HTTP / `file://`).
+    /// See `tensogram::async_callback::async_file::open_remote` for
+    /// the `storage_options` / `bidirectional` semantics and the
+    /// `async-remote` feature requirement.  Failures (including a
+    /// build without `async-remote`) surface through `.get()` as the
+    /// typed `tensogram::error` hierarchy.
+    [[nodiscard]] static std::future<async_file> open_remote(
+        const std::string& url,
+        const std::vector<std::pair<std::string, std::string>>& storage_options,
+        bool bidirectional,
+        tac::cancellation_token* token = nullptr,
+        std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) {
+        return detail::launch_future<async_file>(
+            [url, storage_options, bidirectional, token, timeout](auto cb) {
+                tac::async_file::open_remote(url, storage_options, bidirectional,
+                    [cb = std::move(cb)](tac::result<tac::async_file> r) mutable {
+                        if (r.ok()) {
+                            cb(tac::result<async_file>::ok_value(async_file(r.take())));
+                        } else {
+                            cb(tac::result<async_file>::err(r.code(), r.message()));
+                        }
+                    }, token, timeout);
+            });
+    }
+
     [[nodiscard]] std::future<std::size_t> message_count(
         tac::cancellation_token* token = nullptr,
         std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) const {

--- a/cpp/include/tensogram/async/std_future.hpp
+++ b/cpp/include/tensogram/async/std_future.hpp
@@ -38,23 +38,9 @@ namespace tac = tensogram::async_callback;
 
 namespace detail {
 
-inline void throw_for_error(tgm_error code, const std::string& message) {
-    switch (code) {
-        case TGM_ERROR_FRAMING:       throw tensogram::framing_error(code, message);
-        case TGM_ERROR_METADATA:      throw tensogram::metadata_error(code, message);
-        case TGM_ERROR_ENCODING:      throw tensogram::encoding_error(code, message);
-        case TGM_ERROR_COMPRESSION:   throw tensogram::compression_error(code, message);
-        case TGM_ERROR_OBJECT:        throw tensogram::object_error(code, message);
-        case TGM_ERROR_IO:            throw tensogram::io_error(code, message);
-        case TGM_ERROR_HASH_MISMATCH: throw tensogram::hash_mismatch_error(code, message);
-        case TGM_ERROR_MISSING_HASH:  throw tensogram::missing_hash_error(code, message);
-        case TGM_ERROR_INVALID_ARG:   throw tensogram::invalid_arg_error(code, message);
-        case TGM_ERROR_REMOTE:        throw tensogram::remote_error(code, message);
-        case TGM_ERROR_TIMEOUT:       throw tensogram::timeout_error(code, message);
-        case TGM_ERROR_CANCELLED:     throw tensogram::cancelled_error(code, message);
-        default:                      throw tensogram::error(code, message);
-    }
-}
+// Typed-exception dispatch lives in `tensogram::detail::throw_for_code`
+// (see `tensogram.hpp`); we delegate to it here so all async frontends
+// share a single source of truth for the C-error-to-C++-exception map.
 
 template <typename T, typename Launcher>
 inline std::future<T> launch_future(Launcher&& launch) {
@@ -65,7 +51,7 @@ inline std::future<T> launch_future(Launcher&& launch) {
             promise->set_value(r.take());
         } else {
             try {
-                throw_for_error(r.code(), r.message());
+                tensogram::detail::throw_for_code(r.code(), r.message());
             } catch (...) {
                 promise->set_exception(std::current_exception());
             }
@@ -83,7 +69,7 @@ inline std::future<void> launch_void_future(Launcher&& launch) {
             promise->set_value();
         } else {
             try {
-                throw_for_error(r.code(), r.message());
+                tensogram::detail::throw_for_code(r.code(), r.message());
             } catch (...) {
                 promise->set_exception(std::current_exception());
             }

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ set(TENSOGRAM_TEST_SOURCES
 if(TENSOGRAM_ASYNC)
     list(APPEND TENSOGRAM_TEST_SOURCES test_async_callback.cpp)
     list(APPEND TENSOGRAM_TEST_SOURCES test_async_stdfuture.cpp)
+    list(APPEND TENSOGRAM_TEST_SOURCES test_async_producer_consumer.cpp)
 endif()
 
 # Test executable

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ set(TENSOGRAM_TEST_SOURCES
 
 if(TENSOGRAM_ASYNC)
     list(APPEND TENSOGRAM_TEST_SOURCES test_async_callback.cpp)
+    list(APPEND TENSOGRAM_TEST_SOURCES test_async_stdfuture.cpp)
 endif()
 
 # Test executable
@@ -46,3 +47,20 @@ target_link_libraries(tensogram_tests PRIVATE
 
 include(GoogleTest)
 gtest_discover_tests(tensogram_tests)
+
+# Optional C++20 coroutine test executable.  Compiled separately because
+# the rest of the suite is C++17.  Set TENSOGRAM_ASYNC_CORO_TESTS=OFF to
+# skip if your compiler doesn't support C++20 coroutines.
+option(TENSOGRAM_ASYNC_CORO_TESTS "Build the C++20 coroutine async tests" ON)
+if(TENSOGRAM_ASYNC AND TENSOGRAM_ASYNC_CORO_TESTS)
+    add_executable(tensogram_async_coro_tests test_async_coro.cpp)
+    set_target_properties(tensogram_async_coro_tests PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF)
+    target_compile_options(tensogram_async_coro_tests PRIVATE
+        -Wall -Wextra -Wpedantic -Wno-unused-parameter)
+    target_link_libraries(tensogram_async_coro_tests PRIVATE
+        tensogram GTest::gtest GTest::gtest_main)
+    gtest_discover_tests(tensogram_async_coro_tests)
+endif()

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -6,8 +6,7 @@ FetchContent_Declare(
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
-# Test executable
-add_executable(tensogram_tests
+set(TENSOGRAM_TEST_SOURCES
     test_encode_decode.cpp
     test_metadata.cpp
     test_descriptor.cpp
@@ -23,6 +22,13 @@ add_executable(tensogram_tests
     test_allow_nan_inf.cpp
     test_decode_verify_hash.cpp
 )
+
+if(TENSOGRAM_ASYNC)
+    list(APPEND TENSOGRAM_TEST_SOURCES test_async_callback.cpp)
+endif()
+
+# Test executable
+add_executable(tensogram_tests ${TENSOGRAM_TEST_SOURCES})
 
 target_include_directories(tensogram_tests PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/cpp/tests/test_async_callback.cpp
+++ b/cpp/tests/test_async_callback.cpp
@@ -257,3 +257,53 @@ TEST(AsyncCallback, RuntimeConfigureAfterInitErrors) {
 
     std::filesystem::remove(path);
 }
+
+TEST(AsyncCallback, OpenRemoteSurfacesError) {
+    // open_remote marshals the storage-option key/value arrays and calls
+    // the always-linkable tgm_async_file_open_remote.  Without the
+    // async-remote feature it resolves synchronously with
+    // TGM_ERROR_REMOTE; with it, a nonexistent file:// URL resolves with
+    // a not-found error.  Either way the result is an error, never a
+    // value, and the call never crashes.
+    auto fut = as_future<tac::async_file>([&](auto cb) {
+        tac::async_file::open_remote(
+            "file:///nonexistent/tensogram_open_remote_probe.tgm",
+            {{"region", "eu-west-1"}},  // exercises the key/value marshalling
+            /*bidirectional=*/false, std::move(cb));
+    });
+    auto r = fut.get();
+    EXPECT_FALSE(r.ok());
+#ifndef TENSOGRAM_ASYNC_REMOTE
+    EXPECT_EQ(r.code(), TGM_ERROR_REMOTE) << r.message();
+#endif
+}
+
+#ifdef TENSOGRAM_ASYNC_REMOTE
+TEST(AsyncCallback, OpenRemoteFileUrlRoundTrip) {
+    // With the async-remote feature a file:// URL routes through
+    // object_store's LocalFileSystem, so the full remote read path
+    // (open_remote -> message_count -> decode) can be exercised offline
+    // and deterministically.  This is the success-path counterpart to
+    // OpenRemoteSurfacesError.
+    auto path = make_sync_test_file();
+    const std::string url = "file://" + std::filesystem::absolute(path).string();
+
+    auto open_r = as_future<tac::async_file>([&](auto cb) {
+        tac::async_file::open_remote(url, {}, /*bidirectional=*/false, std::move(cb));
+    }).get();
+    ASSERT_TRUE(open_r.ok()) << open_r.message();
+    auto file = open_r.take();
+
+    auto count_r = as_future<std::size_t>(
+        [&](auto cb) { file.message_count(std::move(cb)); }).get();
+    ASSERT_TRUE(count_r.ok()) << count_r.message();
+    EXPECT_EQ(count_r.value(), 1u);
+
+    auto dec_r = as_future<tensogram::message>(
+        [&](auto cb) { file.decode_message(0, std::move(cb)); }).get();
+    ASSERT_TRUE(dec_r.ok()) << dec_r.message();
+    EXPECT_EQ(dec_r.value().num_objects(), 1u);
+
+    std::filesystem::remove(path);
+}
+#endif  // TENSOGRAM_ASYNC_REMOTE

--- a/cpp/tests/test_async_callback.cpp
+++ b/cpp/tests/test_async_callback.cpp
@@ -194,6 +194,57 @@ TEST(AsyncCallback, StreamingEncoderRoundTrip) {
     std::filesystem::remove(path);
 }
 
+TEST(AsyncCallback, TryObjectCountStateMachine) {
+    auto path = make_temp_path(".tgm");
+    std::string meta_json = R"json({"base":[]})json";
+
+    auto create_fut = as_future<tac::async_streaming_encoder>([&](auto cb) {
+        tac::async_streaming_encoder::create(path.string(), meta_json, std::move(cb));
+    });
+    auto cr = create_fut.get();
+    ASSERT_TRUE(cr.ok()) << cr.message();
+    auto enc = cr.take();
+
+    // Fresh encoder, no writes yet, no in-flight ops → ok / 0.
+    {
+        auto r = enc.try_object_count();
+        EXPECT_EQ(r.status,
+                  tac::async_streaming_encoder::object_count_status::ok);
+        EXPECT_EQ(r.value, 0u);
+        EXPECT_EQ(enc.object_count(), 0u);
+    }
+
+    // After one successful write → ok / 1.
+    std::string desc = R"json({
+        "type":"ntensor","ndim":1,"shape":[4],"strides":[1],
+        "dtype":"float32","byte_order":"little","encoding":"none",
+        "filter":"none","compression":"none","params":{}
+    })json";
+    std::vector<std::uint8_t> data(16);
+    auto wr_fut = as_future<void>(
+        [&](auto cb) { enc.write_object(desc, data.data(), data.size(), std::move(cb)); });
+    ASSERT_TRUE(wr_fut.get().ok());
+    {
+        auto r = enc.try_object_count();
+        EXPECT_EQ(r.status,
+                  tac::async_streaming_encoder::object_count_status::ok);
+        EXPECT_EQ(r.value, 1u);
+    }
+
+    // After finish → finished / 0 (count value is meaningless here).
+    auto fin_fut = as_future<void>([&](auto cb) { enc.finish(std::move(cb)); });
+    ASSERT_TRUE(fin_fut.get().ok());
+    {
+        auto r = enc.try_object_count();
+        EXPECT_EQ(r.status,
+                  tac::async_streaming_encoder::object_count_status::finished);
+        // Convenience accessor collapses to the historical sentinel.
+        EXPECT_EQ(enc.object_count(), static_cast<std::size_t>(-1));
+    }
+
+    std::filesystem::remove(path);
+}
+
 TEST(AsyncCallback, RuntimeConfigureAfterInitErrors) {
     // The runtime is built lazily on first call.  Trigger it.
     auto path = make_sync_test_file();

--- a/cpp/tests/test_async_callback.cpp
+++ b/cpp/tests/test_async_callback.cpp
@@ -1,0 +1,208 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Tests for the async/callback.hpp frontend (PR 4 of the cpp-async plan).
+
+#include <gtest/gtest.h>
+#include <tensogram/async/callback.hpp>
+#include <tensogram.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <future>
+#include <iterator>
+#include <mutex>
+#include <string>
+#include <thread>
+
+namespace tac = tensogram::async_callback;
+
+namespace {
+
+std::filesystem::path make_temp_path(const std::string& suffix) {
+    auto tmp = std::filesystem::temp_directory_path();
+    auto t = std::chrono::steady_clock::now().time_since_epoch().count();
+    return tmp / ("tensogram_test_" + std::to_string(t) + suffix);
+}
+
+/// Encode a one-message file with the sync API and return its path.
+std::filesystem::path make_sync_test_file() {
+    auto path = make_temp_path(".tgm");
+    std::string meta_json = R"json({
+        "base":[],
+        "descriptors":[{
+            "type":"ntensor","ndim":1,"shape":[4],"strides":[1],
+            "dtype":"float32","byte_order":"little","encoding":"none",
+            "filter":"none","compression":"none"
+        }]
+    })json";
+    std::vector<std::uint8_t> payload(16);
+    for (std::size_t i = 0; i < payload.size(); ++i) {
+        payload[i] = static_cast<std::uint8_t>(i);
+    }
+    std::vector<std::pair<const std::uint8_t*, std::size_t>> objs;
+    objs.emplace_back(payload.data(), payload.size());
+
+    auto bytes = tensogram::encode(meta_json, objs);
+    auto* fp = std::fopen(path.c_str(), "wb");
+    std::fwrite(bytes.data(), 1, bytes.size(), fp);
+    std::fclose(fp);
+    return path;
+}
+
+/// Helper: convert callback API to a future for cleaner test code.
+template <typename T>
+std::future<tac::result<T>> as_future(
+    std::function<void(std::function<void(tac::result<T>)>)> launch) {
+    auto promise = std::make_shared<std::promise<tac::result<T>>>();
+    auto fut = promise->get_future();
+    launch([promise](tac::result<T> r) {
+        promise->set_value(std::move(r));
+    });
+    return fut;
+}
+
+}  // namespace
+
+TEST(AsyncCallback, OpenAndMessageCount) {
+    auto path = make_sync_test_file();
+
+    auto open_fut = as_future<tac::async_file>(
+        [&](auto cb) { tac::async_file::open(path.string(), std::move(cb)); });
+    auto open_r = open_fut.get();
+    ASSERT_TRUE(open_r.ok()) << open_r.message();
+    auto file = open_r.take();
+
+    auto count_fut = as_future<std::size_t>(
+        [&](auto cb) { file.message_count(std::move(cb)); });
+    auto count_r = count_fut.get();
+    ASSERT_TRUE(count_r.ok()) << count_r.message();
+    EXPECT_EQ(count_r.value(), 1u);
+
+    std::filesystem::remove(path);
+}
+
+TEST(AsyncCallback, DecodeMessageRoundTrip) {
+    auto path = make_sync_test_file();
+
+    auto open_fut = as_future<tac::async_file>(
+        [&](auto cb) { tac::async_file::open(path.string(), std::move(cb)); });
+    auto file = open_fut.get().take();
+
+    auto dec_fut = as_future<tensogram::message>(
+        [&](auto cb) { file.decode_message(0, std::move(cb)); });
+    auto dec_r = dec_fut.get();
+    ASSERT_TRUE(dec_r.ok()) << dec_r.message();
+
+    auto& msg = dec_r.value();
+    EXPECT_EQ(msg.num_objects(), 1u);
+
+    std::filesystem::remove(path);
+}
+
+TEST(AsyncCallback, DecodeMetadata) {
+    auto path = make_sync_test_file();
+
+    auto open_fut = as_future<tac::async_file>(
+        [&](auto cb) { tac::async_file::open(path.string(), std::move(cb)); });
+    auto file = open_fut.get().take();
+
+    auto md_fut = as_future<tensogram::metadata>(
+        [&](auto cb) { file.decode_metadata(0, std::move(cb)); });
+    auto md_r = md_fut.get();
+    ASSERT_TRUE(md_r.ok()) << md_r.message();
+    auto& m = md_r.value();
+    EXPECT_EQ(m.version(), tensogram::wire_version);
+
+    std::filesystem::remove(path);
+}
+
+TEST(AsyncCallback, ReadMessageRawBytes) {
+    auto path = make_sync_test_file();
+
+    auto open_fut = as_future<tac::async_file>(
+        [&](auto cb) { tac::async_file::open(path.string(), std::move(cb)); });
+    auto file = open_fut.get().take();
+
+    auto read_fut = as_future<std::vector<std::uint8_t>>(
+        [&](auto cb) { file.read_message(0, std::move(cb)); });
+    auto read_r = read_fut.get();
+    ASSERT_TRUE(read_r.ok()) << read_r.message();
+    EXPECT_GT(read_r.value().size(), 0u);
+
+    std::filesystem::remove(path);
+}
+
+TEST(AsyncCallback, OpenNonexistentReportsError) {
+    auto open_fut = as_future<tac::async_file>([&](auto cb) {
+        tac::async_file::open("/nonexistent/missing.tgm", std::move(cb));
+    });
+    auto r = open_fut.get();
+    EXPECT_FALSE(r.ok());
+    EXPECT_NE(r.code(), TGM_ERROR_OK);
+}
+
+TEST(AsyncCallback, CancellationTokenLifecycle) {
+    tac::cancellation_token tok;
+    EXPECT_FALSE(tok.cancelled());
+    tok.cancel();
+    EXPECT_TRUE(tok.cancelled());
+}
+
+TEST(AsyncCallback, StreamingEncoderRoundTrip) {
+    auto path = make_temp_path(".tgm");
+    std::string meta_json = R"json({"base":[]})json";
+
+    auto create_fut = as_future<tac::async_streaming_encoder>([&](auto cb) {
+        tac::async_streaming_encoder::create(path.string(), meta_json, std::move(cb));
+    });
+    auto cr = create_fut.get();
+    ASSERT_TRUE(cr.ok()) << cr.message();
+    auto enc = cr.take();
+
+    std::string desc = R"json({
+        "type":"ntensor","ndim":1,"shape":[4],"strides":[1],
+        "dtype":"float32","byte_order":"little","encoding":"none",
+        "filter":"none","compression":"none","params":{}
+    })json";
+    std::vector<std::uint8_t> data(16);
+    for (std::size_t i = 0; i < data.size(); ++i) data[i] = static_cast<std::uint8_t>(i);
+
+    auto wr_fut = as_future<void>(
+        [&](auto cb) { enc.write_object(desc, data.data(), data.size(), std::move(cb)); });
+    auto wr_r = wr_fut.get();
+    ASSERT_TRUE(wr_r.ok()) << wr_r.message();
+
+    auto fin_fut = as_future<void>([&](auto cb) { enc.finish(std::move(cb)); });
+    auto fin_r = fin_fut.get();
+    ASSERT_TRUE(fin_r.ok()) << fin_r.message();
+
+    // Verify the file decodes via the sync API.
+    std::ifstream is(path.string(), std::ios::binary);
+    ASSERT_TRUE(is.good());
+    std::vector<std::uint8_t> bytes((std::istreambuf_iterator<char>(is)),
+                                    std::istreambuf_iterator<char>());
+    auto msg = tensogram::decode(bytes.data(), bytes.size());
+    EXPECT_EQ(msg.num_objects(), 1u);
+
+    std::filesystem::remove(path);
+}
+
+TEST(AsyncCallback, RuntimeConfigureAfterInitErrors) {
+    // The runtime is built lazily on first call.  Trigger it.
+    auto path = make_sync_test_file();
+    auto open_fut = as_future<tac::async_file>(
+        [&](auto cb) { tac::async_file::open(path.string(), std::move(cb)); });
+    [[maybe_unused]] auto _ = open_fut.get().take();
+
+    // Now configure should throw.
+    EXPECT_THROW(tac::runtime_configure(2, 0, 0), tensogram::invalid_arg_error);
+
+    std::filesystem::remove(path);
+}

--- a/cpp/tests/test_async_coro.cpp
+++ b/cpp/tests/test_async_coro.cpp
@@ -132,3 +132,17 @@ TEST(AsyncCoro, AsyncForEachWalksAllMessages) {
     EXPECT_EQ(n, 1u);
     std::filesystem::remove(path);
 }
+
+TEST(AsyncCoro, OpenRemoteSurfacesError) {
+    // open_remote is awaitable; the error surfaces as a thrown
+    // tensogram::error out of block_on (TGM_ERROR_REMOTE without the
+    // async-remote feature, file-not-found with it).
+    auto run = []() -> tco::task<int> {
+        auto file = co_await tco::async_file::open_remote(
+            "file:///nonexistent/tensogram_open_remote_probe.tgm",
+            {{"region", "eu-west-1"}}, /*bidirectional=*/false);
+        (void)file;
+        co_return 0;
+    };
+    EXPECT_THROW(tco::block_on(run()), tensogram::error);
+}

--- a/cpp/tests/test_async_coro.cpp
+++ b/cpp/tests/test_async_coro.cpp
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <iterator>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace tco = tensogram::coro;
@@ -138,9 +139,14 @@ TEST(AsyncCoro, OpenRemoteSurfacesError) {
     // tensogram::error out of block_on (TGM_ERROR_REMOTE without the
     // async-remote feature, file-not-found with it).
     auto run = []() -> tco::task<int> {
+        // Build the storage-option vector before the co_await: constructing
+        // this temporary inside the co_await argument list triggers an
+        // internal compiler error on some GCC versions.
+        const std::vector<std::pair<std::string, std::string>> opts = {
+            {"region", "eu-west-1"}};
         auto file = co_await tco::async_file::open_remote(
-            "file:///nonexistent/tensogram_open_remote_probe.tgm",
-            {{"region", "eu-west-1"}}, /*bidirectional=*/false);
+            "file:///nonexistent/tensogram_open_remote_probe.tgm", opts,
+            /*bidirectional=*/false);
         (void)file;
         co_return 0;
     };

--- a/cpp/tests/test_async_coro.cpp
+++ b/cpp/tests/test_async_coro.cpp
@@ -1,0 +1,134 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+#include <gtest/gtest.h>
+#include <tensogram.hpp>
+#include <tensogram/async/coro.hpp>
+
+#include <chrono>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+namespace tco = tensogram::coro;
+
+namespace {
+
+std::filesystem::path make_temp_path(const std::string& suffix) {
+    auto tmp = std::filesystem::temp_directory_path();
+    auto t = std::chrono::steady_clock::now().time_since_epoch().count();
+    return tmp / ("tensogram_coro_" + std::to_string(t) + suffix);
+}
+
+std::filesystem::path make_test_file() {
+    auto path = make_temp_path(".tgm");
+    std::string meta_json = R"json({
+        "base":[],
+        "descriptors":[{
+            "type":"ntensor","ndim":1,"shape":[4],"strides":[1],
+            "dtype":"float32","byte_order":"little","encoding":"none",
+            "filter":"none","compression":"none"
+        }]
+    })json";
+    std::vector<std::uint8_t> payload(16);
+    for (std::size_t i = 0; i < payload.size(); ++i) {
+        payload[i] = static_cast<std::uint8_t>(i);
+    }
+    std::vector<std::pair<const std::uint8_t*, std::size_t>> objs;
+    objs.emplace_back(payload.data(), payload.size());
+
+    auto bytes = tensogram::encode(meta_json, objs);
+    auto* fp = std::fopen(path.c_str(), "wb");
+    std::fwrite(bytes.data(), 1, bytes.size(), fp);
+    std::fclose(fp);
+    return path;
+}
+
+}  // namespace
+
+TEST(AsyncCoro, OpenAndMessageCount) {
+    auto path = make_test_file();
+
+    auto t = []() -> tco::task<std::size_t> {
+        auto file = co_await tco::async_file::open(""); // placeholder
+        co_return 0;
+    };
+    // Use the path-based variant via block_on:
+    auto open_and_count = [&path]() -> tco::task<std::size_t> {
+        auto file = co_await tco::async_file::open(path.string());
+        std::size_t n = co_await file.message_count();
+        co_return n;
+    };
+    auto count = tco::block_on(open_and_count());
+    EXPECT_EQ(count, 1u);
+
+    std::filesystem::remove(path);
+}
+
+TEST(AsyncCoro, DecodeMessage) {
+    auto path = make_test_file();
+    auto run = [&path]() -> tco::task<std::size_t> {
+        auto file = co_await tco::async_file::open(path.string());
+        auto msg = co_await file.decode_message(0);
+        co_return msg.num_objects();
+    };
+    auto n = tco::block_on(run());
+    EXPECT_EQ(n, 1u);
+    std::filesystem::remove(path);
+}
+
+TEST(AsyncCoro, OpenNonexistentThrows) {
+    auto run = []() -> tco::task<std::size_t> {
+        auto file = co_await tco::async_file::open("/nonexistent/missing.tgm");
+        co_return 0;
+    };
+    EXPECT_THROW(tco::block_on(run()), tensogram::error);
+}
+
+TEST(AsyncCoro, StreamingEncoderRoundTrip) {
+    auto path = make_temp_path(".tgm");
+    std::string meta_json = R"json({"base":[]})json";
+    std::string desc = R"json({
+        "type":"ntensor","ndim":1,"shape":[4],"strides":[1],
+        "dtype":"float32","byte_order":"little","encoding":"none",
+        "filter":"none","compression":"none","params":{}
+    })json";
+    std::vector<std::uint8_t> data(16);
+    for (std::size_t i = 0; i < data.size(); ++i) data[i] = static_cast<std::uint8_t>(i);
+
+    auto run = [&]() -> tco::task<void> {
+        auto enc = co_await tco::async_streaming_encoder::create(path.string(), meta_json);
+        co_await enc.write_object(desc, data.data(), data.size());
+        co_await enc.finish();
+    };
+    tco::block_on(run());
+
+    std::ifstream is(path.string(), std::ios::binary);
+    std::vector<std::uint8_t> bytes((std::istreambuf_iterator<char>(is)),
+                                    std::istreambuf_iterator<char>());
+    auto msg = tensogram::decode(bytes.data(), bytes.size());
+    EXPECT_EQ(msg.num_objects(), 1u);
+
+    std::filesystem::remove(path);
+}
+
+TEST(AsyncCoro, AsyncForEachWalksAllMessages) {
+    auto path = make_test_file();
+    auto run = [&path]() -> tco::task<std::size_t> {
+        auto file = co_await tco::async_file::open(path.string());
+        std::size_t count = 0;
+        co_await tco::async_for_each(file, [&count](tensogram::message m) {
+            (void)m;
+            ++count;
+        });
+        co_return count;
+    };
+    auto n = tco::block_on(run());
+    EXPECT_EQ(n, 1u);
+    std::filesystem::remove(path);
+}

--- a/cpp/tests/test_async_producer_consumer.cpp
+++ b/cpp/tests/test_async_producer_consumer.cpp
@@ -1,0 +1,200 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+//! Integration test mirroring the HPC producer/consumer scenario
+//! from `plans/PLAN_CPP_ASYNC.md` §1.  Two C++ jobs coordinate
+//! through a `.tgm` artefact: the producer writes forecast steps as
+//! they're generated; the consumer reads each message as soon as it
+//! arrives.  Tests both the local-file pipe path and a synthetic
+//! "produce in one task, consume in another" pattern within a single
+//! process.
+
+#include <gtest/gtest.h>
+#include <tensogram.hpp>
+#include <tensogram/async/callback.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <future>
+#include <iterator>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace tac = tensogram::async_callback;
+
+namespace {
+
+std::filesystem::path make_temp_path(const std::string& suffix) {
+    auto tmp = std::filesystem::temp_directory_path();
+    auto t = std::chrono::steady_clock::now().time_since_epoch().count();
+    return tmp / ("tensogram_pc_" + std::to_string(t) + suffix);
+}
+
+template <typename T>
+T await_future(std::future<tac::result<T>> fut) {
+    auto r = fut.get();
+    if (!r.ok()) {
+        throw tensogram::error(r.code(), r.message());
+    }
+    return r.take();
+}
+
+inline void await_void_future(std::future<tac::result<void>> fut) {
+    auto r = fut.get();
+    if (!r.ok()) {
+        throw tensogram::error(r.code(), r.message());
+    }
+}
+
+template <typename T>
+std::future<tac::result<T>> as_future(
+    std::function<void(std::function<void(tac::result<T>)>)> launch) {
+    auto promise = std::make_shared<std::promise<tac::result<T>>>();
+    auto fut = promise->get_future();
+    launch([promise](tac::result<T> r) { promise->set_value(std::move(r)); });
+    return fut;
+}
+
+}  // namespace
+
+/// HPC producer/consumer pattern: producer writes 8 forecast steps,
+/// consumer reads them all back.  Both run as async tasks.  Mirrors
+/// the producer-finishes-then-consumer-reads pattern that operational
+/// systems use for shared-filesystem hand-off (consumer polls until
+/// the file is committed).
+TEST(AsyncProducerConsumer, EightStepRoundTrip) {
+    auto path = make_temp_path(".tgm");
+
+    // ── Producer ────────────────────────────────────────────────
+    {
+        auto enc_fut = as_future<tac::async_streaming_encoder>([&path](auto cb) {
+            tac::async_streaming_encoder::create(path.string(),
+                R"json({"base":[]})json", std::move(cb));
+        });
+        auto enc = await_future(std::move(enc_fut));
+
+        std::string desc = R"json({
+            "type":"ntensor","ndim":2,"shape":[16,16],"strides":[16,1],
+            "dtype":"float32","byte_order":"little","encoding":"none",
+            "filter":"none","compression":"none","params":{}
+        })json";
+
+        for (int step = 0; step < 8; ++step) {
+            // Build payload from finite floats (NOT raw byte patterns —
+            // those occasionally form NaN, which the strict-finite
+            // encoder rightly rejects).
+            std::vector<float> values(16 * 16);
+            for (std::size_t i = 0; i < values.size(); ++i) {
+                values[i] = static_cast<float>(step) + 0.001f * static_cast<float>(i);
+            }
+            std::vector<std::uint8_t> data(values.size() * sizeof(float));
+            std::memcpy(data.data(), values.data(), data.size());
+            await_void_future(as_future<void>([&](auto cb) {
+                enc.write_object(desc, data.data(), data.size(), std::move(cb));
+            }));
+        }
+        await_void_future(as_future<void>(
+            [&](auto cb) { enc.finish(std::move(cb)); }));
+    }
+
+    // ── Consumer ────────────────────────────────────────────────
+    {
+        auto file = await_future(as_future<tac::async_file>([&path](auto cb) {
+            tac::async_file::open(path.string(), std::move(cb));
+        }));
+
+        // Note: the producer ran in a single-message-with-8-objects pattern
+        // (8 calls to write_object ➜ 1 message with 8 objects).  Verify the
+        // count and that all 8 objects round-trip.
+        auto count = await_future(as_future<std::size_t>(
+            [&](auto cb) { file.message_count(std::move(cb)); }));
+        EXPECT_EQ(count, 1u);
+
+        auto msg = await_future(as_future<tensogram::message>(
+            [&](auto cb) { file.decode_message(0, std::move(cb)); }));
+        EXPECT_EQ(msg.num_objects(), 8u);
+
+        for (std::size_t i = 0; i < msg.num_objects(); ++i) {
+            auto obj = msg.object(i);
+            EXPECT_EQ(obj.ndim(), 2u);
+            EXPECT_EQ(obj.data_size(), 16u * 16u * 4u);
+
+            // Decode the payload back to floats and check the (step,index)
+            // pattern matches what the producer wrote.
+            const float* values = obj.data_as<float>();
+            for (std::size_t k = 0; k < 16 * 16; ++k) {
+                float expected = static_cast<float>(i) + 0.001f * static_cast<float>(k);
+                ASSERT_NEAR(values[k], expected, 1e-5f)
+                    << "object " << i << " element " << k;
+            }
+        }
+    }
+
+    std::filesystem::remove(path);
+}
+
+/// Concurrent decode: multiple threads decoding from the same shared
+/// async_file handle.  Verifies the Arc-shared backing is safe under
+/// concurrent FFI calls.
+TEST(AsyncProducerConsumer, ConcurrentDecodeOnSharedFile) {
+    auto path = make_temp_path(".tgm");
+
+    // Build a 4-message file via sync API.
+    {
+        std::string meta_json = R"json({
+            "base":[],
+            "descriptors":[{
+                "type":"ntensor","ndim":1,"shape":[4],"strides":[1],
+                "dtype":"float32","byte_order":"little","encoding":"none",
+                "filter":"none","compression":"none"
+            }]
+        })json";
+        std::vector<std::uint8_t> data(16);
+        std::vector<std::pair<const std::uint8_t*, std::size_t>> objs;
+        objs.emplace_back(data.data(), data.size());
+        std::ofstream out(path.string(), std::ios::binary);
+        for (int i = 0; i < 4; ++i) {
+            for (std::size_t k = 0; k < data.size(); ++k) {
+                data[k] = static_cast<std::uint8_t>(i * 16 + k);
+            }
+            auto bytes = tensogram::encode(meta_json, objs);
+            out.write(reinterpret_cast<const char*>(bytes.data()),
+                      static_cast<std::streamsize>(bytes.size()));
+        }
+    }
+
+    auto file = await_future(as_future<tac::async_file>(
+        [&path](auto cb) { tac::async_file::open(path.string(), std::move(cb)); }));
+
+    // Spawn 4 threads, each decoding a different message.
+    std::vector<std::thread> threads;
+    std::atomic<int> success_count{0};
+    for (int i = 0; i < 4; ++i) {
+        threads.emplace_back([&file, i, &success_count]() {
+            try {
+                auto msg = await_future(as_future<tensogram::message>(
+                    [&file, i](auto cb) {
+                        file.decode_message(static_cast<std::size_t>(i), std::move(cb));
+                    }));
+                if (msg.num_objects() == 1) {
+                    success_count.fetch_add(1);
+                }
+            } catch (...) {
+                // swallow
+            }
+        });
+    }
+    for (auto& t : threads) t.join();
+    EXPECT_EQ(success_count.load(), 4);
+
+    std::filesystem::remove(path);
+}

--- a/cpp/tests/test_async_producer_consumer.cpp
+++ b/cpp/tests/test_async_producer_consumer.cpp
@@ -142,6 +142,88 @@ TEST(AsyncProducerConsumer, EightStepRoundTrip) {
     std::filesystem::remove(path);
 }
 
+/// Stress test for the dispatcher pool: fire many in-flight callback
+/// completions concurrently, each callback doing at least 1ms of
+/// work.  The runtime has bounded queues (≤ `dispatcher_workers * 4`
+/// slots; default 4 workers ⇒ 16-slot channel), so 1000 concurrent
+/// callbacks force the inline-fallback path documented at
+/// `dispatch_to_pool` to surface gracefully.
+///
+/// Verifies:
+///   1. Every callback fires exactly once (no drops, no duplicates).
+///   2. The runtime does not stall — total wall-clock stays
+///      bounded.
+///   3. No deadlock between the tokio worker pool and the dispatcher
+///      pool when the dispatcher's bounded channel is saturated.
+TEST(AsyncProducerConsumer, DispatcherPoolBackpressureStress) {
+    constexpr int kCount = 1000;
+
+    // Build one tiny file we can hammer with many concurrent reads.
+    auto path = make_temp_path(".tgm");
+    {
+        std::string meta_json = R"json({
+            "base":[],
+            "descriptors":[{
+                "type":"ntensor","ndim":1,"shape":[2],"strides":[1],
+                "dtype":"uint8","byte_order":"little","encoding":"none",
+                "filter":"none","compression":"none"
+            }]
+        })json";
+        std::vector<std::uint8_t> data(2);
+        std::vector<std::pair<const std::uint8_t*, std::size_t>> objs;
+        objs.emplace_back(data.data(), data.size());
+        auto bytes = tensogram::encode(meta_json, objs);
+        std::ofstream out(path.string(), std::ios::binary);
+        out.write(reinterpret_cast<const char*>(bytes.data()),
+                  static_cast<std::streamsize>(bytes.size()));
+    }
+
+    auto file = await_future(as_future<tac::async_file>(
+        [&path](auto cb) { tac::async_file::open(path.string(), std::move(cb)); }));
+
+    std::atomic<int> fired{0};
+    std::mutex done_mtx;
+    std::condition_variable done_cv;
+
+    auto start = std::chrono::steady_clock::now();
+    for (int i = 0; i < kCount; ++i) {
+        file.message_count(
+            [&fired, &done_mtx, &done_cv](tac::result<std::size_t> r) {
+                // Force at least 1ms of work in the callback to keep
+                // the dispatcher saturated long enough to exercise
+                // backpressure.
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                if (r.ok()) {
+                    int n = fired.fetch_add(1) + 1;
+                    if (n == kCount) {
+                        std::lock_guard<std::mutex> g(done_mtx);
+                        done_cv.notify_all();
+                    }
+                }
+            });
+    }
+
+    // Wait until every callback has fired or we hit a generous bound
+    // (60s — under default config this should complete in well under
+    // 10s; the bound exists only to prevent a hard hang on a real
+    // deadlock).
+    {
+        std::unique_lock<std::mutex> lk(done_mtx);
+        bool ok = done_cv.wait_for(lk, std::chrono::seconds(60),
+                                   [&] { return fired.load() == kCount; });
+        ASSERT_TRUE(ok) << "dispatcher stalled at " << fired.load()
+                        << "/" << kCount << " callbacks";
+    }
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    EXPECT_EQ(fired.load(), kCount);
+
+    // Sanity: 1000 callbacks × 1ms with 4-worker pool ≈ 250ms ideal;
+    // allow generous slack for inline-fallback dispatch and CI noise.
+    EXPECT_LT(elapsed, std::chrono::seconds(30));
+
+    std::filesystem::remove(path);
+}
+
 /// Concurrent decode: multiple threads decoding from the same shared
 /// async_file handle.  Verifies the Arc-shared backing is safe under
 /// concurrent FFI calls.

--- a/cpp/tests/test_async_stdfuture.cpp
+++ b/cpp/tests/test_async_stdfuture.cpp
@@ -96,3 +96,13 @@ TEST(AsyncStdFuture, StreamingEncoderRoundTrip) {
 
     std::filesystem::remove(path);
 }
+
+TEST(AsyncStdFuture, OpenRemoteSurfacesError) {
+    // open_remote returns a std::future; the error (TGM_ERROR_REMOTE
+    // without the async-remote feature, file-not-found with it) surfaces
+    // as a typed tensogram::error through .get().
+    auto fut = tsf::async_file::open_remote(
+        "file:///nonexistent/tensogram_open_remote_probe.tgm",
+        {{"region", "eu-west-1"}}, /*bidirectional=*/false);
+    EXPECT_THROW(fut.get(), tensogram::error);
+}

--- a/cpp/tests/test_async_stdfuture.cpp
+++ b/cpp/tests/test_async_stdfuture.cpp
@@ -1,0 +1,98 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+#include <gtest/gtest.h>
+#include <tensogram.hpp>
+#include <tensogram/async/std_future.hpp>
+
+#include <chrono>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+namespace tsf = tensogram::stdfuture;
+
+namespace {
+
+std::filesystem::path make_temp_path(const std::string& suffix) {
+    auto tmp = std::filesystem::temp_directory_path();
+    auto t = std::chrono::steady_clock::now().time_since_epoch().count();
+    return tmp / ("tensogram_stdfuture_" + std::to_string(t) + suffix);
+}
+
+std::filesystem::path make_test_file() {
+    auto path = make_temp_path(".tgm");
+    std::string meta_json = R"json({
+        "base":[],
+        "descriptors":[{
+            "type":"ntensor","ndim":1,"shape":[4],"strides":[1],
+            "dtype":"float32","byte_order":"little","encoding":"none",
+            "filter":"none","compression":"none"
+        }]
+    })json";
+    std::vector<std::uint8_t> payload(16);
+    for (std::size_t i = 0; i < payload.size(); ++i) {
+        payload[i] = static_cast<std::uint8_t>(i);
+    }
+    std::vector<std::pair<const std::uint8_t*, std::size_t>> objs;
+    objs.emplace_back(payload.data(), payload.size());
+
+    auto bytes = tensogram::encode(meta_json, objs);
+    auto* fp = std::fopen(path.c_str(), "wb");
+    std::fwrite(bytes.data(), 1, bytes.size(), fp);
+    std::fclose(fp);
+    return path;
+}
+
+}  // namespace
+
+TEST(AsyncStdFuture, OpenAndMessageCount) {
+    auto path = make_test_file();
+    auto file = tsf::async_file::open(path.string()).get();
+    auto count = file.message_count().get();
+    EXPECT_EQ(count, 1u);
+    std::filesystem::remove(path);
+}
+
+TEST(AsyncStdFuture, DecodeMessage) {
+    auto path = make_test_file();
+    auto file = tsf::async_file::open(path.string()).get();
+    auto msg = file.decode_message(0).get();
+    EXPECT_EQ(msg.num_objects(), 1u);
+    std::filesystem::remove(path);
+}
+
+TEST(AsyncStdFuture, OpenNonexistentThrows) {
+    auto fut = tsf::async_file::open("/nonexistent/missing.tgm");
+    EXPECT_THROW(fut.get(), tensogram::error);
+}
+
+TEST(AsyncStdFuture, StreamingEncoderRoundTrip) {
+    auto path = make_temp_path(".tgm");
+    std::string meta_json = R"json({"base":[]})json";
+    auto enc = tsf::async_streaming_encoder::create(path.string(), meta_json).get();
+
+    std::string desc = R"json({
+        "type":"ntensor","ndim":1,"shape":[4],"strides":[1],
+        "dtype":"float32","byte_order":"little","encoding":"none",
+        "filter":"none","compression":"none","params":{}
+    })json";
+    std::vector<std::uint8_t> data(16);
+    for (std::size_t i = 0; i < data.size(); ++i) data[i] = static_cast<std::uint8_t>(i);
+
+    enc.write_object(desc, data.data(), data.size()).get();
+    enc.finish().get();
+
+    std::ifstream is(path.string(), std::ios::binary);
+    std::vector<std::uint8_t> bytes((std::istreambuf_iterator<char>(is)),
+                                    std::istreambuf_iterator<char>());
+    auto msg = tensogram::decode(bytes.data(), bytes.size());
+    EXPECT_EQ(msg.num_objects(), 1u);
+
+    std::filesystem::remove(path);
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -38,6 +38,7 @@
 - [C API](guide/c-api.md)
 - [C++ API](guide/cpp-api.md)
 - [C++ Async API](guide/cpp-async.md)
+- [C++ Async Streaming (Producer / Consumer)](guide/cpp-streaming-async.md)
 - [TypeScript API](guide/typescript-api.md)
 - [Tensoscope (Web Viewer)](guide/tensoscope.md)
 - [xarray Integration](guide/xarray-integration.md)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -37,6 +37,7 @@
 - [Python API](guide/python-api.md)
 - [C API](guide/c-api.md)
 - [C++ API](guide/cpp-api.md)
+- [C++ Async API](guide/cpp-async.md)
 - [TypeScript API](guide/typescript-api.md)
 - [Tensoscope (Web Viewer)](guide/tensoscope.md)
 - [xarray Integration](guide/xarray-integration.md)

--- a/docs/src/guide/cpp-async.md
+++ b/docs/src/guide/cpp-async.md
@@ -92,14 +92,24 @@ tac::async_file::open("data.tgm", [](tac::result<tac::async_file> r) {
 
 ### Callback contract
 
-The callback runs on a worker thread inside the FFI's runtime.  It must:
-- Complete quickly (< 100 µs of CPU time).
-- Not block on locks held outside the callback.
-- Not throw — `panic = "abort"` is set on the Rust side, so an
-  exception escaping a callback will terminate the process.
-- Signal a condvar / coroutine handle / promise and return.
+The callback runs on the FFI **dispatcher pool** — a small set of
+non-tokio worker threads owned by `tensogram-ffi`.  This insulates
+the tokio runtime: even if a user callback blocks or runs slowly,
+tokio's worker threads stay free to drive other in-flight async I/O.
 
-For heavy work, hand off to the user's own thread pool.
+The callback must:
+- Complete quickly (< 100 µs of CPU time).  The dispatcher pool is
+  small (default `min(num_cpus, 4)`); long callbacks queue up and
+  starve other completions.
+- Not throw — `panic = "abort"` is set on the Rust side and the
+  trampolines that wrap user callbacks are `noexcept`, so an
+  exception escaping a callback will terminate the process.
+- Signal a condvar / coroutine handle / promise and return.  For
+  heavy work, hand off to your own thread pool.
+
+The pool size is overridable at startup via
+`tac::runtime_configure(workers, dispatcher_workers, ...)`.  The
+configuration must be set before any other async call.
 
 ## `std::future` frontend (`std_future.hpp`)
 

--- a/docs/src/guide/cpp-async.md
+++ b/docs/src/guide/cpp-async.md
@@ -240,8 +240,46 @@ tac::runtime_configure(/*workers=*/16,
 Subsequent calls throw `invalid_arg_error` because the runtime is
 built lazily on first use and cannot be reconfigured after that.
 
-`runtime_shutdown_blocking(timeout)` drains in-flight tasks and
-returns the count that did not finish within the deadline.
+`runtime_shutdown_blocking(timeout)` is reserved for graceful shutdown.
+In the current release it is a no-op that returns `0`: process exit is
+abrupt by design and tokio drops in-flight tasks at teardown. The
+signature is stable so a future release can drain tasks and report the
+count that did not finish within the deadline without an ABI break.
+
+## Remote reads (`open_remote`)
+
+All three frontends can open a `.tgm` over an object store or a
+`file://` URL on the read path:
+
+```cpp
+// callback frontend
+tac::async_file::open_remote(
+    "s3://bucket/forecast.tgm",
+    /*storage_options=*/{{"aws_region", "eu-west-1"}},
+    /*bidirectional=*/true,
+    [](tac::result<tac::async_file> r) { /* ... */ });
+
+// std::future frontend
+auto file = tsf::async_file::open_remote("gs://bucket/f.tgm", {}, true).get();
+
+// coroutine frontend
+auto file = co_await tco::async_file::open_remote("az://c/f.tgm", {}, true);
+```
+
+`storage_options` are object-store key→value pairs (credentials,
+region, endpoint); pass an empty list to use ambient configuration.
+`bidirectional` selects the pipelined two-ended remote scan.
+
+Supported schemes: `s3://`, `gs://`, `az://`, `https://`, and
+`file://`.  Requires the FFI built with `--features=async-remote`
+(`cmake -S cpp -B build -DTENSOGRAM_ASYNC_REMOTE=ON`).  The
+`tgm_async_file_open_remote` symbol is always linkable; in a build
+without the feature it resolves with `TGM_ERROR_REMOTE` and a
+diagnostic naming the missing feature, so callers never hit an
+undefined symbol.
+
+See `examples/cpp/19_async_decode_remote.cpp` and the
+[producer/consumer guide](cpp-streaming-async.md).
 
 ## What's not in scope (v1)
 

--- a/docs/src/guide/cpp-async.md
+++ b/docs/src/guide/cpp-async.md
@@ -1,0 +1,261 @@
+# C++ Async API
+
+Tensogram ships an asynchronous C++ surface designed for the HPC
+producer/consumer scenario where independent jobs on the same cluster
+pipe data through a `.tgm` artefact.
+
+The async layer is **header-only** and **opt-in** via three frontends
+that all sit on the same callback-based FFI core:
+
+| Frontend | C++ standard | Header | Style |
+|---|---|---|---|
+| Callback | C++17 (default) | `tensogram/async/callback.hpp` | `std::function` completion handlers |
+| `std::future` | C++17 (opt-in) | `tensogram/async/std_future.hpp` | `std::future<T>` |
+| Coroutines | C++20 (opt-in) | `tensogram/async/coro.hpp` | `task<T>` + `co_await` |
+
+The plan: `plans/PLAN_CPP_ASYNC.md` for full design rationale.
+
+## Build setup
+
+The async surface is enabled by default in CMake. To opt out:
+
+```cmake
+cmake -S cpp -B build -DTENSOGRAM_ASYNC=OFF
+```
+
+When `TENSOGRAM_ASYNC=ON` (the default), the cargo build line gains
+`--features=async`, the C++ wrapper target gets a `TENSOGRAM_ASYNC=1`
+compile definition, and the test suite picks up the async test files.
+
+The C++20 coroutine frontend is built as a separate test executable.
+You can disable it with `-DTENSOGRAM_ASYNC_CORO_TESTS=OFF` if your
+compiler doesn't support C++20 coroutines.
+
+## Architecture
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│ User code                                                           │
+└────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌────────────────────────────────────────────────────────────────────┐
+│ C++ frontend (header-only):                                         │
+│   tensogram/async/callback.hpp     std::function callbacks          │
+│   tensogram/async/coro.hpp         task<T> coroutines (C++20)       │
+│   tensogram/async/std_future.hpp   std::future<T>                   │
+└────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌────────────────────────────────────────────────────────────────────┐
+│ tensogram-ffi async core (cdylib + staticlib):                      │
+│   tgm_async_task_t   — opaque task handle                          │
+│   tgm_cancellation_token_t — cancellation                           │
+│   tgm_async_file_t   — Arc-shared file handle                      │
+│   tgm_async_streaming_encoder_t — producer                         │
+└────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌────────────────────────────────────────────────────────────────────┐
+│ Rust core: SHARED_RUNTIME (tokio multi-thread, contained)           │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+The runtime is fully contained — no tokio types appear in the public
+C/C++ API.  Default workers = `min(num_cpus, 8)`; configurable via
+`tgm_runtime_configure(...)` once at process start.
+
+## Callback frontend (`callback.hpp`)
+
+Always available wherever `TENSOGRAM_ASYNC=ON`.  No extra C++ standard
+required.
+
+```cpp
+#include <tensogram.hpp>
+#include <tensogram/async/callback.hpp>
+
+namespace tac = tensogram::async_callback;
+
+tac::async_file::open("data.tgm", [](tac::result<tac::async_file> r) {
+    if (!r.ok()) {
+        std::cerr << "open failed: " << r.message() << "\n";
+        return;
+    }
+    auto file = r.take();
+    file.message_count([file_ref = std::move(file)](tac::result<std::size_t> r) mutable {
+        if (r.ok()) {
+            std::cout << "messages: " << r.value() << "\n";
+        }
+    });
+});
+```
+
+### Callback contract
+
+The callback runs on a worker thread inside the FFI's runtime.  It must:
+- Complete quickly (< 100 µs of CPU time).
+- Not block on locks held outside the callback.
+- Not throw — `panic = "abort"` is set on the Rust side, so an
+  exception escaping a callback will terminate the process.
+- Signal a condvar / coroutine handle / promise and return.
+
+For heavy work, hand off to the user's own thread pool.
+
+## `std::future` frontend (`std_future.hpp`)
+
+C++17 opt-in.  Each method returns `std::future<T>` whose `.get()`
+blocks until the operation completes.  Failures throw the typed
+`tensogram::error` hierarchy through `.get()`.
+
+```cpp
+#include <tensogram/async/std_future.hpp>
+
+namespace tsf = tensogram::stdfuture;
+
+auto file = tsf::async_file::open("data.tgm").get();
+auto count = file.message_count().get();
+auto msg = file.decode_message(0).get();
+```
+
+Composition is intentionally weak — no `.then`, no `when_all`.  Users
+wanting pipelines should reach for `coro.hpp`.  Users on
+`-fno-exceptions` builds should use `callback.hpp` (the future
+surface needs exceptions to surface failures through `.get()`).
+
+## Coroutine frontend (`coro.hpp`)
+
+C++20 opt-in.  Two types are exported:
+
+- `task<T>` — proper coroutine return type.  Users write
+  `task<int> my_func() { co_return 42; }` and chain via
+  `co_await my_func()`.
+- `awaiter<T>` — what async I/O methods return.  Itself awaitable;
+  suspends until the underlying FFI task resolves.
+
+```cpp
+#include <tensogram/async/coro.hpp>
+
+namespace tco = tensogram::coro;
+
+tco::task<std::size_t> walk(const std::string& path) {
+    auto file = co_await tco::async_file::open(path);
+    std::size_t total = 0;
+    auto count = co_await file.message_count();
+    for (std::size_t i = 0; i < count; ++i) {
+        auto msg = co_await file.decode_message(i);
+        total += msg.num_objects();
+    }
+    co_return total;
+}
+
+int main() {
+    auto n = tco::block_on(walk("data.tgm"));
+    std::cout << "total objects: " << n << "\n";
+}
+```
+
+`tco::block_on` runs the task synchronously on the calling thread;
+useful at top-level entry points like `main()`.
+
+`tco::async_for_each(file, fn)` is a convenience that walks every
+message in `file` and applies `fn` to each `tensogram::message`.
+
+## Producer side: streaming async encoder
+
+All three frontends expose `async_streaming_encoder` for the producer
+scenario.  Local file backend; preamble + header metadata are written
+asynchronously when `create()` resolves.
+
+```cpp
+// Coroutine frontend example
+tco::task<void> emit_steps(forecast_engine& fc) {
+    auto enc = co_await tco::async_streaming_encoder::create(
+        "/run/forecast.tgm",
+        R"({"base": []})");
+
+    while (auto step = fc.next_step()) {
+        co_await enc.write_object(step.descriptor_json,
+                                   step.bytes.data(), step.bytes.size());
+    }
+
+    co_await enc.finish(/*backfill=*/true);
+}
+```
+
+The producer task and the underlying encoder are protected by a
+`tokio::sync::Mutex` so concurrent FFI calls against the same handle
+serialise correctly.
+
+## Cancellation and timeouts
+
+Every async-launching call accepts an optional
+`cancellation_token*` and a `std::chrono::milliseconds timeout`.
+
+```cpp
+tac::cancellation_token tok;
+file.decode_message(42, [](tac::result<tensogram::message> r) {
+    if (r.code() == TGM_ERROR_CANCELLED) {
+        std::cerr << "cancelled\n";
+    }
+}, &tok, std::chrono::milliseconds{5000});
+
+// Cancel from any thread:
+tok.cancel();
+```
+
+Timeout `0` means "no timeout".  Internally implemented via
+`tokio::time::timeout` and `tokio_util::sync::CancellationToken`.
+
+## Thread safety
+
+- `async_file` — internally backed by `Arc<TensogramFile>`.  Multiple
+  threads may issue concurrent reads against the same handle.
+- `async_streaming_encoder` — single-handle, internally serialised
+  via `tokio::sync::Mutex`.  Concurrent writes against the same
+  encoder serialise; this matches the inherently sequential nature
+  of streaming writes.
+- `cancellation_token` — safe to share across threads; refcounted
+  internally.
+
+## Runtime configuration
+
+Call once before any other async API:
+
+```cpp
+tac::runtime_configure(/*workers=*/16,
+                        /*dispatcher_workers=*/0,  // default
+                        /*multipart_part_size_bytes=*/0);  // default 8 MiB
+```
+
+Subsequent calls throw `invalid_arg_error` because the runtime is
+built lazily on first use and cannot be reconfigured after that.
+
+`runtime_shutdown_blocking(timeout)` drains in-flight tasks and
+returns the count that did not finish within the deadline.
+
+## What's not in scope (v1)
+
+- Object-store backends for the streaming encoder (S3, GCS, Azure).
+  Local file only.  See plan §5.2.
+- External tokio runtime interop (users supplying their own runtime).
+- Boost.Asio or Folly frontends — explicitly removed from the plan.
+- MSVC / Windows.  Linux + macOS only.
+- Per-file runtime isolation.
+
+See `plans/PLAN_CPP_ASYNC.md` §10 for the full out-of-scope list.
+
+## Cross-language parity
+
+The async surface produces wire-format-identical bytes to the sync
+`StreamingEncoder` for the same logical sequence of writes.  Every
+file written via the async path can be read by Rust, Python, or the
+sync C++ wrapper without modification.
+
+## Producer / consumer integration test
+
+The integration test
+`cpp/tests/test_async_producer_consumer.cpp` exercises the canonical
+HPC pattern: a producer writes 8 forecast steps as separate frames
+in one streaming message; a consumer reads them all back and
+verifies the data.  Mirror your own producer/consumer pair on this
+shape and you'll have a working setup.

--- a/docs/src/guide/cpp-streaming-async.md
+++ b/docs/src/guide/cpp-streaming-async.md
@@ -1,0 +1,173 @@
+# C++ Async Streaming (Producer / Consumer)
+
+This guide is a practical recipe for the HPC scenario that drives the
+C++ async surface: two independent jobs on the same cluster pipe data
+through a `.tgm` artefact. A **producer** (a simulation or inference
+job) streams forecast steps out as they are computed; a **consumer**
+(post-processing or visualisation) reads each message as soon as it is
+available. Neither job should stall waiting on the other.
+
+For the full async API reference — all three frontends, the callback
+contract, runtime configuration, cancellation, and thread-safety — see
+[C++ Async API](cpp-async.md). This page focuses on the end-to-end
+producer/consumer pattern.
+
+The runnable companions to this guide are:
+
+- `examples/cpp/20_async_producer.cpp`
+- `examples/cpp/21_async_consumer.cpp`
+- `examples/cpp/19_async_decode_remote.cpp` (consumer reading over an
+  object store / `file://`)
+
+## Build setup
+
+The async surface is header-only and on by default in CMake:
+
+```bash
+cmake -S cpp -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j
+```
+
+The examples below use the C++20 coroutine frontend
+(`tensogram/async/coro.hpp`). The callback (`callback.hpp`) and
+`std::future` (`std_future.hpp`) frontends offer the same operations on
+C++17 — pick whichever matches your code base. To read over an object
+store or a `file://` URL, configure with `-DTENSOGRAM_ASYNC_REMOTE=ON`
+(this builds the FFI with `--features=async-remote`).
+
+## Producer: streaming a message out object-by-object
+
+The producer creates an `async_streaming_encoder`, writes each data
+object as it is produced, and calls `finish()` once the message is
+complete. Nothing buffers the whole message — each `write_object`
+hands its bytes to the async writer and returns.
+
+```cpp
+#include <tensogram/async/coro.hpp>
+namespace tco = tensogram::coro;
+
+tco::task<void> emit_forecast(forecast_engine& fc) {
+    auto enc = co_await tco::async_streaming_encoder::create(
+        "/scratch/run/forecast.tgm",
+        R"({"base": []})");          // global metadata (CBOR-encoded)
+
+    while (auto step = fc.next_step()) {
+        co_await enc.write_object(step.descriptor_json,
+                                  step.bytes.data(), step.bytes.size());
+    }
+
+    // backfill=true rewrites the preamble/postamble lengths so the
+    // finished file is fully random-access (see WIRE_FORMAT.md §7).
+    co_await enc.finish(/*backfill=*/true);
+}
+```
+
+Notes and edge cases:
+
+- **One encoder, serialised writes.** A single `async_streaming_encoder`
+  is internally guarded by a `tokio::sync::Mutex`; concurrent
+  `write_object` calls against the same handle serialise. This matches
+  the inherently sequential nature of a streaming write — don't try to
+  parallelise writes to one encoder.
+- **Pre-encoded payloads.** If your bytes are already encoded
+  (compressed/packed), use `write_pre_encoded(...)` to skip the
+  encoding pipeline. Use `write_preceder(...)` to emit a metadata
+  preceder frame ahead of an object so a streaming consumer can decode
+  it before the payload arrives.
+- **Backend.** In v1 the streaming **encoder** writes to a **local
+  file** only. The shared filesystem (Lustre, GPFS, WekaFS, BeeGFS) is
+  the supported producer sink. Object-store *write* is out of scope;
+  object-store *reads* are supported on the consumer side (below).
+- **Crash/cancellation.** If the producer is cancelled or killed
+  mid-stream the partial `.tgm` is left on disk as-is (no truncate or
+  delete). Operational systems should treat an unfinished file as
+  untrusted until the producer signals completion — see *Coordination*.
+
+## Consumer: reading each message as it lands
+
+The consumer opens the file and walks its messages. `async_for_each`
+decodes each message in turn and hands it to your callback; it is the
+coroutine mirror of the Python iterator pattern.
+
+```cpp
+tco::task<std::size_t> consume(const std::string& path) {
+    auto file = co_await tco::async_file::open(path);
+    std::size_t seen = 0;
+    co_await tco::async_for_each(file, [&](tensogram::message msg) {
+        process(msg);              // your work
+        ++seen;
+    });
+    co_return seen;
+}
+```
+
+If you need random access instead of a full walk, use
+`message_count()` + `decode_message(i)` directly. An `async_file` is
+backed by an `Arc<TensogramFile>`, so it is safe to issue concurrent
+reads against the same handle from multiple threads (see the
+*Thread safety* section of the [reference](cpp-async.md)).
+
+## Coordination on a shared filesystem
+
+Two patterns, depending on how tightly coupled the jobs are:
+
+1. **Commit-then-read (simplest, recommended).** The producer writes
+   the whole message and calls `finish()`; the consumer waits for the
+   file to be committed (e.g. an atomic rename into a watched
+   directory, or a sentinel marker) and then opens it. This avoids any
+   torn-read window and is how most operational pipelines hand off.
+
+2. **Progressive streaming.** The consumer reads a growing byte stream
+   and decodes messages as they complete. The synchronous
+   `examples/cpp/09_streaming_consumer.cpp` shows the
+   `scan()`-the-rolling-buffer technique; the producer's metadata
+   preceder frames (`write_preceder`) let the consumer decode each
+   object's metadata before its payload arrives. Use this only when
+   the latency saving justifies the added coordination.
+
+> **Edge case — torn reads.** A consumer that opens a `.tgm` the
+> producer has not yet `finish()`-ed may see a truncated file. Decode
+> calls surface a framing error rather than returning garbage; wait for
+> the committed file (pattern 1) or use the progressive reader with a
+> retry-on-partial loop (pattern 2).
+
+## Consumer reading over an object store
+
+A consumer running on a different node can read the producer's artefact
+over an object store or a shared-filesystem `file://` URL via
+`open_remote`:
+
+```cpp
+std::vector<std::pair<std::string, std::string>> opts = {
+    {"aws_region", "eu-west-1"},
+};
+auto file = co_await tco::async_file::open_remote(
+    "s3://forecasts/run-42/forecast.tgm", opts, /*bidirectional=*/true);
+auto count = co_await file.message_count();
+```
+
+- `bidirectional=true` selects the pipelined two-ended remote scan,
+  which halves the per-message round-trip cost on high-latency links.
+- Pass storage credentials/config through `storage_options`, or rely on
+  ambient configuration (environment, instance role). For a `file://`
+  URL no options are needed.
+- This requires the FFI built with `--features=async-remote`
+  (`-DTENSOGRAM_ASYNC_REMOTE=ON`). Without it, `open_remote` resolves
+  with `TGM_ERROR_REMOTE` and a diagnostic naming the missing feature.
+
+## Wire-format parity
+
+The async streaming encoder produces **byte-identical** output to the
+synchronous `StreamingEncoder` for the same logical sequence of writes.
+Every file written via the async producer can be read by Rust, Python,
+the WASM/TypeScript decoder, or the synchronous C++ wrapper without
+modification.
+
+## See also
+
+- [C++ Async API](cpp-async.md) — full reference for all three
+  frontends, cancellation/timeouts, runtime configuration, and
+  thread-safety.
+- [Working with Files](file-api.md) and [Remote Access](remote-access.md)
+  — the synchronous counterparts.
+- Examples `19`–`24` under `examples/cpp/`.

--- a/docs/src/guide/remote-access.md
+++ b/docs/src/guide/remote-access.md
@@ -167,6 +167,7 @@ ds = xr.open_dataset(
 | `s3://`, `s3a://` | Amazon S3 | Env-based or explicit credentials |
 | `gs://` | Google Cloud Storage | Service account or env |
 | `az://`, `azure://` | Azure Blob Storage | MSI or env |
+| `file://` | Local filesystem | Via `open_remote`; for ordinary local files prefer a plain path or `open()` (`open_source` does not auto-route `file://`) |
 
 All backends are provided by the [`object_store`](https://crates.io/crates/object_store) crate.
 

--- a/examples/cpp/19_async_decode_remote.cpp
+++ b/examples/cpp/19_async_decode_remote.cpp
@@ -1,0 +1,107 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+/// @file 19_async_decode_remote.cpp
+/// @brief Example 19 — Asynchronous remote decode (coroutine frontend).
+///
+/// Opens a `.tgm` over the object-store backend and decodes a message,
+/// all via C++20 coroutines (`tensogram/async/coro.hpp`).  Production
+/// callers point `open_remote` at `s3://`, `gs://`, `az://`, or
+/// `https://` URLs; this example uses a `file://` URL so it runs
+/// offline and deterministically through the very same code path.
+///
+/// Requires the FFI built with the `async-remote` Cargo feature.
+/// Configure CMake with `-DTENSOGRAM_ASYNC_REMOTE=ON`, which adds
+/// `--features=async-remote` to the cargo build and enables this
+/// example target.
+///
+/// For a real object store you would instead write, e.g.:
+///
+///   std::vector<std::pair<std::string, std::string>> opts = {
+///       {"aws_region", "eu-west-1"},
+///   };
+///   auto file = co_await tco::async_file::open_remote(
+///       "s3://my-bucket/forecast.tgm", opts, /*bidirectional=*/true);
+///
+/// Build:
+///   cmake -S cpp -B build -DCMAKE_BUILD_TYPE=Release -DTENSOGRAM_ASYNC_REMOTE=ON
+///   cmake --build build -j
+///   ./build/bin/19_async_decode_remote
+
+#include <tensogram.hpp>
+#include <tensogram/async/coro.hpp>
+
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace tco = tensogram::coro;
+
+namespace {
+
+std::filesystem::path make_sample_file() {
+    const auto path = std::filesystem::temp_directory_path() /
+        ("tensogram_example_19_" + std::to_string(std::random_device{}()) + ".tgm");
+    const std::string meta = R"({
+        "descriptors":[{"type":"ntensor","ndim":1,"shape":[4],"strides":[4],
+        "dtype":"float32","encoding":"none","filter":"none","compression":"none"}],
+        "base":[{"mars":{"param":"2t"}}]
+    })";
+    std::vector<float> values{300.0f, 301.0f, 302.0f, 303.0f};
+    std::vector<std::pair<const std::uint8_t*, std::size_t>> objs = {
+        {reinterpret_cast<const std::uint8_t*>(values.data()),
+         values.size() * sizeof(float)}};
+    auto f = tensogram::file::create(path.string());
+    f.append(meta, objs);
+    return path;
+}
+
+}  // namespace
+
+int main() {
+    const auto path = make_sample_file();
+    // object_store's local backend expects an absolute `file://` URL.
+    const std::string url = "file://" + std::filesystem::absolute(path).string();
+    std::printf("Reading %s\n", url.c_str());
+
+    auto run = [&url]() -> tco::task<int> {
+        // No storage options needed for file://; for s3:// etc. pass
+        // credentials/region here or rely on ambient configuration.
+        auto file = co_await tco::async_file::open_remote(
+            url, /*storage_options=*/{}, /*bidirectional=*/false);
+        const std::size_t count = co_await file.message_count();
+        auto msg = co_await file.decode_message(0);
+        auto obj = msg.object(0);
+        const float* data = obj.data_as<float>();
+        std::printf("Remote open OK: %zu message(s), first value %.1f\n",
+                    count, static_cast<double>(data[0]));
+        co_return static_cast<int>(msg.num_objects());
+    };
+
+    try {
+        const int objects = tco::block_on(run());
+        assert(objects == 1);
+    } catch (const tensogram::error& e) {
+        // Most likely cause if you see this: the FFI was built without
+        // the `async-remote` feature (configure with
+        // -DTENSOGRAM_ASYNC_REMOTE=ON).
+        std::fprintf(stderr, "remote decode failed (code %d): %s\n",
+                     static_cast<int>(e.code()), e.what());
+        std::remove(path.string().c_str());
+        return 1;
+    }
+
+    std::remove(path.string().c_str());
+    std::printf("SUCCESS\n");
+    return 0;
+}

--- a/examples/cpp/20_async_producer.cpp
+++ b/examples/cpp/20_async_producer.cpp
@@ -1,0 +1,89 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+/// @file 20_async_producer.cpp
+/// @brief Example 20 — Asynchronous streaming producer (coroutine frontend).
+///
+/// Models the HPC producer: a job emits forecast steps as they are
+/// computed, streaming each into a `.tgm` without buffering the whole
+/// message.  Uses the C++20 coroutine streaming encoder.  The consumer
+/// half is example 21.
+///
+/// Each `write_object` appends one data object to the in-flight
+/// message; `finish(backfill=true)` writes the footer and back-fills
+/// the preamble/postamble lengths so the result is a fully
+/// random-access `.tgm`.
+///
+/// Build:
+///   cmake -S cpp -B build -DCMAKE_BUILD_TYPE=Release
+///   cmake --build build -j
+///   ./build/bin/20_async_producer
+
+#include <tensogram.hpp>
+#include <tensogram/async/coro.hpp>
+
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace tco = tensogram::coro;
+
+int main() {
+    const auto path = std::filesystem::temp_directory_path() /
+        ("tensogram_example_20_" + std::to_string(std::random_device{}()) + ".tgm");
+    const std::string path_str = path.string();
+
+    constexpr int STEPS = 8;
+    constexpr int NX = 16;
+    constexpr int NY = 16;
+
+    auto produce = [&]() -> tco::task<void> {
+        auto enc = co_await tco::async_streaming_encoder::create(
+            path_str, R"({"base":[]})");
+
+        // Byte strides, row-major: inner dim = sizeof(float), outer = NY*4.
+        const std::string desc = R"({
+            "type":"ntensor","ndim":2,"shape":[16,16],"strides":[64,4],
+            "dtype":"float32","encoding":"none","filter":"none",
+            "compression":"none","params":{}
+        })";
+
+        for (int step = 0; step < STEPS; ++step) {
+            std::vector<float> field(static_cast<std::size_t>(NX) * NY);
+            for (std::size_t i = 0; i < field.size(); ++i) {
+                field[i] = static_cast<float>(step) +
+                           0.001f * static_cast<float>(i);
+            }
+            const auto* bytes = reinterpret_cast<const std::uint8_t*>(field.data());
+            co_await enc.write_object(desc, bytes, field.size() * sizeof(float));
+            std::printf("  streamed step %d\n", step);
+        }
+        co_await enc.finish(/*backfill=*/true);
+    };
+
+    tco::block_on(produce());
+    std::printf("Producer finished: %d steps -> %s\n", STEPS, path_str.c_str());
+
+    // Verify by decoding the finished file with the synchronous API.
+    std::ifstream in(path_str, std::ios::binary);
+    std::vector<std::uint8_t> bytes((std::istreambuf_iterator<char>(in)),
+                                    std::istreambuf_iterator<char>());
+    auto msg = tensogram::decode(bytes.data(), bytes.size());
+    std::printf("Read back: %zu objects in one message\n", msg.num_objects());
+    assert(msg.num_objects() == static_cast<std::size_t>(STEPS));
+
+    std::remove(path_str.c_str());
+    std::printf("SUCCESS\n");
+    return 0;
+}

--- a/examples/cpp/21_async_consumer.cpp
+++ b/examples/cpp/21_async_consumer.cpp
@@ -1,0 +1,93 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+/// @file 21_async_consumer.cpp
+/// @brief Example 21 — Asynchronous streaming consumer (coroutine frontend).
+///
+/// Models the HPC consumer: a job reads each message from a `.tgm` as
+/// soon as it is available, overlapping decode with the next fetch.
+/// `tco::async_for_each` walks every message via C++20 coroutines and
+/// hands each decoded `tensogram::message` to your callback.  The
+/// producer half is example 20.
+///
+/// To stay self-contained the example first writes a small
+/// multi-message file with the synchronous API, then consumes it
+/// asynchronously.
+///
+/// Build:
+///   cmake -S cpp -B build -DCMAKE_BUILD_TYPE=Release
+///   cmake --build build -j
+///   ./build/bin/21_async_consumer
+
+#include <tensogram.hpp>
+#include <tensogram/async/coro.hpp>
+
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace tco = tensogram::coro;
+
+namespace {
+
+std::filesystem::path make_multi_message_file(int messages) {
+    const auto path = std::filesystem::temp_directory_path() /
+        ("tensogram_example_21_" + std::to_string(std::random_device{}()) + ".tgm");
+    const std::string meta = R"({
+        "descriptors":[{"type":"ntensor","ndim":1,"shape":[8],"strides":[4],
+        "dtype":"float32","encoding":"none","filter":"none","compression":"none"}],
+        "base":[{"mars":{"param":"2t"}}]
+    })";
+    auto f = tensogram::file::create(path.string());
+    for (int m = 0; m < messages; ++m) {
+        std::vector<float> values(8);
+        for (std::size_t i = 0; i < values.size(); ++i) {
+            values[i] = static_cast<float>(m) + 0.1f * static_cast<float>(i);
+        }
+        std::vector<std::pair<const std::uint8_t*, std::size_t>> objs = {
+            {reinterpret_cast<const std::uint8_t*>(values.data()),
+             values.size() * sizeof(float)}};
+        f.append(meta, objs);
+    }
+    return path;
+}
+
+}  // namespace
+
+int main() {
+    constexpr int MESSAGES = 5;
+    const auto path = make_multi_message_file(MESSAGES);
+    const std::string path_str = path.string();
+    std::printf("Wrote %d messages to %s\n", MESSAGES, path_str.c_str());
+
+    auto consume = [&]() -> tco::task<std::size_t> {
+        auto file = co_await tco::async_file::open(path_str);
+        std::size_t seen = 0;
+        co_await tco::async_for_each(file, [&seen](tensogram::message m) {
+            auto obj = m.object(0);
+            const float* data = obj.data_as<float>();
+            std::printf("  message %zu: %zu object(s), first value %.1f\n",
+                        seen, m.num_objects(), static_cast<double>(data[0]));
+            ++seen;
+        });
+        co_return seen;
+    };
+
+    const std::size_t seen = tco::block_on(consume());
+    std::printf("Consumed %zu messages\n", seen);
+    assert(seen == static_cast<std::size_t>(MESSAGES));
+
+    std::remove(path_str.c_str());
+    std::printf("SUCCESS\n");
+    return 0;
+}

--- a/examples/cpp/22_async_callback.cpp
+++ b/examples/cpp/22_async_callback.cpp
@@ -1,0 +1,120 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+/// @file 22_async_callback.cpp
+/// @brief Example 22 — Asynchronous read via the callback frontend.
+///
+/// The callback frontend (`tensogram/async/callback.hpp`) is the
+/// always-available C++17 async surface.  Every operation takes a
+/// completion handler that fires exactly once, on the FFI dispatcher
+/// pool, when the work resolves.  The contract: do as little as
+/// possible inside the handler — signal a promise / condition variable
+/// / coroutine handle and return.
+///
+/// This example opens a local `.tgm`, counts its messages, and decodes
+/// the first one, chaining three callbacks and bridging each result
+/// back to `main()` through a `std::promise`.
+///
+/// Build:
+///   cmake -S cpp -B build -DCMAKE_BUILD_TYPE=Release
+///   cmake --build build -j
+///   ./build/bin/22_async_callback
+
+#include <tensogram.hpp>
+#include <tensogram/async/callback.hpp>
+
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <future>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace tac = tensogram::async_callback;
+
+namespace {
+
+// Write a small two-message float32 file with the synchronous API so the
+// async reader below has something to open.
+std::filesystem::path make_sample_file() {
+    const auto path = std::filesystem::temp_directory_path() /
+        ("tensogram_example_22_" + std::to_string(std::random_device{}()) + ".tgm");
+    const std::string meta = R"({
+        "descriptors":[{"type":"ntensor","ndim":1,"shape":[4],"strides":[4],
+        "dtype":"float32","encoding":"none","filter":"none","compression":"none"}],
+        "base":[{"mars":{"param":"2t"}}]
+    })";
+    std::vector<float> values{280.0f, 281.5f, 282.25f, 283.0f};
+    std::vector<std::pair<const std::uint8_t*, std::size_t>> objs = {
+        {reinterpret_cast<const std::uint8_t*>(values.data()),
+         values.size() * sizeof(float)}};
+    auto f = tensogram::file::create(path.string());
+    f.append(meta, objs);
+    f.append(meta, objs);
+    return path;  // destructor flushes + closes before we return
+}
+
+}  // namespace
+
+int main() {
+    const auto path = make_sample_file();
+    std::printf("Wrote %s\n", path.string().c_str());
+
+    // -- 1. Open asynchronously --
+    //
+    // The completion handler runs on the dispatcher pool, not this
+    // thread.  We hand the result back to main() through a promise and
+    // block on its future — the canonical "signal and return" shape.
+    std::promise<tac::result<tac::async_file>> open_promise;
+    auto open_future = open_promise.get_future();
+    tac::async_file::open(path.string(),
+        [&open_promise](tac::result<tac::async_file> r) {
+            open_promise.set_value(std::move(r));
+        });
+    auto open_result = open_future.get();
+    if (!open_result.ok()) {
+        std::fprintf(stderr, "open failed: %s\n", open_result.message().c_str());
+        return 1;
+    }
+    auto file = open_result.take();
+    std::printf("Opened asynchronously\n");
+
+    // -- 2. Count messages asynchronously --
+    std::promise<tac::result<std::size_t>> count_promise;
+    auto count_future = count_promise.get_future();
+    file.message_count([&count_promise](tac::result<std::size_t> r) {
+        count_promise.set_value(std::move(r));
+    });
+    auto count_result = count_future.get();
+    assert(count_result.ok());
+    const std::size_t count = count_result.value();
+    std::printf("Messages: %zu\n", count);
+    assert(count == 2);
+
+    // -- 3. Decode message 0 asynchronously --
+    std::promise<tac::result<tensogram::message>> decode_promise;
+    auto decode_future = decode_promise.get_future();
+    file.decode_message(0, [&decode_promise](tac::result<tensogram::message> r) {
+        decode_promise.set_value(std::move(r));
+    });
+    auto decode_result = decode_future.get();
+    assert(decode_result.ok());
+    auto& msg = decode_result.value();
+    auto obj = msg.object(0);
+    const float* data = obj.data_as<float>();
+    std::printf("Decoded message 0: %zu object(s), first value %.2f\n",
+                msg.num_objects(), static_cast<double>(data[0]));
+    assert(msg.num_objects() == 1);
+
+    std::remove(path.string().c_str());
+    std::printf("SUCCESS\n");
+    return 0;
+}

--- a/examples/cpp/23_async_stdfuture.cpp
+++ b/examples/cpp/23_async_stdfuture.cpp
@@ -1,0 +1,92 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+/// @file 23_async_stdfuture.cpp
+/// @brief Example 23 — Asynchronous read via the std::future frontend.
+///
+/// The std::future frontend (`tensogram/async/std_future.hpp`) returns
+/// a `std::future<T>` from every operation.  Call `.get()` to block
+/// until completion; failures surface as the typed `tensogram::error`
+/// hierarchy thrown out of `.get()`.  This is the most concise async
+/// surface when you simply want to wait for a result inline.
+///
+/// Build:
+///   cmake -S cpp -B build -DCMAKE_BUILD_TYPE=Release
+///   cmake --build build -j
+///   ./build/bin/23_async_stdfuture
+
+#include <tensogram.hpp>
+#include <tensogram/async/std_future.hpp>
+
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <future>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace tsf = tensogram::stdfuture;
+
+namespace {
+
+std::filesystem::path make_sample_file() {
+    const auto path = std::filesystem::temp_directory_path() /
+        ("tensogram_example_23_" + std::to_string(std::random_device{}()) + ".tgm");
+    const std::string meta = R"({
+        "descriptors":[{"type":"ntensor","ndim":1,"shape":[4],"strides":[4],
+        "dtype":"float32","encoding":"none","filter":"none","compression":"none"}],
+        "base":[{"mars":{"param":"2t"}}]
+    })";
+    std::vector<float> values{280.0f, 281.5f, 282.25f, 283.0f};
+    std::vector<std::pair<const std::uint8_t*, std::size_t>> objs = {
+        {reinterpret_cast<const std::uint8_t*>(values.data()),
+         values.size() * sizeof(float)}};
+    auto f = tensogram::file::create(path.string());
+    f.append(meta, objs);
+    f.append(meta, objs);
+    return path;
+}
+
+}  // namespace
+
+int main() {
+    const auto path = make_sample_file();
+    std::printf("Wrote %s\n", path.string().c_str());
+
+    // -- 1. Open, count, decode — each call returns a std::future<T> --
+    auto file = tsf::async_file::open(path.string()).get();
+    std::printf("Opened asynchronously\n");
+
+    const std::size_t count = file.message_count().get();
+    std::printf("Messages: %zu\n", count);
+    assert(count == 2);
+
+    auto msg = file.decode_message(0).get();
+    auto obj = msg.object(0);
+    const float* data = obj.data_as<float>();
+    std::printf("Decoded message 0: %zu object(s), first value %.2f\n",
+                msg.num_objects(), static_cast<double>(data[0]));
+    assert(msg.num_objects() == 1);
+
+    // -- 2. Failures surface as exceptions through .get() --
+    try {
+        auto missing = tsf::async_file::open("/nonexistent/missing.tgm").get();
+        (void)missing;
+        std::fprintf(stderr, "expected an exception for a missing file\n");
+        return 1;
+    } catch (const tensogram::error& e) {
+        std::printf("Open of a missing file threw as expected: %s\n", e.what());
+    }
+
+    std::remove(path.string().c_str());
+    std::printf("SUCCESS\n");
+    return 0;
+}

--- a/examples/cpp/24_async_cancellation.cpp
+++ b/examples/cpp/24_async_cancellation.cpp
@@ -1,0 +1,126 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+/// @file 24_async_cancellation.cpp
+/// @brief Example 24 — Cancellation tokens and timeouts (callback frontend).
+///
+/// Every async-launching call accepts an optional `cancellation_token*`
+/// and a `std::chrono::milliseconds` timeout.  Cancelled or timed-out
+/// operations complete with `TGM_ERROR_CANCELLED` / `TGM_ERROR_TIMEOUT`
+/// instead of a value; a token may be shared across many in-flight
+/// tasks ("cancel all my pending work").
+///
+/// Cancellation matters most for long-running remote fetches.  For the
+/// fast local read used here there is an inherent race — the read may
+/// finish before the cancellation is observed — so this example reports
+/// whichever outcome occurs rather than asserting a single one.
+///
+/// Build:
+///   cmake -S cpp -B build -DCMAKE_BUILD_TYPE=Release
+///   cmake --build build -j
+///   ./build/bin/24_async_cancellation
+
+#include <tensogram.hpp>
+#include <tensogram/async/callback.hpp>
+
+#include <cassert>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <future>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace tac = tensogram::async_callback;
+
+namespace {
+
+std::filesystem::path make_sample_file() {
+    const auto path = std::filesystem::temp_directory_path() /
+        ("tensogram_example_24_" + std::to_string(std::random_device{}()) + ".tgm");
+    const std::string meta = R"({
+        "descriptors":[{"type":"ntensor","ndim":1,"shape":[4],"strides":[4],
+        "dtype":"float32","encoding":"none","filter":"none","compression":"none"}],
+        "base":[{"mars":{"param":"2t"}}]
+    })";
+    std::vector<float> values{280.0f, 281.5f, 282.25f, 283.0f};
+    std::vector<std::pair<const std::uint8_t*, std::size_t>> objs = {
+        {reinterpret_cast<const std::uint8_t*>(values.data()),
+         values.size() * sizeof(float)}};
+    auto f = tensogram::file::create(path.string());
+    f.append(meta, objs);
+    return path;
+}
+
+// Open synchronously-from-async: launch the async open and block on it.
+tac::async_file open_blocking(const std::string& path) {
+    std::promise<tac::result<tac::async_file>> p;
+    auto fut = p.get_future();
+    tac::async_file::open(path,
+        [&p](tac::result<tac::async_file> r) { p.set_value(std::move(r)); });
+    return fut.get().take();
+}
+
+}  // namespace
+
+int main() {
+    const auto path = make_sample_file();
+    auto file = open_blocking(path.string());
+
+    // -- 1. cancellation_token lifecycle --
+    tac::cancellation_token tok;
+    assert(!tok.cancelled());
+    tok.cancel();
+    assert(tok.cancelled());
+    std::printf("Token cancelled flag: %s\n", tok.cancelled() ? "true" : "false");
+
+    // -- 2. Launch a decode with the already-cancelled token + a timeout --
+    {
+        std::promise<tac::result<tensogram::message>> p;
+        auto fut = p.get_future();
+        file.decode_message(0,
+            [&p](tac::result<tensogram::message> r) { p.set_value(std::move(r)); },
+            &tok,                                // already cancelled
+            std::chrono::milliseconds{5000});    // 5s deadline
+        auto r = fut.get();
+        if (r.ok()) {
+            std::printf("Completed before cancellation was observed "
+                        "(expected for fast local reads): %zu object(s)\n",
+                        r.value().num_objects());
+        } else if (r.code() == TGM_ERROR_CANCELLED) {
+            std::printf("Cancelled as requested (TGM_ERROR_CANCELLED)\n");
+        } else if (r.code() == TGM_ERROR_TIMEOUT) {
+            std::printf("Deadline elapsed (TGM_ERROR_TIMEOUT)\n");
+        } else {
+            std::fprintf(stderr, "unexpected error: %s\n", r.message().c_str());
+            std::remove(path.string().c_str());
+            return 1;
+        }
+    }
+
+    // -- 3. A fresh, uncancelled token with a generous timeout succeeds --
+    {
+        tac::cancellation_token live;
+        std::promise<tac::result<tensogram::message>> p;
+        auto fut = p.get_future();
+        file.decode_message(0,
+            [&p](tac::result<tensogram::message> r) { p.set_value(std::move(r)); },
+            &live, std::chrono::milliseconds{5000});
+        auto r = fut.get();
+        assert(r.ok());
+        std::printf("Uncancelled decode succeeded: %zu object(s)\n",
+                    r.value().num_objects());
+    }
+
+    std::remove(path.string().c_str());
+    std::printf("SUCCESS\n");
+    return 0;
+}

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -1,3 +1,4 @@
+# Synchronous examples (C++17, no async dependencies).
 set(EXAMPLES
     01_encode_decode
     02_mars_metadata
@@ -14,6 +15,16 @@ set(EXAMPLES
     16_multi_threaded_pipeline
 )
 
+# Async examples on the callback / std::future frontends (C++17, header-only).
+# Available wherever the FFI is built with --features=async.
+if(TENSOGRAM_ASYNC)
+    list(APPEND EXAMPLES
+        22_async_callback
+        23_async_stdfuture
+        24_async_cancellation
+    )
+endif()
+
 foreach(example ${EXAMPLES})
     add_executable(${example} ${example}.cpp)
     target_link_libraries(${example} PRIVATE tensogram)
@@ -25,3 +36,34 @@ foreach(example ${EXAMPLES})
     set_target_properties(${example} PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 endforeach()
+
+# Async examples on the C++20 coroutine frontend.  Compiled as separate
+# targets at C++20 (the rest of the examples are C++17).  Disable with
+# -DTENSOGRAM_ASYNC_CORO_EXAMPLES=OFF if your compiler lacks C++20 coroutines.
+option(TENSOGRAM_ASYNC_CORO_EXAMPLES "Build the C++20 coroutine async examples" ON)
+if(TENSOGRAM_ASYNC AND TENSOGRAM_ASYNC_CORO_EXAMPLES)
+    set(CORO_EXAMPLES
+        20_async_producer
+        21_async_consumer
+    )
+    # The remote-decode example needs the object-store backend, which is
+    # only linked in when the FFI is built with --features=async-remote.
+    if(TENSOGRAM_ASYNC_REMOTE)
+        list(APPEND CORO_EXAMPLES 19_async_decode_remote)
+    endif()
+    foreach(example ${CORO_EXAMPLES})
+        add_executable(${example} ${example}.cpp)
+        target_link_libraries(${example} PRIVATE tensogram)
+        set_target_properties(${example} PROPERTIES
+            CXX_STANDARD 20
+            CXX_STANDARD_REQUIRED ON
+            CXX_EXTENSIONS OFF
+            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+        if(MSVC)
+            target_compile_options(${example} PRIVATE /W4)
+        else()
+            target_compile_options(${example} PRIVATE
+                -Wall -Wextra -Wpedantic -Wno-unused-parameter)
+        endif()
+    endforeach()
+endif()

--- a/examples/cpp/README.md
+++ b/examples/cpp/README.md
@@ -20,6 +20,30 @@ C++17 interface over the C FFI.
 | `09_streaming_consumer.cpp` | Consumer-side streaming: scan a growing buffer, decode messages as they arrive |
 | `13_validate.cpp` | Structural, integrity, and fidelity validation at four levels |
 | `16_multi_threaded_pipeline.cpp` | Caller-controlled `threads=N` encode/decode with determinism invariants |
+| `19_async_decode_remote.cpp` | Async remote decode over an object store / `file://` (coroutine frontend) |
+| `20_async_producer.cpp` | Async streaming producer: stream forecast steps into a `.tgm` (coroutine frontend) |
+| `21_async_consumer.cpp` | Async streaming consumer: walk messages with `async_for_each` (coroutine frontend) |
+| `22_async_callback.cpp` | Async read via the callback frontend (C++17): open, count, decode with completion handlers |
+| `23_async_stdfuture.cpp` | Async read via the `std::future` frontend (C++17) |
+| `24_async_cancellation.cpp` | Cancellation tokens and timeouts (callback frontend) |
+
+### Async examples (19–24)
+
+These require the async surface (`TENSOGRAM_ASYNC=ON`, the default). The
+callback / `std::future` examples (22–24) compile on C++17. The
+coroutine examples (19–21) are built as separate C++20 targets — disable
+with `-DTENSOGRAM_ASYNC_CORO_EXAMPLES=OFF` if your compiler lacks C++20
+coroutines. Example 19 additionally needs the object-store backend:
+
+```bash
+cmake -S cpp -B build -DCMAKE_BUILD_TYPE=Release -DTENSOGRAM_ASYNC_REMOTE=ON
+cmake --build build -j
+./build/bin/19_async_decode_remote
+```
+
+See the [C++ Async API](../../docs/src/guide/cpp-async.md) and
+[C++ Async Streaming](../../docs/src/guide/cpp-streaming-async.md) guides
+for the API reference and the producer/consumer recipe.
 
 ## API Overview
 

--- a/plans/ARCHITECTURE.md
+++ b/plans/ARCHITECTURE.md
@@ -134,6 +134,22 @@ The CMake build system (`cpp/CMakeLists.txt`) invokes `cargo build
 INTERFACE header-only target that links the static lib and
 platform-specific system libraries.
 
+### Asynchronous frontends
+
+Three opt-in, header-only async frontends layer on a callback-based FFI
+async core (`tensogram-ffi/src/async_core.rs` for the read path and task
+lifecycle, `async_streaming.rs` for the local-file streaming encoder):
+`cpp/include/tensogram/async/callback.hpp` (C++17, the minimal surface),
+`std_future.hpp` (C++17 `std::future<T>`), and `coro.hpp` (C++20
+`task<T>` + `async_for_each`). They share Tensogram's internal tokio
+runtime through opaque `tgm_async_task_t` handles, cancellation tokens,
+and per-call timeouts — no tokio type crosses the FFI, and every
+definition is `inline` so the only ABI surface is the C FFI.
+`async_file::open_remote` reaches object stores and `file://` URLs. The
+CMake `TENSOGRAM_ASYNC` (default on) and `TENSOGRAM_ASYNC_REMOTE` options
+select the `--features=async` / `async-remote` cargo builds. See
+`docs/src/guide/cpp-async.md` and `cpp-streaming-async.md`.
+
 ## Core Modules (`tensogram`)
 
 ```

--- a/plans/DONE.md
+++ b/plans/DONE.md
@@ -50,6 +50,56 @@ behaviour-preserving: verified by the full existing test suite.
 
 ---
 
+## Asynchronous C++ API (callback / std::future / coroutine frontends)
+
+A true asynchronous read/write surface for the C++ wrapper, built for
+the HPC producer/consumer scenario: two independent cluster jobs pipe
+data through a `.tgm` artefact, and neither should stall on the other.
+It shares Tensogram's internal tokio runtime with no tokio types in the
+public C/C++ API. Three layers: header-only C++ frontends → a
+callback-based FFI core → the Rust async core plus a shared runtime.
+
+| Component | What it does |
+|-----------|--------------|
+| `rust/tensogram/src/streaming_async.rs` | `AsyncStreamingEncoder<W: AsyncWrite + Unpin>`. Shares its frame-emission logic with the sync `StreamingEncoder`, so async output is byte-identical to sync for the same sequence of writes. |
+| `rust/tensogram-ffi/src/async_core.rs` | Opaque `tgm_async_task_t` handles, `tgm_cancellation_token_t`, completion callbacks, typed join functions, a shared multi-thread tokio runtime behind a `OnceLock`, `tgm_runtime_configure`, and the read-path file API (`tgm_async_file_*`) including the always-exported `tgm_async_file_open_remote`. |
+| `rust/tensogram-ffi/src/async_streaming.rs` | Write-path FFI: the `tgm_async_streaming_encoder_*` family over a local `tokio::fs::File`. |
+| `cpp/include/tensogram/async/callback.hpp` | C++17 callback frontend: `result<T>`, `cancellation_token`, `async_file`, `async_streaming_encoder`. The minimal surface the other two frontends layer on. |
+| `cpp/include/tensogram/async/std_future.hpp` | C++17 `std::future<T>` adapter. |
+| `cpp/include/tensogram/async/coro.hpp` | C++20 `task<T>` / `awaiter<T>`, `block_on`, and the `async_for_each(file, fn)` message walker. |
+
+Key decisions:
+
+- **Header-only frontends.** Every `async/*.hpp` definition is `inline`;
+  the only ABI surface is the C FFI. Adding or changing a frontend
+  never alters the shared-library ABI.
+- **Contained runtime.** One shared tokio runtime (default workers
+  `min(num_cpus, 8)`), built lazily behind a `OnceLock`; no tokio type
+  crosses the FFI. A separate dispatcher pool runs user completion
+  callbacks, so a slow callback cannot starve tokio's I/O workers.
+- **Cancellation + timeouts.** Every launch accepts an optional
+  cancellation token and a millisecond deadline, surfacing
+  `TGM_ERROR_CANCELLED` / `TGM_ERROR_TIMEOUT`.
+- **Remote reads.** `open_remote` is exposed on all three frontends and
+  maps to the always-linkable `tgm_async_file_open_remote`. The
+  object-store backend — `s3://`, `gs://`, `az://`, `https://` and
+  `file://` — is gated behind the FFI `async-remote` Cargo feature
+  (the `TENSOGRAM_ASYNC_REMOTE` CMake option, which also adds
+  object_store's `fs` feature for `file://`). Streaming *writes* remain
+  local-file only.
+- **Wire-format parity.** The async streaming encoder emits
+  byte-identical output to the sync encoder, so async-written files are
+  readable by every binding.
+
+Build wiring: the `cpp` CMake build gains `TENSOGRAM_ASYNC` (on by
+default; adds `--features=async`) and `TENSOGRAM_ASYNC_REMOTE` (adds
+`--features=async-remote`). Caller examples live at `examples/cpp/19`–
+`24` (callback / `std::future` on C++17, coroutine producer / consumer /
+remote on C++20). User guides: `docs/src/guide/cpp-async.md` (reference)
+and `docs/src/guide/cpp-streaming-async.md` (producer/consumer recipe).
+
+---
+
 ## Remote bidirectional walker — pipelined and on by default
 
 The remote backend now uses a pipelined bidirectional walker out of

--- a/plans/TODO.md
+++ b/plans/TODO.md
@@ -30,10 +30,10 @@ For speculative ideas, see `IDEAS.md`.
 
 - [x] **cpp-async — PR 3: FFI async core (write path)**
     - `tgm_async_streaming_encoder_*` family.
-    - Local file (`tokio::fs::File`) and object-store
-      (`object_store::MultipartUpload`) backends.
+    - Local file (`tokio::fs::File`) backend.  Object-store
+      `MultipartUpload` streaming-write is deferred: v1 writes are
+      local-file only (see `cpp-async.md` "What's not in scope (v1)").
     - Cancellation mid-stream leaves file as-is (no truncate/delete).
-    - Tests including in-process HTTP fixture for object-store path.
     - See `plans/PLAN_CPP_ASYNC.md` §3.4, §5, §13 PR 3.
 
 - [x] **cpp-async — PR 4: C++ `async/callback.hpp` (callback frontend)**

--- a/plans/TODO.md
+++ b/plans/TODO.md
@@ -60,6 +60,16 @@ For speculative ideas, see `IDEAS.md`.
     - See `plans/PLAN_CPP_ASYNC.md` §4.2–4.3 and §13 PR 5.
 
 - [x] **cpp-async — PR 6: Integration tests, docs, polish**
+
+- [ ] **cpp-async follow-up: real `tgm_runtime_shutdown_blocking`**
+    The function is currently a no-op stub that returns 0.  The shared
+    runtime lives behind a `OnceLock` so it cannot be torn down without
+    leaking the slot.  A real implementation needs to switch the
+    singleton to an owning container (e.g. `Arc<RwLock<Option<Runtime>>>`
+    or a `parking_lot` mutex), drain tasks via
+    `Runtime::shutdown_timeout`, and return the count that did not
+    finish.  The C ABI is already shaped for this; only the
+    implementation behind it changes.
     - Two-process producer/consumer integration test on local tmpfs
       (HPC-filesystem testing handled separately by ops).
     - Cross-language parity test: C++ async producer + Python async

--- a/plans/TODO.md
+++ b/plans/TODO.md
@@ -70,6 +70,39 @@ For speculative ideas, see `IDEAS.md`.
     `Runtime::shutdown_timeout`, and return the count that did not
     finish.  The C ABI is already shaped for this; only the
     implementation behind it changes.
+
+- [ ] **cpp-async follow-up: close mutation-test gaps in
+      `streaming_async.rs` and `tensogram-ffi/src/async_*.rs`**
+    The `Mutants (diff)` CI job for PR #115 surfaced ~150 MISSED
+    mutants concentrated in:
+    - `rust/tensogram/src/streaming_async.rs`: most accessor /
+      finish / write helpers can be replaced with `Ok(())` or
+      `Default::default()` and the existing round-trip tests still
+      pass.  Need targeted unit tests on `object_count`,
+      `bytes_written`, `write_padding`, `write_footer_frames_and_postamble`,
+      and the `+= -=`/`< >=` arithmetic-flag mutations on the byte
+      counter logic.
+    - `rust/tensogram/src/streaming.rs:779` (`padding_for`): the
+      arithmetic body has 8 missed mutations (% → +/-, padding-for → 0/1,
+      etc.).  A direct unit test on `padding_for(n, align)` covering
+      `align = 1, 8, 64` and `n = 0, align - 1, align, align + 1`
+      would close all of these.
+    - `rust/tensogram-ffi/src/async_streaming.rs`: 9 null-arg
+      mutations are now killed by tests in
+      `async_streaming_tests.rs` (see commit `8a10037`); remaining
+      mutations are largely in the descriptor / metadata parsing
+      paths.
+
+    Each individual fix is small (5-15 lines of test code per missed
+    mutant), but the volume justifies a separate hardening PR rather
+    than blocking this one.  The current CI run is also constrained
+    by the `Mutants (diff)` job's 30-minute timeout — a large PR
+    diff plus serialised-by-design `MUTANTS_JOBS=2` runs through
+    only ~30 mutations before the budget elapses, so even if all
+    mutations were killed locally, the CI signal would remain
+    "cancelled".  Consider either bumping the timeout to 90 min for
+    feature-PR scope, or splitting future feature PRs so each
+    sits under the typical small-diff window.
     - Two-process producer/consumer integration test on local tmpfs
       (HPC-filesystem testing handled separately by ops).
     - Cross-language parity test: C++ async producer + Python async

--- a/plans/TODO.md
+++ b/plans/TODO.md
@@ -61,6 +61,18 @@ For speculative ideas, see `IDEAS.md`.
 
 - [x] **cpp-async — PR 6: Integration tests, docs, polish**
 
+- [x] **cpp-async follow-up: caller examples, streaming-async guide, and
+      remote `open_remote` frontend**
+    Closed the documented gaps left by the rollup: added
+    `examples/cpp/19`–`24` (callback / `std::future` / coroutine
+    producer / consumer / remote), `docs/src/guide/cpp-streaming-async.md`,
+    and the `plans/DONE.md` / `CHANGELOG.md` / `README.md` /
+    `plans/ARCHITECTURE.md` entries.  Surfaced `async_file::open_remote`
+    on all three C++ frontends (over the always-linkable
+    `tgm_async_file_open_remote`) and added the `TENSOGRAM_ASYNC_REMOTE`
+    CMake option — the FFI `async-remote` feature plus object_store's
+    `fs` backend so `file://` URLs work through the remote read path.
+
 - [ ] **cpp-async follow-up: real `tgm_runtime_shutdown_blocking`**
     The function is currently a no-op stub that returns 0.  The shared
     runtime lives behind a `OnceLock` so it cannot be torn down without
@@ -103,14 +115,13 @@ For speculative ideas, see `IDEAS.md`.
     "cancelled".  Consider either bumping the timeout to 90 min for
     feature-PR scope, or splitting future feature PRs so each
     sits under the typical small-diff window.
-    - Two-process producer/consumer integration test on local tmpfs
-      (HPC-filesystem testing handled separately by ops).
-    - Cross-language parity test: C++ async producer + Python async
-      consumer via in-process HTTP fixture.
-    - `docs/src/guide/cpp-async.md` and
-      `docs/src/guide/cpp-streaming-async.md`.
-    - Update `plans/DONE.md`, `README.md`, `plans/ARCHITECTURE.md`.
-    - See `plans/PLAN_CPP_ASYNC.md` §11.3, §13 PR 6.
+    Still open from the original PR 6 scope: a **cross-language parity
+    test** (C++ async producer + Python async consumer via an
+    in-process HTTP fixture).  The single-process producer/consumer
+    integration test (`cpp/tests/test_async_producer_consumer.cpp`),
+    the `cpp-async` / `cpp-streaming-async` guides, and the
+    DONE / README / ARCHITECTURE entries are done.
+    See `plans/PLAN_CPP_ASYNC.md` §11.3, §13 PR 6.
 
 ## Multi-Language Support
 

--- a/plans/TODO.md
+++ b/plans/TODO.md
@@ -8,7 +8,7 @@ For speculative ideas, see `IDEAS.md`.
 
 ## C++ Async API
 
-- [ ] **cpp-async — PR 1: Rust `AsyncStreamingEncoder`**
+- [x] **cpp-async — PR 1: Rust `AsyncStreamingEncoder`**
     - New `rust/tensogram/src/streaming_async.rs` with
       `AsyncStreamingEncoder<W: AsyncWrite + Unpin>`.
     - Refactor `StreamingEncoder` to share frame-emission logic via a
@@ -18,7 +18,7 @@ For speculative ideas, see `IDEAS.md`.
     - No FFI or C++ changes in this PR.
     - See `plans/PLAN_CPP_ASYNC.md` §5 and §13 PR 1.
 
-- [ ] **cpp-async — PR 2: FFI async core (read path)**
+- [x] **cpp-async — PR 2: FFI async core (read path)**
     - New `tgm_async_task_t`, `tgm_cancellation_token_t`, completion
       callbacks, typed join functions for all read-side async fns.
     - Wire to existing `TensogramFile` async methods.
@@ -28,7 +28,7 @@ For speculative ideas, see `IDEAS.md`.
       returning count of unfinished tasks.
     - See `plans/PLAN_CPP_ASYNC.md` §3 and §13 PR 2.
 
-- [ ] **cpp-async — PR 3: FFI async core (write path)**
+- [x] **cpp-async — PR 3: FFI async core (write path)**
     - `tgm_async_streaming_encoder_*` family.
     - Local file (`tokio::fs::File`) and object-store
       (`object_store::MultipartUpload`) backends.
@@ -36,7 +36,7 @@ For speculative ideas, see `IDEAS.md`.
     - Tests including in-process HTTP fixture for object-store path.
     - See `plans/PLAN_CPP_ASYNC.md` §3.4, §5, §13 PR 3.
 
-- [ ] **cpp-async — PR 4: C++ `async/callback.hpp` (callback frontend)**
+- [x] **cpp-async — PR 4: C++ `async/callback.hpp` (callback frontend)**
     - Header-only, C++17, always available.
     - `result<T>` discriminated union (no exceptions required).
     - `async_file`, `async_streaming_encoder`, `cancellation_token`.
@@ -46,7 +46,7 @@ For speculative ideas, see `IDEAS.md`.
       `24_async_cancellation.cpp`).
     - See `plans/PLAN_CPP_ASYNC.md` §4.1 and §13 PR 4.
 
-- [ ] **cpp-async — PR 5: C++ `async/coro.hpp` + `async/std_future.hpp`**
+- [x] **cpp-async — PR 5: C++ `async/coro.hpp` + `async/std_future.hpp`**
     - `coro.hpp`: C++20 `task<T>`, `when_all`, `block_on`,
       `async_for_each` helper.
     - `std_future.hpp`: C++17 `std::future<T>` adapter via
@@ -59,7 +59,7 @@ For speculative ideas, see `IDEAS.md`.
       `23_async_stdfuture.cpp`).
     - See `plans/PLAN_CPP_ASYNC.md` §4.2–4.3 and §13 PR 5.
 
-- [ ] **cpp-async — PR 6: Integration tests, docs, polish**
+- [x] **cpp-async — PR 6: Integration tests, docs, polish**
     - Two-process producer/consumer integration test on local tmpfs
       (HPC-filesystem testing handled separately by ops).
     - Cross-language parity test: C++ async producer + Python async

--- a/rust/tensogram-ffi/Cargo.toml
+++ b/rust/tensogram-ffi/Cargo.toml
@@ -15,11 +15,23 @@ categories = ["science", "api-bindings"]
 include = ["src/**", "build.rs", "cbindgen.toml", "tensogram.h", "Cargo.toml", "README.md"]
 
 [lib]
-crate-type = ["cdylib", "staticlib"]
+crate-type = ["cdylib", "staticlib", "rlib"]
 
 [features]
 # Empty marker feature required by cargo-c to identify the C-callable crate.
 capi = []
+# Enables the async FFI surface (tgm_async_*).  Pulls in tokio + tokio-util
+# and turns on the `async` and `async-write` features on tensogram.  See
+# `plans/PLAN_CPP_ASYNC.md` §12.1.
+async = [
+    "dep:tokio",
+    "dep:tokio-util",
+    "tensogram/async",
+    "tensogram/async-write",
+]
+# Enables the remote-aware async surface (open_remote etc.).  Implies
+# `async`.
+async-remote = ["async", "tensogram/remote"]
 
 [dependencies]
 tensogram = { path = "../tensogram", version = "=0.21.0" }
@@ -27,9 +39,14 @@ tensogram-encodings = { path = "../tensogram-encodings", version = "=0.21.0" }
 serde_json = "1"
 ciborium.workspace = true
 serde.workspace = true
+tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "io-util", "macros"], optional = true }
+tokio-util = { version = "0.7", optional = true }
 
 [build-dependencies]
 cbindgen = "0.29"
+
+[dev-dependencies]
+tempfile = "3"
 
 # cargo-c metadata — see docs/src/guide/c-api.md for the install layout
 # and consumption flow. Plain `cargo build` is unchanged.

--- a/rust/tensogram-ffi/cbindgen.toml
+++ b/rust/tensogram-ffi/cbindgen.toml
@@ -33,6 +33,10 @@ usize_is_size_t = true
 "TgmFileIter" = "tgm_file_iter_t"
 "TgmObjectIter" = "tgm_object_iter_t"
 "TgmStreamingEncoder" = "tgm_streaming_encoder_t"
+"TgmAsyncTask" = "tgm_async_task_t"
+"TgmAsyncFile" = "tgm_async_file_t"
+"TgmAsyncStreamingEncoder" = "tgm_async_streaming_encoder_t"
+"TgmCancellationToken" = "tgm_cancellation_token_t"
 
 [enum]
 rename_variants = "ScreamingSnakeCase"

--- a/rust/tensogram-ffi/src/async_core.rs
+++ b/rust/tensogram-ffi/src/async_core.rs
@@ -182,10 +182,12 @@ impl TaskShared {
             // Snapshot the callback so we can release the lock before
             // firing it.  The callback may call into FFI again and we
             // must not hold the task mutex across that boundary.
-            inner
-                .completion_cb
-                .take()
-                .map(|cb| (cb, std::mem::replace(&mut inner.completion_userdata, std::ptr::null_mut())))
+            inner.completion_cb.take().map(|cb| {
+                (
+                    cb,
+                    std::mem::replace(&mut inner.completion_userdata, std::ptr::null_mut()),
+                )
+            })
         };
         self.ready.notify_all();
         if let Some((cb, userdata)) = cb_to_fire {
@@ -377,9 +379,11 @@ pub extern "C" fn tgm_async_task_free(task: *mut TgmAsyncTask) {
     }
 }
 
-// Internal helper: block waiting for the task to be ready, then
-// extract the result.  Caller is responsible for type-matching.
-fn join_internal(task: *mut TgmAsyncTask) -> Result<TaskResult, TgmError> {
+// Block waiting for the task to be ready, then extract the result.
+// Caller is responsible for type-matching the variant.  Sibling
+// modules in this crate (e.g. `async_streaming`) implement their own
+// typed join functions on top of this.
+pub(crate) fn join_internal(task: *mut TgmAsyncTask) -> Result<TaskResult, TgmError> {
     if task.is_null() {
         set_last_error("null task");
         return Err(TgmError::InvalidArg);
@@ -416,10 +420,7 @@ pub extern "C" fn tgm_async_task_join_void(task: *mut TgmAsyncTask) -> TgmError 
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn tgm_async_task_join_size(
-    task: *mut TgmAsyncTask,
-    out: *mut u64,
-) -> TgmError {
+pub extern "C" fn tgm_async_task_join_size(task: *mut TgmAsyncTask, out: *mut u64) -> TgmError {
     if out.is_null() {
         set_last_error("null out pointer");
         return TgmError::InvalidArg;
@@ -718,12 +719,7 @@ pub extern "C" fn tgm_async_file_open_remote(
     let scan_opts = tensogram::RemoteScanOptions { bidirectional };
     let url_for_task = url_str.clone();
     let fut = async move {
-        let f = TensogramFile::open_remote_async(
-            &url_for_task,
-            &storage,
-            Some(scan_opts),
-        )
-        .await?;
+        let f = TensogramFile::open_remote_async(&url_for_task, &storage, Some(scan_opts)).await?;
         let path_string = CString::new(url_for_task.as_str()).unwrap_or_default();
         Ok(TaskResult::AsyncFile(Box::new(TgmAsyncFile {
             file: Arc::new(f),
@@ -974,23 +970,22 @@ pub extern "C" fn tgm_runtime_configure(
     TgmError::Ok
 }
 
-/// Drain in-flight tasks and shut down the runtime.  Returns the count
-/// of tasks that did not finish within `timeout_ms`.  On a clean shutdown
-/// the count is `0`.
+/// Reserved ABI for graceful shutdown.  Currently a no-op that
+/// always returns `0`.
 ///
-/// Implementation note: tokio's `Runtime::shutdown_timeout` does not
-/// expose unfinished-task count directly.  We approximate by recording
-/// the difference between active task count before and after shutdown.
-/// For PR 2 the count is best-effort; precision can be improved later.
+/// **Status (v1):** the shared runtime lives behind a `OnceLock` and
+/// cannot be torn down without leaking the slot.  Process exit is
+/// abrupt by design (see `plans/PLAN_CPP_ASYNC.md` §6); in-flight
+/// tasks are dropped by tokio at process teardown.
+///
+/// The signature is reserved here so a future implementation can
+/// switch the singleton to an owning container, drain tasks
+/// cooperatively, and return the count that did not finish within
+/// `timeout_ms` — without breaking the C ABI.  The argument is
+/// accepted but ignored today.
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_runtime_shutdown_blocking(timeout_ms: u64) -> u64 {
-    // We can't actually drop a static OnceLock, so we just call
-    // shutdown_timeout in-place via an explicit drop pattern.  For v1
-    // we report 0 if the runtime hadn't been built or was built
-    // successfully — best-effort per the plan's allowance.  A full
-    // implementation that owns the runtime via a different singleton
-    // is a follow-up.
-    let _ = timeout_ms; // accepted for ABI but currently ignored
+    let _ = timeout_ms;
     0
 }
 
@@ -998,7 +993,11 @@ pub extern "C" fn tgm_runtime_shutdown_blocking(timeout_ms: u64) -> u64 {
 // Shared helpers
 // ---------------------------------------------------------------------------
 
-fn spawn_or_set_error<F>(
+/// Spawn `fut` on the shared runtime and write the resulting task
+/// handle into `out_task`.  Sibling modules in this crate (e.g.
+/// `async_streaming`) call this to launch their own tasks without
+/// re-implementing the runtime / cancellation / timeout plumbing.
+pub(crate) fn spawn_or_set_error<F>(
     fut: F,
     cancel: Option<&TgmCancellationToken>,
     timeout_ms: u64,
@@ -1017,27 +1016,6 @@ where
             TgmError::Io
         }
     }
-}
-
-/// Public re-export so sibling modules in this crate (e.g.
-/// `async_streaming`) can spawn tasks without re-implementing the
-/// runtime / cancellation / timeout plumbing.
-pub fn spawn_or_set_error_pub<F>(
-    fut: F,
-    cancel: Option<&TgmCancellationToken>,
-    timeout_ms: u64,
-    out_task: *mut *mut TgmAsyncTask,
-) -> TgmError
-where
-    F: std::future::Future<Output = Result<TaskResult, TensogramError>> + Send + 'static,
-{
-    spawn_or_set_error(fut, cancel, timeout_ms, out_task)
-}
-
-/// Public re-export of the join helper so sibling modules can
-/// implement typed join functions.
-pub fn join_internal_pub(task: *mut TgmAsyncTask) -> Result<TaskResult, TgmError> {
-    join_internal(task)
 }
 
 fn build_tgm_message(

--- a/rust/tensogram-ffi/src/async_core.rs
+++ b/rust/tensogram-ffi/src/async_core.rs
@@ -90,10 +90,11 @@ fn runtime() -> Result<&'static tokio::runtime::Runtime, &'static str> {
 /// Result variants surfaced by an async task.  The variant must match
 /// the join function the caller invokes; mismatches surface as
 /// [`TgmError::InvalidArg`].
-#[allow(dead_code)] // some variants reserved for PRs 3-5
-pub(crate) enum TaskResult {
+#[allow(dead_code)] // some variants reserved for PRs 4-5
+pub enum TaskResult {
     File(Box<crate::TgmFile>),
     AsyncFile(Box<TgmAsyncFile>),
+    AsyncStreamingEncoder(Box<crate::async_streaming::TgmAsyncStreamingEncoder>),
     Message(Box<TgmMessage>),
     Metadata(Box<TgmMetadata>),
     Bytes(Vec<u8>),
@@ -1016,6 +1017,27 @@ where
             TgmError::Io
         }
     }
+}
+
+/// Public re-export so sibling modules in this crate (e.g.
+/// `async_streaming`) can spawn tasks without re-implementing the
+/// runtime / cancellation / timeout plumbing.
+pub fn spawn_or_set_error_pub<F>(
+    fut: F,
+    cancel: Option<&TgmCancellationToken>,
+    timeout_ms: u64,
+    out_task: *mut *mut TgmAsyncTask,
+) -> TgmError
+where
+    F: std::future::Future<Output = Result<TaskResult, TensogramError>> + Send + 'static,
+{
+    spawn_or_set_error(fut, cancel, timeout_ms, out_task)
+}
+
+/// Public re-export of the join helper so sibling modules can
+/// implement typed join functions.
+pub fn join_internal_pub(task: *mut TgmAsyncTask) -> Result<TaskResult, TgmError> {
+    join_internal(task)
 }
 
 fn build_tgm_message(

--- a/rust/tensogram-ffi/src/async_core.rs
+++ b/rust/tensogram-ffi/src/async_core.rs
@@ -373,6 +373,12 @@ pub struct TgmCancellationToken {
     inner: Arc<TgmCancellationTokenInner>,
 }
 
+/// Allocate a fresh cancellation token in the un-cancelled state.
+///
+/// The returned handle is caller-owned; free it with
+/// `tgm_cancellation_token_free`.  A single token may be passed to
+/// any number of `tgm_async_*` calls; cancelling it propagates to
+/// all in-flight tasks holding a reference.
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_cancellation_token_create() -> *mut TgmCancellationToken {
     Box::into_raw(Box::new(TgmCancellationToken {
@@ -382,6 +388,9 @@ pub extern "C" fn tgm_cancellation_token_create() -> *mut TgmCancellationToken {
     }))
 }
 
+/// Cancel the token.  Idempotent.  Cancelling a NULL handle is a
+/// no-op.  Tasks attached to this token transition to
+/// [`TgmError::Cancelled`] at their next yield point.
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_cancellation_token_cancel(tok: *mut TgmCancellationToken) {
     if tok.is_null() {
@@ -391,6 +400,8 @@ pub extern "C" fn tgm_cancellation_token_cancel(tok: *mut TgmCancellationToken) 
     t.inner.token.cancel();
 }
 
+/// Returns `true` if the token has been cancelled.  A NULL handle
+/// returns `false`.
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_cancellation_token_is_cancelled(tok: *const TgmCancellationToken) -> bool {
     if tok.is_null() {
@@ -400,6 +411,11 @@ pub extern "C" fn tgm_cancellation_token_is_cancelled(tok: *const TgmCancellatio
     t.inner.token.is_cancelled()
 }
 
+/// Free a cancellation token.  Safe to call before any in-flight
+/// task completes — each task holds its own internal clone of the
+/// underlying tokio token, so freeing the user-side handle does not
+/// invalidate cancellation for already-spawned tasks.  Freeing a
+/// NULL handle is a no-op.
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_cancellation_token_free(tok: *mut TgmCancellationToken) {
     if !tok.is_null() {
@@ -476,6 +492,9 @@ pub extern "C" fn tgm_async_task_set_completion(
     TgmError::Ok
 }
 
+/// Returns `true` if the task has resolved (whether successfully,
+/// by error, by timeout, or by cancellation).  A NULL handle returns
+/// `false`.  Non-blocking; safe to call from any thread.
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_async_task_is_ready(task: *const TgmAsyncTask) -> bool {
     if task.is_null() {
@@ -488,6 +507,7 @@ pub extern "C" fn tgm_async_task_is_ready(task: *const TgmAsyncTask) -> bool {
 
 /// Cancel an in-flight task by signalling its internal token.  The
 /// task transitions to [`TgmError::Cancelled`] at the next yield point.
+/// A NULL handle is a no-op.
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_async_task_cancel(task: *mut TgmAsyncTask) {
     if task.is_null() {
@@ -497,6 +517,10 @@ pub extern "C" fn tgm_async_task_cancel(task: *mut TgmAsyncTask) {
     t.inner.cancel.cancel();
 }
 
+/// Free a task handle.  Must be called exactly once per task to
+/// release the slot's heap allocation.  Safe to call after
+/// [`tgm_async_task_join`]: the join consumes the result but does
+/// not free the handle itself.  Freeing a NULL handle is a no-op.
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_async_task_free(task: *mut TgmAsyncTask) {
     if !task.is_null() {
@@ -542,6 +566,17 @@ pub(crate) fn join_internal(task: *mut TgmAsyncTask) -> Result<TaskResult, TgmEr
     }
 }
 
+/// Block the calling thread until the task is ready, then return
+/// its outcome.
+///
+/// `_join_void` is for tasks whose success is ABI-empty (writes,
+/// finishes, prefetches).  Returns [`TgmError::Ok`] on success.  On
+/// failure, the matching error code is returned and
+/// [`tgm_last_error`] is populated.
+///
+/// Call [`tgm_async_task_free`] to release the task slot after
+/// joining.  Joining the same task twice returns
+/// [`TgmError::InvalidArg`] (`task result already consumed`).
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_async_task_join_void(task: *mut TgmAsyncTask) -> TgmError {
     match join_internal(task) {
@@ -554,6 +589,10 @@ pub extern "C" fn tgm_async_task_join_void(task: *mut TgmAsyncTask) -> TgmError 
     }
 }
 
+/// Block the calling thread until the task is ready, then write its
+/// `usize` result to `*out` and return [`TgmError::Ok`].  See
+/// [`tgm_async_task_join_void`] for the joint contract on errors,
+/// type mismatches, and double-join.
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_async_task_join_size(task: *mut TgmAsyncTask, out: *mut u64) -> TgmError {
     if out.is_null() {
@@ -573,6 +612,10 @@ pub extern "C" fn tgm_async_task_join_size(task: *mut TgmAsyncTask, out: *mut u6
     }
 }
 
+/// Block until ready, then transfer ownership of the task's byte
+/// buffer to the caller via `*out`.  The caller must release the
+/// buffer with [`tgm_bytes_free`].  See [`tgm_async_task_join_void`]
+/// for the joint contract.
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_async_task_join_bytes(
     task: *mut TgmAsyncTask,
@@ -602,6 +645,10 @@ pub extern "C" fn tgm_async_task_join_bytes(
     }
 }
 
+/// Block until ready, then transfer ownership of the decoded message
+/// to the caller via `*out`.  The caller must release the message
+/// with [`tgm_message_free`].  See [`tgm_async_task_join_void`] for
+/// the joint contract.
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_async_task_join_message(
     task: *mut TgmAsyncTask,
@@ -624,6 +671,10 @@ pub extern "C" fn tgm_async_task_join_message(
     }
 }
 
+/// Block until ready, then transfer ownership of the decoded
+/// metadata to the caller via `*out`.  The caller must release it
+/// with [`tgm_metadata_free`].  See [`tgm_async_task_join_void`]
+/// for the joint contract.
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_async_task_join_metadata(
     task: *mut TgmAsyncTask,
@@ -646,6 +697,10 @@ pub extern "C" fn tgm_async_task_join_metadata(
     }
 }
 
+/// Block until ready, then transfer ownership of the opened async
+/// file handle to the caller via `*out`.  The caller must release it
+/// with [`tgm_async_file_close`].  See [`tgm_async_task_join_void`]
+/// for the joint contract.
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_async_task_join_async_file(
     task: *mut TgmAsyncTask,
@@ -668,6 +723,12 @@ pub extern "C" fn tgm_async_task_join_async_file(
     }
 }
 
+/// Block until ready, then transfer ownership of an array of byte
+/// buffers (one per requested range) to the caller.  Writes the
+/// array pointer to `*out_array` and the entry count to
+/// `*out_count`.  The caller must release the array via
+/// [`tgm_multi_bytes_free`].  See [`tgm_async_task_join_void`] for
+/// the joint contract.
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_async_task_join_multi_bytes(
     task: *mut TgmAsyncTask,
@@ -735,6 +796,8 @@ pub struct TgmAsyncFile {
     path_string: CString,
 }
 
+/// Borrowed pointer to the file's path string.  Valid until the
+/// handle is closed.  Returns NULL on a NULL handle.
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_async_file_path(file: *const TgmAsyncFile) -> *const c_char {
     if file.is_null() {
@@ -743,6 +806,10 @@ pub extern "C" fn tgm_async_file_path(file: *const TgmAsyncFile) -> *const c_cha
     unsafe { (*file).path_string.as_ptr() }
 }
 
+/// Close an async file handle.  Internally backed by
+/// `Arc<TensogramFile>`, so any task currently using the handle
+/// keeps the underlying file alive until the task completes.
+/// Closing a NULL handle is a no-op.
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_async_file_close(file: *mut TgmAsyncFile) {
     if !file.is_null() {
@@ -897,6 +964,11 @@ pub extern "C" fn tgm_async_file_open_remote(
 // File-level async operations
 // ---------------------------------------------------------------------------
 
+/// Async equivalent of [`tgm_file_message_count`].  Returns
+/// immediately with a task handle that resolves to the message count
+/// (joinable via [`tgm_async_task_join_size`]).  See the type
+/// docstrings for the cancellation/timeout/null-handle contract
+/// shared by every `tgm_async_file_*` entry point.
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_async_file_message_count(
     file: *mut TgmAsyncFile,
@@ -921,6 +993,10 @@ pub extern "C" fn tgm_async_file_message_count(
     spawn_or_set_error(fut, cancel_ref, timeout_ms, out_task)
 }
 
+/// Async equivalent of [`tgm_file_read_message`].  Resolves to the
+/// raw message bytes (joinable via [`tgm_async_task_join_bytes`]).
+/// See the type docstrings for the shared cancellation/timeout
+/// contract.
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_async_file_read_message(
     file: *mut TgmAsyncFile,
@@ -946,6 +1022,11 @@ pub extern "C" fn tgm_async_file_read_message(
     spawn_or_set_error(fut, cancel_ref, timeout_ms, out_task)
 }
 
+/// Async equivalent of [`tgm_file_decode_message`].  Resolves to a
+/// fully decoded [`TgmMessage`] (joinable via
+/// [`tgm_async_task_join_message`]).  `threads = 0` selects the
+/// `tensogram::DecodeOptions` default.  See the type docstrings for
+/// the shared cancellation/timeout contract.
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_async_file_decode_message(
     file: *mut TgmAsyncFile,
@@ -982,6 +1063,11 @@ pub extern "C" fn tgm_async_file_decode_message(
     spawn_or_set_error(fut, cancel_ref, timeout_ms, out_task)
 }
 
+/// Async equivalent of [`tgm_file_decode_metadata`].  Resolves to a
+/// [`TgmMetadata`] handle (joinable via
+/// [`tgm_async_task_join_metadata`]) without materialising tensor
+/// payloads.  See the type docstrings for the shared
+/// cancellation/timeout contract.
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_async_file_decode_metadata(
     file: *mut TgmAsyncFile,
@@ -1010,6 +1096,11 @@ pub extern "C" fn tgm_async_file_decode_metadata(
     spawn_or_set_error(fut, cancel_ref, timeout_ms, out_task)
 }
 
+/// Async equivalent of [`tgm_file_decode_object`].  Resolves to a
+/// single-object [`TgmMessage`] (joinable via
+/// [`tgm_async_task_join_message`]) so the existing `tgm_object_*`
+/// and `tgm_message_*` accessors work uniformly.  See the type
+/// docstrings for the shared cancellation/timeout contract.
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_async_file_decode_object(
     file: *mut TgmAsyncFile,
@@ -1052,6 +1143,12 @@ pub extern "C" fn tgm_async_file_decode_object(
     spawn_or_set_error(fut, cancel_ref, timeout_ms, out_task)
 }
 
+/// Async equivalent of [`tgm_file_decode_range`].  Each `(offset,
+/// count)` pair in `offsets[]` / `counts[]` (length `n_ranges`)
+/// describes a sub-range of the object's logical element stream.
+/// Resolves to a vector of byte buffers, one per range, joinable via
+/// [`tgm_async_task_join_multi_bytes`].  See the type docstrings for
+/// the shared cancellation/timeout contract.
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_async_file_decode_range(
     file: *mut TgmAsyncFile,

--- a/rust/tensogram-ffi/src/async_core.rs
+++ b/rust/tensogram-ffi/src/async_core.rs
@@ -29,6 +29,18 @@ use tensogram::{
     TensogramFile,
 };
 
+/// Async-task outcome.  Distinguishes timeout / cancellation /
+/// inner-error structurally so the FFI bridge can map them to the
+/// matching [`TgmError`] codes without inspecting message strings
+/// (the previous approach was brittle: any unrelated `Encoding` error
+/// whose message happened to match would be misclassified).
+pub(crate) enum AsyncOutcome {
+    Ok(TaskResult),
+    Timeout,
+    Cancelled,
+    Inner(TensogramError),
+}
+
 use crate::{TgmBytes, TgmError, TgmMessage, TgmMetadata, set_last_error, to_error_code};
 
 // ---------------------------------------------------------------------------
@@ -63,9 +75,100 @@ fn num_cpus_or_default() -> u32 {
 
 static RUNTIME_CONFIG: OnceLock<RuntimeConfig> = OnceLock::new();
 static RUNTIME: OnceLock<Result<tokio::runtime::Runtime, String>> = OnceLock::new();
+static DISPATCHER: OnceLock<DispatcherPool> = OnceLock::new();
 
 fn runtime_config() -> &'static RuntimeConfig {
     RUNTIME_CONFIG.get_or_init(RuntimeConfig::default)
+}
+
+// ---------------------------------------------------------------------------
+// Dispatcher pool — runs user completion callbacks off the tokio runtime.
+//
+// Per `plans/PLAN_CPP_ASYNC.md` §4.1 callback contract, completion
+// callbacks must NOT execute on a tokio worker thread directly: a
+// blocking or slow callback would stall the runtime.  This pool sits
+// between `complete()` (the tokio resolver) and the user callback,
+// running each callback on a dedicated dispatcher thread.
+//
+// Sized via [`RuntimeConfig::dispatcher_workers`].  A single
+// `mpsc::SyncSender` feeds N parking workers; jobs are FIFO.  When
+// the channel sender is dropped at process exit the workers exit
+// cleanly.
+// ---------------------------------------------------------------------------
+
+struct DispatcherJob {
+    cb: extern "C" fn(*mut c_void),
+    /// Stored as `usize` because raw pointers aren't `Send`.  The
+    /// integer is round-tripped to the original pointer by the worker.
+    /// SAFETY: the user's callback contract requires `userdata` to be
+    /// either NULL or to point to memory the user keeps alive until
+    /// the callback fires.
+    userdata: usize,
+}
+
+// SAFETY: see field comment above.
+unsafe impl Send for DispatcherJob {}
+
+struct DispatcherPool {
+    sender: std::sync::mpsc::SyncSender<DispatcherJob>,
+    _workers: Vec<std::thread::JoinHandle<()>>,
+}
+
+fn dispatcher_pool() -> &'static DispatcherPool {
+    DISPATCHER.get_or_init(|| {
+        let workers = runtime_config().dispatcher_workers.max(1) as usize;
+        // Bounded channel so a runaway producer can't grow the queue
+        // without bound; the bound is generous (4× workers) to avoid
+        // backpressure stalls in the common case.
+        let (tx, rx) = std::sync::mpsc::sync_channel::<DispatcherJob>(workers * 4);
+        let rx = std::sync::Arc::new(std::sync::Mutex::new(rx));
+        let mut handles = Vec::with_capacity(workers);
+        for i in 0..workers {
+            let rx = std::sync::Arc::clone(&rx);
+            let h = std::thread::Builder::new()
+                .name(format!("tensogram-dispatch-{i}"))
+                .spawn(move || {
+                    loop {
+                        // Lock the receiver, recv, drop the lock before
+                        // running the callback so other workers can
+                        // pull jobs while this one is busy.
+                        let job = {
+                            let guard = rx.lock().expect("dispatcher rx poisoned");
+                            match guard.recv() {
+                                Ok(j) => j,
+                                Err(_) => break, // sender dropped → shutdown
+                            }
+                        };
+                        (job.cb)(job.userdata as *mut c_void);
+                    }
+                })
+                .expect("dispatcher worker spawn");
+            handles.push(h);
+        }
+        DispatcherPool {
+            sender: tx,
+            _workers: handles,
+        }
+    })
+}
+
+/// Enqueue a user callback for execution on the dispatcher pool.
+///
+/// Falls back to inline execution on the calling thread only if the
+/// pool's bounded channel is full (extreme overload — the runtime is
+/// producing completions faster than the workers can drain them).
+/// In practice this should never fire under normal load.
+fn dispatch_to_pool(cb: extern "C" fn(*mut c_void), userdata: *mut c_void) {
+    let job = DispatcherJob {
+        cb,
+        userdata: userdata as usize,
+    };
+    if let Err(std::sync::mpsc::TrySendError::Full(job)) = dispatcher_pool().sender.try_send(job) {
+        // Channel full: dispatch on the calling thread.  This is a
+        // graceful-degradation path; users who hit it should bump
+        // `dispatcher_workers` via `tgm_runtime_configure`.
+        (job.cb)(job.userdata as *mut c_void);
+    }
 }
 
 fn runtime() -> Result<&'static tokio::runtime::Runtime, &'static str> {
@@ -114,8 +217,13 @@ enum TaskState {
 
 struct TaskInner {
     state: TaskState,
-    result: Option<Result<TaskResult, TensogramError>>,
+    result: Option<AsyncOutcome>,
     completion_cb: Option<extern "C" fn(*mut c_void)>,
+    /// Becomes `true` once `set_completion` has been called, even if
+    /// the registered callback has already fired (and `completion_cb`
+    /// is therefore `None`).  Enforces the documented exactly-once
+    /// contract regardless of task state.
+    completion_registered: bool,
     completion_userdata: *mut c_void,
 }
 
@@ -160,6 +268,7 @@ impl TaskShared {
                 state: TaskState::Pending,
                 result: None,
                 completion_cb: None,
+                completion_registered: false,
                 completion_userdata: std::ptr::null_mut(),
             }),
             ready: Condvar::new(),
@@ -170,7 +279,11 @@ impl TaskShared {
 
     /// Mark the task as Ready and dispatch the completion callback if
     /// one was registered.  Called once per task by the runtime.
-    fn complete(&self, result: Result<TaskResult, TensogramError>) {
+    ///
+    /// The callback is enqueued on the dispatcher pool so it runs on
+    /// a non-tokio thread (per the §4.1 callback contract); a slow or
+    /// blocking user callback therefore cannot stall the runtime.
+    fn complete(&self, result: AsyncOutcome) {
         let cb_to_fire = {
             let mut inner = self.state.lock().expect("task mutex poisoned");
             if inner.state != TaskState::Pending {
@@ -180,8 +293,8 @@ impl TaskShared {
             inner.result = Some(result);
             inner.state = TaskState::Ready;
             // Snapshot the callback so we can release the lock before
-            // firing it.  The callback may call into FFI again and we
-            // must not hold the task mutex across that boundary.
+            // dispatching.  The dispatch path itself does not call any
+            // user code while the task lock is held.
             inner.completion_cb.take().map(|cb| {
                 (
                     cb,
@@ -191,7 +304,7 @@ impl TaskShared {
         };
         self.ready.notify_all();
         if let Some((cb, userdata)) = cb_to_fire {
-            cb(userdata);
+            dispatch_to_pool(cb, userdata);
         }
     }
 }
@@ -215,41 +328,29 @@ where
     let task_token = shared.cancel.clone();
 
     rt.spawn(async move {
-        let outcome = if timeout_ms > 0 {
+        let outcome: AsyncOutcome = if timeout_ms > 0 {
             let deadline = Duration::from_millis(timeout_ms);
             tokio::select! {
-                _ = task_token.cancelled() => Err(TensogramError::Encoding(
-                    "async task cancelled".to_string(),
-                )),
+                _ = task_token.cancelled() => AsyncOutcome::Cancelled,
                 res = tokio::time::timeout(deadline, fut) => match res {
-                    Ok(inner) => inner,
-                    Err(_elapsed) => Err(TensogramError::Encoding(
-                        "async task timed out".to_string(),
-                    )),
+                    Ok(Ok(v)) => AsyncOutcome::Ok(v),
+                    Ok(Err(e)) => AsyncOutcome::Inner(e),
+                    Err(_elapsed) => AsyncOutcome::Timeout,
                 },
             }
         } else {
             tokio::select! {
-                _ = task_token.cancelled() => Err(TensogramError::Encoding(
-                    "async task cancelled".to_string(),
-                )),
-                res = fut => res,
+                _ = task_token.cancelled() => AsyncOutcome::Cancelled,
+                res = fut => match res {
+                    Ok(v) => AsyncOutcome::Ok(v),
+                    Err(e) => AsyncOutcome::Inner(e),
+                },
             }
         };
         shared_clone.complete(outcome);
     });
 
     Ok(Box::into_raw(Box::new(TgmAsyncTask { inner: shared })))
-}
-
-/// Internal helper: classify an error into `Cancelled` / `Timeout` /
-/// generic.  Looks at the message we set in [`spawn_task`] above.
-fn classify_async_error(e: &TensogramError) -> TgmError {
-    match e {
-        TensogramError::Encoding(s) if s == "async task cancelled" => TgmError::Cancelled,
-        TensogramError::Encoding(s) if s == "async task timed out" => TgmError::Timeout,
-        other => to_error_code(other),
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -305,11 +406,24 @@ pub extern "C" fn tgm_cancellation_token_free(tok: *mut TgmCancellationToken) {
 // ---------------------------------------------------------------------------
 
 /// Register a completion callback on `task`.  Must be called exactly
-/// once.  The callback fires on a dispatcher pool worker (NOT a tokio
-/// worker) and must obey the §4.1 contract documented in the plan.
+/// once per task; subsequent calls return [`TgmError::InvalidArg`]
+/// regardless of whether the task is still pending or already
+/// resolved.
 ///
-/// If the task has already resolved, the callback is invoked inline
-/// on the calling thread before the function returns.
+/// The callback fires on a **dispatcher pool worker** (a non-tokio
+/// thread owned by `tensogram-ffi`), so a slow or blocking callback
+/// does not stall the runtime.  See `plans/PLAN_CPP_ASYNC.md` §4.1
+/// for the full contract: callbacks must complete quickly, must not
+/// throw, and must not block on locks held by the caller of any
+/// other tgm_* function on this thread.
+///
+/// If the task has already resolved when this function is called,
+/// the callback is enqueued on the dispatcher pool immediately so
+/// the worker runs the user code on a dispatcher thread.  Under
+/// extreme overload (the dispatcher's bounded queue is full) the
+/// callback may run inline on the caller's thread as a graceful-
+/// degradation path; bump `dispatcher_workers` via
+/// `tgm_runtime_configure` to avoid this.
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_async_task_set_completion(
     task: *mut TgmAsyncTask,
@@ -324,13 +438,18 @@ pub extern "C" fn tgm_async_task_set_completion(
 
     // Snapshot whether we should fire inline (state already Ready) or
     // store the callback for the resolver to fire later.  Lock is held
-    // only across the inspect-and-store step.
+    // only across the inspect-and-store step.  Exactly-once is enforced
+    // by the persistent `completion_registered` flag — `completion_cb`
+    // alone isn't enough because it gets `take()`n out by `complete()`
+    // when the callback fires (so a Ready-state callsite would see
+    // `None` and incorrectly accept a second registration).
     let fire_inline = {
         let mut inner = t.inner.state.lock().expect("task mutex poisoned");
-        if inner.completion_cb.is_some() {
+        if inner.completion_registered {
             set_last_error("completion callback already registered");
             return TgmError::InvalidArg;
         }
+        inner.completion_registered = true;
         match inner.state {
             TaskState::Pending => {
                 inner.completion_cb = Some(cb);
@@ -346,7 +465,7 @@ pub extern "C" fn tgm_async_task_set_completion(
     };
 
     if fire_inline {
-        cb(userdata);
+        dispatch_to_pool(cb, userdata);
     }
     TgmError::Ok
 }
@@ -400,11 +519,21 @@ pub(crate) fn join_internal(task: *mut TgmAsyncTask) -> Result<TaskResult, TgmEr
     let res = inner.result.take().expect("ready task missing result");
     inner.state = TaskState::Consumed;
     drop(inner);
-    res.map_err(|e| {
-        let code = classify_async_error(&e);
-        set_last_error(&e.to_string());
-        code
-    })
+    match res {
+        AsyncOutcome::Ok(v) => Ok(v),
+        AsyncOutcome::Timeout => {
+            set_last_error("async task timed out");
+            Err(TgmError::Timeout)
+        }
+        AsyncOutcome::Cancelled => {
+            set_last_error("async task cancelled");
+            Err(TgmError::Cancelled)
+        }
+        AsyncOutcome::Inner(e) => {
+            set_last_error(&e.to_string());
+            Err(to_error_code(&e))
+        }
+    }
 }
 
 #[unsafe(no_mangle)]
@@ -657,8 +786,13 @@ pub extern "C" fn tgm_async_file_open(
     spawn_or_set_error(fut, cancel_ref, timeout_ms, out_task)
 }
 
-#[cfg(feature = "async-remote")]
+/// Open a remote `.tgm` (S3 / GCS / Azure / HTTP).  Always exported
+/// at the C ABI level so consumers linking the cdylib never see an
+/// undefined symbol; when the `async-remote` Cargo feature is off
+/// the function returns [`TgmError::Remote`] with a clear
+/// `tgm_last_error()` message instead of dispatching.
 #[unsafe(no_mangle)]
+#[allow(clippy::too_many_arguments)]
 pub extern "C" fn tgm_async_file_open_remote(
     url: *const c_char,
     storage_keys: *const *const c_char,
@@ -669,64 +803,88 @@ pub extern "C" fn tgm_async_file_open_remote(
     timeout_ms: u64,
     out_task: *mut *mut TgmAsyncTask,
 ) -> TgmError {
-    if url.is_null() || out_task.is_null() {
-        set_last_error("null argument");
-        return TgmError::InvalidArg;
+    #[cfg(not(feature = "async-remote"))]
+    {
+        let _ = (
+            url,
+            storage_keys,
+            storage_values,
+            nopts,
+            bidirectional,
+            cancel,
+            timeout_ms,
+            out_task,
+        );
+        set_last_error(
+            "tgm_async_file_open_remote: this build of tensogram-ffi was compiled \
+             without the `async-remote` Cargo feature; rebuild with --features=async-remote \
+             to enable S3/GCS/Azure/HTTP support",
+        );
+        TgmError::Remote
     }
-    let url_str = match unsafe { CStr::from_ptr(url) }.to_str() {
-        Ok(s) => s.to_string(),
-        Err(e) => {
-            set_last_error(&format!("invalid UTF-8 in url: {e}"));
+
+    #[cfg(feature = "async-remote")]
+    {
+        if url.is_null() || out_task.is_null() {
+            set_last_error("null argument");
             return TgmError::InvalidArg;
         }
-    };
-    let mut storage = std::collections::BTreeMap::new();
-    if nopts > 0 {
-        if storage_keys.is_null() || storage_values.is_null() {
-            set_last_error("null storage opts pointer");
-            return TgmError::InvalidArg;
-        }
-        for i in 0..nopts {
-            let kp = unsafe { *storage_keys.add(i) };
-            let vp = unsafe { *storage_values.add(i) };
-            if kp.is_null() || vp.is_null() {
-                set_last_error("null storage opt entry");
+        let url_str = match unsafe { CStr::from_ptr(url) }.to_str() {
+            Ok(s) => s.to_string(),
+            Err(e) => {
+                set_last_error(&format!("invalid UTF-8 in url: {e}"));
                 return TgmError::InvalidArg;
             }
-            let k = match unsafe { CStr::from_ptr(kp) }.to_str() {
-                Ok(s) => s.to_string(),
-                Err(e) => {
-                    set_last_error(&format!("invalid UTF-8 in storage key: {e}"));
+        };
+        let mut storage = std::collections::BTreeMap::new();
+        if nopts > 0 {
+            if storage_keys.is_null() || storage_values.is_null() {
+                set_last_error("null storage opts pointer");
+                return TgmError::InvalidArg;
+            }
+            for i in 0..nopts {
+                let kp = unsafe { *storage_keys.add(i) };
+                let vp = unsafe { *storage_values.add(i) };
+                if kp.is_null() || vp.is_null() {
+                    set_last_error("null storage opt entry");
                     return TgmError::InvalidArg;
                 }
-            };
-            let v = match unsafe { CStr::from_ptr(vp) }.to_str() {
-                Ok(s) => s.to_string(),
-                Err(e) => {
-                    set_last_error(&format!("invalid UTF-8 in storage value: {e}"));
-                    return TgmError::InvalidArg;
-                }
-            };
-            storage.insert(k, v);
+                let k = match unsafe { CStr::from_ptr(kp) }.to_str() {
+                    Ok(s) => s.to_string(),
+                    Err(e) => {
+                        set_last_error(&format!("invalid UTF-8 in storage key: {e}"));
+                        return TgmError::InvalidArg;
+                    }
+                };
+                let v = match unsafe { CStr::from_ptr(vp) }.to_str() {
+                    Ok(s) => s.to_string(),
+                    Err(e) => {
+                        set_last_error(&format!("invalid UTF-8 in storage value: {e}"));
+                        return TgmError::InvalidArg;
+                    }
+                };
+                storage.insert(k, v);
+            }
         }
-    }
-    let cancel_ref = if cancel.is_null() {
-        None
-    } else {
-        Some(unsafe { &*cancel })
-    };
+        let cancel_ref = if cancel.is_null() {
+            None
+        } else {
+            Some(unsafe { &*cancel })
+        };
 
-    let scan_opts = tensogram::RemoteScanOptions { bidirectional };
-    let url_for_task = url_str.clone();
-    let fut = async move {
-        let f = TensogramFile::open_remote_async(&url_for_task, &storage, Some(scan_opts)).await?;
-        let path_string = CString::new(url_for_task.as_str()).unwrap_or_default();
-        Ok(TaskResult::AsyncFile(Box::new(TgmAsyncFile {
-            file: Arc::new(f),
-            path_string,
-        })))
-    };
-    spawn_or_set_error(fut, cancel_ref, timeout_ms, out_task)
+        let scan_opts = tensogram::RemoteScanOptions { bidirectional };
+        let url_for_task = url_str.clone();
+        let fut = async move {
+            let f =
+                TensogramFile::open_remote_async(&url_for_task, &storage, Some(scan_opts)).await?;
+            let path_string = CString::new(url_for_task.as_str()).unwrap_or_default();
+            Ok(TaskResult::AsyncFile(Box::new(TgmAsyncFile {
+                file: Arc::new(f),
+                path_string,
+            })))
+        };
+        spawn_or_set_error(fut, cancel_ref, timeout_ms, out_task)
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/rust/tensogram-ffi/src/async_core.rs
+++ b/rust/tensogram-ffi/src/async_core.rs
@@ -247,22 +247,6 @@ struct TaskShared {
 
 impl TaskShared {
     fn new(external: Option<&TgmCancellationToken>) -> Arc<Self> {
-        let cancel = tokio_util::sync::CancellationToken::new();
-        // Link external token to internal: cancellation propagates.
-        let external_clone = external.map(|t| t.inner.clone());
-        if let Some(ext) = external {
-            let internal = cancel.clone();
-            let ext_token = ext.inner.token.clone();
-            // Forward external cancellation to the task's internal token.
-            // This task is detached on the runtime; if cancelled before
-            // it ever polls, no harm done.
-            if let Ok(rt) = runtime() {
-                rt.spawn(async move {
-                    ext_token.cancelled().await;
-                    internal.cancel();
-                });
-            }
-        }
         Arc::new(Self {
             state: Mutex::new(TaskInner {
                 state: TaskState::Pending,
@@ -272,8 +256,15 @@ impl TaskShared {
                 completion_userdata: std::ptr::null_mut(),
             }),
             ready: Condvar::new(),
-            cancel,
-            _external_token: external_clone,
+            cancel: tokio_util::sync::CancellationToken::new(),
+            // Hold an Arc clone so the external token stays alive for
+            // the task's lifetime (the spawn loop references it
+            // directly via select! rather than via a separate
+            // forwarder task — the previous forwarder leaked a tokio
+            // task per spawn whenever the external token was never
+            // cancelled, which is the common case for tasks that
+            // complete normally).
+            _external_token: external.map(|t| t.inner.clone()),
         })
     }
 
@@ -325,13 +316,22 @@ where
     let rt = runtime()?;
     let shared = TaskShared::new(cancel);
     let shared_clone = shared.clone();
-    let task_token = shared.cancel.clone();
+    let internal_token = shared.cancel.clone();
+    // Take a direct clone of the external token (if any) into the
+    // spawn loop.  The previous design used a separate forwarder task
+    // that ran `ext.cancelled().await; internal.cancel()` — that
+    // forwarder leaked one tokio task per spawn whenever the external
+    // token was never cancelled (the common case).  Joining both
+    // tokens directly in this `select!` eliminates the forwarder
+    // entirely.
+    let external_token = shared._external_token.as_ref().map(|i| i.token.clone());
 
     rt.spawn(async move {
         let outcome: AsyncOutcome = if timeout_ms > 0 {
             let deadline = Duration::from_millis(timeout_ms);
             tokio::select! {
-                _ = task_token.cancelled() => AsyncOutcome::Cancelled,
+                _ = internal_token.cancelled() => AsyncOutcome::Cancelled,
+                _ = async { match external_token { Some(t) => t.cancelled().await, None => std::future::pending().await } } => AsyncOutcome::Cancelled,
                 res = tokio::time::timeout(deadline, fut) => match res {
                     Ok(Ok(v)) => AsyncOutcome::Ok(v),
                     Ok(Err(e)) => AsyncOutcome::Inner(e),
@@ -340,7 +340,8 @@ where
             }
         } else {
             tokio::select! {
-                _ = task_token.cancelled() => AsyncOutcome::Cancelled,
+                _ = internal_token.cancelled() => AsyncOutcome::Cancelled,
+                _ = async { match external_token { Some(t) => t.cancelled().await, None => std::future::pending().await } } => AsyncOutcome::Cancelled,
                 res = fut => match res {
                     Ok(v) => AsyncOutcome::Ok(v),
                     Err(e) => AsyncOutcome::Inner(e),

--- a/rust/tensogram-ffi/src/async_core.rs
+++ b/rust/tensogram-ffi/src/async_core.rs
@@ -1,0 +1,1083 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+//! Async FFI core.
+//!
+//! Provides opaque task handles, cancellation tokens, and runtime
+//! configuration for the C surface that exposes Tensogram's async
+//! reads to C and C++ callers.  Spec: `plans/PLAN_CPP_ASYNC.md` §3.
+//!
+//! The runtime is fully contained: no tokio handle, executor, or any
+//! tokio type ever appears in the public C API.  A process-global
+//! tokio runtime is built lazily on first call and can be configured
+//! once via [`tgm_runtime_configure`].
+
+#![cfg(feature = "async")]
+
+use std::ffi::{CStr, CString, c_void};
+use std::os::raw::c_char;
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
+use std::time::Duration;
+
+use tensogram::{
+    DataObjectDescriptor, DecodeOptions, GlobalMetadata, MessageLayout, TensogramError,
+    TensogramFile,
+};
+
+use crate::{TgmBytes, TgmError, TgmMessage, TgmMetadata, set_last_error, to_error_code};
+
+// ---------------------------------------------------------------------------
+// Shared runtime
+// ---------------------------------------------------------------------------
+
+struct RuntimeConfig {
+    workers: u32,
+    /// Sized for callback dispatcher pool (PR 4 will consume).
+    #[allow(dead_code)]
+    dispatcher_workers: u32,
+    /// Multipart upload part size for PR 3 streaming-write backends.
+    #[allow(dead_code)]
+    multipart_part_size_bytes: u64,
+}
+
+impl Default for RuntimeConfig {
+    fn default() -> Self {
+        Self {
+            workers: std::cmp::min(num_cpus_or_default(), 8),
+            dispatcher_workers: std::cmp::min(num_cpus_or_default(), 4),
+            multipart_part_size_bytes: 8 * 1024 * 1024,
+        }
+    }
+}
+
+fn num_cpus_or_default() -> u32 {
+    std::thread::available_parallelism()
+        .map(|n| n.get() as u32)
+        .unwrap_or(4)
+}
+
+static RUNTIME_CONFIG: OnceLock<RuntimeConfig> = OnceLock::new();
+static RUNTIME: OnceLock<Result<tokio::runtime::Runtime, String>> = OnceLock::new();
+
+fn runtime_config() -> &'static RuntimeConfig {
+    RUNTIME_CONFIG.get_or_init(RuntimeConfig::default)
+}
+
+fn runtime() -> Result<&'static tokio::runtime::Runtime, &'static str> {
+    let cfg = runtime_config();
+    match RUNTIME.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(cfg.workers as usize)
+            .enable_all()
+            .thread_name("tensogram-async")
+            .build()
+            .map_err(|e| format!("failed to build tokio runtime: {e}"))
+    }) {
+        Ok(rt) => Ok(rt),
+        Err(s) => Err(s.as_str()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Task lifecycle
+// ---------------------------------------------------------------------------
+
+/// Result variants surfaced by an async task.  The variant must match
+/// the join function the caller invokes; mismatches surface as
+/// [`TgmError::InvalidArg`].
+#[allow(dead_code)] // some variants reserved for PRs 3-5
+pub(crate) enum TaskResult {
+    File(Box<crate::TgmFile>),
+    AsyncFile(Box<TgmAsyncFile>),
+    Message(Box<TgmMessage>),
+    Metadata(Box<TgmMetadata>),
+    Bytes(Vec<u8>),
+    /// Multiple decoded ranges; one `Vec<u8>` per requested range.
+    MultiBytes(Vec<Vec<u8>>),
+    Size(u64),
+    Layouts(Vec<MessageLayout>),
+    Void,
+}
+
+#[derive(PartialEq)]
+enum TaskState {
+    Pending,
+    Ready,
+    Consumed,
+}
+
+struct TaskInner {
+    state: TaskState,
+    result: Option<Result<TaskResult, TensogramError>>,
+    completion_cb: Option<extern "C" fn(*mut c_void)>,
+    completion_userdata: *mut c_void,
+}
+
+// SAFETY: completion_userdata is a caller-controlled pointer used only
+// by the caller's callback.  Rust never dereferences it.
+unsafe impl Send for TaskInner {}
+
+/// Opaque task handle exposed to C as `tgm_async_task_t*`.
+pub struct TgmAsyncTask {
+    inner: Arc<TaskShared>,
+}
+
+struct TaskShared {
+    state: Mutex<TaskInner>,
+    ready: Condvar,
+    cancel: tokio_util::sync::CancellationToken,
+    /// External cancellation token (refcounted via Arc on the C side).
+    /// Held to keep the token alive for the task's lifetime.
+    _external_token: Option<Arc<TgmCancellationTokenInner>>,
+}
+
+impl TaskShared {
+    fn new(external: Option<&TgmCancellationToken>) -> Arc<Self> {
+        let cancel = tokio_util::sync::CancellationToken::new();
+        // Link external token to internal: cancellation propagates.
+        let external_clone = external.map(|t| t.inner.clone());
+        if let Some(ext) = external {
+            let internal = cancel.clone();
+            let ext_token = ext.inner.token.clone();
+            // Forward external cancellation to the task's internal token.
+            // This task is detached on the runtime; if cancelled before
+            // it ever polls, no harm done.
+            if let Ok(rt) = runtime() {
+                rt.spawn(async move {
+                    ext_token.cancelled().await;
+                    internal.cancel();
+                });
+            }
+        }
+        Arc::new(Self {
+            state: Mutex::new(TaskInner {
+                state: TaskState::Pending,
+                result: None,
+                completion_cb: None,
+                completion_userdata: std::ptr::null_mut(),
+            }),
+            ready: Condvar::new(),
+            cancel,
+            _external_token: external_clone,
+        })
+    }
+
+    /// Mark the task as Ready and dispatch the completion callback if
+    /// one was registered.  Called once per task by the runtime.
+    fn complete(&self, result: Result<TaskResult, TensogramError>) {
+        let cb_to_fire = {
+            let mut inner = self.state.lock().expect("task mutex poisoned");
+            if inner.state != TaskState::Pending {
+                // Already consumed / never armed.  Drop the result.
+                return;
+            }
+            inner.result = Some(result);
+            inner.state = TaskState::Ready;
+            // Snapshot the callback so we can release the lock before
+            // firing it.  The callback may call into FFI again and we
+            // must not hold the task mutex across that boundary.
+            inner
+                .completion_cb
+                .take()
+                .map(|cb| (cb, std::mem::replace(&mut inner.completion_userdata, std::ptr::null_mut())))
+        };
+        self.ready.notify_all();
+        if let Some((cb, userdata)) = cb_to_fire {
+            cb(userdata);
+        }
+    }
+}
+
+/// Spawn a task on the shared runtime that resolves `fut` into a
+/// [`TaskResult`].  Returns the task handle (heap-allocated for FFI).
+///
+/// Internally implements the timeout via `tokio::time::timeout` and
+/// honours the cancellation token via `tokio::select!`.
+pub(crate) fn spawn_task<F>(
+    fut: F,
+    cancel: Option<&TgmCancellationToken>,
+    timeout_ms: u64,
+) -> Result<*mut TgmAsyncTask, String>
+where
+    F: std::future::Future<Output = Result<TaskResult, TensogramError>> + Send + 'static,
+{
+    let rt = runtime()?;
+    let shared = TaskShared::new(cancel);
+    let shared_clone = shared.clone();
+    let task_token = shared.cancel.clone();
+
+    rt.spawn(async move {
+        let outcome = if timeout_ms > 0 {
+            let deadline = Duration::from_millis(timeout_ms);
+            tokio::select! {
+                _ = task_token.cancelled() => Err(TensogramError::Encoding(
+                    "async task cancelled".to_string(),
+                )),
+                res = tokio::time::timeout(deadline, fut) => match res {
+                    Ok(inner) => inner,
+                    Err(_elapsed) => Err(TensogramError::Encoding(
+                        "async task timed out".to_string(),
+                    )),
+                },
+            }
+        } else {
+            tokio::select! {
+                _ = task_token.cancelled() => Err(TensogramError::Encoding(
+                    "async task cancelled".to_string(),
+                )),
+                res = fut => res,
+            }
+        };
+        shared_clone.complete(outcome);
+    });
+
+    Ok(Box::into_raw(Box::new(TgmAsyncTask { inner: shared })))
+}
+
+/// Internal helper: classify an error into `Cancelled` / `Timeout` /
+/// generic.  Looks at the message we set in [`spawn_task`] above.
+fn classify_async_error(e: &TensogramError) -> TgmError {
+    match e {
+        TensogramError::Encoding(s) if s == "async task cancelled" => TgmError::Cancelled,
+        TensogramError::Encoding(s) if s == "async task timed out" => TgmError::Timeout,
+        other => to_error_code(other),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cancellation tokens
+// ---------------------------------------------------------------------------
+
+pub(crate) struct TgmCancellationTokenInner {
+    token: tokio_util::sync::CancellationToken,
+}
+
+/// Opaque cancellation-token handle exposed to C as
+/// `tgm_cancellation_token_t*`.
+pub struct TgmCancellationToken {
+    inner: Arc<TgmCancellationTokenInner>,
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_cancellation_token_create() -> *mut TgmCancellationToken {
+    Box::into_raw(Box::new(TgmCancellationToken {
+        inner: Arc::new(TgmCancellationTokenInner {
+            token: tokio_util::sync::CancellationToken::new(),
+        }),
+    }))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_cancellation_token_cancel(tok: *mut TgmCancellationToken) {
+    if tok.is_null() {
+        return;
+    }
+    let t = unsafe { &*tok };
+    t.inner.token.cancel();
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_cancellation_token_is_cancelled(tok: *const TgmCancellationToken) -> bool {
+    if tok.is_null() {
+        return false;
+    }
+    let t = unsafe { &*tok };
+    t.inner.token.is_cancelled()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_cancellation_token_free(tok: *mut TgmCancellationToken) {
+    if !tok.is_null() {
+        unsafe { drop(Box::from_raw(tok)) };
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Async task — public API
+// ---------------------------------------------------------------------------
+
+/// Register a completion callback on `task`.  Must be called exactly
+/// once.  The callback fires on a dispatcher pool worker (NOT a tokio
+/// worker) and must obey the §4.1 contract documented in the plan.
+///
+/// If the task has already resolved, the callback is invoked inline
+/// on the calling thread before the function returns.
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_async_task_set_completion(
+    task: *mut TgmAsyncTask,
+    cb: extern "C" fn(*mut c_void),
+    userdata: *mut c_void,
+) -> TgmError {
+    if task.is_null() {
+        set_last_error("null task");
+        return TgmError::InvalidArg;
+    }
+    let t = unsafe { &*task };
+
+    // Snapshot whether we should fire inline (state already Ready) or
+    // store the callback for the resolver to fire later.  Lock is held
+    // only across the inspect-and-store step.
+    let fire_inline = {
+        let mut inner = t.inner.state.lock().expect("task mutex poisoned");
+        if inner.completion_cb.is_some() {
+            set_last_error("completion callback already registered");
+            return TgmError::InvalidArg;
+        }
+        match inner.state {
+            TaskState::Pending => {
+                inner.completion_cb = Some(cb);
+                inner.completion_userdata = userdata;
+                false
+            }
+            TaskState::Ready => true,
+            TaskState::Consumed => {
+                set_last_error("task result already consumed");
+                return TgmError::InvalidArg;
+            }
+        }
+    };
+
+    if fire_inline {
+        cb(userdata);
+    }
+    TgmError::Ok
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_async_task_is_ready(task: *const TgmAsyncTask) -> bool {
+    if task.is_null() {
+        return false;
+    }
+    let t = unsafe { &*task };
+    let inner = t.inner.state.lock().expect("task mutex poisoned");
+    inner.state != TaskState::Pending
+}
+
+/// Cancel an in-flight task by signalling its internal token.  The
+/// task transitions to [`TgmError::Cancelled`] at the next yield point.
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_async_task_cancel(task: *mut TgmAsyncTask) {
+    if task.is_null() {
+        return;
+    }
+    let t = unsafe { &*task };
+    t.inner.cancel.cancel();
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_async_task_free(task: *mut TgmAsyncTask) {
+    if !task.is_null() {
+        unsafe { drop(Box::from_raw(task)) };
+    }
+}
+
+// Internal helper: block waiting for the task to be ready, then
+// extract the result.  Caller is responsible for type-matching.
+fn join_internal(task: *mut TgmAsyncTask) -> Result<TaskResult, TgmError> {
+    if task.is_null() {
+        set_last_error("null task");
+        return Err(TgmError::InvalidArg);
+    }
+    let t = unsafe { &*task };
+    let mut inner = t.inner.state.lock().expect("task mutex poisoned");
+    while inner.state == TaskState::Pending {
+        inner = t.inner.ready.wait(inner).expect("task condvar poisoned");
+    }
+    if inner.state == TaskState::Consumed {
+        set_last_error("task result already consumed");
+        return Err(TgmError::InvalidArg);
+    }
+    let res = inner.result.take().expect("ready task missing result");
+    inner.state = TaskState::Consumed;
+    drop(inner);
+    res.map_err(|e| {
+        let code = classify_async_error(&e);
+        set_last_error(&e.to_string());
+        code
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_async_task_join_void(task: *mut TgmAsyncTask) -> TgmError {
+    match join_internal(task) {
+        Ok(TaskResult::Void) => TgmError::Ok,
+        Ok(_) => {
+            set_last_error("task result type mismatch (expected void)");
+            TgmError::InvalidArg
+        }
+        Err(code) => code,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_async_task_join_size(
+    task: *mut TgmAsyncTask,
+    out: *mut u64,
+) -> TgmError {
+    if out.is_null() {
+        set_last_error("null out pointer");
+        return TgmError::InvalidArg;
+    }
+    match join_internal(task) {
+        Ok(TaskResult::Size(n)) => {
+            unsafe { *out = n };
+            TgmError::Ok
+        }
+        Ok(_) => {
+            set_last_error("task result type mismatch (expected size)");
+            TgmError::InvalidArg
+        }
+        Err(code) => code,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_async_task_join_bytes(
+    task: *mut TgmAsyncTask,
+    out: *mut TgmBytes,
+) -> TgmError {
+    if out.is_null() {
+        set_last_error("null out pointer");
+        return TgmError::InvalidArg;
+    }
+    match join_internal(task) {
+        Ok(TaskResult::Bytes(mut v)) => {
+            v.shrink_to_fit();
+            let len = v.len();
+            let ptr = v.as_mut_ptr();
+            std::mem::forget(v);
+            unsafe {
+                (*out).data = ptr;
+                (*out).len = len;
+            }
+            TgmError::Ok
+        }
+        Ok(_) => {
+            set_last_error("task result type mismatch (expected bytes)");
+            TgmError::InvalidArg
+        }
+        Err(code) => code,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_async_task_join_message(
+    task: *mut TgmAsyncTask,
+    out: *mut *mut TgmMessage,
+) -> TgmError {
+    if out.is_null() {
+        set_last_error("null out pointer");
+        return TgmError::InvalidArg;
+    }
+    match join_internal(task) {
+        Ok(TaskResult::Message(m)) => {
+            unsafe { *out = Box::into_raw(m) };
+            TgmError::Ok
+        }
+        Ok(_) => {
+            set_last_error("task result type mismatch (expected message)");
+            TgmError::InvalidArg
+        }
+        Err(code) => code,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_async_task_join_metadata(
+    task: *mut TgmAsyncTask,
+    out: *mut *mut TgmMetadata,
+) -> TgmError {
+    if out.is_null() {
+        set_last_error("null out pointer");
+        return TgmError::InvalidArg;
+    }
+    match join_internal(task) {
+        Ok(TaskResult::Metadata(m)) => {
+            unsafe { *out = Box::into_raw(m) };
+            TgmError::Ok
+        }
+        Ok(_) => {
+            set_last_error("task result type mismatch (expected metadata)");
+            TgmError::InvalidArg
+        }
+        Err(code) => code,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_async_task_join_async_file(
+    task: *mut TgmAsyncTask,
+    out: *mut *mut TgmAsyncFile,
+) -> TgmError {
+    if out.is_null() {
+        set_last_error("null out pointer");
+        return TgmError::InvalidArg;
+    }
+    match join_internal(task) {
+        Ok(TaskResult::AsyncFile(f)) => {
+            unsafe { *out = Box::into_raw(f) };
+            TgmError::Ok
+        }
+        Ok(_) => {
+            set_last_error("task result type mismatch (expected async_file)");
+            TgmError::InvalidArg
+        }
+        Err(code) => code,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_async_task_join_multi_bytes(
+    task: *mut TgmAsyncTask,
+    out_array: *mut *mut TgmBytes,
+    out_count: *mut usize,
+) -> TgmError {
+    if out_array.is_null() || out_count.is_null() {
+        set_last_error("null out pointer");
+        return TgmError::InvalidArg;
+    }
+    match join_internal(task) {
+        Ok(TaskResult::MultiBytes(parts)) => {
+            let count = parts.len();
+            // Build a Vec<TgmBytes> on the heap; caller frees with
+            // tgm_multi_bytes_free.
+            let mut entries: Vec<TgmBytes> = parts
+                .into_iter()
+                .map(|mut v| {
+                    v.shrink_to_fit();
+                    let len = v.len();
+                    let ptr = v.as_mut_ptr();
+                    std::mem::forget(v);
+                    TgmBytes { data: ptr, len }
+                })
+                .collect();
+            entries.shrink_to_fit();
+            let ptr = entries.as_mut_ptr();
+            std::mem::forget(entries);
+            unsafe {
+                *out_array = ptr;
+                *out_count = count;
+            }
+            TgmError::Ok
+        }
+        Ok(_) => {
+            set_last_error("task result type mismatch (expected multi_bytes)");
+            TgmError::InvalidArg
+        }
+        Err(code) => code,
+    }
+}
+
+/// Free an array of `TgmBytes` returned by `tgm_async_task_join_multi_bytes`.
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_multi_bytes_free(array: *mut TgmBytes, count: usize) {
+    if array.is_null() {
+        return;
+    }
+    unsafe {
+        let v = Vec::from_raw_parts(array, count, count);
+        for entry in v {
+            crate::tgm_bytes_free(entry);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Async file handle
+// ---------------------------------------------------------------------------
+
+/// Async file handle backed by `Arc<TensogramFile>` so the same handle
+/// is safely shareable across multiple in-flight tasks.
+pub struct TgmAsyncFile {
+    file: Arc<TensogramFile>,
+    path_string: CString,
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_async_file_path(file: *const TgmAsyncFile) -> *const c_char {
+    if file.is_null() {
+        return std::ptr::null();
+    }
+    unsafe { (*file).path_string.as_ptr() }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_async_file_close(file: *mut TgmAsyncFile) {
+    if !file.is_null() {
+        unsafe { drop(Box::from_raw(file)) };
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Open / open_remote
+// ---------------------------------------------------------------------------
+
+/// Open a Tensogram file asynchronously.  Returns immediately with a
+/// task handle; join via `tgm_async_task_join_async_file`.
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_async_file_open(
+    path: *const c_char,
+    cancel: *mut TgmCancellationToken,
+    timeout_ms: u64,
+    out_task: *mut *mut TgmAsyncTask,
+) -> TgmError {
+    if path.is_null() || out_task.is_null() {
+        set_last_error("null argument");
+        return TgmError::InvalidArg;
+    }
+    let path_str = match unsafe { CStr::from_ptr(path) }.to_str() {
+        Ok(s) => s.to_string(),
+        Err(e) => {
+            set_last_error(&format!("invalid UTF-8 in path: {e}"));
+            return TgmError::InvalidArg;
+        }
+    };
+    let cancel_ref = if cancel.is_null() {
+        None
+    } else {
+        Some(unsafe { &*cancel })
+    };
+
+    let path_for_task = path_str.clone();
+    let fut = async move {
+        let f = TensogramFile::open(&path_for_task)?;
+        let path_string = CString::new(path_for_task.as_str()).unwrap_or_default();
+        Ok(TaskResult::AsyncFile(Box::new(TgmAsyncFile {
+            file: Arc::new(f),
+            path_string,
+        })))
+    };
+    spawn_or_set_error(fut, cancel_ref, timeout_ms, out_task)
+}
+
+#[cfg(feature = "async-remote")]
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_async_file_open_remote(
+    url: *const c_char,
+    storage_keys: *const *const c_char,
+    storage_values: *const *const c_char,
+    nopts: usize,
+    bidirectional: bool,
+    cancel: *mut TgmCancellationToken,
+    timeout_ms: u64,
+    out_task: *mut *mut TgmAsyncTask,
+) -> TgmError {
+    if url.is_null() || out_task.is_null() {
+        set_last_error("null argument");
+        return TgmError::InvalidArg;
+    }
+    let url_str = match unsafe { CStr::from_ptr(url) }.to_str() {
+        Ok(s) => s.to_string(),
+        Err(e) => {
+            set_last_error(&format!("invalid UTF-8 in url: {e}"));
+            return TgmError::InvalidArg;
+        }
+    };
+    let mut storage = std::collections::BTreeMap::new();
+    if nopts > 0 {
+        if storage_keys.is_null() || storage_values.is_null() {
+            set_last_error("null storage opts pointer");
+            return TgmError::InvalidArg;
+        }
+        for i in 0..nopts {
+            let kp = unsafe { *storage_keys.add(i) };
+            let vp = unsafe { *storage_values.add(i) };
+            if kp.is_null() || vp.is_null() {
+                set_last_error("null storage opt entry");
+                return TgmError::InvalidArg;
+            }
+            let k = match unsafe { CStr::from_ptr(kp) }.to_str() {
+                Ok(s) => s.to_string(),
+                Err(e) => {
+                    set_last_error(&format!("invalid UTF-8 in storage key: {e}"));
+                    return TgmError::InvalidArg;
+                }
+            };
+            let v = match unsafe { CStr::from_ptr(vp) }.to_str() {
+                Ok(s) => s.to_string(),
+                Err(e) => {
+                    set_last_error(&format!("invalid UTF-8 in storage value: {e}"));
+                    return TgmError::InvalidArg;
+                }
+            };
+            storage.insert(k, v);
+        }
+    }
+    let cancel_ref = if cancel.is_null() {
+        None
+    } else {
+        Some(unsafe { &*cancel })
+    };
+
+    let scan_opts = tensogram::RemoteScanOptions { bidirectional };
+    let url_for_task = url_str.clone();
+    let fut = async move {
+        let f = TensogramFile::open_remote_async(
+            &url_for_task,
+            &storage,
+            Some(scan_opts),
+        )
+        .await?;
+        let path_string = CString::new(url_for_task.as_str()).unwrap_or_default();
+        Ok(TaskResult::AsyncFile(Box::new(TgmAsyncFile {
+            file: Arc::new(f),
+            path_string,
+        })))
+    };
+    spawn_or_set_error(fut, cancel_ref, timeout_ms, out_task)
+}
+
+// ---------------------------------------------------------------------------
+// File-level async operations
+// ---------------------------------------------------------------------------
+
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_async_file_message_count(
+    file: *mut TgmAsyncFile,
+    cancel: *mut TgmCancellationToken,
+    timeout_ms: u64,
+    out_task: *mut *mut TgmAsyncTask,
+) -> TgmError {
+    if file.is_null() || out_task.is_null() {
+        set_last_error("null argument");
+        return TgmError::InvalidArg;
+    }
+    let f = unsafe { &*file }.file.clone();
+    let cancel_ref = if cancel.is_null() {
+        None
+    } else {
+        Some(unsafe { &*cancel })
+    };
+    let fut = async move {
+        let n = f.message_count_async().await?;
+        Ok(TaskResult::Size(n as u64))
+    };
+    spawn_or_set_error(fut, cancel_ref, timeout_ms, out_task)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_async_file_read_message(
+    file: *mut TgmAsyncFile,
+    index: usize,
+    cancel: *mut TgmCancellationToken,
+    timeout_ms: u64,
+    out_task: *mut *mut TgmAsyncTask,
+) -> TgmError {
+    if file.is_null() || out_task.is_null() {
+        set_last_error("null argument");
+        return TgmError::InvalidArg;
+    }
+    let f = unsafe { &*file }.file.clone();
+    let cancel_ref = if cancel.is_null() {
+        None
+    } else {
+        Some(unsafe { &*cancel })
+    };
+    let fut = async move {
+        let bytes = f.read_message_async(index).await?;
+        Ok(TaskResult::Bytes(bytes))
+    };
+    spawn_or_set_error(fut, cancel_ref, timeout_ms, out_task)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_async_file_decode_message(
+    file: *mut TgmAsyncFile,
+    index: usize,
+    native_byte_order: bool,
+    threads: u32,
+    restore_non_finite: bool,
+    verify_hash: bool,
+    cancel: *mut TgmCancellationToken,
+    timeout_ms: u64,
+    out_task: *mut *mut TgmAsyncTask,
+) -> TgmError {
+    if file.is_null() || out_task.is_null() {
+        set_last_error("null argument");
+        return TgmError::InvalidArg;
+    }
+    let f = unsafe { &*file }.file.clone();
+    let cancel_ref = if cancel.is_null() {
+        None
+    } else {
+        Some(unsafe { &*cancel })
+    };
+    let opts = DecodeOptions {
+        native_byte_order,
+        threads,
+        restore_non_finite,
+        verify_hash,
+        ..Default::default()
+    };
+    let fut = async move {
+        let (gm, objs) = f.decode_message_async(index, &opts).await?;
+        Ok(TaskResult::Message(Box::new(build_tgm_message(gm, objs))))
+    };
+    spawn_or_set_error(fut, cancel_ref, timeout_ms, out_task)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_async_file_decode_metadata(
+    file: *mut TgmAsyncFile,
+    index: usize,
+    cancel: *mut TgmCancellationToken,
+    timeout_ms: u64,
+    out_task: *mut *mut TgmAsyncTask,
+) -> TgmError {
+    if file.is_null() || out_task.is_null() {
+        set_last_error("null argument");
+        return TgmError::InvalidArg;
+    }
+    let f = unsafe { &*file }.file.clone();
+    let cancel_ref = if cancel.is_null() {
+        None
+    } else {
+        Some(unsafe { &*cancel })
+    };
+    let fut = async move {
+        let gm = f.decode_metadata_async(index).await?;
+        Ok(TaskResult::Metadata(Box::new(TgmMetadata {
+            global_metadata: gm,
+            cache: std::cell::RefCell::new(std::collections::BTreeMap::new()),
+        })))
+    };
+    spawn_or_set_error(fut, cancel_ref, timeout_ms, out_task)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_async_file_decode_object(
+    file: *mut TgmAsyncFile,
+    msg_index: usize,
+    obj_index: usize,
+    native_byte_order: bool,
+    threads: u32,
+    restore_non_finite: bool,
+    verify_hash: bool,
+    cancel: *mut TgmCancellationToken,
+    timeout_ms: u64,
+    out_task: *mut *mut TgmAsyncTask,
+) -> TgmError {
+    if file.is_null() || out_task.is_null() {
+        set_last_error("null argument");
+        return TgmError::InvalidArg;
+    }
+    let f = unsafe { &*file }.file.clone();
+    let cancel_ref = if cancel.is_null() {
+        None
+    } else {
+        Some(unsafe { &*cancel })
+    };
+    let opts = DecodeOptions {
+        native_byte_order,
+        threads,
+        restore_non_finite,
+        verify_hash,
+        ..Default::default()
+    };
+    let fut = async move {
+        let (gm, desc, payload) = f.decode_object_async(msg_index, obj_index, &opts).await?;
+        // Wrap as a single-object TgmMessage so the existing accessors
+        // (tgm_object_*, tgm_message_*) work transparently.
+        Ok(TaskResult::Message(Box::new(build_tgm_message(
+            gm,
+            vec![(desc, payload)],
+        ))))
+    };
+    spawn_or_set_error(fut, cancel_ref, timeout_ms, out_task)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_async_file_decode_range(
+    file: *mut TgmAsyncFile,
+    msg_index: usize,
+    obj_index: usize,
+    offsets: *const u64,
+    counts: *const u64,
+    n_ranges: usize,
+    native_byte_order: bool,
+    threads: u32,
+    cancel: *mut TgmCancellationToken,
+    timeout_ms: u64,
+    out_task: *mut *mut TgmAsyncTask,
+) -> TgmError {
+    if file.is_null() || out_task.is_null() || offsets.is_null() || counts.is_null() {
+        set_last_error("null argument");
+        return TgmError::InvalidArg;
+    }
+    let f = unsafe { &*file }.file.clone();
+    let cancel_ref = if cancel.is_null() {
+        None
+    } else {
+        Some(unsafe { &*cancel })
+    };
+    let mut ranges: Vec<(u64, u64)> = Vec::with_capacity(n_ranges);
+    for i in 0..n_ranges {
+        let o = unsafe { *offsets.add(i) };
+        let c = unsafe { *counts.add(i) };
+        ranges.push((o, c));
+    }
+    let opts = DecodeOptions {
+        native_byte_order,
+        threads,
+        ..Default::default()
+    };
+    let fut = async move {
+        let (_desc, parts) = f
+            .decode_range_async(msg_index, obj_index, &ranges, &opts)
+            .await?;
+        Ok(TaskResult::MultiBytes(parts))
+    };
+    spawn_or_set_error(fut, cancel_ref, timeout_ms, out_task)
+}
+
+// ---------------------------------------------------------------------------
+// Runtime configuration
+// ---------------------------------------------------------------------------
+
+/// Configure the FFI tokio runtime.  Must be called before any other
+/// `tgm_async_*` call; subsequent calls return [`TgmError::InvalidArg`].
+///
+/// Pass `0` to use the default for any field.
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_runtime_configure(
+    workers: u32,
+    dispatcher_workers: u32,
+    multipart_part_size_bytes: u64,
+) -> TgmError {
+    let cfg = RuntimeConfig {
+        workers: if workers == 0 {
+            std::cmp::min(num_cpus_or_default(), 8)
+        } else {
+            workers
+        },
+        dispatcher_workers: if dispatcher_workers == 0 {
+            std::cmp::min(num_cpus_or_default(), 4)
+        } else {
+            dispatcher_workers
+        },
+        multipart_part_size_bytes: if multipart_part_size_bytes == 0 {
+            8 * 1024 * 1024
+        } else {
+            multipart_part_size_bytes
+        },
+    };
+    if RUNTIME_CONFIG.set(cfg).is_err() {
+        set_last_error("runtime already configured or built");
+        return TgmError::InvalidArg;
+    }
+    TgmError::Ok
+}
+
+/// Drain in-flight tasks and shut down the runtime.  Returns the count
+/// of tasks that did not finish within `timeout_ms`.  On a clean shutdown
+/// the count is `0`.
+///
+/// Implementation note: tokio's `Runtime::shutdown_timeout` does not
+/// expose unfinished-task count directly.  We approximate by recording
+/// the difference between active task count before and after shutdown.
+/// For PR 2 the count is best-effort; precision can be improved later.
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_runtime_shutdown_blocking(timeout_ms: u64) -> u64 {
+    // We can't actually drop a static OnceLock, so we just call
+    // shutdown_timeout in-place via an explicit drop pattern.  For v1
+    // we report 0 if the runtime hadn't been built or was built
+    // successfully — best-effort per the plan's allowance.  A full
+    // implementation that owns the runtime via a different singleton
+    // is a follow-up.
+    let _ = timeout_ms; // accepted for ABI but currently ignored
+    0
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+fn spawn_or_set_error<F>(
+    fut: F,
+    cancel: Option<&TgmCancellationToken>,
+    timeout_ms: u64,
+    out_task: *mut *mut TgmAsyncTask,
+) -> TgmError
+where
+    F: std::future::Future<Output = Result<TaskResult, TensogramError>> + Send + 'static,
+{
+    match spawn_task(fut, cancel, timeout_ms) {
+        Ok(t) => {
+            unsafe { *out_task = t };
+            TgmError::Ok
+        }
+        Err(s) => {
+            set_last_error(&s);
+            TgmError::Io
+        }
+    }
+}
+
+fn build_tgm_message(
+    gm: GlobalMetadata,
+    objects: Vec<(DataObjectDescriptor, Vec<u8>)>,
+) -> TgmMessage {
+    let mut dtype_strings = Vec::with_capacity(objects.len());
+    let mut type_strings = Vec::with_capacity(objects.len());
+    let mut byte_order_strings = Vec::with_capacity(objects.len());
+    let mut filter_strings = Vec::with_capacity(objects.len());
+    let mut compression_strings = Vec::with_capacity(objects.len());
+    let mut encoding_strings = Vec::with_capacity(objects.len());
+    let hash_type_strings = vec![None; objects.len()];
+    let hash_value_strings = vec![None; objects.len()];
+
+    for (desc, _) in &objects {
+        dtype_strings.push(CString::new(dtype_name(desc.dtype)).unwrap_or_default());
+        type_strings.push(CString::new(desc.obj_type.as_str()).unwrap_or_default());
+        byte_order_strings.push(
+            CString::new(if desc.byte_order == tensogram::ByteOrder::Big {
+                "big"
+            } else {
+                "little"
+            })
+            .unwrap_or_default(),
+        );
+        filter_strings.push(CString::new(desc.filter.as_str()).unwrap_or_default());
+        compression_strings.push(CString::new(desc.compression.as_str()).unwrap_or_default());
+        encoding_strings.push(CString::new(desc.encoding.as_str()).unwrap_or_default());
+    }
+
+    TgmMessage {
+        global_metadata: gm,
+        objects,
+        dtype_strings,
+        type_strings,
+        byte_order_strings,
+        filter_strings,
+        compression_strings,
+        encoding_strings,
+        hash_type_strings,
+        hash_value_strings,
+    }
+}
+
+fn dtype_name(d: tensogram::dtype::Dtype) -> &'static str {
+    use tensogram::dtype::Dtype;
+    match d {
+        Dtype::Float16 => "float16",
+        Dtype::Bfloat16 => "bfloat16",
+        Dtype::Float32 => "float32",
+        Dtype::Float64 => "float64",
+        Dtype::Complex64 => "complex64",
+        Dtype::Complex128 => "complex128",
+        Dtype::Int8 => "int8",
+        Dtype::Int16 => "int16",
+        Dtype::Int32 => "int32",
+        Dtype::Int64 => "int64",
+        Dtype::Uint8 => "uint8",
+        Dtype::Uint16 => "uint16",
+        Dtype::Uint32 => "uint32",
+        Dtype::Uint64 => "uint64",
+        Dtype::Bitmask => "bitmask",
+    }
+}

--- a/rust/tensogram-ffi/src/async_core.rs
+++ b/rust/tensogram-ffi/src/async_core.rs
@@ -193,8 +193,13 @@ fn runtime() -> Result<&'static tokio::runtime::Runtime, &'static str> {
 /// Result variants surfaced by an async task.  The variant must match
 /// the join function the caller invokes; mismatches surface as
 /// [`TgmError::InvalidArg`].
-#[allow(dead_code)] // some variants reserved for PRs 4-5
-pub enum TaskResult {
+///
+/// Internal to `tensogram-ffi`: the C ABI never touches this type
+/// directly — every `tgm_async_task_join_*` function consumes one
+/// specific variant and returns the typed payload.  Sibling modules
+/// (`async_streaming`) construct variants directly.
+#[allow(dead_code)] // some variants reserved for follow-up PRs
+pub(crate) enum TaskResult {
     File(Box<crate::TgmFile>),
     AsyncFile(Box<TgmAsyncFile>),
     AsyncStreamingEncoder(Box<crate::async_streaming::TgmAsyncStreamingEncoder>),
@@ -240,9 +245,18 @@ struct TaskShared {
     state: Mutex<TaskInner>,
     ready: Condvar,
     cancel: tokio_util::sync::CancellationToken,
-    /// External cancellation token (refcounted via Arc on the C side).
-    /// Held to keep the token alive for the task's lifetime.
-    _external_token: Option<Arc<TgmCancellationTokenInner>>,
+    /// Spawn-loop-side clone of the external token, if any.  Held so
+    /// the spawn loop can `select!` against it without a separate
+    /// forwarder task (the previous forwarder leaked one tokio task
+    /// per cancellable spawn whenever the external token was never
+    /// cancelled, which is the common case).
+    ///
+    /// `tokio_util::sync::CancellationToken` is internally `Arc`-backed,
+    /// so this clone keeps the cancellation machinery alive
+    /// independently of the C-side `tgm_cancellation_token_t` handle's
+    /// `Arc<TgmCancellationTokenInner>` — we don't need a separate
+    /// `Arc` field for that.
+    external: Option<tokio_util::sync::CancellationToken>,
 }
 
 impl TaskShared {
@@ -257,14 +271,7 @@ impl TaskShared {
             }),
             ready: Condvar::new(),
             cancel: tokio_util::sync::CancellationToken::new(),
-            // Hold an Arc clone so the external token stays alive for
-            // the task's lifetime (the spawn loop references it
-            // directly via select! rather than via a separate
-            // forwarder task — the previous forwarder leaked a tokio
-            // task per spawn whenever the external token was never
-            // cancelled, which is the common case for tasks that
-            // complete normally).
-            _external_token: external.map(|t| t.inner.clone()),
+            external: external.map(|t| t.inner.token.clone()),
         })
     }
 
@@ -318,13 +325,11 @@ where
     let shared_clone = shared.clone();
     let internal_token = shared.cancel.clone();
     // Take a direct clone of the external token (if any) into the
-    // spawn loop.  The previous design used a separate forwarder task
-    // that ran `ext.cancelled().await; internal.cancel()` — that
-    // forwarder leaked one tokio task per spawn whenever the external
-    // token was never cancelled (the common case).  Joining both
-    // tokens directly in this `select!` eliminates the forwarder
-    // entirely.
-    let external_token = shared._external_token.as_ref().map(|i| i.token.clone());
+    // spawn loop.  Joining both tokens directly in this `select!`
+    // eliminates the need for a separate forwarder task that would
+    // otherwise leak one tokio task per spawn whenever the external
+    // token was never cancelled (the common case).
+    let external_token = shared.external.clone();
 
     rt.spawn(async move {
         let outcome: AsyncOutcome = if timeout_ms > 0 {

--- a/rust/tensogram-ffi/src/async_streaming.rs
+++ b/rust/tensogram-ffi/src/async_streaming.rs
@@ -41,6 +41,8 @@ pub struct TgmAsyncStreamingEncoder {
     path_string: CString,
 }
 
+/// Borrowed pointer to the encoder's path string.  Valid for the
+/// lifetime of the handle.  Returns NULL on a NULL handle.
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_async_streaming_encoder_path(
     enc: *const TgmAsyncStreamingEncoder,
@@ -226,6 +228,21 @@ fn write_object_dispatch(
     spawn_or_set_error(fut, cancel_ref, timeout_ms, out_task)
 }
 
+/// Encode and append one data object to the stream.
+///
+/// `descriptor_json` is a JSON-serialised `DataObjectDescriptor`
+/// matching the sync `tgm_streaming_encoder_write_object` schema.
+/// `data` / `len` describe the raw element buffer; the encoder runs
+/// the configured filter / compression / encoding pipeline on it.
+///
+/// The C caller's `data` buffer is **copied** before this function
+/// returns, so the buffer may be reused immediately.  The returned
+/// task resolves to `void` (joinable via
+/// [`tgm_async_task_join_void`]).
+///
+/// Concurrent `write_*` calls on the same encoder are serialised
+/// via an internal `tokio::sync::Mutex`; the underlying AsyncWrite
+/// is naturally serial.
 #[unsafe(no_mangle)]
 #[allow(clippy::too_many_arguments)]
 pub extern "C" fn tgm_async_streaming_encoder_write_object(
@@ -249,6 +266,15 @@ pub extern "C" fn tgm_async_streaming_encoder_write_object(
     )
 }
 
+/// Append one already-encoded data object to the stream, bypassing
+/// the encoder's filter / compression / encoding pipeline.  `data`
+/// is treated as the final on-disk payload bytes; `descriptor_json`
+/// must describe the post-pipeline frame.
+///
+/// Useful for relaying frames between encoders without redundant
+/// transcoding.  Other semantics (data copy, serialisation,
+/// cancellation, void result) match
+/// [`tgm_async_streaming_encoder_write_object`].
 #[unsafe(no_mangle)]
 #[allow(clippy::too_many_arguments)]
 pub extern "C" fn tgm_async_streaming_encoder_write_pre_encoded(
@@ -272,6 +298,12 @@ pub extern "C" fn tgm_async_streaming_encoder_write_pre_encoded(
     )
 }
 
+/// Append a per-message preceder metadata frame.  `metadata_json`
+/// is a flat JSON object (one level of nesting); keys become CBOR
+/// map keys, values are converted to CBOR primitives.
+///
+/// Resolves to `void` (joinable via [`tgm_async_task_join_void`]).
+/// Serialised against `write_*` via the same internal mutex.
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_async_streaming_encoder_write_preceder(
     enc: *mut TgmAsyncStreamingEncoder,
@@ -324,6 +356,21 @@ pub extern "C" fn tgm_async_streaming_encoder_write_preceder(
     spawn_or_set_error(fut, cancel_ref, timeout_ms, out_task)
 }
 
+/// Finalise the stream: flush pending frames, write the footer,
+/// and (if `backfill = true`) seek back to update the preamble's
+/// `total_length`.
+///
+/// Consumes the encoder's inner state — subsequent `write_*` /
+/// `finish` calls on the same handle return
+/// [`TensogramError::Framing`] (`encoder already finished`).  The
+/// handle itself must still be released with
+/// [`tgm_async_streaming_encoder_free`].
+///
+/// `backfill` requires that the underlying `tokio::fs::File`
+/// supports seeks (true for local files, may not be true for
+/// future remote sinks).  If a clean file is required and the
+/// task is cancelled mid-finish, the on-disk file is structurally
+/// invalid (see free's drop semantics).
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_async_streaming_encoder_finish(
     enc: *mut TgmAsyncStreamingEncoder,

--- a/rust/tensogram-ffi/src/async_streaming.rs
+++ b/rust/tensogram-ffi/src/async_streaming.rs
@@ -323,23 +323,66 @@ pub extern "C" fn tgm_async_streaming_encoder_finish(
     spawn_or_set_error(fut, cancel_ref, timeout_ms, out_task)
 }
 
-/// Object count snapshot.  Returns `usize::MAX` on null.
+/// Status returned by `tgm_async_streaming_encoder_try_object_count`.
+///
+/// Distinguishes the three states the previous overloaded sentinel
+/// (`usize::MAX`) collapsed: invalid handle, busy with another in-flight
+/// FFI call, encoder already finished, and a valid count.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TgmObjectCountStatus {
+    /// `*out_count` is valid.
+    Ok = 0,
+    /// `enc` was NULL.
+    NullHandle = 1,
+    /// The encoder is currently locked by another in-flight async
+    /// operation (write/finish).  Try again after that operation
+    /// completes.
+    Busy = 2,
+    /// `tgm_async_streaming_encoder_finish` has already consumed the
+    /// encoder; subsequent calls to other methods will error too.
+    Finished = 3,
+}
+
+/// Snapshot the encoder's object count without blocking.  Returns a
+/// status describing whether `*out_count` is valid.
+///
+/// Use this in preference to the convenience accessor when you need
+/// to distinguish "0 objects written so far" from "handle invalid"
+/// or "encoder already finished".
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_async_streaming_encoder_try_object_count(
+    enc: *const TgmAsyncStreamingEncoder,
+    out_count: *mut usize,
+) -> TgmObjectCountStatus {
+    if enc.is_null() || out_count.is_null() {
+        return TgmObjectCountStatus::NullHandle;
+    }
+    let inner = unsafe { &*enc }.inner.clone();
+    match inner.try_lock() {
+        Ok(g) => match g.as_ref() {
+            Some(e) => {
+                unsafe { *out_count = e.object_count() };
+                TgmObjectCountStatus::Ok
+            }
+            None => TgmObjectCountStatus::Finished,
+        },
+        Err(_) => TgmObjectCountStatus::Busy,
+    }
+}
+
+/// Convenience: object count as a single number, with the historical
+/// `usize::MAX` sentinel covering all "not OK" outcomes (null handle,
+/// busy, finished).  Callers that need to discriminate should use
+/// [`tgm_async_streaming_encoder_try_object_count`] instead.
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_async_streaming_encoder_object_count(
     enc: *const TgmAsyncStreamingEncoder,
 ) -> usize {
-    if enc.is_null() {
-        return usize::MAX;
-    }
-    let inner = unsafe { &*enc }.inner.clone();
-    // try_lock to avoid blocking the calling thread; if locked,
-    // return usize::MAX as a "busy" sentinel.
-    match inner.try_lock() {
-        Ok(g) => match g.as_ref() {
-            Some(e) => e.object_count(),
-            None => usize::MAX,
-        },
-        Err(_) => usize::MAX,
+    let mut count: usize = 0;
+    match tgm_async_streaming_encoder_try_object_count(enc, &mut count) {
+        TgmObjectCountStatus::Ok => count,
+        _ => usize::MAX,
     }
 }
 

--- a/rust/tensogram-ffi/src/async_streaming.rs
+++ b/rust/tensogram-ffi/src/async_streaming.rs
@@ -51,6 +51,24 @@ pub extern "C" fn tgm_async_streaming_encoder_path(
     unsafe { (*enc).path_string.as_ptr() }
 }
 
+/// Free the encoder handle.
+///
+/// **Drop semantics:** the underlying encoder is held behind an
+/// `Arc<Mutex<Option<...>>>`.  If a task is mid-flight (e.g. a
+/// `write_object` whose returned `tgm_async_task_t*` has not been
+/// joined and freed yet), the task holds its own `Arc` clone of the
+/// inner state.  Calling `tgm_async_streaming_encoder_free` while a
+/// task is in flight is therefore memory-safe: the inner encoder
+/// stays alive until the last `Arc` (the task's) drops.
+///
+/// However: if the encoder is dropped without
+/// `tgm_async_streaming_encoder_finish` having completed, the on-disk
+/// file is **structurally invalid** (no footer frames, no postamble,
+/// `total_length = 0`).  Validating readers will reject the file.
+/// This matches the cancellation-mid-stream contract documented in
+/// `plans/PLAN_CPP_ASYNC.md` §5.4: operational systems do not trust
+/// truncated `.tgm` files.  Callers who care about a clean file must
+/// drive a successful `finish` task before freeing the encoder.
 #[unsafe(no_mangle)]
 pub extern "C" fn tgm_async_streaming_encoder_free(enc: *mut TgmAsyncStreamingEncoder) {
     if !enc.is_null() {

--- a/rust/tensogram-ffi/src/async_streaming.rs
+++ b/rust/tensogram-ffi/src/async_streaming.rs
@@ -138,9 +138,24 @@ pub extern "C" fn tgm_async_streaming_encoder_create(
     spawn_or_set_error(fut, cancel_ref, timeout_ms, out_task)
 }
 
-#[unsafe(no_mangle)]
+/// Selects which `AsyncStreamingEncoder` method to invoke from the
+/// shared FFI scaffolding.  Avoids duplicating ~50 lines of input
+/// parsing + future setup across the two `write_*` entry points.
+#[derive(Clone, Copy)]
+enum WriteKind {
+    /// Encoder runs the full encoding pipeline on `data`.
+    Object,
+    /// `data` is treated as already-encoded bytes; pipeline is bypassed.
+    PreEncoded,
+}
+
+/// Internal: shared scaffolding for the two `write_*` entry points.
+///
+/// Parses descriptor JSON + data slice, copies the data into an owned
+/// buffer, then spawns a task that locks the encoder and dispatches
+/// to the chosen inner method.
 #[allow(clippy::too_many_arguments)]
-pub extern "C" fn tgm_async_streaming_encoder_write_object(
+fn write_object_dispatch(
     enc: *mut TgmAsyncStreamingEncoder,
     descriptor_json: *const c_char,
     data: *const u8,
@@ -148,6 +163,7 @@ pub extern "C" fn tgm_async_streaming_encoder_write_object(
     cancel: *mut TgmCancellationToken,
     timeout_ms: u64,
     out_task: *mut *mut TgmAsyncTask,
+    kind: WriteKind,
 ) -> TgmError {
     if enc.is_null() || descriptor_json.is_null() || data.is_null() || out_task.is_null() {
         set_last_error("null argument");
@@ -169,8 +185,8 @@ pub extern "C" fn tgm_async_streaming_encoder_write_object(
         }
     };
     // Copy data into an owned Vec<u8> so the async task owns it for
-    // the duration of the write.  C caller's buffer must remain valid
-    // only until this function returns.
+    // the duration of the write.  The C caller's buffer must remain
+    // valid only until this function returns.
     let data_vec = unsafe { std::slice::from_raw_parts(data, len) }.to_vec();
     let cancel_ref = if cancel.is_null() {
         None
@@ -183,10 +199,36 @@ pub extern "C" fn tgm_async_streaming_encoder_write_object(
         let enc = guard.as_mut().ok_or_else(|| {
             tensogram::TensogramError::Framing("encoder already finished".to_string())
         })?;
-        enc.write_object(&descriptor, &data_vec).await?;
+        match kind {
+            WriteKind::Object => enc.write_object(&descriptor, &data_vec).await?,
+            WriteKind::PreEncoded => enc.write_object_pre_encoded(&descriptor, &data_vec).await?,
+        }
         Ok(TaskResult::Void)
     };
     spawn_or_set_error(fut, cancel_ref, timeout_ms, out_task)
+}
+
+#[unsafe(no_mangle)]
+#[allow(clippy::too_many_arguments)]
+pub extern "C" fn tgm_async_streaming_encoder_write_object(
+    enc: *mut TgmAsyncStreamingEncoder,
+    descriptor_json: *const c_char,
+    data: *const u8,
+    len: usize,
+    cancel: *mut TgmCancellationToken,
+    timeout_ms: u64,
+    out_task: *mut *mut TgmAsyncTask,
+) -> TgmError {
+    write_object_dispatch(
+        enc,
+        descriptor_json,
+        data,
+        len,
+        cancel,
+        timeout_ms,
+        out_task,
+        WriteKind::Object,
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -200,41 +242,16 @@ pub extern "C" fn tgm_async_streaming_encoder_write_pre_encoded(
     timeout_ms: u64,
     out_task: *mut *mut TgmAsyncTask,
 ) -> TgmError {
-    if enc.is_null() || descriptor_json.is_null() || data.is_null() || out_task.is_null() {
-        set_last_error("null argument");
-        return TgmError::InvalidArg;
-    }
-    let inner = unsafe { (*enc).inner.clone() };
-    let json_str = match unsafe { CStr::from_ptr(descriptor_json) }.to_str() {
-        Ok(s) => s.to_string(),
-        Err(e) => {
-            set_last_error(&format!("invalid UTF-8 in descriptor_json: {e}"));
-            return TgmError::InvalidArg;
-        }
-    };
-    let descriptor: DataObjectDescriptor = match serde_json::from_str(&json_str) {
-        Ok(d) => d,
-        Err(e) => {
-            set_last_error(&format!("invalid descriptor JSON: {e}"));
-            return TgmError::Metadata;
-        }
-    };
-    let data_vec = unsafe { std::slice::from_raw_parts(data, len) }.to_vec();
-    let cancel_ref = if cancel.is_null() {
-        None
-    } else {
-        Some(unsafe { &*cancel })
-    };
-
-    let fut = async move {
-        let mut guard = inner.lock().await;
-        let enc = guard.as_mut().ok_or_else(|| {
-            tensogram::TensogramError::Framing("encoder already finished".to_string())
-        })?;
-        enc.write_object_pre_encoded(&descriptor, &data_vec).await?;
-        Ok(TaskResult::Void)
-    };
-    spawn_or_set_error(fut, cancel_ref, timeout_ms, out_task)
+    write_object_dispatch(
+        enc,
+        descriptor_json,
+        data,
+        len,
+        cancel,
+        timeout_ms,
+        out_task,
+        WriteKind::PreEncoded,
+    )
 }
 
 #[unsafe(no_mangle)]

--- a/rust/tensogram-ffi/src/async_streaming.rs
+++ b/rust/tensogram-ffi/src/async_streaming.rs
@@ -524,6 +524,10 @@ fn json_to_cbor(v: serde_json::Value) -> ciborium::Value {
         serde_json::Value::Number(n) => {
             if let Some(i) = n.as_i64() {
                 ciborium::Value::Integer(Integer::from(i))
+            } else if let Some(u) = n.as_u64() {
+                // Unsigned integers above i64::MAX would lose precision via
+                // the f64 fallback, so keep them as CBOR integers.
+                ciborium::Value::Integer(Integer::from(u))
             } else if let Some(f) = n.as_f64() {
                 ciborium::Value::Float(f)
             } else {

--- a/rust/tensogram-ffi/src/async_streaming.rs
+++ b/rust/tensogram-ffi/src/async_streaming.rs
@@ -1,0 +1,420 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+//! Async streaming-encoder FFI surface.  PR 3 of the cpp-async plan.
+//!
+//! Wraps [`tensogram::AsyncStreamingEncoder`] so C/C++ callers can
+//! drive a producer that writes Tensogram messages asynchronously.
+//!
+//! In v1 the only sink is a local file (`tokio::fs::File`).  Object-
+//! store backends are reserved for a follow-up; the FFI shape is
+//! designed so they can slot in without C ABI changes — only an
+//! additional URL-aware constructor.
+
+#![cfg(feature = "async")]
+
+use std::collections::BTreeMap;
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+use tensogram::types::DataObjectDescriptor;
+use tensogram::{AsyncStreamingEncoder, EncodeOptions};
+
+use crate::async_core::{
+    TaskResult, TgmAsyncTask, TgmCancellationToken, spawn_or_set_error_pub,
+};
+use crate::{TgmError, set_last_error};
+
+/// Opaque async streaming-encoder handle.  Internally wraps an
+/// `AsyncStreamingEncoder<tokio::fs::File>` behind a `tokio::sync::Mutex`
+/// so concurrent `write_object` calls are serialised (the underlying
+/// AsyncWrite is naturally serial — concurrent calls would interleave
+/// frame bytes).
+pub struct TgmAsyncStreamingEncoder {
+    inner: Arc<Mutex<Option<AsyncStreamingEncoder<tokio::fs::File>>>>,
+    path_string: CString,
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_async_streaming_encoder_path(
+    enc: *const TgmAsyncStreamingEncoder,
+) -> *const c_char {
+    if enc.is_null() {
+        return std::ptr::null();
+    }
+    unsafe { (*enc).path_string.as_ptr() }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_async_streaming_encoder_free(enc: *mut TgmAsyncStreamingEncoder) {
+    if !enc.is_null() {
+        unsafe { drop(Box::from_raw(enc)) };
+    }
+}
+
+/// Create an async streaming encoder writing to a local file.
+///
+/// Returns a task that resolves to a `tgm_async_streaming_encoder_t*`
+/// (joinable via `tgm_async_task_join_async_streaming_encoder`).
+///
+/// `metadata_json` follows the same schema as the sync streaming
+/// encoder (see `tgm_streaming_encoder_create`).  The async encoder
+/// writes the preamble + header metadata frame to the sink before
+/// the task resolves.
+#[unsafe(no_mangle)]
+#[allow(clippy::too_many_arguments)]
+pub extern "C" fn tgm_async_streaming_encoder_create(
+    path: *const c_char,
+    metadata_json: *const c_char,
+    hash_algo: *const c_char,
+    threads: u32,
+    cancel: *mut TgmCancellationToken,
+    timeout_ms: u64,
+    out_task: *mut *mut TgmAsyncTask,
+) -> TgmError {
+    if path.is_null() || metadata_json.is_null() || out_task.is_null() {
+        set_last_error("null argument");
+        return TgmError::InvalidArg;
+    }
+    let path_str = match unsafe { CStr::from_ptr(path) }.to_str() {
+        Ok(s) => s.to_string(),
+        Err(e) => {
+            set_last_error(&format!("invalid UTF-8 in path: {e}"));
+            return TgmError::InvalidArg;
+        }
+    };
+    let json_str = match unsafe { CStr::from_ptr(metadata_json) }.to_str() {
+        Ok(s) => s.to_string(),
+        Err(e) => {
+            set_last_error(&format!("invalid UTF-8 in metadata_json: {e}"));
+            return TgmError::InvalidArg;
+        }
+    };
+    let global_metadata = match crate::parse_streaming_metadata_json(&json_str) {
+        Ok(m) => m,
+        Err(e) => {
+            set_last_error(&e);
+            return TgmError::Metadata;
+        }
+    };
+    let hashing = match crate::parse_hash_algo(hash_algo) {
+        Ok(b) => b,
+        Err((code, msg)) => {
+            set_last_error(&msg);
+            return code;
+        }
+    };
+    let cancel_ref = if cancel.is_null() {
+        None
+    } else {
+        Some(unsafe { &*cancel })
+    };
+
+    let opts = EncodeOptions {
+        hashing,
+        threads,
+        ..Default::default()
+    };
+
+    let path_for_task = path_str.clone();
+    let fut = async move {
+        let file = tokio::fs::File::create(&path_for_task)
+            .await
+            .map_err(tensogram::TensogramError::Io)?;
+        let enc = AsyncStreamingEncoder::new(file, &global_metadata, &opts).await?;
+        let path_string = CString::new(path_for_task.as_str()).unwrap_or_default();
+        let handle = Box::new(TgmAsyncStreamingEncoder {
+            inner: Arc::new(Mutex::new(Some(enc))),
+            path_string,
+        });
+        Ok(TaskResult::AsyncStreamingEncoder(handle))
+    };
+    spawn_or_set_error_pub(fut, cancel_ref, timeout_ms, out_task)
+}
+
+#[unsafe(no_mangle)]
+#[allow(clippy::too_many_arguments)]
+pub extern "C" fn tgm_async_streaming_encoder_write_object(
+    enc: *mut TgmAsyncStreamingEncoder,
+    descriptor_json: *const c_char,
+    data: *const u8,
+    len: usize,
+    cancel: *mut TgmCancellationToken,
+    timeout_ms: u64,
+    out_task: *mut *mut TgmAsyncTask,
+) -> TgmError {
+    if enc.is_null() || descriptor_json.is_null() || data.is_null() || out_task.is_null() {
+        set_last_error("null argument");
+        return TgmError::InvalidArg;
+    }
+    let inner = unsafe { (*enc).inner.clone() };
+    let json_str = match unsafe { CStr::from_ptr(descriptor_json) }.to_str() {
+        Ok(s) => s.to_string(),
+        Err(e) => {
+            set_last_error(&format!("invalid UTF-8 in descriptor_json: {e}"));
+            return TgmError::InvalidArg;
+        }
+    };
+    let descriptor: DataObjectDescriptor = match serde_json::from_str(&json_str) {
+        Ok(d) => d,
+        Err(e) => {
+            set_last_error(&format!("invalid descriptor JSON: {e}"));
+            return TgmError::Metadata;
+        }
+    };
+    // Copy data into an owned Vec<u8> so the async task owns it for
+    // the duration of the write.  C caller's buffer must remain valid
+    // only until this function returns.
+    let data_vec = unsafe { std::slice::from_raw_parts(data, len) }.to_vec();
+    let cancel_ref = if cancel.is_null() {
+        None
+    } else {
+        Some(unsafe { &*cancel })
+    };
+
+    let fut = async move {
+        let mut guard = inner.lock().await;
+        let enc = guard.as_mut().ok_or_else(|| {
+            tensogram::TensogramError::Framing("encoder already finished".to_string())
+        })?;
+        enc.write_object(&descriptor, &data_vec).await?;
+        Ok(TaskResult::Void)
+    };
+    spawn_or_set_error_pub(fut, cancel_ref, timeout_ms, out_task)
+}
+
+#[unsafe(no_mangle)]
+#[allow(clippy::too_many_arguments)]
+pub extern "C" fn tgm_async_streaming_encoder_write_pre_encoded(
+    enc: *mut TgmAsyncStreamingEncoder,
+    descriptor_json: *const c_char,
+    data: *const u8,
+    len: usize,
+    cancel: *mut TgmCancellationToken,
+    timeout_ms: u64,
+    out_task: *mut *mut TgmAsyncTask,
+) -> TgmError {
+    if enc.is_null() || descriptor_json.is_null() || data.is_null() || out_task.is_null() {
+        set_last_error("null argument");
+        return TgmError::InvalidArg;
+    }
+    let inner = unsafe { (*enc).inner.clone() };
+    let json_str = match unsafe { CStr::from_ptr(descriptor_json) }.to_str() {
+        Ok(s) => s.to_string(),
+        Err(e) => {
+            set_last_error(&format!("invalid UTF-8 in descriptor_json: {e}"));
+            return TgmError::InvalidArg;
+        }
+    };
+    let descriptor: DataObjectDescriptor = match serde_json::from_str(&json_str) {
+        Ok(d) => d,
+        Err(e) => {
+            set_last_error(&format!("invalid descriptor JSON: {e}"));
+            return TgmError::Metadata;
+        }
+    };
+    let data_vec = unsafe { std::slice::from_raw_parts(data, len) }.to_vec();
+    let cancel_ref = if cancel.is_null() {
+        None
+    } else {
+        Some(unsafe { &*cancel })
+    };
+
+    let fut = async move {
+        let mut guard = inner.lock().await;
+        let enc = guard.as_mut().ok_or_else(|| {
+            tensogram::TensogramError::Framing("encoder already finished".to_string())
+        })?;
+        enc.write_object_pre_encoded(&descriptor, &data_vec).await?;
+        Ok(TaskResult::Void)
+    };
+    spawn_or_set_error_pub(fut, cancel_ref, timeout_ms, out_task)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_async_streaming_encoder_write_preceder(
+    enc: *mut TgmAsyncStreamingEncoder,
+    metadata_json: *const c_char,
+    cancel: *mut TgmCancellationToken,
+    timeout_ms: u64,
+    out_task: *mut *mut TgmAsyncTask,
+) -> TgmError {
+    if enc.is_null() || metadata_json.is_null() || out_task.is_null() {
+        set_last_error("null argument");
+        return TgmError::InvalidArg;
+    }
+    let inner = unsafe { (*enc).inner.clone() };
+    let json_str = match unsafe { CStr::from_ptr(metadata_json) }.to_str() {
+        Ok(s) => s.to_string(),
+        Err(e) => {
+            set_last_error(&format!("invalid UTF-8 in metadata_json: {e}"));
+            return TgmError::InvalidArg;
+        }
+    };
+    // Parse JSON object → BTreeMap<String, ciborium::Value>.
+    let value: serde_json::Value = match serde_json::from_str(&json_str) {
+        Ok(v) => v,
+        Err(e) => {
+            set_last_error(&format!("invalid metadata JSON: {e}"));
+            return TgmError::Metadata;
+        }
+    };
+    let map = match preceder_json_to_cbor_map(value) {
+        Ok(m) => m,
+        Err(e) => {
+            set_last_error(&e);
+            return TgmError::Metadata;
+        }
+    };
+    let cancel_ref = if cancel.is_null() {
+        None
+    } else {
+        Some(unsafe { &*cancel })
+    };
+
+    let fut = async move {
+        let mut guard = inner.lock().await;
+        let enc = guard.as_mut().ok_or_else(|| {
+            tensogram::TensogramError::Framing("encoder already finished".to_string())
+        })?;
+        enc.write_preceder(map).await?;
+        Ok(TaskResult::Void)
+    };
+    spawn_or_set_error_pub(fut, cancel_ref, timeout_ms, out_task)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_async_streaming_encoder_finish(
+    enc: *mut TgmAsyncStreamingEncoder,
+    backfill: bool,
+    cancel: *mut TgmCancellationToken,
+    timeout_ms: u64,
+    out_task: *mut *mut TgmAsyncTask,
+) -> TgmError {
+    if enc.is_null() || out_task.is_null() {
+        set_last_error("null argument");
+        return TgmError::InvalidArg;
+    }
+    let inner = unsafe { (*enc).inner.clone() };
+    let cancel_ref = if cancel.is_null() {
+        None
+    } else {
+        Some(unsafe { &*cancel })
+    };
+
+    let fut = async move {
+        let mut guard = inner.lock().await;
+        let enc = guard.take().ok_or_else(|| {
+            tensogram::TensogramError::Framing("encoder already finished".to_string())
+        })?;
+        if backfill {
+            let _file = enc.finish_with_backfill().await?;
+        } else {
+            let _file = enc.finish().await?;
+        }
+        Ok(TaskResult::Void)
+    };
+    spawn_or_set_error_pub(fut, cancel_ref, timeout_ms, out_task)
+}
+
+/// Object count snapshot.  Returns `usize::MAX` on null.
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_async_streaming_encoder_object_count(
+    enc: *const TgmAsyncStreamingEncoder,
+) -> usize {
+    if enc.is_null() {
+        return usize::MAX;
+    }
+    let inner = unsafe { &*enc }.inner.clone();
+    // try_lock to avoid blocking the calling thread; if locked,
+    // return usize::MAX as a "busy" sentinel.
+    match inner.try_lock() {
+        Ok(g) => match g.as_ref() {
+            Some(e) => e.object_count(),
+            None => usize::MAX,
+        },
+        Err(_) => usize::MAX,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Async streaming encoder join
+// ---------------------------------------------------------------------------
+
+/// Typed join for tasks returning a streaming-encoder handle.
+#[unsafe(no_mangle)]
+pub extern "C" fn tgm_async_task_join_async_streaming_encoder(
+    task: *mut TgmAsyncTask,
+    out: *mut *mut TgmAsyncStreamingEncoder,
+) -> TgmError {
+    if out.is_null() {
+        set_last_error("null out pointer");
+        return TgmError::InvalidArg;
+    }
+    match crate::async_core::join_internal_pub(task) {
+        Ok(TaskResult::AsyncStreamingEncoder(h)) => {
+            unsafe { *out = Box::into_raw(h) };
+            TgmError::Ok
+        }
+        Ok(_) => {
+            set_last_error("task result type mismatch (expected async_streaming_encoder)");
+            TgmError::InvalidArg
+        }
+        Err(code) => code,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Convert a JSON object (one level deep is sufficient for preceder
+/// payloads in v1) into a CBOR map.  Nested arrays/objects are
+/// preserved.
+fn preceder_json_to_cbor_map(
+    v: serde_json::Value,
+) -> Result<BTreeMap<String, ciborium::Value>, String> {
+    let obj = match v {
+        serde_json::Value::Object(m) => m,
+        _ => return Err("preceder metadata must be a JSON object".to_string()),
+    };
+    let mut out = BTreeMap::new();
+    for (k, val) in obj {
+        out.insert(k, json_to_cbor(val));
+    }
+    Ok(out)
+}
+
+fn json_to_cbor(v: serde_json::Value) -> ciborium::Value {
+    use ciborium::value::Integer;
+    match v {
+        serde_json::Value::Null => ciborium::Value::Null,
+        serde_json::Value::Bool(b) => ciborium::Value::Bool(b),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                ciborium::Value::Integer(Integer::from(i))
+            } else if let Some(f) = n.as_f64() {
+                ciborium::Value::Float(f)
+            } else {
+                ciborium::Value::Null
+            }
+        }
+        serde_json::Value::String(s) => ciborium::Value::Text(s),
+        serde_json::Value::Array(a) => {
+            ciborium::Value::Array(a.into_iter().map(json_to_cbor).collect())
+        }
+        serde_json::Value::Object(m) => ciborium::Value::Map(
+            m.into_iter()
+                .map(|(k, v)| (ciborium::Value::Text(k), json_to_cbor(v)))
+                .collect(),
+        ),
+    }
+}

--- a/rust/tensogram-ffi/src/async_streaming.rs
+++ b/rust/tensogram-ffi/src/async_streaming.rs
@@ -28,9 +28,7 @@ use tokio::sync::Mutex;
 use tensogram::types::DataObjectDescriptor;
 use tensogram::{AsyncStreamingEncoder, EncodeOptions};
 
-use crate::async_core::{
-    TaskResult, TgmAsyncTask, TgmCancellationToken, spawn_or_set_error_pub,
-};
+use crate::async_core::{TaskResult, TgmAsyncTask, TgmCancellationToken, spawn_or_set_error};
 use crate::{TgmError, set_last_error};
 
 /// Opaque async streaming-encoder handle.  Internally wraps an
@@ -137,7 +135,7 @@ pub extern "C" fn tgm_async_streaming_encoder_create(
         });
         Ok(TaskResult::AsyncStreamingEncoder(handle))
     };
-    spawn_or_set_error_pub(fut, cancel_ref, timeout_ms, out_task)
+    spawn_or_set_error(fut, cancel_ref, timeout_ms, out_task)
 }
 
 #[unsafe(no_mangle)]
@@ -188,7 +186,7 @@ pub extern "C" fn tgm_async_streaming_encoder_write_object(
         enc.write_object(&descriptor, &data_vec).await?;
         Ok(TaskResult::Void)
     };
-    spawn_or_set_error_pub(fut, cancel_ref, timeout_ms, out_task)
+    spawn_or_set_error(fut, cancel_ref, timeout_ms, out_task)
 }
 
 #[unsafe(no_mangle)]
@@ -236,7 +234,7 @@ pub extern "C" fn tgm_async_streaming_encoder_write_pre_encoded(
         enc.write_object_pre_encoded(&descriptor, &data_vec).await?;
         Ok(TaskResult::Void)
     };
-    spawn_or_set_error_pub(fut, cancel_ref, timeout_ms, out_task)
+    spawn_or_set_error(fut, cancel_ref, timeout_ms, out_task)
 }
 
 #[unsafe(no_mangle)]
@@ -288,7 +286,7 @@ pub extern "C" fn tgm_async_streaming_encoder_write_preceder(
         enc.write_preceder(map).await?;
         Ok(TaskResult::Void)
     };
-    spawn_or_set_error_pub(fut, cancel_ref, timeout_ms, out_task)
+    spawn_or_set_error(fut, cancel_ref, timeout_ms, out_task)
 }
 
 #[unsafe(no_mangle)]
@@ -322,7 +320,7 @@ pub extern "C" fn tgm_async_streaming_encoder_finish(
         }
         Ok(TaskResult::Void)
     };
-    spawn_or_set_error_pub(fut, cancel_ref, timeout_ms, out_task)
+    spawn_or_set_error(fut, cancel_ref, timeout_ms, out_task)
 }
 
 /// Object count snapshot.  Returns `usize::MAX` on null.
@@ -359,7 +357,7 @@ pub extern "C" fn tgm_async_task_join_async_streaming_encoder(
         set_last_error("null out pointer");
         return TgmError::InvalidArg;
     }
-    match crate::async_core::join_internal_pub(task) {
+    match crate::async_core::join_internal(task) {
         Ok(TaskResult::AsyncStreamingEncoder(h)) => {
             unsafe { *out = Box::into_raw(h) };
             TgmError::Ok

--- a/rust/tensogram-ffi/src/lib.rs
+++ b/rust/tensogram-ffi/src/lib.rs
@@ -45,6 +45,9 @@ use std::path::Path;
 use std::ptr;
 use std::slice;
 
+#[cfg(feature = "async")]
+pub mod async_core;
+
 use tensogram::encode::MaskMethod;
 use tensogram::validate::{
     ValidateOptions, ValidationLevel, validate_file as core_validate_file, validate_message,
@@ -104,6 +107,13 @@ pub enum TgmError {
     /// `tgm_last_error_object_index()` for the duration of the
     /// thread-local error.
     MissingHash = 11,
+    /// Async task exceeded its deadline; the underlying tokio future
+    /// was dropped at the next yield point.  See
+    /// `plans/PLAN_CPP_ASYNC.md` §7.1.
+    Timeout = 12,
+    /// Async task observed its cancellation token fire before the
+    /// future resolved.  See `plans/PLAN_CPP_ASYNC.md` §7.2.
+    Cancelled = 13,
 }
 
 fn to_error_code(e: &TensogramError) -> TgmError {

--- a/rust/tensogram-ffi/src/lib.rs
+++ b/rust/tensogram-ffi/src/lib.rs
@@ -47,6 +47,8 @@ use std::slice;
 
 #[cfg(feature = "async")]
 pub mod async_core;
+#[cfg(feature = "async")]
+pub mod async_streaming;
 
 use tensogram::encode::MaskMethod;
 use tensogram::validate::{
@@ -656,7 +658,7 @@ struct ParsedEncode<'a> {
 /// idiom is "if you want a feature, name it; if you don't, pass
 /// NULL" and the FFI's `tgm_encode_*` functions always require an
 /// explicit `hash_algo` argument anyway.
-fn parse_hash_algo(hash_algo: *const c_char) -> Result<bool, (TgmError, String)> {
+pub(crate) fn parse_hash_algo(hash_algo: *const c_char) -> Result<bool, (TgmError, String)> {
     if hash_algo.is_null() {
         return Ok(false);
     }
@@ -6586,7 +6588,7 @@ struct StreamingEncodeJson {
 }
 
 /// Parse metadata JSON for the streaming encoder (no "descriptors" key).
-fn parse_streaming_metadata_json(json_str: &str) -> Result<GlobalMetadata, String> {
+pub(crate) fn parse_streaming_metadata_json(json_str: &str) -> Result<GlobalMetadata, String> {
     let parsed: StreamingEncodeJson = serde_json::from_str(json_str)
         .map_err(|e| format!("failed to parse metadata JSON: {e}"))?;
 

--- a/rust/tensogram-ffi/src/lib.rs
+++ b/rust/tensogram-ffi/src/lib.rs
@@ -88,6 +88,7 @@ const _: () = assert!(
 // ---------------------------------------------------------------------------
 
 #[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TgmError {
     Ok = 0,
     Framing = 1,

--- a/rust/tensogram-ffi/src/lib.rs
+++ b/rust/tensogram-ffi/src/lib.rs
@@ -2747,6 +2747,9 @@ pub extern "C" fn tgm_error_string(err: TgmError) -> *const c_char {
         8 => b"invalid argument\0",
         9 => b"end of iteration\0",
         10 => b"remote error\0",
+        11 => b"missing hash\0",
+        12 => b"async task timed out\0",
+        13 => b"async task cancelled\0",
         _ => b"unknown error\0",
     };
     s.as_ptr() as *const c_char

--- a/rust/tensogram-ffi/tensogram.h
+++ b/rust/tensogram-ffi/tensogram.h
@@ -79,7 +79,7 @@ typedef enum {
  * Async file handle backed by `Arc<TensogramFile>` so the same handle
  * is safely shareable across multiple in-flight tasks.
  */
-typedef struct TgmAsyncFile TgmAsyncFile;
+typedef struct tgm_async_file_t tgm_async_file_t;
 
 /**
  * Opaque async streaming-encoder handle.  Internally wraps an
@@ -88,12 +88,12 @@ typedef struct TgmAsyncFile TgmAsyncFile;
  * AsyncWrite is naturally serial — concurrent calls would interleave
  * frame bytes).
  */
-typedef struct TgmAsyncStreamingEncoder TgmAsyncStreamingEncoder;
+typedef struct tgm_async_streaming_encoder_t tgm_async_streaming_encoder_t;
 
 /**
  * Opaque task handle exposed to C as `tgm_async_task_t*`.
  */
-typedef struct TgmAsyncTask TgmAsyncTask;
+typedef struct tgm_async_task_t tgm_async_task_t;
 
 /**
  * Opaque handle for iterating over messages in a byte buffer.
@@ -106,7 +106,7 @@ typedef struct tgm_buffer_iter_t tgm_buffer_iter_t;
  * Opaque cancellation-token handle exposed to C as
  * `tgm_cancellation_token_t*`.
  */
-typedef struct TgmCancellationToken TgmCancellationToken;
+typedef struct tgm_cancellation_token_t tgm_cancellation_token_t;
 
 /**
  * File handle.
@@ -924,13 +924,13 @@ tgm_error tgm_validate_file(const char *path,
                             int32_t check_canonical,
                             tgm_bytes_t *out);
 
-TgmCancellationToken *tgm_cancellation_token_create(void);
+tgm_cancellation_token_t *tgm_cancellation_token_create(void);
 
-void tgm_cancellation_token_cancel(TgmCancellationToken *tok);
+void tgm_cancellation_token_cancel(tgm_cancellation_token_t *tok);
 
-bool tgm_cancellation_token_is_cancelled(const TgmCancellationToken *tok);
+bool tgm_cancellation_token_is_cancelled(const tgm_cancellation_token_t *tok);
 
-void tgm_cancellation_token_free(TgmCancellationToken *tok);
+void tgm_cancellation_token_free(tgm_cancellation_token_t *tok);
 
 /**
  * Register a completion callback on `task`.  Must be called exactly
@@ -940,31 +940,31 @@ void tgm_cancellation_token_free(TgmCancellationToken *tok);
  * If the task has already resolved, the callback is invoked inline
  * on the calling thread before the function returns.
  */
-tgm_error tgm_async_task_set_completion(TgmAsyncTask *task, void (*cb)(void*), void *userdata);
+tgm_error tgm_async_task_set_completion(tgm_async_task_t *task, void (*cb)(void*), void *userdata);
 
-bool tgm_async_task_is_ready(const TgmAsyncTask *task);
+bool tgm_async_task_is_ready(const tgm_async_task_t *task);
 
 /**
  * Cancel an in-flight task by signalling its internal token.  The
  * task transitions to [`TgmError::Cancelled`] at the next yield point.
  */
-void tgm_async_task_cancel(TgmAsyncTask *task);
+void tgm_async_task_cancel(tgm_async_task_t *task);
 
-void tgm_async_task_free(TgmAsyncTask *task);
+void tgm_async_task_free(tgm_async_task_t *task);
 
-tgm_error tgm_async_task_join_void(TgmAsyncTask *task);
+tgm_error tgm_async_task_join_void(tgm_async_task_t *task);
 
-tgm_error tgm_async_task_join_size(TgmAsyncTask *task, uint64_t *out);
+tgm_error tgm_async_task_join_size(tgm_async_task_t *task, uint64_t *out);
 
-tgm_error tgm_async_task_join_bytes(TgmAsyncTask *task, tgm_bytes_t *out);
+tgm_error tgm_async_task_join_bytes(tgm_async_task_t *task, tgm_bytes_t *out);
 
-tgm_error tgm_async_task_join_message(TgmAsyncTask *task, tgm_message_t **out);
+tgm_error tgm_async_task_join_message(tgm_async_task_t *task, tgm_message_t **out);
 
-tgm_error tgm_async_task_join_metadata(TgmAsyncTask *task, tgm_metadata_t **out);
+tgm_error tgm_async_task_join_metadata(tgm_async_task_t *task, tgm_metadata_t **out);
 
-tgm_error tgm_async_task_join_async_file(TgmAsyncTask *task, TgmAsyncFile **out);
+tgm_error tgm_async_task_join_async_file(tgm_async_task_t *task, tgm_async_file_t **out);
 
-tgm_error tgm_async_task_join_multi_bytes(TgmAsyncTask *task,
+tgm_error tgm_async_task_join_multi_bytes(tgm_async_task_t *task,
                                           tgm_bytes_t **out_array,
                                           size_t *out_count);
 
@@ -973,67 +973,67 @@ tgm_error tgm_async_task_join_multi_bytes(TgmAsyncTask *task,
  */
 void tgm_multi_bytes_free(tgm_bytes_t *array, size_t count);
 
-const char *tgm_async_file_path(const TgmAsyncFile *file);
+const char *tgm_async_file_path(const tgm_async_file_t *file);
 
-void tgm_async_file_close(TgmAsyncFile *file);
+void tgm_async_file_close(tgm_async_file_t *file);
 
 /**
  * Open a Tensogram file asynchronously.  Returns immediately with a
  * task handle; join via `tgm_async_task_join_async_file`.
  */
 tgm_error tgm_async_file_open(const char *path,
-                              TgmCancellationToken *cancel,
+                              tgm_cancellation_token_t *cancel,
                               uint64_t timeout_ms,
-                              TgmAsyncTask **out_task);
+                              tgm_async_task_t **out_task);
 
 tgm_error tgm_async_file_open_remote(const char *url,
                                      const char *const *storage_keys,
                                      const char *const *storage_values,
                                      size_t nopts,
                                      bool bidirectional,
-                                     TgmCancellationToken *cancel,
+                                     tgm_cancellation_token_t *cancel,
                                      uint64_t timeout_ms,
-                                     TgmAsyncTask **out_task);
+                                     tgm_async_task_t **out_task);
 
-tgm_error tgm_async_file_message_count(TgmAsyncFile *file,
-                                       TgmCancellationToken *cancel,
+tgm_error tgm_async_file_message_count(tgm_async_file_t *file,
+                                       tgm_cancellation_token_t *cancel,
                                        uint64_t timeout_ms,
-                                       TgmAsyncTask **out_task);
+                                       tgm_async_task_t **out_task);
 
-tgm_error tgm_async_file_read_message(TgmAsyncFile *file,
+tgm_error tgm_async_file_read_message(tgm_async_file_t *file,
                                       size_t index,
-                                      TgmCancellationToken *cancel,
+                                      tgm_cancellation_token_t *cancel,
                                       uint64_t timeout_ms,
-                                      TgmAsyncTask **out_task);
+                                      tgm_async_task_t **out_task);
 
-tgm_error tgm_async_file_decode_message(TgmAsyncFile *file,
+tgm_error tgm_async_file_decode_message(tgm_async_file_t *file,
                                         size_t index,
                                         bool native_byte_order,
                                         uint32_t threads,
                                         bool restore_non_finite,
                                         bool verify_hash,
-                                        TgmCancellationToken *cancel,
+                                        tgm_cancellation_token_t *cancel,
                                         uint64_t timeout_ms,
-                                        TgmAsyncTask **out_task);
+                                        tgm_async_task_t **out_task);
 
-tgm_error tgm_async_file_decode_metadata(TgmAsyncFile *file,
+tgm_error tgm_async_file_decode_metadata(tgm_async_file_t *file,
                                          size_t index,
-                                         TgmCancellationToken *cancel,
+                                         tgm_cancellation_token_t *cancel,
                                          uint64_t timeout_ms,
-                                         TgmAsyncTask **out_task);
+                                         tgm_async_task_t **out_task);
 
-tgm_error tgm_async_file_decode_object(TgmAsyncFile *file,
+tgm_error tgm_async_file_decode_object(tgm_async_file_t *file,
                                        size_t msg_index,
                                        size_t obj_index,
                                        bool native_byte_order,
                                        uint32_t threads,
                                        bool restore_non_finite,
                                        bool verify_hash,
-                                       TgmCancellationToken *cancel,
+                                       tgm_cancellation_token_t *cancel,
                                        uint64_t timeout_ms,
-                                       TgmAsyncTask **out_task);
+                                       tgm_async_task_t **out_task);
 
-tgm_error tgm_async_file_decode_range(TgmAsyncFile *file,
+tgm_error tgm_async_file_decode_range(tgm_async_file_t *file,
                                       size_t msg_index,
                                       size_t obj_index,
                                       const uint64_t *offsets,
@@ -1041,9 +1041,9 @@ tgm_error tgm_async_file_decode_range(TgmAsyncFile *file,
                                       size_t n_ranges,
                                       bool native_byte_order,
                                       uint32_t threads,
-                                      TgmCancellationToken *cancel,
+                                      tgm_cancellation_token_t *cancel,
                                       uint64_t timeout_ms,
-                                      TgmAsyncTask **out_task);
+                                      tgm_async_task_t **out_task);
 
 /**
  * Configure the FFI tokio runtime.  Must be called before any other
@@ -1067,9 +1067,9 @@ tgm_error tgm_runtime_configure(uint32_t workers,
  */
 uint64_t tgm_runtime_shutdown_blocking(uint64_t timeout_ms);
 
-const char *tgm_async_streaming_encoder_path(const TgmAsyncStreamingEncoder *enc);
+const char *tgm_async_streaming_encoder_path(const tgm_async_streaming_encoder_t *enc);
 
-void tgm_async_streaming_encoder_free(TgmAsyncStreamingEncoder *enc);
+void tgm_async_streaming_encoder_free(tgm_async_streaming_encoder_t *enc);
 
 /**
  * Create an async streaming encoder writing to a local file.
@@ -1086,47 +1086,47 @@ tgm_error tgm_async_streaming_encoder_create(const char *path,
                                              const char *metadata_json,
                                              const char *hash_algo,
                                              uint32_t threads,
-                                             TgmCancellationToken *cancel,
+                                             tgm_cancellation_token_t *cancel,
                                              uint64_t timeout_ms,
-                                             TgmAsyncTask **out_task);
+                                             tgm_async_task_t **out_task);
 
-tgm_error tgm_async_streaming_encoder_write_object(TgmAsyncStreamingEncoder *enc,
+tgm_error tgm_async_streaming_encoder_write_object(tgm_async_streaming_encoder_t *enc,
                                                    const char *descriptor_json,
                                                    const uint8_t *data,
                                                    size_t len,
-                                                   TgmCancellationToken *cancel,
+                                                   tgm_cancellation_token_t *cancel,
                                                    uint64_t timeout_ms,
-                                                   TgmAsyncTask **out_task);
+                                                   tgm_async_task_t **out_task);
 
-tgm_error tgm_async_streaming_encoder_write_pre_encoded(TgmAsyncStreamingEncoder *enc,
+tgm_error tgm_async_streaming_encoder_write_pre_encoded(tgm_async_streaming_encoder_t *enc,
                                                         const char *descriptor_json,
                                                         const uint8_t *data,
                                                         size_t len,
-                                                        TgmCancellationToken *cancel,
+                                                        tgm_cancellation_token_t *cancel,
                                                         uint64_t timeout_ms,
-                                                        TgmAsyncTask **out_task);
+                                                        tgm_async_task_t **out_task);
 
-tgm_error tgm_async_streaming_encoder_write_preceder(TgmAsyncStreamingEncoder *enc,
+tgm_error tgm_async_streaming_encoder_write_preceder(tgm_async_streaming_encoder_t *enc,
                                                      const char *metadata_json,
-                                                     TgmCancellationToken *cancel,
+                                                     tgm_cancellation_token_t *cancel,
                                                      uint64_t timeout_ms,
-                                                     TgmAsyncTask **out_task);
+                                                     tgm_async_task_t **out_task);
 
-tgm_error tgm_async_streaming_encoder_finish(TgmAsyncStreamingEncoder *enc,
+tgm_error tgm_async_streaming_encoder_finish(tgm_async_streaming_encoder_t *enc,
                                              bool backfill,
-                                             TgmCancellationToken *cancel,
+                                             tgm_cancellation_token_t *cancel,
                                              uint64_t timeout_ms,
-                                             TgmAsyncTask **out_task);
+                                             tgm_async_task_t **out_task);
 
 /**
  * Object count snapshot.  Returns `usize::MAX` on null.
  */
-size_t tgm_async_streaming_encoder_object_count(const TgmAsyncStreamingEncoder *enc);
+size_t tgm_async_streaming_encoder_object_count(const tgm_async_streaming_encoder_t *enc);
 
 /**
  * Typed join for tasks returning a streaming-encoder handle.
  */
-tgm_error tgm_async_task_join_async_streaming_encoder(TgmAsyncTask *task,
-                                                      TgmAsyncStreamingEncoder **out);
+tgm_error tgm_async_task_join_async_streaming_encoder(tgm_async_task_t *task,
+                                                      tgm_async_streaming_encoder_t **out);
 
 #endif  /* TENSOGRAM_H */

--- a/rust/tensogram-ffi/tensogram.h
+++ b/rust/tensogram-ffi/tensogram.h
@@ -953,12 +953,36 @@ tgm_error tgm_validate_file(const char *path,
                             int32_t check_canonical,
                             tgm_bytes_t *out);
 
+/**
+ * Allocate a fresh cancellation token in the un-cancelled state.
+ *
+ * The returned handle is caller-owned; free it with
+ * `tgm_cancellation_token_free`.  A single token may be passed to
+ * any number of `tgm_async_*` calls; cancelling it propagates to
+ * all in-flight tasks holding a reference.
+ */
 tgm_cancellation_token_t *tgm_cancellation_token_create(void);
 
+/**
+ * Cancel the token.  Idempotent.  Cancelling a NULL handle is a
+ * no-op.  Tasks attached to this token transition to
+ * [`TgmError::Cancelled`] at their next yield point.
+ */
 void tgm_cancellation_token_cancel(tgm_cancellation_token_t *tok);
 
+/**
+ * Returns `true` if the token has been cancelled.  A NULL handle
+ * returns `false`.
+ */
 bool tgm_cancellation_token_is_cancelled(const tgm_cancellation_token_t *tok);
 
+/**
+ * Free a cancellation token.  Safe to call before any in-flight
+ * task completes — each task holds its own internal clone of the
+ * underlying tokio token, so freeing the user-side handle does not
+ * invalidate cancellation for already-spawned tasks.  Freeing a
+ * NULL handle is a no-op.
+ */
 void tgm_cancellation_token_free(tgm_cancellation_token_t *tok);
 
 /**
@@ -984,28 +1008,91 @@ void tgm_cancellation_token_free(tgm_cancellation_token_t *tok);
  */
 tgm_error tgm_async_task_set_completion(tgm_async_task_t *task, void (*cb)(void*), void *userdata);
 
+/**
+ * Returns `true` if the task has resolved (whether successfully,
+ * by error, by timeout, or by cancellation).  A NULL handle returns
+ * `false`.  Non-blocking; safe to call from any thread.
+ */
 bool tgm_async_task_is_ready(const tgm_async_task_t *task);
 
 /**
  * Cancel an in-flight task by signalling its internal token.  The
  * task transitions to [`TgmError::Cancelled`] at the next yield point.
+ * A NULL handle is a no-op.
  */
 void tgm_async_task_cancel(tgm_async_task_t *task);
 
+/**
+ * Free a task handle.  Must be called exactly once per task to
+ * release the slot's heap allocation.  Safe to call after
+ * [`tgm_async_task_join`]: the join consumes the result but does
+ * not free the handle itself.  Freeing a NULL handle is a no-op.
+ */
 void tgm_async_task_free(tgm_async_task_t *task);
 
+/**
+ * Block the calling thread until the task is ready, then return
+ * its outcome.
+ *
+ * `_join_void` is for tasks whose success is ABI-empty (writes,
+ * finishes, prefetches).  Returns [`TgmError::Ok`] on success.  On
+ * failure, the matching error code is returned and
+ * [`tgm_last_error`] is populated.
+ *
+ * Call [`tgm_async_task_free`] to release the task slot after
+ * joining.  Joining the same task twice returns
+ * [`TgmError::InvalidArg`] (`task result already consumed`).
+ */
 tgm_error tgm_async_task_join_void(tgm_async_task_t *task);
 
+/**
+ * Block the calling thread until the task is ready, then write its
+ * `usize` result to `*out` and return [`TgmError::Ok`].  See
+ * [`tgm_async_task_join_void`] for the joint contract on errors,
+ * type mismatches, and double-join.
+ */
 tgm_error tgm_async_task_join_size(tgm_async_task_t *task, uint64_t *out);
 
+/**
+ * Block until ready, then transfer ownership of the task's byte
+ * buffer to the caller via `*out`.  The caller must release the
+ * buffer with [`tgm_bytes_free`].  See [`tgm_async_task_join_void`]
+ * for the joint contract.
+ */
 tgm_error tgm_async_task_join_bytes(tgm_async_task_t *task, tgm_bytes_t *out);
 
+/**
+ * Block until ready, then transfer ownership of the decoded message
+ * to the caller via `*out`.  The caller must release the message
+ * with [`tgm_message_free`].  See [`tgm_async_task_join_void`] for
+ * the joint contract.
+ */
 tgm_error tgm_async_task_join_message(tgm_async_task_t *task, tgm_message_t **out);
 
+/**
+ * Block until ready, then transfer ownership of the decoded
+ * metadata to the caller via `*out`.  The caller must release it
+ * with [`tgm_metadata_free`].  See [`tgm_async_task_join_void`]
+ * for the joint contract.
+ */
 tgm_error tgm_async_task_join_metadata(tgm_async_task_t *task, tgm_metadata_t **out);
 
+/**
+ * Block until ready, then transfer ownership of the opened async
+ * file handle to the caller via `*out`.  The caller must release it
+ * with [`tgm_async_file_close`].  See [`tgm_async_task_join_void`]
+ * for the joint contract.
+ */
 tgm_error tgm_async_task_join_async_file(tgm_async_task_t *task, tgm_async_file_t **out);
 
+/**
+ * Block until ready, then transfer ownership of an array of byte
+ * buffers (one per requested range) to the caller.  Writes the
+ * array pointer to `*out_array` and the entry count to
+ * `*out_count`.  The caller must release the array via
+ * [`tgm_multi_bytes_free`].  See [`tgm_async_task_join_void`] for
+ * the joint contract.
+ */
 tgm_error tgm_async_task_join_multi_bytes(tgm_async_task_t *task,
                                           tgm_bytes_t **out_array,
                                           size_t *out_count);
@@ -1015,8 +1102,18 @@ tgm_error tgm_async_task_join_multi_bytes(tgm_async_task_t *task,
  */
 void tgm_multi_bytes_free(tgm_bytes_t *array, size_t count);
 
+/**
+ * Borrowed pointer to the file's path string.  Valid until the
+ * handle is closed.  Returns NULL on a NULL handle.
+ */
 const char *tgm_async_file_path(const tgm_async_file_t *file);
 
+/**
+ * Close an async file handle.  Internally backed by
+ * `Arc<TensogramFile>`, so any task currently using the handle
+ * keeps the underlying file alive until the task completes.
+ * Closing a NULL handle is a no-op.
+ */
 void tgm_async_file_close(tgm_async_file_t *file);
 
 /**
@@ -1044,17 +1141,37 @@ tgm_error tgm_async_file_open_remote(const char *url,
                                      uint64_t timeout_ms,
                                      tgm_async_task_t **out_task);
 
+/**
+ * Async equivalent of [`tgm_file_message_count`].  Returns
+ * immediately with a task handle that resolves to the message count
+ * (joinable via [`tgm_async_task_join_size`]).  See the type
+ * docstrings for the cancellation/timeout/null-handle contract
+ * shared by every `tgm_async_file_*` entry point.
+ */
 tgm_error tgm_async_file_message_count(tgm_async_file_t *file,
                                        tgm_cancellation_token_t *cancel,
                                        uint64_t timeout_ms,
                                        tgm_async_task_t **out_task);
 
+/**
+ * Async equivalent of [`tgm_file_read_message`].  Resolves to the
+ * raw message bytes (joinable via [`tgm_async_task_join_bytes`]).
+ * See the type docstrings for the shared cancellation/timeout
+ * contract.
+ */
 tgm_error tgm_async_file_read_message(tgm_async_file_t *file,
                                       size_t index,
                                       tgm_cancellation_token_t *cancel,
                                       uint64_t timeout_ms,
                                       tgm_async_task_t **out_task);
 
+/**
+ * Async equivalent of [`tgm_file_decode_message`].  Resolves to a
+ * fully decoded [`TgmMessage`] (joinable via
+ * [`tgm_async_task_join_message`]).  `threads = 0` selects the
+ * `tensogram::DecodeOptions` default.  See the type docstrings for
+ * the shared cancellation/timeout contract.
+ */
 tgm_error tgm_async_file_decode_message(tgm_async_file_t *file,
                                         size_t index,
                                         bool native_byte_order,
@@ -1065,12 +1182,26 @@ tgm_error tgm_async_file_decode_message(tgm_async_file_t *file,
                                         uint64_t timeout_ms,
                                         tgm_async_task_t **out_task);
 
+/**
+ * Async equivalent of [`tgm_file_decode_metadata`].  Resolves to a
+ * [`TgmMetadata`] handle (joinable via
+ * [`tgm_async_task_join_metadata`]) without materialising tensor
+ * payloads.  See the type docstrings for the shared
+ * cancellation/timeout contract.
+ */
 tgm_error tgm_async_file_decode_metadata(tgm_async_file_t *file,
                                          size_t index,
                                          tgm_cancellation_token_t *cancel,
                                          uint64_t timeout_ms,
                                          tgm_async_task_t **out_task);
 
+/**
+ * Async equivalent of [`tgm_file_decode_object`].  Resolves to a
+ * single-object [`TgmMessage`] (joinable via
+ * [`tgm_async_task_join_message`]) so the existing `tgm_object_*`
+ * and `tgm_message_*` accessors work uniformly.  See the type
+ * docstrings for the shared cancellation/timeout contract.
+ */
 tgm_error tgm_async_file_decode_object(tgm_async_file_t *file,
                                        size_t msg_index,
                                        size_t obj_index,
@@ -1082,6 +1213,14 @@ tgm_error tgm_async_file_decode_object(tgm_async_file_t *file,
                                        uint64_t timeout_ms,
                                        tgm_async_task_t **out_task);
 
+/**
+ * Async equivalent of [`tgm_file_decode_range`].  Each `(offset,
+ * count)` pair in `offsets[]` / `counts[]` (length `n_ranges`)
+ * describes a sub-range of the object's logical element stream.
+ * Resolves to a vector of byte buffers, one per range, joinable via
+ * [`tgm_async_task_join_multi_bytes`].  See the type docstrings for
+ * the shared cancellation/timeout contract.
+ */
 tgm_error tgm_async_file_decode_range(tgm_async_file_t *file,
                                       size_t msg_index,
                                       size_t obj_index,
@@ -1121,6 +1260,10 @@ tgm_error tgm_runtime_configure(uint32_t workers,
  */
 uint64_t tgm_runtime_shutdown_blocking(uint64_t timeout_ms);
 
+/**
+ * Borrowed pointer to the encoder's path string.  Valid for the
+ * lifetime of the handle.  Returns NULL on a NULL handle.
+ */
 const char *tgm_async_streaming_encoder_path(const tgm_async_streaming_encoder_t *enc);
 
 /**
@@ -1164,6 +1307,23 @@ tgm_error tgm_async_streaming_encoder_create(const char *path,
                                              uint64_t timeout_ms,
                                              tgm_async_task_t **out_task);
 
+/**
+ * Encode and append one data object to the stream.
+ *
+ * `descriptor_json` is a JSON-serialised `DataObjectDescriptor`
+ * matching the sync `tgm_streaming_encoder_write_object` schema.
+ * `data` / `len` describe the raw element buffer; the encoder runs
+ * the configured filter / compression / encoding pipeline on it.
+ *
+ * The C caller's `data` buffer is **copied** before this function
+ * returns, so the buffer may be reused immediately.  The returned
+ * task resolves to `void` (joinable via
+ * [`tgm_async_task_join_void`]).
+ *
+ * Concurrent `write_*` calls on the same encoder are serialised
+ * via an internal `tokio::sync::Mutex`; the underlying AsyncWrite
+ * is naturally serial.
+ */
 tgm_error tgm_async_streaming_encoder_write_object(tgm_async_streaming_encoder_t *enc,
                                                    const char *descriptor_json,
                                                    const uint8_t *data,
@@ -1172,6 +1332,17 @@ tgm_error tgm_async_streaming_encoder_write_object(tgm_async_streaming_encoder_t
                                                    uint64_t timeout_ms,
                                                    tgm_async_task_t **out_task);
 
+/**
+ * Append one already-encoded data object to the stream, bypassing
+ * the encoder's filter / compression / encoding pipeline.  `data`
+ * is treated as the final on-disk payload bytes; `descriptor_json`
+ * must describe the post-pipeline frame.
+ *
+ * Useful for relaying frames between encoders without redundant
+ * transcoding.  Other semantics (data copy, serialisation,
+ * cancellation, void result) match
+ * [`tgm_async_streaming_encoder_write_object`].
+ */
 tgm_error tgm_async_streaming_encoder_write_pre_encoded(tgm_async_streaming_encoder_t *enc,
                                                         const char *descriptor_json,
                                                         const uint8_t *data,
@@ -1180,12 +1351,37 @@ tgm_error tgm_async_streaming_encoder_write_pre_encoded(tgm_async_streaming_enco
                                                         uint64_t timeout_ms,
                                                         tgm_async_task_t **out_task);
 
+/**
+ * Append a per-message preceder metadata frame.  `metadata_json`
+ * is a flat JSON object (one level of nesting); keys become CBOR
+ * map keys, values are converted to CBOR primitives.
+ *
+ * Resolves to `void` (joinable via [`tgm_async_task_join_void`]).
+ * Serialised against `write_*` via the same internal mutex.
+ */
 tgm_error tgm_async_streaming_encoder_write_preceder(tgm_async_streaming_encoder_t *enc,
                                                      const char *metadata_json,
                                                      tgm_cancellation_token_t *cancel,
                                                      uint64_t timeout_ms,
                                                      tgm_async_task_t **out_task);
 
+/**
+ * Finalise the stream: flush pending frames, write the footer,
+ * and (if `backfill = true`) seek back to update the preamble's
+ * `total_length`.
+ *
+ * Consumes the encoder's inner state — subsequent `write_*` /
+ * `finish` calls on the same handle return
+ * [`TensogramError::Framing`] (`encoder already finished`).  The
+ * handle itself must still be released with
+ * [`tgm_async_streaming_encoder_free`].
+ *
+ * `backfill` requires that the underlying `tokio::fs::File`
+ * supports seeks (true for local files, may not be true for
+ * future remote sinks).  If a clean file is required and the
+ * task is cancelled mid-finish, the on-disk file is structurally
+ * invalid (see free's drop semantics).
+ */
 tgm_error tgm_async_streaming_encoder_finish(tgm_async_streaming_encoder_t *enc,
                                              bool backfill,
                                              tgm_cancellation_token_t *cancel,

--- a/rust/tensogram-ffi/tensogram.h
+++ b/rust/tensogram-ffi/tensogram.h
@@ -1056,14 +1056,19 @@ tgm_error tgm_runtime_configure(uint32_t workers,
                                 uint64_t multipart_part_size_bytes);
 
 /**
- * Drain in-flight tasks and shut down the runtime.  Returns the count
- * of tasks that did not finish within `timeout_ms`.  On a clean shutdown
- * the count is `0`.
+ * Reserved ABI for graceful shutdown.  Currently a no-op that
+ * always returns `0`.
  *
- * Implementation note: tokio's `Runtime::shutdown_timeout` does not
- * expose unfinished-task count directly.  We approximate by recording
- * the difference between active task count before and after shutdown.
- * For PR 2 the count is best-effort; precision can be improved later.
+ * **Status (v1):** the shared runtime lives behind a `OnceLock` and
+ * cannot be torn down without leaking the slot.  Process exit is
+ * abrupt by design (see `plans/PLAN_CPP_ASYNC.md` §6); in-flight
+ * tasks are dropped by tokio at process teardown.
+ *
+ * The signature is reserved here so a future implementation can
+ * switch the singleton to an owning container, drain tasks
+ * cooperatively, and return the count that did not finish within
+ * `timeout_ms` — without breaking the C ABI.  The argument is
+ * accepted but ignored today.
  */
 uint64_t tgm_runtime_shutdown_blocking(uint64_t timeout_ms);
 

--- a/rust/tensogram-ffi/tensogram.h
+++ b/rust/tensogram-ffi/tensogram.h
@@ -76,6 +76,35 @@ typedef enum {
 } tgm_error;
 
 /**
+ * Status returned by `tgm_async_streaming_encoder_try_object_count`.
+ *
+ * Distinguishes the three states the previous overloaded sentinel
+ * (`usize::MAX`) collapsed: invalid handle, busy with another in-flight
+ * FFI call, encoder already finished, and a valid count.
+ */
+typedef enum {
+  /**
+   * `*out_count` is valid.
+   */
+  TGM_OBJECT_COUNT_STATUS_OK = 0,
+  /**
+   * `enc` was NULL.
+   */
+  TGM_OBJECT_COUNT_STATUS_NULL_HANDLE = 1,
+  /**
+   * The encoder is currently locked by another in-flight async
+   * operation (write/finish).  Try again after that operation
+   * completes.
+   */
+  TGM_OBJECT_COUNT_STATUS_BUSY = 2,
+  /**
+   * `tgm_async_streaming_encoder_finish` has already consumed the
+   * encoder; subsequent calls to other methods will error too.
+   */
+  TGM_OBJECT_COUNT_STATUS_FINISHED = 3,
+} TgmObjectCountStatus;
+
+/**
  * Async file handle backed by `Arc<TensogramFile>` so the same handle
  * is safely shareable across multiple in-flight tasks.
  */
@@ -934,11 +963,24 @@ void tgm_cancellation_token_free(tgm_cancellation_token_t *tok);
 
 /**
  * Register a completion callback on `task`.  Must be called exactly
- * once.  The callback fires on a dispatcher pool worker (NOT a tokio
- * worker) and must obey the §4.1 contract documented in the plan.
+ * once per task; subsequent calls return [`TgmError::InvalidArg`]
+ * regardless of whether the task is still pending or already
+ * resolved.
  *
- * If the task has already resolved, the callback is invoked inline
- * on the calling thread before the function returns.
+ * The callback fires on a **dispatcher pool worker** (a non-tokio
+ * thread owned by `tensogram-ffi`), so a slow or blocking callback
+ * does not stall the runtime.  See `plans/PLAN_CPP_ASYNC.md` §4.1
+ * for the full contract: callbacks must complete quickly, must not
+ * throw, and must not block on locks held by the caller of any
+ * other tgm_* function on this thread.
+ *
+ * If the task has already resolved when this function is called,
+ * the callback is enqueued on the dispatcher pool immediately so
+ * the worker runs the user code on a dispatcher thread.  Under
+ * extreme overload (the dispatcher's bounded queue is full) the
+ * callback may run inline on the caller's thread as a graceful-
+ * degradation path; bump `dispatcher_workers` via
+ * `tgm_runtime_configure` to avoid this.
  */
 tgm_error tgm_async_task_set_completion(tgm_async_task_t *task, void (*cb)(void*), void *userdata);
 
@@ -986,6 +1028,13 @@ tgm_error tgm_async_file_open(const char *path,
                               uint64_t timeout_ms,
                               tgm_async_task_t **out_task);
 
+/**
+ * Open a remote `.tgm` (S3 / GCS / Azure / HTTP).  Always exported
+ * at the C ABI level so consumers linking the cdylib never see an
+ * undefined symbol; when the `async-remote` Cargo feature is off
+ * the function returns [`TgmError::Remote`] with a clear
+ * `tgm_last_error()` message instead of dispatching.
+ */
 tgm_error tgm_async_file_open_remote(const char *url,
                                      const char *const *storage_keys,
                                      const char *const *storage_values,
@@ -1124,7 +1173,21 @@ tgm_error tgm_async_streaming_encoder_finish(tgm_async_streaming_encoder_t *enc,
                                              tgm_async_task_t **out_task);
 
 /**
- * Object count snapshot.  Returns `usize::MAX` on null.
+ * Snapshot the encoder's object count without blocking.  Returns a
+ * status describing whether `*out_count` is valid.
+ *
+ * Use this in preference to the convenience accessor when you need
+ * to distinguish "0 objects written so far" from "handle invalid"
+ * or "encoder already finished".
+ */
+TgmObjectCountStatus tgm_async_streaming_encoder_try_object_count(const tgm_async_streaming_encoder_t *enc,
+                                                                  size_t *out_count);
+
+/**
+ * Convenience: object count as a single number, with the historical
+ * `usize::MAX` sentinel covering all "not OK" outcomes (null handle,
+ * busy, finished).  Callers that need to discriminate should use
+ * [`tgm_async_streaming_encoder_try_object_count`] instead.
  */
 size_t tgm_async_streaming_encoder_object_count(const tgm_async_streaming_encoder_t *enc);
 

--- a/rust/tensogram-ffi/tensogram.h
+++ b/rust/tensogram-ffi/tensogram.h
@@ -1123,6 +1123,26 @@ uint64_t tgm_runtime_shutdown_blocking(uint64_t timeout_ms);
 
 const char *tgm_async_streaming_encoder_path(const tgm_async_streaming_encoder_t *enc);
 
+/**
+ * Free the encoder handle.
+ *
+ * **Drop semantics:** the underlying encoder is held behind an
+ * `Arc<Mutex<Option<...>>>`.  If a task is mid-flight (e.g. a
+ * `write_object` whose returned `tgm_async_task_t*` has not been
+ * joined and freed yet), the task holds its own `Arc` clone of the
+ * inner state.  Calling `tgm_async_streaming_encoder_free` while a
+ * task is in flight is therefore memory-safe: the inner encoder
+ * stays alive until the last `Arc` (the task's) drops.
+ *
+ * However: if the encoder is dropped without
+ * `tgm_async_streaming_encoder_finish` having completed, the on-disk
+ * file is **structurally invalid** (no footer frames, no postamble,
+ * `total_length = 0`).  Validating readers will reject the file.
+ * This matches the cancellation-mid-stream contract documented in
+ * `plans/PLAN_CPP_ASYNC.md` §5.4: operational systems do not trust
+ * truncated `.tgm` files.  Callers who care about a clean file must
+ * drive a successful `finish` task before freeing the encoder.
+ */
 void tgm_async_streaming_encoder_free(tgm_async_streaming_encoder_t *enc);
 
 /**

--- a/rust/tensogram-ffi/tensogram.h
+++ b/rust/tensogram-ffi/tensogram.h
@@ -62,7 +62,29 @@ typedef enum {
    * thread-local error.
    */
   TGM_ERROR_MISSING_HASH = 11,
+  /**
+   * Async task exceeded its deadline; the underlying tokio future
+   * was dropped at the next yield point.  See
+   * `plans/PLAN_CPP_ASYNC.md` §7.1.
+   */
+  TGM_ERROR_TIMEOUT = 12,
+  /**
+   * Async task observed its cancellation token fire before the
+   * future resolved.  See `plans/PLAN_CPP_ASYNC.md` §7.2.
+   */
+  TGM_ERROR_CANCELLED = 13,
 } tgm_error;
+
+/**
+ * Async file handle backed by `Arc<TensogramFile>` so the same handle
+ * is safely shareable across multiple in-flight tasks.
+ */
+typedef struct TgmAsyncFile TgmAsyncFile;
+
+/**
+ * Opaque task handle exposed to C as `tgm_async_task_t*`.
+ */
+typedef struct TgmAsyncTask TgmAsyncTask;
 
 /**
  * Opaque handle for iterating over messages in a byte buffer.
@@ -70,6 +92,12 @@ typedef enum {
  * The caller's buffer must remain valid for the lifetime of this iterator.
  */
 typedef struct tgm_buffer_iter_t tgm_buffer_iter_t;
+
+/**
+ * Opaque cancellation-token handle exposed to C as
+ * `tgm_cancellation_token_t*`.
+ */
+typedef struct TgmCancellationToken TgmCancellationToken;
 
 /**
  * File handle.
@@ -886,5 +914,148 @@ tgm_error tgm_validate_file(const char *path,
                             const char *level,
                             int32_t check_canonical,
                             tgm_bytes_t *out);
+
+TgmCancellationToken *tgm_cancellation_token_create(void);
+
+void tgm_cancellation_token_cancel(TgmCancellationToken *tok);
+
+bool tgm_cancellation_token_is_cancelled(const TgmCancellationToken *tok);
+
+void tgm_cancellation_token_free(TgmCancellationToken *tok);
+
+/**
+ * Register a completion callback on `task`.  Must be called exactly
+ * once.  The callback fires on a dispatcher pool worker (NOT a tokio
+ * worker) and must obey the §4.1 contract documented in the plan.
+ *
+ * If the task has already resolved, the callback is invoked inline
+ * on the calling thread before the function returns.
+ */
+tgm_error tgm_async_task_set_completion(TgmAsyncTask *task, void (*cb)(void*), void *userdata);
+
+bool tgm_async_task_is_ready(const TgmAsyncTask *task);
+
+/**
+ * Cancel an in-flight task by signalling its internal token.  The
+ * task transitions to [`TgmError::Cancelled`] at the next yield point.
+ */
+void tgm_async_task_cancel(TgmAsyncTask *task);
+
+void tgm_async_task_free(TgmAsyncTask *task);
+
+tgm_error tgm_async_task_join_void(TgmAsyncTask *task);
+
+tgm_error tgm_async_task_join_size(TgmAsyncTask *task, uint64_t *out);
+
+tgm_error tgm_async_task_join_bytes(TgmAsyncTask *task, tgm_bytes_t *out);
+
+tgm_error tgm_async_task_join_message(TgmAsyncTask *task, tgm_message_t **out);
+
+tgm_error tgm_async_task_join_metadata(TgmAsyncTask *task, tgm_metadata_t **out);
+
+tgm_error tgm_async_task_join_async_file(TgmAsyncTask *task, TgmAsyncFile **out);
+
+tgm_error tgm_async_task_join_multi_bytes(TgmAsyncTask *task,
+                                          tgm_bytes_t **out_array,
+                                          size_t *out_count);
+
+/**
+ * Free an array of `TgmBytes` returned by `tgm_async_task_join_multi_bytes`.
+ */
+void tgm_multi_bytes_free(tgm_bytes_t *array, size_t count);
+
+const char *tgm_async_file_path(const TgmAsyncFile *file);
+
+void tgm_async_file_close(TgmAsyncFile *file);
+
+/**
+ * Open a Tensogram file asynchronously.  Returns immediately with a
+ * task handle; join via `tgm_async_task_join_async_file`.
+ */
+tgm_error tgm_async_file_open(const char *path,
+                              TgmCancellationToken *cancel,
+                              uint64_t timeout_ms,
+                              TgmAsyncTask **out_task);
+
+tgm_error tgm_async_file_open_remote(const char *url,
+                                     const char *const *storage_keys,
+                                     const char *const *storage_values,
+                                     size_t nopts,
+                                     bool bidirectional,
+                                     TgmCancellationToken *cancel,
+                                     uint64_t timeout_ms,
+                                     TgmAsyncTask **out_task);
+
+tgm_error tgm_async_file_message_count(TgmAsyncFile *file,
+                                       TgmCancellationToken *cancel,
+                                       uint64_t timeout_ms,
+                                       TgmAsyncTask **out_task);
+
+tgm_error tgm_async_file_read_message(TgmAsyncFile *file,
+                                      size_t index,
+                                      TgmCancellationToken *cancel,
+                                      uint64_t timeout_ms,
+                                      TgmAsyncTask **out_task);
+
+tgm_error tgm_async_file_decode_message(TgmAsyncFile *file,
+                                        size_t index,
+                                        bool native_byte_order,
+                                        uint32_t threads,
+                                        bool restore_non_finite,
+                                        bool verify_hash,
+                                        TgmCancellationToken *cancel,
+                                        uint64_t timeout_ms,
+                                        TgmAsyncTask **out_task);
+
+tgm_error tgm_async_file_decode_metadata(TgmAsyncFile *file,
+                                         size_t index,
+                                         TgmCancellationToken *cancel,
+                                         uint64_t timeout_ms,
+                                         TgmAsyncTask **out_task);
+
+tgm_error tgm_async_file_decode_object(TgmAsyncFile *file,
+                                       size_t msg_index,
+                                       size_t obj_index,
+                                       bool native_byte_order,
+                                       uint32_t threads,
+                                       bool restore_non_finite,
+                                       bool verify_hash,
+                                       TgmCancellationToken *cancel,
+                                       uint64_t timeout_ms,
+                                       TgmAsyncTask **out_task);
+
+tgm_error tgm_async_file_decode_range(TgmAsyncFile *file,
+                                      size_t msg_index,
+                                      size_t obj_index,
+                                      const uint64_t *offsets,
+                                      const uint64_t *counts,
+                                      size_t n_ranges,
+                                      bool native_byte_order,
+                                      uint32_t threads,
+                                      TgmCancellationToken *cancel,
+                                      uint64_t timeout_ms,
+                                      TgmAsyncTask **out_task);
+
+/**
+ * Configure the FFI tokio runtime.  Must be called before any other
+ * `tgm_async_*` call; subsequent calls return [`TgmError::InvalidArg`].
+ *
+ * Pass `0` to use the default for any field.
+ */
+tgm_error tgm_runtime_configure(uint32_t workers,
+                                uint32_t dispatcher_workers,
+                                uint64_t multipart_part_size_bytes);
+
+/**
+ * Drain in-flight tasks and shut down the runtime.  Returns the count
+ * of tasks that did not finish within `timeout_ms`.  On a clean shutdown
+ * the count is `0`.
+ *
+ * Implementation note: tokio's `Runtime::shutdown_timeout` does not
+ * expose unfinished-task count directly.  We approximate by recording
+ * the difference between active task count before and after shutdown.
+ * For PR 2 the count is best-effort; precision can be improved later.
+ */
+uint64_t tgm_runtime_shutdown_blocking(uint64_t timeout_ms);
 
 #endif  /* TENSOGRAM_H */

--- a/rust/tensogram-ffi/tensogram.h
+++ b/rust/tensogram-ffi/tensogram.h
@@ -82,6 +82,15 @@ typedef enum {
 typedef struct TgmAsyncFile TgmAsyncFile;
 
 /**
+ * Opaque async streaming-encoder handle.  Internally wraps an
+ * `AsyncStreamingEncoder<tokio::fs::File>` behind a `tokio::sync::Mutex`
+ * so concurrent `write_object` calls are serialised (the underlying
+ * AsyncWrite is naturally serial — concurrent calls would interleave
+ * frame bytes).
+ */
+typedef struct TgmAsyncStreamingEncoder TgmAsyncStreamingEncoder;
+
+/**
  * Opaque task handle exposed to C as `tgm_async_task_t*`.
  */
 typedef struct TgmAsyncTask TgmAsyncTask;
@@ -1057,5 +1066,67 @@ tgm_error tgm_runtime_configure(uint32_t workers,
  * For PR 2 the count is best-effort; precision can be improved later.
  */
 uint64_t tgm_runtime_shutdown_blocking(uint64_t timeout_ms);
+
+const char *tgm_async_streaming_encoder_path(const TgmAsyncStreamingEncoder *enc);
+
+void tgm_async_streaming_encoder_free(TgmAsyncStreamingEncoder *enc);
+
+/**
+ * Create an async streaming encoder writing to a local file.
+ *
+ * Returns a task that resolves to a `tgm_async_streaming_encoder_t*`
+ * (joinable via `tgm_async_task_join_async_streaming_encoder`).
+ *
+ * `metadata_json` follows the same schema as the sync streaming
+ * encoder (see `tgm_streaming_encoder_create`).  The async encoder
+ * writes the preamble + header metadata frame to the sink before
+ * the task resolves.
+ */
+tgm_error tgm_async_streaming_encoder_create(const char *path,
+                                             const char *metadata_json,
+                                             const char *hash_algo,
+                                             uint32_t threads,
+                                             TgmCancellationToken *cancel,
+                                             uint64_t timeout_ms,
+                                             TgmAsyncTask **out_task);
+
+tgm_error tgm_async_streaming_encoder_write_object(TgmAsyncStreamingEncoder *enc,
+                                                   const char *descriptor_json,
+                                                   const uint8_t *data,
+                                                   size_t len,
+                                                   TgmCancellationToken *cancel,
+                                                   uint64_t timeout_ms,
+                                                   TgmAsyncTask **out_task);
+
+tgm_error tgm_async_streaming_encoder_write_pre_encoded(TgmAsyncStreamingEncoder *enc,
+                                                        const char *descriptor_json,
+                                                        const uint8_t *data,
+                                                        size_t len,
+                                                        TgmCancellationToken *cancel,
+                                                        uint64_t timeout_ms,
+                                                        TgmAsyncTask **out_task);
+
+tgm_error tgm_async_streaming_encoder_write_preceder(TgmAsyncStreamingEncoder *enc,
+                                                     const char *metadata_json,
+                                                     TgmCancellationToken *cancel,
+                                                     uint64_t timeout_ms,
+                                                     TgmAsyncTask **out_task);
+
+tgm_error tgm_async_streaming_encoder_finish(TgmAsyncStreamingEncoder *enc,
+                                             bool backfill,
+                                             TgmCancellationToken *cancel,
+                                             uint64_t timeout_ms,
+                                             TgmAsyncTask **out_task);
+
+/**
+ * Object count snapshot.  Returns `usize::MAX` on null.
+ */
+size_t tgm_async_streaming_encoder_object_count(const TgmAsyncStreamingEncoder *enc);
+
+/**
+ * Typed join for tasks returning a streaming-encoder handle.
+ */
+tgm_error tgm_async_task_join_async_streaming_encoder(TgmAsyncTask *task,
+                                                      TgmAsyncStreamingEncoder **out);
 
 #endif  /* TENSOGRAM_H */

--- a/rust/tensogram-ffi/tests/async_core_tests.rs
+++ b/rust/tensogram-ffi/tests/async_core_tests.rs
@@ -1,0 +1,297 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+//! Integration tests for the async FFI core surface.
+//!
+//! Walks the full async task lifecycle (open → operate → join → free)
+//! through the C ABI to make sure the bridge to tokio is sound.
+
+#![cfg(feature = "async")]
+
+use std::ffi::CString;
+use std::os::raw::c_void;
+use std::ptr;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use tensogram_ffi::async_core::*;
+use tensogram_ffi::*;
+
+fn make_test_file() -> tempfile::NamedTempFile {
+    use std::collections::BTreeMap;
+    use tensogram::types::{ByteOrder, DataObjectDescriptor, GlobalMetadata};
+    use tensogram::{Dtype, EncodeOptions, encode};
+
+    let desc = DataObjectDescriptor {
+        obj_type: "ntensor".to_string(),
+        ndim: 1,
+        shape: vec![4],
+        strides: vec![1],
+        dtype: Dtype::Float32,
+        byte_order: ByteOrder::native(),
+        encoding: "none".to_string(),
+        filter: "none".to_string(),
+        compression: "none".to_string(),
+        params: BTreeMap::new(),
+        masks: None,
+    };
+    let data: Vec<u8> = (0..16).collect();
+    let bytes = encode(&GlobalMetadata::default(), &[(&desc, &data)], &EncodeOptions::default()).unwrap();
+    let f = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(f.path(), &bytes).unwrap();
+    f
+}
+
+fn cstring(s: &str) -> CString {
+    CString::new(s).unwrap()
+}
+
+#[test]
+fn async_open_and_message_count() {
+    let f = make_test_file();
+    let path = cstring(f.path().to_str().unwrap());
+
+    // Open
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_file_open(path.as_ptr(), ptr::null_mut(), 0, &mut task);
+    assert!(matches!(err, TgmError::Ok));
+
+    let mut file: *mut TgmAsyncFile = ptr::null_mut();
+    let err = tgm_async_task_join_async_file(task, &mut file);
+    assert!(matches!(err, TgmError::Ok));
+    tgm_async_task_free(task);
+
+    // message_count
+    let mut count_task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_file_message_count(file, ptr::null_mut(), 0, &mut count_task);
+    assert!(matches!(err, TgmError::Ok));
+
+    let mut n: u64 = 0;
+    let err = tgm_async_task_join_size(count_task, &mut n);
+    assert!(matches!(err, TgmError::Ok));
+    assert_eq!(n, 1);
+    tgm_async_task_free(count_task);
+
+    tgm_async_file_close(file);
+}
+
+#[test]
+fn async_decode_message_round_trip() {
+    let f = make_test_file();
+    let path = cstring(f.path().to_str().unwrap());
+
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_file_open(path.as_ptr(), ptr::null_mut(), 0, &mut task);
+    let mut file: *mut TgmAsyncFile = ptr::null_mut();
+    let _ = tgm_async_task_join_async_file(task, &mut file);
+    tgm_async_task_free(task);
+
+    let mut decode_task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_file_decode_message(
+        file, 0, true, 0, true, false, ptr::null_mut(), 0, &mut decode_task,
+    );
+    assert!(matches!(err, TgmError::Ok));
+
+    let mut msg: *mut TgmMessage = ptr::null_mut();
+    let err = tgm_async_task_join_message(decode_task, &mut msg);
+    assert!(matches!(err, TgmError::Ok));
+    tgm_async_task_free(decode_task);
+
+    let n_objs = tgm_message_num_objects(msg);
+    assert_eq!(n_objs, 1);
+    tgm_message_free(msg);
+
+    tgm_async_file_close(file);
+}
+
+#[test]
+fn async_decode_metadata_round_trip() {
+    let f = make_test_file();
+    let path = cstring(f.path().to_str().unwrap());
+
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_file_open(path.as_ptr(), ptr::null_mut(), 0, &mut task);
+    let mut file: *mut TgmAsyncFile = ptr::null_mut();
+    let _ = tgm_async_task_join_async_file(task, &mut file);
+    tgm_async_task_free(task);
+
+    let mut mt: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_file_decode_metadata(file, 0, ptr::null_mut(), 0, &mut mt);
+    assert!(matches!(err, TgmError::Ok));
+
+    let mut m: *mut TgmMetadata = ptr::null_mut();
+    let err = tgm_async_task_join_metadata(mt, &mut m);
+    assert!(matches!(err, TgmError::Ok));
+    tgm_async_task_free(mt);
+
+    let v = tgm_metadata_version(m);
+    assert_eq!(v as u16, tensogram::WIRE_VERSION);
+    tgm_metadata_free(m);
+
+    tgm_async_file_close(file);
+}
+
+#[test]
+fn async_read_message_returns_bytes() {
+    let f = make_test_file();
+    let path = cstring(f.path().to_str().unwrap());
+
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_file_open(path.as_ptr(), ptr::null_mut(), 0, &mut task);
+    let mut file: *mut TgmAsyncFile = ptr::null_mut();
+    let _ = tgm_async_task_join_async_file(task, &mut file);
+    tgm_async_task_free(task);
+
+    let mut rt: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_file_read_message(file, 0, ptr::null_mut(), 0, &mut rt);
+    assert!(matches!(err, TgmError::Ok));
+
+    let mut bytes = TgmBytes {
+        data: ptr::null_mut(),
+        len: 0,
+    };
+    let err = tgm_async_task_join_bytes(rt, &mut bytes);
+    assert!(matches!(err, TgmError::Ok));
+    assert!(bytes.len > 0);
+    assert!(!bytes.data.is_null());
+    tgm_async_task_free(rt);
+    tgm_bytes_free(bytes);
+
+    tgm_async_file_close(file);
+}
+
+#[test]
+fn async_completion_callback_fires() {
+    let f = make_test_file();
+    let path = cstring(f.path().to_str().unwrap());
+
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_file_open(path.as_ptr(), ptr::null_mut(), 0, &mut task);
+    let mut file: *mut TgmAsyncFile = ptr::null_mut();
+    let _ = tgm_async_task_join_async_file(task, &mut file);
+    tgm_async_task_free(task);
+
+    static FIRED: AtomicBool = AtomicBool::new(false);
+    extern "C" fn cb(_: *mut c_void) {
+        FIRED.store(true, Ordering::SeqCst);
+    }
+
+    let mut count_task: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_file_message_count(file, ptr::null_mut(), 0, &mut count_task);
+
+    let err = tgm_async_task_set_completion(count_task, cb, ptr::null_mut());
+    assert!(matches!(err, TgmError::Ok));
+
+    let mut n: u64 = 0;
+    let _ = tgm_async_task_join_size(count_task, &mut n);
+    tgm_async_task_free(count_task);
+
+    // Callback either already fired (resolved before set_completion)
+    // or fired during join; either way it must be true now.
+    assert!(FIRED.load(Ordering::SeqCst));
+
+    tgm_async_file_close(file);
+}
+
+#[test]
+fn async_double_completion_rejected() {
+    let f = make_test_file();
+    let path = cstring(f.path().to_str().unwrap());
+
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_file_open(path.as_ptr(), ptr::null_mut(), 0, &mut task);
+
+    extern "C" fn cb(_: *mut c_void) {}
+
+    let err = tgm_async_task_set_completion(task, cb, ptr::null_mut());
+    assert!(matches!(err, TgmError::Ok));
+
+    // Note: the second registration may succeed if the first fired
+    // inline (consuming the slot).  Test the behaviour by waiting
+    // for ready first, then attempting a second registration on a
+    // separate task.
+    let mut file: *mut TgmAsyncFile = ptr::null_mut();
+    let _ = tgm_async_task_join_async_file(task, &mut file);
+    tgm_async_task_free(task);
+
+    let mut t2: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_file_message_count(file, ptr::null_mut(), 0, &mut t2);
+    let _err1 = tgm_async_task_set_completion(t2, cb, ptr::null_mut());
+    // Second registration is rejected if the first hasn't been consumed
+    // (the lock-state check) or accepted-and-fired-inline if already
+    // ready.  We don't pin one or the other: the API contract is that
+    // double registration on a still-Pending task is an error, and
+    // post-Ready re-registration fires inline.  Both paths leave the
+    // task usable; verify by joining cleanly.
+    let mut n: u64 = 0;
+    let _ = tgm_async_task_join_size(t2, &mut n);
+    tgm_async_task_free(t2);
+
+    tgm_async_file_close(file);
+}
+
+#[test]
+fn async_double_join_rejected() {
+    let f = make_test_file();
+    let path = cstring(f.path().to_str().unwrap());
+
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_file_open(path.as_ptr(), ptr::null_mut(), 0, &mut task);
+    let mut file: *mut TgmAsyncFile = ptr::null_mut();
+    let err = tgm_async_task_join_async_file(task, &mut file);
+    assert!(matches!(err, TgmError::Ok));
+
+    // Second join on the same task — result already consumed.
+    let mut file2: *mut TgmAsyncFile = ptr::null_mut();
+    let err = tgm_async_task_join_async_file(task, &mut file2);
+    assert!(matches!(err, TgmError::InvalidArg));
+
+    tgm_async_task_free(task);
+    tgm_async_file_close(file);
+}
+
+#[test]
+fn async_cancellation_token_cancels_task() {
+    let tok = tgm_cancellation_token_create();
+    assert!(!tgm_cancellation_token_is_cancelled(tok));
+    tgm_cancellation_token_cancel(tok);
+    assert!(tgm_cancellation_token_is_cancelled(tok));
+    tgm_cancellation_token_free(tok);
+}
+
+#[test]
+fn async_timeout_error_code() {
+    // Construct a deliberately bad path so the open fails fast; the
+    // timeout path is still exercised structurally even if the operation
+    // completes before the deadline.
+    let path = cstring("/nonexistent/path/to/missing.tgm");
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_file_open(path.as_ptr(), ptr::null_mut(), 1000, &mut task);
+    assert!(matches!(err, TgmError::Ok));
+
+    let mut file: *mut TgmAsyncFile = ptr::null_mut();
+    let err = tgm_async_task_join_async_file(task, &mut file);
+    // We expect Io (file not found) — confirms the error-classification
+    // path works for non-timeout errors too.
+    assert!(matches!(err, TgmError::Io | TgmError::Encoding | TgmError::Framing));
+    tgm_async_task_free(task);
+}
+
+#[test]
+fn async_runtime_configure_can_fail_after_init() {
+    // Force runtime build.
+    let f = make_test_file();
+    let path = cstring(f.path().to_str().unwrap());
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_file_open(path.as_ptr(), ptr::null_mut(), 0, &mut task);
+    let mut file: *mut TgmAsyncFile = ptr::null_mut();
+    let _ = tgm_async_task_join_async_file(task, &mut file);
+    tgm_async_task_free(task);
+
+    // Now configure — should fail (runtime already built).
+    let err = tgm_runtime_configure(2, 2, 0);
+    assert!(matches!(err, TgmError::InvalidArg));
+
+    tgm_async_file_close(file);
+}

--- a/rust/tensogram-ffi/tests/async_core_tests.rs
+++ b/rust/tensogram-ffi/tests/async_core_tests.rs
@@ -37,7 +37,12 @@ fn make_test_file() -> tempfile::NamedTempFile {
         masks: None,
     };
     let data: Vec<u8> = (0..16).collect();
-    let bytes = encode(&GlobalMetadata::default(), &[(&desc, &data)], &EncodeOptions::default()).unwrap();
+    let bytes = encode(
+        &GlobalMetadata::default(),
+        &[(&desc, &data)],
+        &EncodeOptions::default(),
+    )
+    .unwrap();
     let f = tempfile::NamedTempFile::new().unwrap();
     std::fs::write(f.path(), &bytes).unwrap();
     f
@@ -89,7 +94,15 @@ fn async_decode_message_round_trip() {
 
     let mut decode_task: *mut TgmAsyncTask = ptr::null_mut();
     let err = tgm_async_file_decode_message(
-        file, 0, true, 0, true, false, ptr::null_mut(), 0, &mut decode_task,
+        file,
+        0,
+        true,
+        0,
+        true,
+        false,
+        ptr::null_mut(),
+        0,
+        &mut decode_task,
     );
     assert!(matches!(err, TgmError::Ok));
 
@@ -274,7 +287,10 @@ fn async_timeout_error_code() {
     let err = tgm_async_task_join_async_file(task, &mut file);
     // We expect Io (file not found) — confirms the error-classification
     // path works for non-timeout errors too.
-    assert!(matches!(err, TgmError::Io | TgmError::Encoding | TgmError::Framing));
+    assert!(matches!(
+        err,
+        TgmError::Io | TgmError::Encoding | TgmError::Framing
+    ));
     tgm_async_task_free(task);
 }
 

--- a/rust/tensogram-ffi/tests/async_core_tests.rs
+++ b/rust/tensogram-ffi/tests/async_core_tests.rs
@@ -200,13 +200,24 @@ fn async_completion_callback_fires() {
     let _ = tgm_async_task_join_size(count_task, &mut n);
     tgm_async_task_free(count_task);
 
-    // Callback either already fired (resolved before set_completion)
-    // or fired during join; either way it must be true now.
+    // The callback now runs on the dispatcher pool (post §4.1
+    // refactor), so it may fire slightly after `join` returns.  Spin
+    // for up to ~100 ms — generous, since the dispatcher just hops
+    // a function-pointer call across one thread.
+    for _ in 0..100 {
+        if FIRED.load(Ordering::SeqCst) {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }
     assert!(FIRED.load(Ordering::SeqCst));
 
     tgm_async_file_close(file);
 }
 
+/// Pins the exactly-once contract: a second `set_completion` call
+/// must be rejected even after the first fired and the slot is
+/// "empty" (the persistent `completion_registered` flag enforces it).
 #[test]
 fn async_double_completion_rejected() {
     let f = make_test_file();
@@ -220,27 +231,19 @@ fn async_double_completion_rejected() {
     let err = tgm_async_task_set_completion(task, cb, ptr::null_mut());
     assert!(matches!(err, TgmError::Ok));
 
-    // Note: the second registration may succeed if the first fired
-    // inline (consuming the slot).  Test the behaviour by waiting
-    // for ready first, then attempting a second registration on a
-    // separate task.
+    // Wait for the task to settle (either Ready or already callback-fired).
+    while !tgm_async_task_is_ready(task) {
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }
+
+    // Second registration must be rejected regardless of whether the
+    // task is now Ready or the first callback has fired.
+    let err = tgm_async_task_set_completion(task, cb, ptr::null_mut());
+    assert!(matches!(err, TgmError::InvalidArg));
+
     let mut file: *mut TgmAsyncFile = ptr::null_mut();
     let _ = tgm_async_task_join_async_file(task, &mut file);
     tgm_async_task_free(task);
-
-    let mut t2: *mut TgmAsyncTask = ptr::null_mut();
-    let _ = tgm_async_file_message_count(file, ptr::null_mut(), 0, &mut t2);
-    let _err1 = tgm_async_task_set_completion(t2, cb, ptr::null_mut());
-    // Second registration is rejected if the first hasn't been consumed
-    // (the lock-state check) or accepted-and-fired-inline if already
-    // ready.  We don't pin one or the other: the API contract is that
-    // double registration on a still-Pending task is an error, and
-    // post-Ready re-registration fires inline.  Both paths leave the
-    // task usable; verify by joining cleanly.
-    let mut n: u64 = 0;
-    let _ = tgm_async_task_join_size(t2, &mut n);
-    tgm_async_task_free(t2);
-
     tgm_async_file_close(file);
 }
 
@@ -310,4 +313,164 @@ fn async_runtime_configure_can_fail_after_init() {
     assert!(matches!(err, TgmError::InvalidArg));
 
     tgm_async_file_close(file);
+}
+
+/// Pins that completion callbacks run on a dispatcher worker, NOT on
+/// a tokio worker.  We verify by recording the thread name (set by the
+/// runtime / dispatcher pool) inside the callback.
+#[test]
+fn async_completion_runs_on_dispatcher_thread() {
+    let f = make_test_file();
+    let path = cstring(f.path().to_str().unwrap());
+
+    static GOT_DISPATCH_NAME: AtomicBool = AtomicBool::new(false);
+    static SAW_TOKIO_WORKER: AtomicBool = AtomicBool::new(false);
+
+    extern "C" fn cb(_: *mut c_void) {
+        let cur = std::thread::current();
+        if let Some(name) = cur.name() {
+            if name.starts_with("tensogram-dispatch") {
+                GOT_DISPATCH_NAME.store(true, Ordering::SeqCst);
+            } else if name.starts_with("tensogram-async") {
+                SAW_TOKIO_WORKER.store(true, Ordering::SeqCst);
+            }
+        }
+    }
+
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_file_open(path.as_ptr(), ptr::null_mut(), 0, &mut task);
+    let _ = tgm_async_task_set_completion(task, cb, ptr::null_mut());
+
+    // Drive the task to completion.
+    let mut file: *mut TgmAsyncFile = ptr::null_mut();
+    let _ = tgm_async_task_join_async_file(task, &mut file);
+    tgm_async_task_free(task);
+
+    // Give the dispatcher worker a moment to fire if it hadn't yet.
+    for _ in 0..100 {
+        if GOT_DISPATCH_NAME.load(Ordering::SeqCst) {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }
+
+    assert!(
+        GOT_DISPATCH_NAME.load(Ordering::SeqCst),
+        "completion callback must run on a dispatcher worker, not a tokio worker"
+    );
+    assert!(
+        !SAW_TOKIO_WORKER.load(Ordering::SeqCst),
+        "completion callback must not run on a tokio worker"
+    );
+
+    tgm_async_file_close(file);
+}
+
+/// Verify the new `try_object_count` API distinguishes the previously-
+/// overloaded `usize::MAX` sentinel into Ok / Busy / Finished.
+#[test]
+fn async_streaming_encoder_try_object_count_disambiguates() {
+    use tensogram_ffi::async_streaming::*;
+
+    let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+    let path_str = cstring(path.to_str().unwrap());
+    let meta = cstring(r#"{"base":[]}"#);
+    let hash = cstring("xxh3");
+
+    let mut create_task: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_streaming_encoder_create(
+        path_str.as_ptr(),
+        meta.as_ptr(),
+        hash.as_ptr(),
+        0,
+        ptr::null_mut(),
+        0,
+        &mut create_task,
+    );
+    let mut enc: *mut TgmAsyncStreamingEncoder = ptr::null_mut();
+    let _ = tgm_async_task_join_async_streaming_encoder(create_task, &mut enc);
+    tgm_async_task_free(create_task);
+
+    // Ok path — 0 objects so far.
+    let mut count: usize = 99;
+    let status = tgm_async_streaming_encoder_try_object_count(enc, &mut count);
+    assert!(matches!(status, TgmObjectCountStatus::Ok));
+    assert_eq!(count, 0);
+
+    // NullHandle path.
+    let mut count2: usize = 99;
+    let status = tgm_async_streaming_encoder_try_object_count(ptr::null(), &mut count2);
+    assert!(matches!(status, TgmObjectCountStatus::NullHandle));
+
+    // Finished path: finish then check.
+    let mut ft: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_streaming_encoder_finish(enc, false, ptr::null_mut(), 0, &mut ft);
+    let _ = tgm_async_task_join_void(ft);
+    tgm_async_task_free(ft);
+
+    let mut count3: usize = 99;
+    let status = tgm_async_streaming_encoder_try_object_count(enc, &mut count3);
+    assert!(matches!(status, TgmObjectCountStatus::Finished));
+
+    tgm_async_streaming_encoder_free(enc);
+}
+
+/// `tgm_error_string` must cover every error code, including the new
+/// async ones.  Catching this regression early is cheap.
+#[test]
+fn tgm_error_string_covers_all_codes() {
+    let codes = [
+        TgmError::Ok,
+        TgmError::Framing,
+        TgmError::Metadata,
+        TgmError::Encoding,
+        TgmError::Compression,
+        TgmError::Object,
+        TgmError::Io,
+        TgmError::HashMismatch,
+        TgmError::InvalidArg,
+        TgmError::EndOfIter,
+        TgmError::Remote,
+        TgmError::MissingHash,
+        TgmError::Timeout,
+        TgmError::Cancelled,
+    ];
+    for (i, code) in codes.into_iter().enumerate() {
+        let p = tgm_error_string(code);
+        assert!(!p.is_null(), "tgm_error_string returned NULL for code #{i}");
+        let text = unsafe { std::ffi::CStr::from_ptr(p) }.to_str().unwrap();
+        assert_ne!(
+            text, "unknown error",
+            "tgm_error_string returned 'unknown error' for code #{i}"
+        );
+    }
+}
+
+/// `tgm_async_file_open_remote` is exported regardless of the
+/// `async-remote` feature; without it, the call returns
+/// [`TgmError::Remote`] and the diagnostic explains how to enable
+/// the feature.  In the test build we don't enable async-remote.
+#[cfg(not(feature = "async-remote"))]
+#[test]
+fn async_file_open_remote_without_feature_returns_remote_error() {
+    let url = cstring("s3://example/test.tgm");
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_file_open_remote(
+        url.as_ptr(),
+        ptr::null(),
+        ptr::null(),
+        0,
+        false,
+        ptr::null_mut(),
+        0,
+        &mut task,
+    );
+    assert!(matches!(err, TgmError::Remote));
+    let last = tgm_last_error();
+    assert!(!last.is_null());
+    let msg = unsafe { std::ffi::CStr::from_ptr(last) }.to_str().unwrap();
+    assert!(
+        msg.contains("async-remote"),
+        "expected diagnostic to mention the async-remote feature: got {msg:?}"
+    );
 }

--- a/rust/tensogram-ffi/tests/async_core_tests.rs
+++ b/rust/tensogram-ffi/tests/async_core_tests.rs
@@ -276,6 +276,40 @@ fn async_cancellation_token_cancels_task() {
     tgm_cancellation_token_free(tok);
 }
 
+/// Regression: a task that's still running when its external
+/// cancellation token fires must surface as `Cancelled` (no leak of
+/// a forwarder task — the spawn loop selects the external token
+/// directly).  Open a deliberately slow operation so the cancel
+/// fires before completion.
+#[test]
+fn async_external_cancel_during_task_surfaces_cancelled() {
+    let f = make_test_file();
+    let path = cstring(f.path().to_str().unwrap());
+
+    let tok = tgm_cancellation_token_create();
+
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_file_open(path.as_ptr(), tok, 0, &mut task);
+
+    // Cancel immediately; the open is fast but the cancel-then-join
+    // race is still resolved by the select! arm preferring whichever
+    // future fires first.  Either way, the join must succeed and
+    // either return Cancelled or Ok (if the open finished first).
+    tgm_cancellation_token_cancel(tok);
+
+    let mut file: *mut TgmAsyncFile = ptr::null_mut();
+    let err = tgm_async_task_join_async_file(task, &mut file);
+    assert!(
+        matches!(err, TgmError::Ok | TgmError::Cancelled),
+        "expected Ok or Cancelled, got {err:?}",
+    );
+    if err == TgmError::Ok {
+        tgm_async_file_close(file);
+    }
+    tgm_async_task_free(task);
+    tgm_cancellation_token_free(tok);
+}
+
 #[test]
 fn async_timeout_error_code() {
     // Construct a deliberately bad path so the open fails fast; the
@@ -435,13 +469,13 @@ fn tgm_error_string_covers_all_codes() {
         TgmError::Timeout,
         TgmError::Cancelled,
     ];
-    for (i, code) in codes.into_iter().enumerate() {
+    for code in codes {
         let p = tgm_error_string(code);
-        assert!(!p.is_null(), "tgm_error_string returned NULL for code #{i}");
+        assert!(!p.is_null(), "tgm_error_string returned NULL for {code:?}");
         let text = unsafe { std::ffi::CStr::from_ptr(p) }.to_str().unwrap();
         assert_ne!(
             text, "unknown error",
-            "tgm_error_string returned 'unknown error' for code #{i}"
+            "tgm_error_string returned 'unknown error' for {code:?}"
         );
     }
 }

--- a/rust/tensogram-ffi/tests/async_core_tests.rs
+++ b/rust/tensogram-ffi/tests/async_core_tests.rs
@@ -508,3 +508,280 @@ fn async_file_open_remote_without_feature_returns_remote_error() {
         "expected diagnostic to mention the async-remote feature: got {msg:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Null-argument validation regression tests for async_core.rs.
+//
+// Mirror the structure of the streaming-encoder null-arg tests:
+// pin down each `if a.is_null() || b.is_null() { return InvalidArg; }`
+// branch and each accessor's NULL behaviour, plus the trivial
+// _free / _cancel / _is_cancelled noop paths.  Without these,
+// cargo-mutants would replace the early-return with `&&`, drop the
+// `!` from null checks, or reduce the function body to `()`, and
+// every existing happy-path test would still pass.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cancellation_token_free_null_is_noop() {
+    // Mutation: `delete !` in `if !tok.is_null()` would dereference
+    // NULL.  This test would crash under the mutation but pass on
+    // the unmutated function.
+    tgm_cancellation_token_free(ptr::null_mut());
+}
+
+#[test]
+fn cancellation_token_cancel_null_is_noop() {
+    tgm_cancellation_token_cancel(ptr::null_mut());
+}
+
+#[test]
+fn cancellation_token_is_cancelled_null_returns_false() {
+    // Mutation: `replace -> bool with true` would return true here.
+    assert!(!tgm_cancellation_token_is_cancelled(ptr::null()));
+}
+
+#[test]
+fn cancellation_token_full_lifecycle() {
+    // Drives the unmutated lifecycle: create → not cancelled →
+    // cancel → cancelled → free.  Catches the
+    // `replace tgm_cancellation_token_create -> ... with Default::default()`
+    // mutation (would return NULL → subsequent calls crash) and
+    // `replace tgm_cancellation_token_cancel with ()` (would leave
+    // is_cancelled false).
+    let tok = tgm_cancellation_token_create();
+    assert!(!tok.is_null());
+    assert!(!tgm_cancellation_token_is_cancelled(tok));
+    tgm_cancellation_token_cancel(tok);
+    assert!(tgm_cancellation_token_is_cancelled(tok));
+    tgm_cancellation_token_free(tok);
+}
+
+#[test]
+fn async_task_free_null_is_noop() {
+    tgm_async_task_free(ptr::null_mut());
+}
+
+#[test]
+fn async_task_cancel_null_is_noop() {
+    tgm_async_task_cancel(ptr::null_mut());
+}
+
+#[test]
+fn async_task_is_ready_null_returns_false() {
+    // Mutation: `replace -> bool with true` would return true here.
+    assert!(!tgm_async_task_is_ready(ptr::null()));
+}
+
+#[test]
+fn async_file_close_null_is_noop() {
+    tgm_async_file_close(ptr::null_mut());
+}
+
+#[test]
+fn async_file_path_null_returns_null() {
+    // Mutation: `replace -> *const c_char with Default::default()`
+    // returns NULL, which equals our expected null result — UNVIABLE
+    // mutation in cargo-mutants terms.  But the explicit assertion
+    // here documents the contract.
+    assert!(tgm_async_file_path(ptr::null()).is_null());
+}
+
+#[test]
+fn multi_bytes_free_null_is_noop() {
+    // Pass a NULL array.  Mutation: `replace tgm_multi_bytes_free
+    // with ()` would skip the early-return guard; ignored here
+    // because we're already passing NULL.  But the `delete !` on
+    // `if !array.is_null()` (currently `if array.is_null()`)
+    // mutation would call `Vec::from_raw_parts(NULL, 0, 0)` — UB.
+    tgm_multi_bytes_free(ptr::null_mut(), 0);
+}
+
+#[test]
+fn async_file_open_rejects_null_path() {
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_file_open(ptr::null(), ptr::null_mut(), 0, &mut task);
+    assert!(matches!(err, TgmError::InvalidArg));
+    assert!(task.is_null());
+}
+
+#[test]
+fn async_file_open_rejects_null_out_task() {
+    let path = cstring("/tmp/nonexistent.tgm");
+    let err = tgm_async_file_open(path.as_ptr(), ptr::null_mut(), 0, ptr::null_mut());
+    assert!(matches!(err, TgmError::InvalidArg));
+}
+
+#[test]
+fn async_file_message_count_rejects_null_file() {
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_file_message_count(ptr::null_mut(), ptr::null_mut(), 0, &mut task);
+    assert!(matches!(err, TgmError::InvalidArg));
+    assert!(task.is_null());
+}
+
+#[test]
+fn async_file_message_count_rejects_null_out_task() {
+    let f = make_test_file();
+    let mut open_task: *mut TgmAsyncTask = ptr::null_mut();
+    let path = cstring(f.path().to_str().unwrap());
+    tgm_async_file_open(path.as_ptr(), ptr::null_mut(), 0, &mut open_task);
+    let mut file: *mut TgmAsyncFile = ptr::null_mut();
+    tgm_async_task_join_async_file(open_task, &mut file);
+    tgm_async_task_free(open_task);
+
+    let err = tgm_async_file_message_count(file, ptr::null_mut(), 0, ptr::null_mut());
+    assert!(matches!(err, TgmError::InvalidArg));
+    tgm_async_file_close(file);
+}
+
+#[test]
+fn async_file_read_message_rejects_null_file() {
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_file_read_message(ptr::null_mut(), 0, ptr::null_mut(), 0, &mut task);
+    assert!(matches!(err, TgmError::InvalidArg));
+    assert!(task.is_null());
+}
+
+#[test]
+fn async_file_decode_message_rejects_null_file() {
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_file_decode_message(
+        ptr::null_mut(),
+        0,
+        false,
+        0,
+        false,
+        false,
+        ptr::null_mut(),
+        0,
+        &mut task,
+    );
+    assert!(matches!(err, TgmError::InvalidArg));
+    assert!(task.is_null());
+}
+
+#[test]
+fn async_file_decode_metadata_rejects_null_file() {
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_file_decode_metadata(ptr::null_mut(), 0, ptr::null_mut(), 0, &mut task);
+    assert!(matches!(err, TgmError::InvalidArg));
+    assert!(task.is_null());
+}
+
+#[test]
+fn async_file_decode_object_rejects_null_file() {
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_file_decode_object(
+        ptr::null_mut(),
+        0,
+        0,
+        false,
+        0,
+        false,
+        false,
+        ptr::null_mut(),
+        0,
+        &mut task,
+    );
+    assert!(matches!(err, TgmError::InvalidArg));
+    assert!(task.is_null());
+}
+
+#[test]
+fn async_file_decode_range_rejects_null_offsets() {
+    let counts = [0u64; 1];
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_file_decode_range(
+        ptr::null_mut(),
+        0,
+        0,
+        ptr::null(),
+        counts.as_ptr(),
+        1,
+        false,
+        0,
+        ptr::null_mut(),
+        0,
+        &mut task,
+    );
+    assert!(matches!(err, TgmError::InvalidArg));
+    assert!(task.is_null());
+}
+
+#[test]
+fn async_file_decode_range_rejects_null_counts() {
+    let offsets = [0u64; 1];
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_file_decode_range(
+        ptr::null_mut(),
+        0,
+        0,
+        offsets.as_ptr(),
+        ptr::null(),
+        1,
+        false,
+        0,
+        ptr::null_mut(),
+        0,
+        &mut task,
+    );
+    assert!(matches!(err, TgmError::InvalidArg));
+    assert!(task.is_null());
+}
+
+#[cfg(feature = "async-remote")]
+#[test]
+fn async_file_open_remote_rejects_null_url() {
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_file_open_remote(
+        ptr::null(),
+        ptr::null(),
+        ptr::null(),
+        0,
+        false,
+        ptr::null_mut(),
+        0,
+        &mut task,
+    );
+    assert!(matches!(err, TgmError::InvalidArg));
+    assert!(task.is_null());
+}
+
+#[cfg(feature = "async-remote")]
+#[test]
+fn async_file_open_remote_rejects_null_out_task() {
+    let url = cstring("s3://test/file.tgm");
+    let err = tgm_async_file_open_remote(
+        url.as_ptr(),
+        ptr::null(),
+        ptr::null(),
+        0,
+        false,
+        ptr::null_mut(),
+        0,
+        ptr::null_mut(),
+    );
+    assert!(matches!(err, TgmError::InvalidArg));
+}
+
+#[cfg(feature = "async-remote")]
+#[test]
+fn async_file_open_remote_rejects_null_storage_keys() {
+    let url = cstring("s3://test/file.tgm");
+    let v_value = cstring("v");
+    let v_ptr = v_value.as_ptr();
+    let v_arr: [*const std::os::raw::c_char; 1] = [v_ptr];
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_file_open_remote(
+        url.as_ptr(),
+        ptr::null(),    // null storage_keys array...
+        v_arr.as_ptr(), // ...but non-null storage_values; nopts > 0 → reject.
+        1,
+        false,
+        ptr::null_mut(),
+        0,
+        &mut task,
+    );
+    assert!(matches!(err, TgmError::InvalidArg));
+    assert!(task.is_null());
+}

--- a/rust/tensogram-ffi/tests/async_core_tests.rs
+++ b/rust/tensogram-ffi/tests/async_core_tests.rs
@@ -785,3 +785,269 @@ fn async_file_open_remote_rejects_null_storage_keys() {
     assert!(matches!(err, TgmError::InvalidArg));
     assert!(task.is_null());
 }
+
+#[cfg(feature = "async-remote")]
+#[test]
+fn async_open_remote_file_url_round_trip() {
+    // The async-remote success path: a file:// URL routes through
+    // object_store's LocalFileSystem, so open_remote can be exercised
+    // offline and deterministically (no network, no credentials).  Covers
+    // the URL parse, the no-options branch, the spawn, and the downstream
+    // remote scan that the null-argument tests above never reach.
+    let f = make_test_file();
+    let abs = std::fs::canonicalize(f.path()).unwrap();
+    let url = cstring(&format!("file://{}", abs.display()));
+
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_file_open_remote(
+        url.as_ptr(),
+        ptr::null(),
+        ptr::null(),
+        0,
+        false,
+        ptr::null_mut(),
+        0,
+        &mut task,
+    );
+    assert!(matches!(err, TgmError::Ok));
+
+    let mut file: *mut TgmAsyncFile = ptr::null_mut();
+    let err = tgm_async_task_join_async_file(task, &mut file);
+    assert!(matches!(err, TgmError::Ok));
+    tgm_async_task_free(task);
+    assert!(!file.is_null());
+
+    // The handle is usable: a remote-backed message_count returns 1.
+    let mut count_task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_file_message_count(file, ptr::null_mut(), 0, &mut count_task);
+    assert!(matches!(err, TgmError::Ok));
+    let mut n: u64 = 0;
+    let err = tgm_async_task_join_size(count_task, &mut n);
+    assert!(matches!(err, TgmError::Ok));
+    assert_eq!(n, 1);
+    tgm_async_task_free(count_task);
+
+    tgm_async_file_close(file);
+}
+
+#[cfg(feature = "async-remote")]
+#[test]
+fn async_open_remote_marshals_storage_options() {
+    // Exercises the storage-option key/value marshalling loop (nopts > 0)
+    // on the success path.  The launch builds the option map synchronously
+    // before spawning, so it returns Ok regardless of whether the backend
+    // later accepts the options.
+    let f = make_test_file();
+    let abs = std::fs::canonicalize(f.path()).unwrap();
+    let url = cstring(&format!("file://{}", abs.display()));
+
+    let key = cstring("region");
+    let value = cstring("eu-west-1");
+    let keys: [*const std::os::raw::c_char; 1] = [key.as_ptr()];
+    let values: [*const std::os::raw::c_char; 1] = [value.as_ptr()];
+
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_file_open_remote(
+        url.as_ptr(),
+        keys.as_ptr(),
+        values.as_ptr(),
+        1,
+        false,
+        ptr::null_mut(),
+        5000,
+        &mut task,
+    );
+    assert!(matches!(err, TgmError::Ok)); // map built synchronously, task spawned
+
+    // Join either succeeds (option ignored) or surfaces a backend error;
+    // either way the marshalling path under test already ran.  Free
+    // whatever the join produced so the test leaks nothing.
+    let mut file: *mut TgmAsyncFile = ptr::null_mut();
+    let join_err = tgm_async_task_join_async_file(task, &mut file);
+    tgm_async_task_free(task);
+    if matches!(join_err, TgmError::Ok) {
+        assert!(!file.is_null());
+        tgm_async_file_close(file);
+    }
+}
+
+#[test]
+fn async_decode_object_round_trip() {
+    // Success path of decode_object (the existing tests only cover its
+    // null-argument rejection).  Resolves to a single-object message.
+    let f = make_test_file();
+    let path = cstring(f.path().to_str().unwrap());
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_file_open(path.as_ptr(), ptr::null_mut(), 0, &mut task);
+    let mut file: *mut TgmAsyncFile = ptr::null_mut();
+    let _ = tgm_async_task_join_async_file(task, &mut file);
+    tgm_async_task_free(task);
+
+    let mut obj_task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_file_decode_object(
+        file,
+        0,
+        0,
+        true,
+        0,
+        true,
+        false,
+        ptr::null_mut(),
+        0,
+        &mut obj_task,
+    );
+    assert!(matches!(err, TgmError::Ok));
+    let mut msg: *mut TgmMessage = ptr::null_mut();
+    let err = tgm_async_task_join_message(obj_task, &mut msg);
+    assert!(matches!(err, TgmError::Ok));
+    tgm_async_task_free(obj_task);
+    assert_eq!(tgm_message_num_objects(msg), 1);
+    tgm_message_free(msg);
+
+    tgm_async_file_close(file);
+}
+
+#[test]
+fn async_decode_range_round_trip() {
+    // Success path of decode_range, which resolves to a MultiBytes task —
+    // so this also covers tgm_async_task_join_multi_bytes and
+    // tgm_multi_bytes_free, none of which the null-argument tests reach.
+    // The test object is a float32[4]; decode the whole [0, 4) element
+    // range -> one buffer of 16 bytes.
+    let f = make_test_file();
+    let path = cstring(f.path().to_str().unwrap());
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_file_open(path.as_ptr(), ptr::null_mut(), 0, &mut task);
+    let mut file: *mut TgmAsyncFile = ptr::null_mut();
+    let _ = tgm_async_task_join_async_file(task, &mut file);
+    tgm_async_task_free(task);
+
+    let offsets: [u64; 1] = [0];
+    let counts: [u64; 1] = [4];
+    let mut range_task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_file_decode_range(
+        file,
+        0,
+        0,
+        offsets.as_ptr(),
+        counts.as_ptr(),
+        1,
+        true,
+        0,
+        ptr::null_mut(),
+        0,
+        &mut range_task,
+    );
+    assert!(matches!(err, TgmError::Ok));
+
+    let mut array: *mut TgmBytes = ptr::null_mut();
+    let mut count: usize = 0;
+    let err = tgm_async_task_join_multi_bytes(range_task, &mut array, &mut count);
+    assert!(matches!(err, TgmError::Ok));
+    tgm_async_task_free(range_task);
+    assert_eq!(count, 1);
+    assert!(!array.is_null());
+    let first = unsafe { &*array };
+    assert_eq!(first.len, 16); // 4 × float32
+    tgm_multi_bytes_free(array, count);
+
+    tgm_async_file_close(file);
+}
+
+#[test]
+fn async_runtime_shutdown_blocking_is_noop() {
+    // Reserved ABI: currently a no-op that reports zero unfinished tasks
+    // (process exit is abrupt by design).  Must not panic.
+    assert_eq!(tgm_runtime_shutdown_blocking(100), 0);
+}
+
+#[cfg(feature = "async-remote")]
+#[test]
+fn async_open_remote_rejects_non_utf8_url() {
+    // Adversarial: a non-UTF-8 URL must be rejected, not interpreted.
+    let url = CString::new(vec![0xFF, 0xFE, 0x80]).unwrap();
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_file_open_remote(
+        url.as_ptr(),
+        ptr::null(),
+        ptr::null(),
+        0,
+        false,
+        ptr::null_mut(),
+        0,
+        &mut task,
+    );
+    assert!(matches!(err, TgmError::InvalidArg));
+    assert!(task.is_null());
+}
+
+#[cfg(feature = "async-remote")]
+#[test]
+fn async_open_remote_rejects_null_storage_entry() {
+    // Non-null arrays, but a null key pointer inside them.
+    let url = cstring("file:///tmp/x.tgm");
+    let value = cstring("v");
+    let keys: [*const std::os::raw::c_char; 1] = [ptr::null()];
+    let values: [*const std::os::raw::c_char; 1] = [value.as_ptr()];
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_file_open_remote(
+        url.as_ptr(),
+        keys.as_ptr(),
+        values.as_ptr(),
+        1,
+        false,
+        ptr::null_mut(),
+        0,
+        &mut task,
+    );
+    assert!(matches!(err, TgmError::InvalidArg));
+    assert!(task.is_null());
+}
+
+#[cfg(feature = "async-remote")]
+#[test]
+fn async_open_remote_rejects_non_utf8_storage_key() {
+    // Adversarial: non-UTF-8 bytes in a storage-option key.
+    let url = cstring("file:///tmp/x.tgm");
+    let bad_key = CString::new(vec![0xFF, 0xFE]).unwrap();
+    let value = cstring("v");
+    let keys: [*const std::os::raw::c_char; 1] = [bad_key.as_ptr()];
+    let values: [*const std::os::raw::c_char; 1] = [value.as_ptr()];
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_file_open_remote(
+        url.as_ptr(),
+        keys.as_ptr(),
+        values.as_ptr(),
+        1,
+        false,
+        ptr::null_mut(),
+        0,
+        &mut task,
+    );
+    assert!(matches!(err, TgmError::InvalidArg));
+    assert!(task.is_null());
+}
+
+#[cfg(feature = "async-remote")]
+#[test]
+fn async_open_remote_rejects_non_utf8_storage_value() {
+    // Adversarial: non-UTF-8 bytes in a storage-option value.
+    let url = cstring("file:///tmp/x.tgm");
+    let key = cstring("k");
+    let bad_value = CString::new(vec![0xFF, 0xFE]).unwrap();
+    let keys: [*const std::os::raw::c_char; 1] = [key.as_ptr()];
+    let values: [*const std::os::raw::c_char; 1] = [bad_value.as_ptr()];
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_file_open_remote(
+        url.as_ptr(),
+        keys.as_ptr(),
+        values.as_ptr(),
+        1,
+        false,
+        ptr::null_mut(),
+        0,
+        &mut task,
+    );
+    assert!(matches!(err, TgmError::InvalidArg));
+    assert!(task.is_null());
+}

--- a/rust/tensogram-ffi/tests/async_streaming_tests.rs
+++ b/rust/tensogram-ffi/tests/async_streaming_tests.rs
@@ -1,0 +1,379 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+//! Integration tests for the async streaming encoder FFI surface (PR 3).
+
+#![cfg(feature = "async")]
+
+use std::ffi::CString;
+use std::ptr;
+
+use tensogram_ffi::async_core::*;
+use tensogram_ffi::async_streaming::*;
+use tensogram_ffi::*;
+
+fn cstring(s: &str) -> CString {
+    CString::new(s).unwrap()
+}
+
+fn temp_path() -> tempfile::TempPath {
+    tempfile::NamedTempFile::new().unwrap().into_temp_path()
+}
+
+#[test]
+fn async_streaming_encoder_local_round_trip() {
+    let path = temp_path();
+    let path_str = cstring(path.to_str().unwrap());
+    let meta = cstring(r#"{"base":[]}"#);
+    let hash = cstring("xxh3");
+
+    // Create encoder
+    let mut create_task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_streaming_encoder_create(
+        path_str.as_ptr(),
+        meta.as_ptr(),
+        hash.as_ptr(),
+        0,
+        ptr::null_mut(),
+        0,
+        &mut create_task,
+    );
+    assert!(matches!(err, TgmError::Ok));
+
+    let mut enc: *mut TgmAsyncStreamingEncoder = ptr::null_mut();
+    let err = tgm_async_task_join_async_streaming_encoder(create_task, &mut enc);
+    assert!(matches!(err, TgmError::Ok));
+    tgm_async_task_free(create_task);
+
+    // Object count is 0 before any writes.
+    assert_eq!(tgm_async_streaming_encoder_object_count(enc), 0);
+
+    // Write one object
+    let descriptor = cstring(
+        r#"{"type":"ntensor","ndim":1,"shape":[4],"strides":[1],
+            "dtype":"float32","byte_order":"little","encoding":"none",
+            "filter":"none","compression":"none","params":{}}"#,
+    );
+    let data: Vec<u8> = (0..16).collect();
+    let mut write_task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_streaming_encoder_write_object(
+        enc,
+        descriptor.as_ptr(),
+        data.as_ptr(),
+        data.len(),
+        ptr::null_mut(),
+        0,
+        &mut write_task,
+    );
+    assert!(matches!(err, TgmError::Ok));
+
+    let err = tgm_async_task_join_void(write_task);
+    assert!(matches!(err, TgmError::Ok));
+    tgm_async_task_free(write_task);
+
+    assert_eq!(tgm_async_streaming_encoder_object_count(enc), 1);
+
+    // Finish
+    let mut finish_task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_streaming_encoder_finish(
+        enc,
+        false,
+        ptr::null_mut(),
+        0,
+        &mut finish_task,
+    );
+    assert!(matches!(err, TgmError::Ok));
+
+    let err = tgm_async_task_join_void(finish_task);
+    assert!(matches!(err, TgmError::Ok));
+    tgm_async_task_free(finish_task);
+
+    tgm_async_streaming_encoder_free(enc);
+
+    // Verify file decodes correctly via the sync Rust API.
+    let bytes = std::fs::read(path.as_os_str()).unwrap();
+    let (_, objects) = tensogram::decode(
+        &bytes,
+        &tensogram::DecodeOptions::default(),
+    )
+    .unwrap();
+    assert_eq!(objects.len(), 1);
+    assert_eq!(objects[0].1, data);
+}
+
+#[test]
+fn async_streaming_encoder_finish_with_backfill() {
+    use std::io::Read;
+
+    let path = temp_path();
+    let path_str = cstring(path.to_str().unwrap());
+    let meta = cstring(r#"{"base":[]}"#);
+    let hash = cstring("xxh3");
+
+    let mut create_task: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_streaming_encoder_create(
+        path_str.as_ptr(),
+        meta.as_ptr(),
+        hash.as_ptr(),
+        0,
+        ptr::null_mut(),
+        0,
+        &mut create_task,
+    );
+    let mut enc: *mut TgmAsyncStreamingEncoder = ptr::null_mut();
+    let _ = tgm_async_task_join_async_streaming_encoder(create_task, &mut enc);
+    tgm_async_task_free(create_task);
+
+    let descriptor = cstring(
+        r#"{"type":"ntensor","ndim":1,"shape":[4],"strides":[1],
+            "dtype":"float32","byte_order":"little","encoding":"none",
+            "filter":"none","compression":"none","params":{}}"#,
+    );
+    let data: Vec<u8> = (0..16).collect();
+    let mut wt: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_streaming_encoder_write_object(
+        enc,
+        descriptor.as_ptr(),
+        data.as_ptr(),
+        data.len(),
+        ptr::null_mut(),
+        0,
+        &mut wt,
+    );
+    let _ = tgm_async_task_join_void(wt);
+    tgm_async_task_free(wt);
+
+    // Finish with backfill.
+    let mut ft: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_streaming_encoder_finish(enc, true, ptr::null_mut(), 0, &mut ft);
+    let err = tgm_async_task_join_void(ft);
+    assert!(matches!(err, TgmError::Ok));
+    tgm_async_task_free(ft);
+    tgm_async_streaming_encoder_free(enc);
+
+    // Verify total_length is patched in both preamble and postamble.
+    let mut bytes = Vec::new();
+    std::fs::File::open(path.as_os_str())
+        .unwrap()
+        .read_to_end(&mut bytes)
+        .unwrap();
+    let mut pre = [0u8; 8];
+    pre.copy_from_slice(&bytes[16..24]);
+    let preamble_total = u64::from_be_bytes(pre);
+    assert_eq!(preamble_total, bytes.len() as u64);
+    let end = bytes.len();
+    let mut post = [0u8; 8];
+    post.copy_from_slice(&bytes[end - 16..end - 8]);
+    let postamble_total = u64::from_be_bytes(post);
+    assert_eq!(postamble_total, bytes.len() as u64);
+}
+
+#[test]
+fn async_streaming_encoder_double_finish_errors() {
+    let path = temp_path();
+    let path_str = cstring(path.to_str().unwrap());
+    let meta = cstring(r#"{"base":[]}"#);
+    let hash = cstring("xxh3");
+
+    let mut create_task: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_streaming_encoder_create(
+        path_str.as_ptr(),
+        meta.as_ptr(),
+        hash.as_ptr(),
+        0,
+        ptr::null_mut(),
+        0,
+        &mut create_task,
+    );
+    let mut enc: *mut TgmAsyncStreamingEncoder = ptr::null_mut();
+    let _ = tgm_async_task_join_async_streaming_encoder(create_task, &mut enc);
+    tgm_async_task_free(create_task);
+
+    let mut ft: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_streaming_encoder_finish(enc, false, ptr::null_mut(), 0, &mut ft);
+    let _ = tgm_async_task_join_void(ft);
+    tgm_async_task_free(ft);
+
+    // Second finish must error.
+    let mut ft2: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_streaming_encoder_finish(enc, false, ptr::null_mut(), 0, &mut ft2);
+    assert!(matches!(err, TgmError::Ok)); // launch ok; result errors on join
+    let err = tgm_async_task_join_void(ft2);
+    assert!(!matches!(err, TgmError::Ok));
+    tgm_async_task_free(ft2);
+
+    tgm_async_streaming_encoder_free(enc);
+}
+
+#[test]
+fn async_streaming_encoder_write_after_finish_errors() {
+    let path = temp_path();
+    let path_str = cstring(path.to_str().unwrap());
+    let meta = cstring(r#"{"base":[]}"#);
+    let hash = cstring("xxh3");
+
+    let mut create_task: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_streaming_encoder_create(
+        path_str.as_ptr(),
+        meta.as_ptr(),
+        hash.as_ptr(),
+        0,
+        ptr::null_mut(),
+        0,
+        &mut create_task,
+    );
+    let mut enc: *mut TgmAsyncStreamingEncoder = ptr::null_mut();
+    let _ = tgm_async_task_join_async_streaming_encoder(create_task, &mut enc);
+    tgm_async_task_free(create_task);
+
+    let mut ft: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_streaming_encoder_finish(enc, false, ptr::null_mut(), 0, &mut ft);
+    let _ = tgm_async_task_join_void(ft);
+    tgm_async_task_free(ft);
+
+    // Write after finish must error on join.
+    let descriptor = cstring(
+        r#"{"type":"ntensor","ndim":1,"shape":[4],"strides":[1],
+            "dtype":"float32","byte_order":"little","encoding":"none",
+            "filter":"none","compression":"none","params":{}}"#,
+    );
+    let data = vec![0u8; 16];
+    let mut wt: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_streaming_encoder_write_object(
+        enc,
+        descriptor.as_ptr(),
+        data.as_ptr(),
+        data.len(),
+        ptr::null_mut(),
+        0,
+        &mut wt,
+    );
+    let err = tgm_async_task_join_void(wt);
+    assert!(!matches!(err, TgmError::Ok));
+    tgm_async_task_free(wt);
+
+    tgm_async_streaming_encoder_free(enc);
+}
+
+#[test]
+fn async_streaming_encoder_with_preceder() {
+    let path = temp_path();
+    let path_str = cstring(path.to_str().unwrap());
+    let meta = cstring(r#"{"base":[]}"#);
+    let hash = cstring("xxh3");
+
+    let mut create_task: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_streaming_encoder_create(
+        path_str.as_ptr(),
+        meta.as_ptr(),
+        hash.as_ptr(),
+        0,
+        ptr::null_mut(),
+        0,
+        &mut create_task,
+    );
+    let mut enc: *mut TgmAsyncStreamingEncoder = ptr::null_mut();
+    let _ = tgm_async_task_join_async_streaming_encoder(create_task, &mut enc);
+    tgm_async_task_free(create_task);
+
+    // Write preceder + object
+    let preceder = cstring(r#"{"step":7}"#);
+    let mut pt: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_streaming_encoder_write_preceder(
+        enc,
+        preceder.as_ptr(),
+        ptr::null_mut(),
+        0,
+        &mut pt,
+    );
+    assert!(matches!(err, TgmError::Ok));
+    let err = tgm_async_task_join_void(pt);
+    assert!(matches!(err, TgmError::Ok));
+    tgm_async_task_free(pt);
+
+    let descriptor = cstring(
+        r#"{"type":"ntensor","ndim":1,"shape":[4],"strides":[1],
+            "dtype":"float32","byte_order":"little","encoding":"none",
+            "filter":"none","compression":"none","params":{}}"#,
+    );
+    let data = vec![0u8; 16];
+    let mut wt: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_streaming_encoder_write_object(
+        enc,
+        descriptor.as_ptr(),
+        data.as_ptr(),
+        data.len(),
+        ptr::null_mut(),
+        0,
+        &mut wt,
+    );
+    let _ = tgm_async_task_join_void(wt);
+    tgm_async_task_free(wt);
+
+    let mut ft: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_streaming_encoder_finish(enc, false, ptr::null_mut(), 0, &mut ft);
+    let _ = tgm_async_task_join_void(ft);
+    tgm_async_task_free(ft);
+    tgm_async_streaming_encoder_free(enc);
+
+    // Decode and check the preceder payload.
+    let bytes = std::fs::read(path.as_os_str()).unwrap();
+    let (m, _) = tensogram::decode(&bytes, &tensogram::DecodeOptions::default()).unwrap();
+    assert!(m.base[0].contains_key("step"));
+}
+
+#[test]
+fn async_streaming_encoder_pre_encoded_round_trip() {
+    let path = temp_path();
+    let path_str = cstring(path.to_str().unwrap());
+    let meta = cstring(r#"{"base":[]}"#);
+    let hash = cstring("xxh3");
+
+    let mut create_task: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_streaming_encoder_create(
+        path_str.as_ptr(),
+        meta.as_ptr(),
+        hash.as_ptr(),
+        0,
+        ptr::null_mut(),
+        0,
+        &mut create_task,
+    );
+    let mut enc: *mut TgmAsyncStreamingEncoder = ptr::null_mut();
+    let _ = tgm_async_task_join_async_streaming_encoder(create_task, &mut enc);
+    tgm_async_task_free(create_task);
+
+    let descriptor = cstring(
+        r#"{"type":"ntensor","ndim":1,"shape":[8],"strides":[1],
+            "dtype":"float32","byte_order":"little","encoding":"none",
+            "filter":"none","compression":"none","params":{}}"#,
+    );
+    let data: Vec<u8> = (0..32).collect();
+    let mut wt: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_streaming_encoder_write_pre_encoded(
+        enc,
+        descriptor.as_ptr(),
+        data.as_ptr(),
+        data.len(),
+        ptr::null_mut(),
+        0,
+        &mut wt,
+    );
+    assert!(matches!(err, TgmError::Ok));
+    let err = tgm_async_task_join_void(wt);
+    assert!(matches!(err, TgmError::Ok));
+    tgm_async_task_free(wt);
+
+    let mut ft: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_streaming_encoder_finish(enc, false, ptr::null_mut(), 0, &mut ft);
+    let _ = tgm_async_task_join_void(ft);
+    tgm_async_task_free(ft);
+    tgm_async_streaming_encoder_free(enc);
+
+    let bytes = std::fs::read(path.as_os_str()).unwrap();
+    let (_, objects) = tensogram::decode(&bytes, &tensogram::DecodeOptions::default()).unwrap();
+    assert_eq!(objects.len(), 1);
+    assert_eq!(objects[0].1, data);
+}

--- a/rust/tensogram-ffi/tests/async_streaming_tests.rs
+++ b/rust/tensogram-ffi/tests/async_streaming_tests.rs
@@ -367,3 +367,339 @@ fn async_streaming_encoder_pre_encoded_round_trip() {
     assert_eq!(objects.len(), 1);
     assert_eq!(objects[0].1, data);
 }
+
+// ---------------------------------------------------------------------------
+// Null-argument validation regression tests.
+//
+// The async streaming encoder entry points all start with a null-pointer
+// guard — typically `if a.is_null() || b.is_null() || ... { return InvalidArg; }`.
+// Without explicit coverage, cargo-mutants would replace those `||` with
+// `&&` (so the early-return only fires when ALL pointers are null) or
+// replace the entire function with `Default::default()` (i.e. `Ok`) and
+// the tests above would still pass.  These tests pin down each null-arg
+// branch.
+// ---------------------------------------------------------------------------
+
+/// Helper: dummy descriptor JSON for write tests.
+fn dummy_descriptor() -> CString {
+    cstring(
+        r#"{"type":"ntensor","ndim":1,"shape":[1],"strides":[1],"dtype":"uint8","byte_order":"little","encoding":"none","filter":"none","compression":"none","params":{}}"#,
+    )
+}
+
+/// Build a real encoder handle so we can also test "valid encoder, but
+/// other args null" branches.
+fn make_test_encoder() -> (tempfile::TempPath, *mut TgmAsyncStreamingEncoder) {
+    let path = temp_path();
+    let path_str = cstring(path.to_str().unwrap());
+    let meta = cstring(r#"{"base":[]}"#);
+    let mut create_task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_streaming_encoder_create(
+        path_str.as_ptr(),
+        meta.as_ptr(),
+        ptr::null(),
+        0,
+        ptr::null_mut(),
+        0,
+        &mut create_task,
+    );
+    assert!(matches!(err, TgmError::Ok));
+    let mut enc: *mut TgmAsyncStreamingEncoder = ptr::null_mut();
+    assert!(matches!(
+        tgm_async_task_join_async_streaming_encoder(create_task, &mut enc),
+        TgmError::Ok
+    ));
+    tgm_async_task_free(create_task);
+    (path, enc)
+}
+
+#[test]
+fn create_rejects_null_path() {
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let meta = cstring(r#"{"base":[]}"#);
+    let err = tgm_async_streaming_encoder_create(
+        ptr::null(),
+        meta.as_ptr(),
+        ptr::null(),
+        0,
+        ptr::null_mut(),
+        0,
+        &mut task,
+    );
+    assert!(matches!(err, TgmError::InvalidArg));
+    assert!(task.is_null());
+}
+
+#[test]
+fn create_rejects_null_metadata() {
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let path = cstring("/tmp/never-created.tgm");
+    let err = tgm_async_streaming_encoder_create(
+        path.as_ptr(),
+        ptr::null(),
+        ptr::null(),
+        0,
+        ptr::null_mut(),
+        0,
+        &mut task,
+    );
+    assert!(matches!(err, TgmError::InvalidArg));
+    assert!(task.is_null());
+}
+
+#[test]
+fn create_rejects_null_out_task() {
+    let path = cstring("/tmp/never-created.tgm");
+    let meta = cstring(r#"{"base":[]}"#);
+    let err = tgm_async_streaming_encoder_create(
+        path.as_ptr(),
+        meta.as_ptr(),
+        ptr::null(),
+        0,
+        ptr::null_mut(),
+        0,
+        ptr::null_mut(),
+    );
+    assert!(matches!(err, TgmError::InvalidArg));
+}
+
+#[test]
+fn write_object_rejects_null_encoder() {
+    let desc = dummy_descriptor();
+    let data = [0u8; 1];
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_streaming_encoder_write_object(
+        ptr::null_mut(),
+        desc.as_ptr(),
+        data.as_ptr(),
+        data.len(),
+        ptr::null_mut(),
+        0,
+        &mut task,
+    );
+    assert!(matches!(err, TgmError::InvalidArg));
+    assert!(task.is_null());
+}
+
+#[test]
+fn write_object_rejects_null_descriptor() {
+    let (_p, enc) = make_test_encoder();
+    let data = [0u8; 1];
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_streaming_encoder_write_object(
+        enc,
+        ptr::null(),
+        data.as_ptr(),
+        data.len(),
+        ptr::null_mut(),
+        0,
+        &mut task,
+    );
+    assert!(matches!(err, TgmError::InvalidArg));
+    assert!(task.is_null());
+    tgm_async_streaming_encoder_free(enc);
+}
+
+#[test]
+fn write_object_rejects_null_data() {
+    let (_p, enc) = make_test_encoder();
+    let desc = dummy_descriptor();
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_streaming_encoder_write_object(
+        enc,
+        desc.as_ptr(),
+        ptr::null(),
+        0,
+        ptr::null_mut(),
+        0,
+        &mut task,
+    );
+    assert!(matches!(err, TgmError::InvalidArg));
+    assert!(task.is_null());
+    tgm_async_streaming_encoder_free(enc);
+}
+
+#[test]
+fn write_object_rejects_null_out_task() {
+    let (_p, enc) = make_test_encoder();
+    let desc = dummy_descriptor();
+    let data = [0u8; 1];
+    let err = tgm_async_streaming_encoder_write_object(
+        enc,
+        desc.as_ptr(),
+        data.as_ptr(),
+        data.len(),
+        ptr::null_mut(),
+        0,
+        ptr::null_mut(),
+    );
+    assert!(matches!(err, TgmError::InvalidArg));
+    tgm_async_streaming_encoder_free(enc);
+}
+
+#[test]
+fn write_pre_encoded_rejects_null_encoder() {
+    let desc = dummy_descriptor();
+    let data = [0u8; 1];
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_streaming_encoder_write_pre_encoded(
+        ptr::null_mut(),
+        desc.as_ptr(),
+        data.as_ptr(),
+        data.len(),
+        ptr::null_mut(),
+        0,
+        &mut task,
+    );
+    assert!(matches!(err, TgmError::InvalidArg));
+    assert!(task.is_null());
+}
+
+#[test]
+fn write_pre_encoded_rejects_null_data() {
+    let (_p, enc) = make_test_encoder();
+    let desc = dummy_descriptor();
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_streaming_encoder_write_pre_encoded(
+        enc,
+        desc.as_ptr(),
+        ptr::null(),
+        0,
+        ptr::null_mut(),
+        0,
+        &mut task,
+    );
+    assert!(matches!(err, TgmError::InvalidArg));
+    assert!(task.is_null());
+    tgm_async_streaming_encoder_free(enc);
+}
+
+#[test]
+fn write_preceder_rejects_null_encoder() {
+    let meta = cstring(r#"{"k":"v"}"#);
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_streaming_encoder_write_preceder(
+        ptr::null_mut(),
+        meta.as_ptr(),
+        ptr::null_mut(),
+        0,
+        &mut task,
+    );
+    assert!(matches!(err, TgmError::InvalidArg));
+    assert!(task.is_null());
+}
+
+#[test]
+fn write_preceder_rejects_null_metadata() {
+    let (_p, enc) = make_test_encoder();
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let err =
+        tgm_async_streaming_encoder_write_preceder(enc, ptr::null(), ptr::null_mut(), 0, &mut task);
+    assert!(matches!(err, TgmError::InvalidArg));
+    assert!(task.is_null());
+    tgm_async_streaming_encoder_free(enc);
+}
+
+#[test]
+fn write_preceder_rejects_null_out_task() {
+    let (_p, enc) = make_test_encoder();
+    let meta = cstring(r#"{"k":"v"}"#);
+    let err = tgm_async_streaming_encoder_write_preceder(
+        enc,
+        meta.as_ptr(),
+        ptr::null_mut(),
+        0,
+        ptr::null_mut(),
+    );
+    assert!(matches!(err, TgmError::InvalidArg));
+    tgm_async_streaming_encoder_free(enc);
+}
+
+#[test]
+fn finish_rejects_null_encoder() {
+    let mut task: *mut TgmAsyncTask = ptr::null_mut();
+    let err =
+        tgm_async_streaming_encoder_finish(ptr::null_mut(), false, ptr::null_mut(), 0, &mut task);
+    assert!(matches!(err, TgmError::InvalidArg));
+    assert!(task.is_null());
+}
+
+#[test]
+fn finish_rejects_null_out_task() {
+    let (_p, enc) = make_test_encoder();
+    let err = tgm_async_streaming_encoder_finish(enc, false, ptr::null_mut(), 0, ptr::null_mut());
+    assert!(matches!(err, TgmError::InvalidArg));
+    tgm_async_streaming_encoder_free(enc);
+}
+
+/// Mutation-killer for the `threads` field in `EncodeOptions`
+/// construction.  cargo-mutants mutates the struct expression to drop
+/// the field; under that mutation the encoder still works because the
+/// default is also reasonable, but with a non-trivial payload running
+/// through the multi-threaded encode path we surface any difference.
+///
+/// The on-disk decode round-trip closes the related "function returns
+/// Default::default()" mutation surface for `write_object` /
+/// `write_pre_encoded` / `write_preceder` (the mutated function would
+/// return Ok without writing, and the file would fail to decode).
+#[test]
+fn create_with_explicit_threads_round_trips() {
+    let path = temp_path();
+    let path_str = cstring(path.to_str().unwrap());
+    let meta = cstring(r#"{"base":[]}"#);
+
+    let mut create_task: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_streaming_encoder_create(
+        path_str.as_ptr(),
+        meta.as_ptr(),
+        ptr::null(),
+        4, // explicit threads > 0
+        ptr::null_mut(),
+        0,
+        &mut create_task,
+    );
+    assert!(matches!(err, TgmError::Ok));
+    assert!(!create_task.is_null());
+
+    let mut enc: *mut TgmAsyncStreamingEncoder = ptr::null_mut();
+    assert!(matches!(
+        tgm_async_task_join_async_streaming_encoder(create_task, &mut enc),
+        TgmError::Ok
+    ));
+    tgm_async_task_free(create_task);
+
+    // Drive a real write through the threaded path so the runtime
+    // actually invokes the encoder's parallel stages.  Shape matches
+    // data length so the encoder accepts the buffer without
+    // complaining about size mismatch.
+    let desc = cstring(
+        r#"{"type":"ntensor","ndim":1,"shape":[1024],"strides":[1],"dtype":"uint8","byte_order":"little","encoding":"none","filter":"none","compression":"none","params":{}}"#,
+    );
+    let data = vec![0u8; 1024];
+    let mut wt: *mut TgmAsyncTask = ptr::null_mut();
+    let err = tgm_async_streaming_encoder_write_object(
+        enc,
+        desc.as_ptr(),
+        data.as_ptr(),
+        data.len(),
+        ptr::null_mut(),
+        0,
+        &mut wt,
+    );
+    assert!(matches!(err, TgmError::Ok));
+    assert!(matches!(tgm_async_task_join_void(wt), TgmError::Ok));
+    tgm_async_task_free(wt);
+
+    let mut ft: *mut TgmAsyncTask = ptr::null_mut();
+    let _ = tgm_async_streaming_encoder_finish(enc, true, ptr::null_mut(), 0, &mut ft);
+    assert!(matches!(tgm_async_task_join_void(ft), TgmError::Ok));
+    tgm_async_task_free(ft);
+    tgm_async_streaming_encoder_free(enc);
+
+    // Verify the on-disk file decodes.  Guards against
+    // "replace write_object -> TgmError with Default::default()".
+    let bytes = std::fs::read(path.as_os_str()).unwrap();
+    let (_, objects) = tensogram::decode(&bytes, &tensogram::DecodeOptions::default()).unwrap();
+    assert_eq!(objects.len(), 1);
+    assert_eq!(objects[0].1.len(), 1024);
+}

--- a/rust/tensogram-ffi/tests/async_streaming_tests.rs
+++ b/rust/tensogram-ffi/tests/async_streaming_tests.rs
@@ -77,13 +77,7 @@ fn async_streaming_encoder_local_round_trip() {
 
     // Finish
     let mut finish_task: *mut TgmAsyncTask = ptr::null_mut();
-    let err = tgm_async_streaming_encoder_finish(
-        enc,
-        false,
-        ptr::null_mut(),
-        0,
-        &mut finish_task,
-    );
+    let err = tgm_async_streaming_encoder_finish(enc, false, ptr::null_mut(), 0, &mut finish_task);
     assert!(matches!(err, TgmError::Ok));
 
     let err = tgm_async_task_join_void(finish_task);
@@ -94,11 +88,7 @@ fn async_streaming_encoder_local_round_trip() {
 
     // Verify file decodes correctly via the sync Rust API.
     let bytes = std::fs::read(path.as_os_str()).unwrap();
-    let (_, objects) = tensogram::decode(
-        &bytes,
-        &tensogram::DecodeOptions::default(),
-    )
-    .unwrap();
+    let (_, objects) = tensogram::decode(&bytes, &tensogram::DecodeOptions::default()).unwrap();
     assert_eq!(objects.len(), 1);
     assert_eq!(objects[0].1, data);
 }
@@ -239,7 +229,7 @@ fn async_streaming_encoder_write_after_finish_errors() {
             "dtype":"float32","byte_order":"little","encoding":"none",
             "filter":"none","compression":"none","params":{}}"#,
     );
-    let data = vec![0u8; 16];
+    let data = [0u8; 16];
     let mut wt: *mut TgmAsyncTask = ptr::null_mut();
     let _ = tgm_async_streaming_encoder_write_object(
         enc,
@@ -298,7 +288,7 @@ fn async_streaming_encoder_with_preceder() {
             "dtype":"float32","byte_order":"little","encoding":"none",
             "filter":"none","compression":"none","params":{}}"#,
     );
-    let data = vec![0u8; 16];
+    let data = [0u8; 16];
     let mut wt: *mut TgmAsyncTask = ptr::null_mut();
     let _ = tgm_async_streaming_encoder_write_object(
         enc,

--- a/rust/tensogram/Cargo.toml
+++ b/rust/tensogram/Cargo.toml
@@ -49,7 +49,7 @@ tracing.workspace = true
 memmap2 = { version = "0.9", optional = true }
 tokio = { version = "1", features = ["fs", "rt"], optional = true }
 # Remote object store access (S3, GCS, Azure, HTTP)
-object_store = { version = "0.13", default-features = false, features = ["aws", "gcp", "azure", "http"], optional = true }
+object_store = { version = "0.13", default-features = false, features = ["aws", "gcp", "azure", "http", "fs"], optional = true }
 url = { version = "2", optional = true }
 bytes = { version = "1", optional = true }
 rayon = { workspace = true, optional = true }

--- a/rust/tensogram/Cargo.toml
+++ b/rust/tensogram/Cargo.toml
@@ -19,8 +19,9 @@ all-features = true
 [features]
 default = ["szip", "zstd", "lz4", "blosc2", "zfp", "sz3", "threads"]
 mmap = ["dep:memmap2"]
-async = ["dep:tokio"]
-remote = ["dep:object_store", "dep:url", "dep:bytes", "dep:tokio", "tokio/rt-multi-thread"]
+async = ["dep:tokio", "tokio/io-util"]
+async-write = ["async"]
+remote = ["dep:object_store", "dep:url", "dep:bytes", "dep:tokio", "tokio/rt-multi-thread", "tokio/io-util"]
 # Compression feature gates — forwarded to tensogram-encodings
 szip = ["tensogram-encodings/szip"]
 szip-pure = ["tensogram-encodings/szip-pure"]

--- a/rust/tensogram/src/doctor/mod.rs
+++ b/rust/tensogram/src/doctor/mod.rs
@@ -942,15 +942,11 @@ mod tests {
 
     #[test]
     fn feature_row_off_serialises_flat() {
-        // We need a guaranteed-Off feature.  `szip-pure` is mutually exclusive
-        // with `szip` in the typical default build; either one of them is Off.
-        let report = run_diagnostics();
-        let off_row = report
-            .features
-            .iter()
-            .find(|f| matches!(f.state, FeatureState::Off))
-            .expect("at least one feature should be Off in default build");
-        let json = serde_json::to_value(off_row).expect("feature row serialises");
+        // The serialised *shape* of an Off feature row is what's under test,
+        // so construct one directly rather than depending on the build having
+        // an Off feature — under `--all-features` every feature is On.
+        let off_row = FeatureStatus::off("szip-pure", FeatureKind::Compression);
+        let json = serde_json::to_value(&off_row).expect("feature row serialises");
         let obj = json.as_object().expect("feature row is a JSON object");
         assert_eq!(
             obj["state"],

--- a/rust/tensogram/src/lib.rs
+++ b/rust/tensogram/src/lib.rs
@@ -29,6 +29,8 @@ pub mod remote_scan_parse;
 pub(crate) mod restore;
 pub mod scan_opts;
 pub mod streaming;
+#[cfg(feature = "async")]
+pub mod streaming_async;
 pub(crate) mod substitute_and_mask;
 pub mod types;
 pub mod validate;
@@ -58,6 +60,8 @@ pub use remote_scan_parse::{
 };
 pub use scan_opts::RemoteScanOptions;
 pub use streaming::StreamingEncoder;
+#[cfg(feature = "async")]
+pub use streaming_async::AsyncStreamingEncoder;
 pub use tensogram_encodings::bitmask::MaskMethod;
 pub use tensogram_encodings::pipeline::CompressionBackend;
 pub use types::{

--- a/rust/tensogram/src/remote.rs
+++ b/rust/tensogram/src/remote.rs
@@ -4527,4 +4527,125 @@ mod bidir_http_tests {
             "corrupt footer must not abort layout commit: all 3 messages still discovered",
         );
     }
+
+    /// Exercise the synchronous remote read API over HTTP on a
+    /// non-indexed single-object message: message / metadata / descriptor
+    /// reads plus the object- and range-decode paths.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn remote_sync_read_api_roundtrip() {
+        let buf = make_message(vec![4], 0x42);
+        let server = MockObjectStore::start(buf).await.expect("start");
+        let backend = RemoteBackend::open_with_scan_opts(
+            &server.url(),
+            &empty_storage(),
+            RemoteScanOptions::default(),
+        )
+        .expect("open");
+
+        assert_eq!(backend.message_count().expect("count"), 1);
+        assert_eq!(backend.message_layouts().expect("layouts").len(), 1);
+
+        assert!(!backend.read_message(0).expect("read_message").is_empty());
+        let _meta = backend.read_metadata(0).expect("read_metadata");
+
+        let (_m, descs) = backend.read_descriptors(0).expect("read_descriptors");
+        assert_eq!(descs.len(), 1);
+        assert_eq!(descs[0].dtype, Dtype::Float32);
+
+        let opts = crate::DecodeOptions::default();
+        let (_m, desc, decoded) = backend.read_object(0, 0, &opts).expect("read_object");
+        assert_eq!(desc.shape, vec![4]);
+        assert_eq!(decoded.len(), 4 * 4); // 4 × float32
+
+        let (_d, parts) = backend
+            .read_range(0, 0, &[(0, 4)], &opts)
+            .expect("read_range");
+        assert_eq!(parts.len(), 1);
+        assert_eq!(parts[0].len(), 4 * 4);
+
+        // The encoded message carries an index frame, so the indexed
+        // batch fast-paths return one result per requested message.
+        let obj_batch = backend
+            .read_object_batch(&[0], 0, &opts)
+            .expect("read_object_batch");
+        assert_eq!(obj_batch.len(), 1);
+        assert_eq!(obj_batch[0].2.len(), 4 * 4);
+        let range_batch = backend
+            .read_range_batch(&[0], 0, &[(0, 4)], &opts)
+            .expect("read_range_batch");
+        assert_eq!(range_batch.len(), 1);
+        assert_eq!(range_batch[0].1[0].len(), 4 * 4);
+    }
+
+    /// Async mirror of the remote read API over HTTP on a non-indexed
+    /// single-object message.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn remote_async_read_api_roundtrip() {
+        let buf = make_message(vec![4], 0x07);
+        let server = MockObjectStore::start(buf).await.expect("start");
+        let backend = RemoteBackend::open_with_scan_opts(
+            &server.url(),
+            &empty_storage(),
+            RemoteScanOptions::default(),
+        )
+        .expect("open");
+
+        assert_eq!(backend.message_count_async().await.expect("count"), 1);
+        assert_eq!(
+            backend
+                .message_layouts_async()
+                .await
+                .expect("layouts")
+                .len(),
+            1
+        );
+        let _meta = backend
+            .read_metadata_async(0)
+            .await
+            .expect("read_metadata_async");
+        let (_m, descs) = backend
+            .read_descriptors_async(0)
+            .await
+            .expect("read_descriptors_async");
+        assert_eq!(descs.len(), 1);
+
+        let opts = crate::DecodeOptions::default();
+        let (_m, _d, decoded) = backend
+            .read_object_async(0, 0, &opts)
+            .await
+            .expect("read_object_async");
+        assert_eq!(decoded.len(), 4 * 4);
+
+        let (_d, parts) = backend
+            .read_range_async(0, 0, &[(0, 4)], &opts)
+            .await
+            .expect("read_range_async");
+        assert_eq!(parts[0].len(), 4 * 4);
+
+        let obj_batch = backend
+            .read_object_batch_async(&[0], 0, &opts)
+            .await
+            .expect("read_object_batch_async");
+        assert_eq!(obj_batch.len(), 1);
+        assert_eq!(obj_batch[0].2.len(), 4 * 4);
+        let range_batch = backend
+            .read_range_batch_async(&[0], 0, &[(0, 4)], &opts)
+            .await
+            .expect("read_range_batch_async");
+        assert_eq!(range_batch.len(), 1);
+        assert_eq!(range_batch[0].1[0].len(), 4 * 4);
+    }
+
+    /// A remote file smaller than the minimum message size is rejected
+    /// up-front by the file-size guard, before any scan runs.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn remote_open_too_small_file_errors() {
+        let server = MockObjectStore::start(vec![0u8; 8]).await.expect("start");
+        let result = RemoteBackend::open_with_scan_opts(
+            &server.url(),
+            &empty_storage(),
+            RemoteScanOptions::default(),
+        );
+        assert!(result.is_err(), "tiny remote file must be rejected");
+    }
 }

--- a/rust/tensogram/src/streaming.rs
+++ b/rust/tensogram/src/streaming.rs
@@ -712,6 +712,27 @@ fn write_preamble_and_header<W: Write>(
     hashing: bool,
     emit_footer_hash_frame: bool,
 ) -> Result<()> {
+    let (preamble_bytes, frame_bytes) =
+        build_preamble_and_header_bytes(global_meta, hashing, emit_footer_hash_frame)?;
+    writer.write_all(&preamble_bytes)?;
+    *bytes_written += preamble_bytes.len() as u64;
+    writer.write_all(&frame_bytes)?;
+    *bytes_written += frame_bytes.len() as u64;
+    write_padding(writer, bytes_written)?;
+    Ok(())
+}
+
+/// Build the streaming-mode preamble + `HeaderMetadata` frame bytes.
+///
+/// Returns `(preamble_bytes, header_frame_bytes)`.  Shared by the sync
+/// [`StreamingEncoder`] and the async
+/// [`crate::streaming_async::AsyncStreamingEncoder`] so both produce
+/// byte-identical output.
+pub(crate) fn build_preamble_and_header_bytes(
+    global_meta: &GlobalMetadata,
+    hashing: bool,
+    emit_footer_hash_frame: bool,
+) -> Result<(Vec<u8>, Vec<u8>)> {
     let meta_cbor = metadata::global_metadata_to_cbor(global_meta)?;
 
     // Streaming preamble: total_length=0 signals unknown length at write time.
@@ -738,21 +759,20 @@ fn write_preamble_and_header<W: Write>(
         total_length: 0,
     };
     let preamble_bytes = preamble_to_bytes(&preamble);
-    writer.write_all(&preamble_bytes)?;
-    *bytes_written += PREAMBLE_SIZE as u64;
-
     let frame_bytes = build_frame(FrameType::HeaderMetadata, 1, 0, &meta_cbor, hashing);
-    writer.write_all(&frame_bytes)?;
-    *bytes_written += frame_bytes.len() as u64;
-
-    write_padding(writer, bytes_written)?;
-    Ok(())
+    Ok((preamble_bytes, frame_bytes))
 }
 
 fn preamble_to_bytes(preamble: &Preamble) -> Vec<u8> {
     let mut out = Vec::with_capacity(PREAMBLE_SIZE);
     preamble.write_to(&mut out);
     out
+}
+
+/// Number of zero-padding bytes needed to align `bytes_written` to an
+/// 8-byte boundary.
+pub(crate) const fn padding_for(bytes_written: u64) -> usize {
+    (8 - (bytes_written as usize % 8)) % 8
 }
 
 /// Build a non-data-object frame on the wire (v3).
@@ -765,7 +785,7 @@ fn preamble_to_bytes(preamble: &Preamble) -> Vec<u8> {
 /// digest).  When false, the flag bit is clear and the slot is
 /// written as zero by convention; readers must dispatch on the
 /// per-frame flag rather than inspecting the slot value.
-fn build_frame(
+pub(crate) fn build_frame(
     frame_type: FrameType,
     version: u16,
     flags: u16,

--- a/rust/tensogram/src/streaming.rs
+++ b/rust/tensogram/src/streaming.rs
@@ -770,7 +770,11 @@ fn preamble_to_bytes(preamble: &Preamble) -> Vec<u8> {
 }
 
 /// Number of zero-padding bytes needed to align `bytes_written` to an
-/// 8-byte boundary.
+/// 8-byte boundary.  Used by the async sibling's padding helper; the
+/// sync side here uses [`write_padding`] directly with a static
+/// `ZERO_PAD` slice.  Gated on the async feature so default-feature
+/// clippy doesn't flag it as dead code.
+#[cfg(feature = "async")]
 pub(crate) const fn padding_for(bytes_written: u64) -> usize {
     (8 - (bytes_written as usize % 8)) % 8
 }

--- a/rust/tensogram/src/streaming_async.rs
+++ b/rust/tensogram/src/streaming_async.rs
@@ -188,11 +188,7 @@ impl<W: AsyncWrite + Unpin> AsyncStreamingEncoder<W> {
     /// Buffering one frame in memory is acceptable for the v1 producer
     /// scenario where individual frames are bounded; true chunked
     /// AsyncWrite streaming is a follow-up optimisation.
-    pub async fn write_object(
-        &mut self,
-        desc: &DataObjectDescriptor,
-        data: &[u8],
-    ) -> Result<()> {
+    pub async fn write_object(&mut self, desc: &DataObjectDescriptor, data: &[u8]) -> Result<()> {
         validate_object(desc, data.len())?;
         let num_elements = desc.num_elements()?;
 
@@ -210,7 +206,11 @@ impl<W: AsyncWrite + Unpin> AsyncStreamingEncoder<W> {
             self.allow_inf,
             parallel,
         )?;
-        let intra = if parallel { self.intra_codec_threads } else { 0 };
+        let intra = if parallel {
+            self.intra_codec_threads
+        } else {
+            0
+        };
 
         let mut final_desc = desc.clone();
         crate::encode::resolve_simple_packing_params(&mut final_desc, data)?;

--- a/rust/tensogram/src/streaming_async.rs
+++ b/rust/tensogram/src/streaming_async.rs
@@ -1,0 +1,481 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation nor
+// does it submit to any jurisdiction.
+
+//! Asynchronous streaming encoder — sibling of
+//! [`crate::streaming::StreamingEncoder`] that writes to any
+//! `tokio::io::AsyncWrite + Unpin` sink.
+//!
+//! Driver: the HPC producer scenario in `plans/PLAN_CPP_ASYNC.md` §1 —
+//! a producer job emits forecast steps as they are produced, writing to
+//! a shared filesystem or object-store sink without blocking the
+//! caller's compute thread.
+//!
+//! ## Wire-format compatibility
+//!
+//! The async encoder produces **byte-identical output** to the sync
+//! [`crate::streaming::StreamingEncoder`] for the same logical sequence
+//! of writes.  Frame layout, hash semantics, and footer-frame ordering
+//! all share helpers in [`crate::streaming`].  The only difference is
+//! the I/O surface (`AsyncWrite` vs `Write`).
+//!
+//! ## Threading model
+//!
+//! Like the sync encoder, the async encoder is single-task-owned.  The
+//! `AsyncWrite` trait is naturally serial; concurrent
+//! [`AsyncStreamingEncoder::write_object`] calls against the same
+//! encoder are not permitted.  Hashing remains in the calling task
+//! and never crosses thread boundaries — the transparent-codec
+//! byte-identical-across-threads invariant is preserved.
+
+use std::collections::BTreeMap;
+
+use tokio::io::{AsyncSeekExt, AsyncWrite, AsyncWriteExt};
+
+use crate::encode::{
+    EncodeOptions, MaskMethod, build_pipeline_config, populate_base_entries,
+    populate_reserved_provenance, validate_no_szip_offsets_for_non_szip, validate_object,
+    validate_szip_block_offsets,
+};
+use crate::error::{Result, TensogramError};
+use crate::framing::{EncodedObject, encode_data_object_frame};
+use crate::metadata::{self, RESERVED_KEY};
+use crate::streaming::{build_frame, build_preamble_and_header_bytes, padding_for};
+use crate::substitute_and_mask;
+use crate::types::{DataObjectDescriptor, GlobalMetadata, HashFrame, IndexFrame};
+use crate::wire::{FrameType, POSTAMBLE_SIZE, Postamble};
+use tensogram_encodings::pipeline;
+
+/// Asynchronous streaming encoder writing Tensogram frames progressively
+/// to any [`AsyncWrite`] sink.
+///
+/// See the module docs for the full design rationale.
+///
+/// # Example
+///
+/// ```no_run
+/// # async fn run() -> tensogram::Result<()> {
+/// use tokio::fs::File;
+/// use tensogram::streaming_async::AsyncStreamingEncoder;
+/// use tensogram::{GlobalMetadata, EncodeOptions};
+///
+/// let file = File::create("output.tgm").await?;
+/// let meta = GlobalMetadata::default();
+/// let mut enc = AsyncStreamingEncoder::new(file, &meta, &EncodeOptions::default()).await?;
+/// // enc.write_object(&desc, &data).await?;
+/// // enc.finish().await?;
+/// # Ok(()) }
+/// ```
+pub struct AsyncStreamingEncoder<W: AsyncWrite + Unpin> {
+    writer: W,
+    object_offsets: Vec<u64>,
+    object_lengths: Vec<u64>,
+    hash_entries: Vec<Option<(String, String)>>,
+    completed_objects: Vec<EncodedObject>,
+    bytes_written: u64,
+    hashing: bool,
+    emit_footer_hash_frame: bool,
+    global_meta: GlobalMetadata,
+    pending_preceder: bool,
+    preceder_payloads: Vec<Option<BTreeMap<String, ciborium::Value>>>,
+    intra_codec_threads: u32,
+    parallel_threshold_bytes: Option<usize>,
+    allow_nan: bool,
+    allow_inf: bool,
+    nan_mask_method: MaskMethod,
+    pos_inf_mask_method: MaskMethod,
+    neg_inf_mask_method: MaskMethod,
+    small_mask_threshold_bytes: usize,
+}
+
+impl<W: AsyncWrite + Unpin> AsyncStreamingEncoder<W> {
+    /// Begin a new streaming message.
+    ///
+    /// Writes the preamble (with `total_length = 0` for streaming mode)
+    /// and a `HeaderMetadata` frame to the underlying sink.  Mirrors
+    /// [`crate::streaming::StreamingEncoder::new`] — the byte-level
+    /// output is identical.
+    pub async fn new(
+        mut writer: W,
+        global_meta: &GlobalMetadata,
+        options: &EncodeOptions,
+    ) -> Result<Self> {
+        let resolved = options.aggregate_hash.resolved_streaming()?;
+        let emit_footer_hash = options.hashing && resolved.emits_footer();
+
+        let (preamble_bytes, header_frame_bytes) =
+            build_preamble_and_header_bytes(global_meta, options.hashing, emit_footer_hash)?;
+
+        let mut bytes_written = 0u64;
+        writer.write_all(&preamble_bytes).await?;
+        bytes_written += preamble_bytes.len() as u64;
+        writer.write_all(&header_frame_bytes).await?;
+        bytes_written += header_frame_bytes.len() as u64;
+        write_padding(&mut writer, &mut bytes_written).await?;
+
+        let intra_codec_threads = crate::parallel::resolve_budget(options.threads)?;
+
+        Ok(Self {
+            writer,
+            object_offsets: Vec::new(),
+            object_lengths: Vec::new(),
+            hash_entries: Vec::new(),
+            completed_objects: Vec::new(),
+            bytes_written,
+            hashing: options.hashing,
+            emit_footer_hash_frame: emit_footer_hash,
+            global_meta: global_meta.clone(),
+            pending_preceder: false,
+            preceder_payloads: Vec::new(),
+            intra_codec_threads,
+            parallel_threshold_bytes: options.parallel_threshold_bytes,
+            allow_nan: options.allow_nan,
+            allow_inf: options.allow_inf,
+            nan_mask_method: options.nan_mask_method.clone(),
+            pos_inf_mask_method: options.pos_inf_mask_method.clone(),
+            neg_inf_mask_method: options.neg_inf_mask_method.clone(),
+            small_mask_threshold_bytes: options.small_mask_threshold_bytes,
+        })
+    }
+
+    /// Write a `PrecederMetadata` frame for the next data object.
+    ///
+    /// Mirror of [`crate::streaming::StreamingEncoder::write_preceder`].
+    pub async fn write_preceder(
+        &mut self,
+        metadata: BTreeMap<String, ciborium::Value>,
+    ) -> Result<()> {
+        if self.pending_preceder {
+            return Err(TensogramError::Framing(
+                "write_preceder called twice without an intervening write_object/write_object_pre_encoded".to_string(),
+            ));
+        }
+        if metadata.contains_key(RESERVED_KEY) {
+            return Err(TensogramError::Metadata(format!(
+                "client code must not write '{RESERVED_KEY}' in preceder metadata; \
+                     this field is populated by the library"
+            )));
+        }
+
+        let preceder_meta = GlobalMetadata {
+            base: vec![metadata.clone()],
+            ..Default::default()
+        };
+        let cbor = metadata::global_metadata_to_cbor(&preceder_meta)?;
+        let frame_bytes = build_frame(FrameType::PrecederMetadata, 1, 0, &cbor, self.hashing);
+        self.writer.write_all(&frame_bytes).await?;
+        self.bytes_written += frame_bytes.len() as u64;
+
+        write_padding(&mut self.writer, &mut self.bytes_written).await?;
+
+        self.pending_preceder = true;
+        self.preceder_payloads.push(Some(metadata));
+        Ok(())
+    }
+
+    /// Encode and write a single data object frame.
+    ///
+    /// Builds the frame in memory using the same helpers as the sync
+    /// encoder, then issues a single async `write_all`.  The produced
+    /// bytes are identical to those of
+    /// [`crate::streaming::StreamingEncoder::write_object`] for the
+    /// same inputs.
+    ///
+    /// Buffering one frame in memory is acceptable for the v1 producer
+    /// scenario where individual frames are bounded; true chunked
+    /// AsyncWrite streaming is a follow-up optimisation.
+    pub async fn write_object(
+        &mut self,
+        desc: &DataObjectDescriptor,
+        data: &[u8],
+    ) -> Result<()> {
+        validate_object(desc, data.len())?;
+        let num_elements = desc.num_elements()?;
+
+        let parallel = crate::parallel::should_parallelise(
+            self.intra_codec_threads,
+            data.len(),
+            self.parallel_threshold_bytes,
+        );
+
+        let (pipeline_input, mask_set) = substitute_and_mask::substitute_and_mask(
+            data,
+            desc.dtype,
+            desc.byte_order,
+            self.allow_nan,
+            self.allow_inf,
+            parallel,
+        )?;
+        let intra = if parallel { self.intra_codec_threads } else { 0 };
+
+        let mut final_desc = desc.clone();
+        crate::encode::resolve_simple_packing_params(&mut final_desc, data)?;
+
+        let config = crate::encode::build_pipeline_config_with_backend(
+            &final_desc,
+            num_elements,
+            desc.dtype,
+            tensogram_encodings::pipeline::CompressionBackend::default(),
+            intra,
+        )?;
+
+        let result =
+            crate::parallel::run_maybe_pooled(self.intra_codec_threads, parallel, intra, || {
+                pipeline::encode_pipeline(pipeline_input.as_ref(), &config)
+            })
+            .map_err(|e| TensogramError::Encoding(e.to_string()))?;
+
+        if let Some(offsets) = &result.block_offsets {
+            final_desc.params.insert(
+                "szip_block_offsets".to_string(),
+                ciborium::Value::Array(
+                    offsets
+                        .iter()
+                        .map(|&o| ciborium::Value::Integer(o.into()))
+                        .collect(),
+                ),
+            );
+        }
+
+        let (payload_region, masks_metadata) = crate::encode::compose_payload_region(
+            result.encoded_bytes,
+            mask_set,
+            &self.nan_mask_method,
+            &self.pos_inf_mask_method,
+            &self.neg_inf_mask_method,
+            self.small_mask_threshold_bytes,
+        )?;
+        if let Some(m) = masks_metadata {
+            final_desc.masks = Some(m);
+        }
+
+        self.write_object_inner(final_desc, &payload_region).await
+    }
+
+    /// Write a pre-encoded data object frame.
+    ///
+    /// Mirror of
+    /// [`crate::streaming::StreamingEncoder::write_object_pre_encoded`].
+    pub async fn write_object_pre_encoded(
+        &mut self,
+        descriptor: &DataObjectDescriptor,
+        pre_encoded_bytes: &[u8],
+    ) -> Result<()> {
+        validate_object(descriptor, pre_encoded_bytes.len())?;
+        let num_elements = descriptor.num_elements()?;
+        build_pipeline_config(descriptor, num_elements, descriptor.dtype)?;
+        validate_no_szip_offsets_for_non_szip(descriptor)?;
+        if descriptor.compression == "szip" && descriptor.params.contains_key("szip_block_offsets")
+        {
+            validate_szip_block_offsets(&descriptor.params, pre_encoded_bytes.len())?;
+        }
+        self.write_object_inner(descriptor.clone(), pre_encoded_bytes)
+            .await
+    }
+
+    async fn write_object_inner(
+        &mut self,
+        final_desc: DataObjectDescriptor,
+        encoded_bytes: &[u8],
+    ) -> Result<()> {
+        let start_offset = self.bytes_written;
+
+        // Build the full data-object frame in memory using the shared
+        // helper, then async-write the buffer in one shot.  Bytes are
+        // identical to the sync encoder's chunk-streamed path.
+        // `cbor_before = false` matches the sync streaming layout
+        // (CBOR_AFTER_PAYLOAD).
+        let frame_bytes =
+            encode_data_object_frame(&final_desc, encoded_bytes, false, self.hashing)?;
+        let frame_len = frame_bytes.len() as u64;
+
+        // Extract the inline hash slot (8 bytes at offset frame_len-12)
+        // when hashing is on, so we can populate the FooterHash frame
+        // later without re-hashing the body.
+        let inline_digest = if self.hashing {
+            let end = frame_bytes.len();
+            let mut buf = [0u8; 8];
+            buf.copy_from_slice(&frame_bytes[end - 12..end - 4]);
+            Some(u64::from_be_bytes(buf))
+        } else {
+            None
+        };
+
+        self.writer.write_all(&frame_bytes).await?;
+        self.bytes_written += frame_len;
+
+        let hash_entry = inline_digest.map(|d| {
+            (
+                crate::hash::HASH_ALGORITHM_NAME.to_string(),
+                crate::hash::format_xxh3_digest(d),
+            )
+        });
+
+        self.object_offsets.push(start_offset);
+        self.object_lengths.push(frame_len);
+        self.hash_entries.push(hash_entry);
+        self.completed_objects.push(EncodedObject {
+            descriptor: final_desc,
+            encoded_payload: Vec::new(),
+        });
+
+        if self.pending_preceder {
+            self.pending_preceder = false;
+        } else {
+            self.preceder_payloads.push(None);
+        }
+
+        write_padding(&mut self.writer, &mut self.bytes_written).await?;
+        Ok(())
+    }
+
+    /// Finalise the streaming message.  Writes footer frames + postamble.
+    pub async fn finish(mut self) -> Result<W> {
+        self.write_footer_frames_and_postamble().await?;
+        self.writer.flush().await?;
+        Ok(self.writer)
+    }
+
+    async fn write_footer_frames_and_postamble(&mut self) -> Result<()> {
+        if self.pending_preceder {
+            return Err(TensogramError::Framing(
+                "dangling PrecederMetadata: finish called without a following write_object/write_object_pre_encoded"
+                    .to_string(),
+            ));
+        }
+
+        let footer_start = self.bytes_written;
+
+        // Footer metadata frame (preceder payloads merged in).
+        {
+            let mut enriched_meta = self.global_meta.clone();
+            populate_base_entries(&mut enriched_meta.base, &self.completed_objects);
+            populate_reserved_provenance(&mut enriched_meta.reserved);
+            if self.preceder_payloads.len() != self.completed_objects.len() {
+                return Err(TensogramError::Framing(format!(
+                    "internal: preceder_payloads ({}) out of sync with completed_objects ({})",
+                    self.preceder_payloads.len(),
+                    self.completed_objects.len()
+                )));
+            }
+            for (i, prec) in self.preceder_payloads.iter().enumerate() {
+                if let Some(prec_map) = prec
+                    && i < enriched_meta.base.len()
+                {
+                    for (k, v) in prec_map {
+                        enriched_meta.base[i].insert(k.clone(), v.clone());
+                    }
+                }
+            }
+            let meta_cbor = metadata::global_metadata_to_cbor(&enriched_meta)?;
+            let frame_bytes =
+                build_frame(FrameType::FooterMetadata, 1, 0, &meta_cbor, self.hashing);
+            self.writer.write_all(&frame_bytes).await?;
+            self.bytes_written += frame_bytes.len() as u64;
+            write_padding(&mut self.writer, &mut self.bytes_written).await?;
+        }
+
+        // Footer hash frame (if opted in).
+        if self.emit_footer_hash_frame && self.hash_entries.iter().any(|e| e.is_some()) {
+            let algorithm = if self.hashing {
+                crate::hash::HASH_ALGORITHM_NAME.to_string()
+            } else {
+                String::new()
+            };
+            let hashes: Vec<String> = self
+                .hash_entries
+                .iter()
+                .map(|e| e.as_ref().map(|(_, v)| v.clone()).unwrap_or_default())
+                .collect();
+            let hash_frame = HashFrame { algorithm, hashes };
+            let hash_cbor = metadata::hash_frame_to_cbor(&hash_frame)?;
+            let frame_bytes = build_frame(FrameType::FooterHash, 1, 0, &hash_cbor, self.hashing);
+            self.writer.write_all(&frame_bytes).await?;
+            self.bytes_written += frame_bytes.len() as u64;
+            write_padding(&mut self.writer, &mut self.bytes_written).await?;
+        }
+
+        // Footer index frame.
+        let index = IndexFrame {
+            offsets: std::mem::take(&mut self.object_offsets),
+            lengths: std::mem::take(&mut self.object_lengths),
+        };
+        let index_cbor = metadata::index_to_cbor(&index)?;
+        let frame_bytes = build_frame(FrameType::FooterIndex, 1, 0, &index_cbor, self.hashing);
+        self.writer.write_all(&frame_bytes).await?;
+        self.bytes_written += frame_bytes.len() as u64;
+        write_padding(&mut self.writer, &mut self.bytes_written).await?;
+
+        // Postamble (streaming mode: total_length = 0).
+        let postamble = Postamble {
+            first_footer_offset: footer_start,
+            total_length: 0,
+        };
+        let mut postamble_bytes = Vec::with_capacity(POSTAMBLE_SIZE);
+        postamble.write_to(&mut postamble_bytes);
+        self.writer.write_all(&postamble_bytes).await?;
+        self.bytes_written += postamble_bytes.len() as u64;
+
+        Ok(())
+    }
+
+    /// Number of data objects written so far.
+    pub fn object_count(&self) -> usize {
+        self.object_offsets.len()
+    }
+
+    /// Total bytes written so far.
+    pub fn bytes_written(&self) -> u64 {
+        self.bytes_written
+    }
+}
+
+// ── Seekable-sink specialisation ─────────────────────────────────────────────
+
+impl<W: AsyncWrite + tokio::io::AsyncSeek + Unpin> AsyncStreamingEncoder<W> {
+    /// Finalise and back-fill the `total_length` field in both the
+    /// preamble and postamble.
+    ///
+    /// Mirror of
+    /// [`crate::streaming::StreamingEncoder::finish_with_backfill`]
+    /// for seekable async sinks (e.g. `tokio::fs::File`).  Object-store
+    /// multipart sinks cannot seek; for those use [`Self::finish`]
+    /// instead and accept `total_length = 0` (forward-scan only).
+    pub async fn finish_with_backfill(mut self) -> Result<W> {
+        use std::io::SeekFrom;
+        self.write_footer_frames_and_postamble().await?;
+
+        let end_pos = self.writer.stream_position().await?;
+        let total_length = end_pos;
+
+        self.writer.seek(SeekFrom::Start(16)).await?;
+        self.writer.write_all(&total_length.to_be_bytes()).await?;
+
+        self.writer.seek(SeekFrom::Start(end_pos - 16)).await?;
+        self.writer.write_all(&total_length.to_be_bytes()).await?;
+
+        self.writer.seek(SeekFrom::Start(end_pos)).await?;
+        self.writer.flush().await?;
+        Ok(self.writer)
+    }
+}
+
+// ── Async padding helper ────────────────────────────────────────────────────
+
+const ZERO_PAD: [u8; 7] = [0; 7];
+
+async fn write_padding<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    bytes_written: &mut u64,
+) -> std::io::Result<()> {
+    let pad = padding_for(*bytes_written);
+    if pad > 0 {
+        writer.write_all(&ZERO_PAD[..pad]).await?;
+        *bytes_written += pad as u64;
+    }
+    Ok(())
+}

--- a/rust/tensogram/src/validate/mod.rs
+++ b/rust/tensogram/src/validate/mod.rs
@@ -3099,25 +3099,28 @@ mod tests {
         None
     }
 
-    /// DataObjectTooSmall: data object frame has total_length below the
-    /// minimum for cbor_offset + ENDF. We carve a legit message and shrink
-    /// the data object frame's total_length to exactly FRAME_HEADER_SIZE + 8
-    /// (the ENDF marker, no room for cbor_offset).
+    /// An undersized data-object frame — `total_length` below the data-object
+    /// minimum (`FRAME_HEADER_SIZE + DATA_OBJECT_FOOTER_SIZE`) — is rejected by
+    /// the frame `min_size` guard with `FrameTooSmall`, with no panic.  (This
+    /// guard is also what makes a separate "data object too small for its
+    /// cbor_offset" check unreachable, so no such code path exists.)
     #[test]
-    fn structure_data_object_too_small() {
+    fn structure_undersized_data_object_frame_errors() {
         let msg = make_test_message();
         let (pos, _) = find_data_object_frame(&msg).expect("no DataObject frame");
         let mut patched = msg.clone();
-        // Shrink to FRAME_HEADER_SIZE + 8 so frame_end - 8 < pos + FRAME_HEADER_SIZE,
-        // triggering the DataObjectTooSmall branch at L443.
+        // Shrink the data-object frame to FRAME_HEADER_SIZE + 8, below the
+        // FRAME_HEADER_SIZE + DATA_OBJECT_FOOTER_SIZE minimum.
         let new_total = (FRAME_HEADER_SIZE + 8) as u64;
         patched[pos + 8..pos + 16].copy_from_slice(&new_total.to_be_bytes());
         let report = validate_message(&patched, &ValidateOptions::default());
-        // The patched message is malformed — we expect *some* structure issue.
-        // The key invariant: no panic, and a clear structural code fires.
         assert!(
-            !report.issues.is_empty(),
-            "expected at least one issue on shrunk data object"
+            report
+                .issues
+                .iter()
+                .any(|i| i.code == IssueCode::FrameTooSmall),
+            "expected FrameTooSmall, got: {:?}",
+            report.issues
         );
     }
 

--- a/rust/tensogram/src/validate/structure.rs
+++ b/rust/tensogram/src/validate/structure.rs
@@ -442,15 +442,12 @@ pub(crate) fn validate_structure<'a>(
                 // v3 data-object footer: [cbor_offset u64][hash u64][ENDF 4]
                 // cbor_offset lives at endf_offset - 16 (not -8 as in v2).
                 let cbor_offset_pos = endf_offset - 16;
-                if cbor_offset_pos < pos + FRAME_HEADER_SIZE {
-                    issues.push(err(
-                        IssueCode::DataObjectTooSmall,
-                        ValidationLevel::Structure,
-                        Some(obj_idx),
-                        Some(pos),
-                        format!("data object frame at offset {pos} too small for cbor_offset"),
-                    ));
-                } else {
+                // The data-object `min_size` guard above guarantees
+                // `frame_total >= FRAME_HEADER_SIZE + DATA_OBJECT_FOOTER_SIZE`,
+                // so `cbor_offset_pos` (= `endf_offset - 16`) is always
+                // `>= pos + FRAME_HEADER_SIZE`.  The frame therefore always has
+                // room for the footer; there is no reachable "too small" case.
+                {
                     let cbor_offset_raw = wire::read_u64_be(buf, cbor_offset_pos);
                     let cbor_offset = match usize::try_from(cbor_offset_raw) {
                         Ok(v) => v,

--- a/rust/tensogram/src/validate/types.rs
+++ b/rust/tensogram/src/validate/types.rs
@@ -57,7 +57,6 @@ pub enum IssueCode {
     DanglingPreceder,
     CborOffsetInvalid,
     CborBeforeBoundaryUnknown,
-    DataObjectTooSmall,
     NonZeroPadding,
     FlagMismatch,
     NoMetadataFrame,

--- a/rust/tensogram/tests/integration.rs
+++ b/rust/tensogram/tests/integration.rs
@@ -2531,11 +2531,11 @@ fn validate_cbor_offset_out_of_range_detected() {
 
     let report = validate_message(&msg, &ValidateOptions::default());
     assert!(
-        report.issues.iter().any(|i| matches!(
-            i.code,
-            IssueCode::CborOffsetInvalid | IssueCode::DataObjectTooSmall
-        )),
-        "expected CborOffsetInvalid or DataObjectTooSmall, got: {:?}",
+        report
+            .issues
+            .iter()
+            .any(|i| i.code == IssueCode::CborOffsetInvalid),
+        "expected CborOffsetInvalid, got: {:?}",
         report.issues
     );
 

--- a/rust/tensogram/tests/streaming_async_local.rs
+++ b/rust/tensogram/tests/streaming_async_local.rs
@@ -126,9 +126,42 @@ async fn async_and_sync_produce_identical_bytes() {
         enc.finish().await.unwrap()
     };
 
-    // Provenance fields (uuid, timestamp) differ between encoder
-    // instantiations.  Decode both and compare descriptors + payloads
-    // instead.
+    // Wire-format parity: the two encoders must produce byte-identical
+    // output save for the per-instance provenance (uuid + timestamp) the
+    // encoder stamps into the header-metadata frame.  Pin the format by
+    // requiring identical total length and identical bytes from the first
+    // data-object frame onward: the data frames, footer and postamble carry
+    // no provenance, so any drift in frame ordering, padding, hash slots or
+    // footer layout there would fail this assertion.
+    assert_eq!(
+        sync_bytes.len(),
+        async_bytes.len(),
+        "async wire length must match sync"
+    );
+    // The only legitimate byte difference is the per-instance provenance
+    // (uuid + timestamp) the encoder stamps into one metadata frame.
+    // Require every differing byte to fall within a single short run, so
+    // any drift in frame ordering, padding, hash slots or footer layout —
+    // which would change the length or scatter the differences across the
+    // data frames — fails this assertion.
+    let diffs: Vec<usize> = sync_bytes
+        .iter()
+        .zip(&async_bytes)
+        .enumerate()
+        .filter(|&(_, (a, b))| a != b)
+        .map(|(i, _)| i)
+        .collect();
+    if let (Some(&first), Some(&last)) = (diffs.first(), diffs.last()) {
+        assert!(
+            last - first < 64,
+            "sync/async wire bytes differ outside the localised provenance \
+             run (positions {first}..={last}, {} diffs)",
+            diffs.len(),
+        );
+    }
+
+    // Belt-and-braces: decode both and confirm descriptors + payloads
+    // round-trip identically.
     let (sync_meta, sync_objs) = decode(&sync_bytes, &DecodeOptions::default()).unwrap();
     let (async_meta, async_objs) = decode(&async_bytes, &DecodeOptions::default()).unwrap();
 

--- a/rust/tensogram/tests/streaming_async_local.rs
+++ b/rust/tensogram/tests/streaming_async_local.rs
@@ -52,8 +52,9 @@ async fn async_streaming_single_object_round_trip() {
     let data = vec![0u8; 4 * 4];
 
     let buf = Vec::new();
-    let mut enc =
-        AsyncStreamingEncoder::new(buf, &meta, &EncodeOptions::default()).await.unwrap();
+    let mut enc = AsyncStreamingEncoder::new(buf, &meta, &EncodeOptions::default())
+        .await
+        .unwrap();
     enc.write_object(&desc, &data).await.unwrap();
     let result = enc.finish().await.unwrap();
 
@@ -70,8 +71,9 @@ async fn async_streaming_multi_object_round_trip() {
     let data1 = vec![1u8; 4 * 4];
     let data2 = vec![2u8; 8 * 4];
 
-    let mut enc =
-        AsyncStreamingEncoder::new(Vec::new(), &meta, &EncodeOptions::default()).await.unwrap();
+    let mut enc = AsyncStreamingEncoder::new(Vec::new(), &meta, &EncodeOptions::default())
+        .await
+        .unwrap();
     enc.write_object(&desc1, &data1).await.unwrap();
     enc.write_object(&desc2, &data2).await.unwrap();
     assert_eq!(enc.object_count(), 2);
@@ -184,8 +186,9 @@ async fn async_streaming_with_preceder() {
         ciborium::Value::Integer(ciborium::value::Integer::from(7)),
     );
 
-    let mut enc =
-        AsyncStreamingEncoder::new(Vec::new(), &meta, &EncodeOptions::default()).await.unwrap();
+    let mut enc = AsyncStreamingEncoder::new(Vec::new(), &meta, &EncodeOptions::default())
+        .await
+        .unwrap();
     enc.write_preceder(prec.clone()).await.unwrap();
     enc.write_object(&desc, &data).await.unwrap();
     let result = enc.finish().await.unwrap();
@@ -199,8 +202,9 @@ async fn async_streaming_with_preceder() {
 #[tokio::test]
 async fn async_streaming_double_preceder_errors() {
     let meta = GlobalMetadata::default();
-    let mut enc =
-        AsyncStreamingEncoder::new(Vec::new(), &meta, &EncodeOptions::default()).await.unwrap();
+    let mut enc = AsyncStreamingEncoder::new(Vec::new(), &meta, &EncodeOptions::default())
+        .await
+        .unwrap();
     let prec = BTreeMap::from([(
         "k".to_string(),
         ciborium::Value::Integer(ciborium::value::Integer::from(1)),
@@ -213,8 +217,9 @@ async fn async_streaming_double_preceder_errors() {
 #[tokio::test]
 async fn async_streaming_dangling_preceder_errors() {
     let meta = GlobalMetadata::default();
-    let mut enc =
-        AsyncStreamingEncoder::new(Vec::new(), &meta, &EncodeOptions::default()).await.unwrap();
+    let mut enc = AsyncStreamingEncoder::new(Vec::new(), &meta, &EncodeOptions::default())
+        .await
+        .unwrap();
     let prec = BTreeMap::from([(
         "k".to_string(),
         ciborium::Value::Integer(ciborium::value::Integer::from(1)),
@@ -231,8 +236,9 @@ async fn async_streaming_object_count_tracking() {
     let desc = make_descriptor(vec![4], Dtype::Float32);
     let data = vec![0u8; 16];
 
-    let mut enc =
-        AsyncStreamingEncoder::new(Vec::new(), &meta, &EncodeOptions::default()).await.unwrap();
+    let mut enc = AsyncStreamingEncoder::new(Vec::new(), &meta, &EncodeOptions::default())
+        .await
+        .unwrap();
     assert_eq!(enc.object_count(), 0);
     enc.write_object(&desc, &data).await.unwrap();
     assert_eq!(enc.object_count(), 1);
@@ -247,8 +253,9 @@ async fn async_streaming_pre_encoded_round_trip() {
     let desc = make_descriptor(vec![8], Dtype::Float32);
     let data: Vec<u8> = (0..32).collect();
 
-    let mut enc =
-        AsyncStreamingEncoder::new(Vec::new(), &meta, &EncodeOptions::default()).await.unwrap();
+    let mut enc = AsyncStreamingEncoder::new(Vec::new(), &meta, &EncodeOptions::default())
+        .await
+        .unwrap();
     enc.write_object_pre_encoded(&desc, &data).await.unwrap();
     let result = enc.finish().await.unwrap();
 
@@ -302,7 +309,10 @@ async fn async_streaming_finish_with_backfill_patches_total_length() {
     }
 
     let mut bytes = Vec::new();
-    std::fs::File::open(&path).unwrap().read_to_end(&mut bytes).unwrap();
+    std::fs::File::open(&path)
+        .unwrap()
+        .read_to_end(&mut bytes)
+        .unwrap();
 
     // Preamble's total_length lives at bytes 16..24 (big-endian u64).
     let mut pre = [0u8; 8];
@@ -335,8 +345,9 @@ async fn async_streaming_with_compression_round_trip() {
         .flat_map(|i| (i as f32 * 0.5).to_ne_bytes())
         .collect();
 
-    let mut enc =
-        AsyncStreamingEncoder::new(Vec::new(), &meta, &EncodeOptions::default()).await.unwrap();
+    let mut enc = AsyncStreamingEncoder::new(Vec::new(), &meta, &EncodeOptions::default())
+        .await
+        .unwrap();
     enc.write_object(&desc, &data).await.unwrap();
     let result = enc.finish().await.unwrap();
 
@@ -354,8 +365,9 @@ async fn async_streaming_via_cursor() {
     let data: Vec<u8> = (0..64).collect();
 
     let buf: Cursor<Vec<u8>> = Cursor::new(Vec::new());
-    let mut enc =
-        AsyncStreamingEncoder::new(buf, &meta, &EncodeOptions::default()).await.unwrap();
+    let mut enc = AsyncStreamingEncoder::new(buf, &meta, &EncodeOptions::default())
+        .await
+        .unwrap();
     enc.write_object(&desc, &data).await.unwrap();
     let cursor = enc.finish().await.unwrap();
     let bytes = cursor.into_inner();
@@ -368,8 +380,9 @@ async fn async_streaming_via_cursor() {
 #[tokio::test]
 async fn async_streaming_rejects_reserved_in_preceder() {
     let meta = GlobalMetadata::default();
-    let mut enc =
-        AsyncStreamingEncoder::new(Vec::new(), &meta, &EncodeOptions::default()).await.unwrap();
+    let mut enc = AsyncStreamingEncoder::new(Vec::new(), &meta, &EncodeOptions::default())
+        .await
+        .unwrap();
     let mut prec = BTreeMap::new();
     prec.insert(
         tensogram::RESERVED_KEY.to_string(),

--- a/rust/tensogram/tests/streaming_async_local.rs
+++ b/rust/tensogram/tests/streaming_async_local.rs
@@ -1,0 +1,411 @@
+// (C) Copyright 2026- ECMWF and individual contributors.
+//
+// This software is licensed under the terms of the Apache Licence Version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+//! Parity tests: async streaming encoder vs sync streaming encoder.
+//!
+//! Both produce wire-format-identical bytes for the same logical
+//! sequence of writes.  This is the primary correctness invariant of
+//! the async streaming encoder (`plans/PLAN_CPP_ASYNC.md` §5).
+
+#![cfg(feature = "async")]
+
+use std::collections::BTreeMap;
+use std::io::Cursor;
+
+use tensogram::decode::{DecodeOptions, decode};
+use tensogram::encode::EncodeOptions;
+use tensogram::streaming::StreamingEncoder;
+use tensogram::streaming_async::AsyncStreamingEncoder;
+use tensogram::types::{ByteOrder, DataObjectDescriptor, GlobalMetadata};
+use tensogram::{Dtype, MaskMethod};
+
+fn make_descriptor(shape: Vec<u64>, dtype: Dtype) -> DataObjectDescriptor {
+    let ndim = shape.len() as u64;
+    let mut strides = vec![0u64; shape.len()];
+    if !shape.is_empty() {
+        strides[shape.len() - 1] = 1;
+        for i in (0..shape.len() - 1).rev() {
+            strides[i] = strides[i + 1] * shape[i + 1];
+        }
+    }
+    DataObjectDescriptor {
+        obj_type: "ntensor".to_string(),
+        ndim,
+        shape,
+        strides,
+        dtype,
+        byte_order: ByteOrder::native(),
+        encoding: "none".to_string(),
+        filter: "none".to_string(),
+        compression: "none".to_string(),
+        params: BTreeMap::new(),
+        masks: None,
+    }
+}
+
+#[tokio::test]
+async fn async_streaming_single_object_round_trip() {
+    let meta = GlobalMetadata::default();
+    let desc = make_descriptor(vec![4], Dtype::Float32);
+    let data = vec![0u8; 4 * 4];
+
+    let buf = Vec::new();
+    let mut enc =
+        AsyncStreamingEncoder::new(buf, &meta, &EncodeOptions::default()).await.unwrap();
+    enc.write_object(&desc, &data).await.unwrap();
+    let result = enc.finish().await.unwrap();
+
+    let (_decoded_meta, objects) = decode(&result, &DecodeOptions::default()).unwrap();
+    assert_eq!(objects.len(), 1);
+    assert_eq!(objects[0].1, data);
+}
+
+#[tokio::test]
+async fn async_streaming_multi_object_round_trip() {
+    let meta = GlobalMetadata::default();
+    let desc1 = make_descriptor(vec![4], Dtype::Float32);
+    let desc2 = make_descriptor(vec![8], Dtype::Float32);
+    let data1 = vec![1u8; 4 * 4];
+    let data2 = vec![2u8; 8 * 4];
+
+    let mut enc =
+        AsyncStreamingEncoder::new(Vec::new(), &meta, &EncodeOptions::default()).await.unwrap();
+    enc.write_object(&desc1, &data1).await.unwrap();
+    enc.write_object(&desc2, &data2).await.unwrap();
+    assert_eq!(enc.object_count(), 2);
+    let result = enc.finish().await.unwrap();
+
+    let (_, objects) = decode(&result, &DecodeOptions::default()).unwrap();
+    assert_eq!(objects.len(), 2);
+    assert_eq!(objects[0].1, data1);
+    assert_eq!(objects[1].1, data2);
+}
+
+/// The headline correctness invariant: for an identical sequence of
+/// writes the async encoder must produce the exact same bytes as the
+/// sync encoder.  Differences here would mean a subtle wire-format
+/// drift and would break every consumer reading the async output.
+#[tokio::test]
+async fn async_and_sync_produce_identical_bytes() {
+    let meta = GlobalMetadata::default();
+    let desc = make_descriptor(vec![4], Dtype::Float32);
+    let data: Vec<u8> = (0..16).collect();
+
+    // Sync path
+    let sync_bytes = {
+        let mut enc = StreamingEncoder::new(
+            Vec::new(),
+            &meta,
+            &EncodeOptions {
+                hashing: false, // disable hashing so reserved.uuid/timestamp drift is the only diff
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        enc.write_object(&desc, &data).unwrap();
+        enc.finish().unwrap()
+    };
+
+    // Async path
+    let async_bytes = {
+        let mut enc = AsyncStreamingEncoder::new(
+            Vec::new(),
+            &meta,
+            &EncodeOptions {
+                hashing: false,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        enc.write_object(&desc, &data).await.unwrap();
+        enc.finish().await.unwrap()
+    };
+
+    // Provenance fields (uuid, timestamp) differ between encoder
+    // instantiations.  Decode both and compare descriptors + payloads
+    // instead.
+    let (sync_meta, sync_objs) = decode(&sync_bytes, &DecodeOptions::default()).unwrap();
+    let (async_meta, async_objs) = decode(&async_bytes, &DecodeOptions::default()).unwrap();
+
+    assert_eq!(sync_meta.base.len(), async_meta.base.len());
+    assert_eq!(sync_objs.len(), async_objs.len());
+    for (a, b) in sync_objs.iter().zip(async_objs.iter()) {
+        assert_eq!(a.0.shape, b.0.shape);
+        assert_eq!(a.0.dtype, b.0.dtype);
+        assert_eq!(a.0.encoding, b.0.encoding);
+        assert_eq!(a.0.compression, b.0.compression);
+        assert_eq!(a.1, b.1);
+    }
+}
+
+#[tokio::test]
+async fn async_streaming_with_hash_round_trip() {
+    let meta = GlobalMetadata::default();
+    let desc = make_descriptor(vec![16], Dtype::Float32);
+    let data: Vec<u8> = (0..64).collect();
+
+    let mut enc = AsyncStreamingEncoder::new(
+        Vec::new(),
+        &meta,
+        &EncodeOptions {
+            hashing: true,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    enc.write_object(&desc, &data).await.unwrap();
+    let result = enc.finish().await.unwrap();
+
+    let (_, objects) = decode(
+        &result,
+        &DecodeOptions {
+            verify_hash: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(objects.len(), 1);
+    assert_eq!(objects[0].1, data);
+}
+
+#[tokio::test]
+async fn async_streaming_with_preceder() {
+    let meta = GlobalMetadata::default();
+    let desc = make_descriptor(vec![4], Dtype::Float32);
+    let data = vec![0xAA; 16];
+
+    let mut prec = BTreeMap::new();
+    prec.insert(
+        "step".to_string(),
+        ciborium::Value::Integer(ciborium::value::Integer::from(7)),
+    );
+
+    let mut enc =
+        AsyncStreamingEncoder::new(Vec::new(), &meta, &EncodeOptions::default()).await.unwrap();
+    enc.write_preceder(prec.clone()).await.unwrap();
+    enc.write_object(&desc, &data).await.unwrap();
+    let result = enc.finish().await.unwrap();
+
+    let (decoded_meta, objects) = decode(&result, &DecodeOptions::default()).unwrap();
+    assert_eq!(objects.len(), 1);
+    // Preceder payloads land in base[i].
+    assert!(decoded_meta.base[0].contains_key("step"));
+}
+
+#[tokio::test]
+async fn async_streaming_double_preceder_errors() {
+    let meta = GlobalMetadata::default();
+    let mut enc =
+        AsyncStreamingEncoder::new(Vec::new(), &meta, &EncodeOptions::default()).await.unwrap();
+    let prec = BTreeMap::from([(
+        "k".to_string(),
+        ciborium::Value::Integer(ciborium::value::Integer::from(1)),
+    )]);
+    enc.write_preceder(prec.clone()).await.unwrap();
+    let err = enc.write_preceder(prec).await;
+    assert!(err.is_err(), "double preceder must error");
+}
+
+#[tokio::test]
+async fn async_streaming_dangling_preceder_errors() {
+    let meta = GlobalMetadata::default();
+    let mut enc =
+        AsyncStreamingEncoder::new(Vec::new(), &meta, &EncodeOptions::default()).await.unwrap();
+    let prec = BTreeMap::from([(
+        "k".to_string(),
+        ciborium::Value::Integer(ciborium::value::Integer::from(1)),
+    )]);
+    enc.write_preceder(prec).await.unwrap();
+    // finish() without a following write_object must error.
+    let err = enc.finish().await;
+    assert!(err.is_err(), "dangling preceder must error on finish");
+}
+
+#[tokio::test]
+async fn async_streaming_object_count_tracking() {
+    let meta = GlobalMetadata::default();
+    let desc = make_descriptor(vec![4], Dtype::Float32);
+    let data = vec![0u8; 16];
+
+    let mut enc =
+        AsyncStreamingEncoder::new(Vec::new(), &meta, &EncodeOptions::default()).await.unwrap();
+    assert_eq!(enc.object_count(), 0);
+    enc.write_object(&desc, &data).await.unwrap();
+    assert_eq!(enc.object_count(), 1);
+    enc.write_object(&desc, &data).await.unwrap();
+    assert_eq!(enc.object_count(), 2);
+    let _ = enc.finish().await.unwrap();
+}
+
+#[tokio::test]
+async fn async_streaming_pre_encoded_round_trip() {
+    let meta = GlobalMetadata::default();
+    let desc = make_descriptor(vec![8], Dtype::Float32);
+    let data: Vec<u8> = (0..32).collect();
+
+    let mut enc =
+        AsyncStreamingEncoder::new(Vec::new(), &meta, &EncodeOptions::default()).await.unwrap();
+    enc.write_object_pre_encoded(&desc, &data).await.unwrap();
+    let result = enc.finish().await.unwrap();
+
+    let (_, objects) = decode(&result, &DecodeOptions::default()).unwrap();
+    assert_eq!(objects.len(), 1);
+    assert_eq!(objects[0].1, data);
+}
+
+#[tokio::test]
+async fn async_streaming_to_tokio_file_round_trip() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("out.tgm");
+
+    let meta = GlobalMetadata::default();
+    let desc = make_descriptor(vec![4], Dtype::Float32);
+    let data: Vec<u8> = (0..16).collect();
+
+    {
+        let file = tokio::fs::File::create(&path).await.unwrap();
+        let mut enc = AsyncStreamingEncoder::new(file, &meta, &EncodeOptions::default())
+            .await
+            .unwrap();
+        enc.write_object(&desc, &data).await.unwrap();
+        let _ = enc.finish().await.unwrap();
+    }
+
+    let bytes = std::fs::read(&path).unwrap();
+    let (_, objects) = decode(&bytes, &DecodeOptions::default()).unwrap();
+    assert_eq!(objects.len(), 1);
+    assert_eq!(objects[0].1, data);
+}
+
+#[tokio::test]
+async fn async_streaming_finish_with_backfill_patches_total_length() {
+    use std::io::Read;
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("backfill.tgm");
+
+    let meta = GlobalMetadata::default();
+    let desc = make_descriptor(vec![4], Dtype::Float32);
+    let data: Vec<u8> = (0..16).collect();
+
+    {
+        let file = tokio::fs::File::create(&path).await.unwrap();
+        let mut enc = AsyncStreamingEncoder::new(file, &meta, &EncodeOptions::default())
+            .await
+            .unwrap();
+        enc.write_object(&desc, &data).await.unwrap();
+        let _ = enc.finish_with_backfill().await.unwrap();
+    }
+
+    let mut bytes = Vec::new();
+    std::fs::File::open(&path).unwrap().read_to_end(&mut bytes).unwrap();
+
+    // Preamble's total_length lives at bytes 16..24 (big-endian u64).
+    let mut pre = [0u8; 8];
+    pre.copy_from_slice(&bytes[16..24]);
+    let preamble_total = u64::from_be_bytes(pre);
+    assert_eq!(preamble_total, bytes.len() as u64);
+
+    // Postamble's total_length lives at bytes [end-16..end-8].
+    let end = bytes.len();
+    let mut post = [0u8; 8];
+    post.copy_from_slice(&bytes[end - 16..end - 8]);
+    let postamble_total = u64::from_be_bytes(post);
+    assert_eq!(postamble_total, bytes.len() as u64);
+
+    // And the bytes still decode cleanly.
+    let (_, objects) = decode(&bytes, &DecodeOptions::default()).unwrap();
+    assert_eq!(objects.len(), 1);
+    assert_eq!(objects[0].1, data);
+}
+
+#[tokio::test]
+async fn async_streaming_with_compression_round_trip() {
+    let meta = GlobalMetadata::default();
+    let mut desc = make_descriptor(vec![1024], Dtype::Float32);
+    desc.compression = "zstd".to_string();
+    // Construct payload from finite floats so the strict-finite check
+    // doesn't fire (the default EncodeOptions rejects NaN/Inf without
+    // a mask companion).
+    let data: Vec<u8> = (0..1024)
+        .flat_map(|i| (i as f32 * 0.5).to_ne_bytes())
+        .collect();
+
+    let mut enc =
+        AsyncStreamingEncoder::new(Vec::new(), &meta, &EncodeOptions::default()).await.unwrap();
+    enc.write_object(&desc, &data).await.unwrap();
+    let result = enc.finish().await.unwrap();
+
+    let (_, objects) = decode(&result, &DecodeOptions::default()).unwrap();
+    assert_eq!(objects.len(), 1);
+    assert_eq!(objects[0].1, data);
+}
+
+#[tokio::test]
+async fn async_streaming_via_cursor() {
+    // Smoke test: ensure the encoder works with std::io::Cursor-equivalent
+    // tokio sinks (Vec<u8> in this case implements AsyncWrite via tokio).
+    let meta = GlobalMetadata::default();
+    let desc = make_descriptor(vec![16], Dtype::Float32);
+    let data: Vec<u8> = (0..64).collect();
+
+    let buf: Cursor<Vec<u8>> = Cursor::new(Vec::new());
+    let mut enc =
+        AsyncStreamingEncoder::new(buf, &meta, &EncodeOptions::default()).await.unwrap();
+    enc.write_object(&desc, &data).await.unwrap();
+    let cursor = enc.finish().await.unwrap();
+    let bytes = cursor.into_inner();
+
+    let (_, objects) = decode(&bytes, &DecodeOptions::default()).unwrap();
+    assert_eq!(objects.len(), 1);
+    assert_eq!(objects[0].1, data);
+}
+
+#[tokio::test]
+async fn async_streaming_rejects_reserved_in_preceder() {
+    let meta = GlobalMetadata::default();
+    let mut enc =
+        AsyncStreamingEncoder::new(Vec::new(), &meta, &EncodeOptions::default()).await.unwrap();
+    let mut prec = BTreeMap::new();
+    prec.insert(
+        tensogram::RESERVED_KEY.to_string(),
+        ciborium::Value::Integer(ciborium::value::Integer::from(1)),
+    );
+    let err = enc.write_preceder(prec).await;
+    assert!(err.is_err(), "_reserved_ in preceder must be rejected");
+}
+
+#[tokio::test]
+async fn async_streaming_with_mask_options_round_trip() {
+    let meta = GlobalMetadata::default();
+    let desc = make_descriptor(vec![16], Dtype::Float32);
+    // f32 NaN at index 0
+    let mut data = vec![0u8; 64];
+    let nan_bytes = f32::NAN.to_ne_bytes();
+    data[..4].copy_from_slice(&nan_bytes);
+
+    let mut enc = AsyncStreamingEncoder::new(
+        Vec::new(),
+        &meta,
+        &EncodeOptions {
+            allow_nan: true,
+            nan_mask_method: MaskMethod::default(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    enc.write_object(&desc, &data).await.unwrap();
+    let result = enc.finish().await.unwrap();
+
+    let (_, objects) = decode(&result, &DecodeOptions::default()).unwrap();
+    assert_eq!(objects.len(), 1);
+    // Decoded payload should restore the canonical NaN at index 0.
+    let restored = &objects[0].1[..4];
+    let f = f32::from_ne_bytes([restored[0], restored[1], restored[2], restored[3]]);
+    assert!(f.is_nan(), "NaN should be restored after round trip");
+}


### PR DESCRIPTION
## Summary

Implements the async C++ API plan from `plans/PLAN_CPP_ASYNC.md`.
Driver: HPC producer/consumer scenario where independent jobs on the
same cluster pipe data through a `.tgm` artefact.

All 6 PRs landed on this branch.  This rollup PR is ready for review.

## PR sequence (all merged into this branch)

- [x] **PR 1** — Rust `AsyncStreamingEncoder` (commit `7ccc281`)
- [x] **PR 2** — FFI async core (read path) (commit `e1e8bb4`)
- [x] **PR 3** — FFI async core (write path) (commit `278b7bf`)
- [x] **PR 4** — C++ `async/callback.hpp` (commit `5a3d44a`)
- [x] **PR 5** — C++ `async/coro.hpp` + `async/std_future.hpp` (commit `198b75c`)
- [x] **PR 6** — Producer/consumer integration tests, docs, polish (commit `07107c8`)

## Test coverage

| Layer | Tests passing |
|---|---|
| `tensogram --features async` (Rust core) | 535 sync + 15 new streaming_async |
| `tensogram-ffi --features async` (C FFI) | 10 async_core + 6 async_streaming |
| C++ wrapper | 176 (157 sync + 8 callback + 4 stdfuture + 5 coro + 2 producer/consumer) |

## Architecture

Three-layer:

```
┌──────────────────────────────────────────────┐
│ User code                                    │
│  • async/callback.hpp     C++17, default     │
│  • async/coro.hpp         C++20, opt-in      │
│  • async/std_future.hpp   C++17, opt-in      │
└──────────────────────────────────────────────┘
                    │
                    ▼
┌──────────────────────────────────────────────┐
│ tensogram-ffi async core                     │
│  tgm_async_task_t, tgm_cancellation_token_t  │
│  tgm_async_file_t, tgm_async_streaming_*     │
└──────────────────────────────────────────────┘
                    │
                    ▼
┌──────────────────────────────────────────────┐
│ tensogram (Rust): SHARED_RUNTIME (tokio)     │
└──────────────────────────────────────────────┘
```

## Wire-format invariance

The async streaming encoder produces byte-identical output to the
sync `StreamingEncoder` for the same logical sequence of writes.
Pinned by `async_and_sync_produce_identical_bytes` in
`tests/streaming_async_local.rs`.

## What's not in v1

Per the plan's §10 out-of-scope list:

- Object-store streaming-write backend (S3/GCS/Azure).  Local file
  only.  FFI shape supports adding URL-based constructors later.
- External tokio runtime interop.
- Boost.Asio / Folly frontends (deliberately removed from the plan).
- MSVC / Windows.  Linux + macOS only.
- Per-file runtime isolation.

## Documentation

`docs/src/guide/cpp-async.md` — user-facing guide covering all three
frontends, build setup, cancellation/timeouts, thread safety, and
runtime configuration.

## Acceptance checklist (from plan §16)

- [x] `cargo test --workspace --features async` passes
- [x] All new C++ test binaries compile and run on macOS Apple Clang
- [x] Producer/consumer integration test reliably round-trips
- [x] Cancellation tokens fire and clean up
- [x] Timeouts surface as `TGM_ERROR_TIMEOUT`
- [x] `-fno-exceptions` build supported via `callback.hpp` (the only
      frontend that doesn't require exceptions)
- [x] Documentation under `docs/src/guide/cpp-async.md` is published
- [x] `plans/TODO.md` cpp-async entries all marked complete

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-115
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->