### PR TITLE
perf(tensoscope): lazy-load Cesium, fix label toggle, stream CORS proxy

### DIFF
--- a/tensoscope/package-lock.json
+++ b/tensoscope/package-lock.json
@@ -15,7 +15,7 @@
         "@ecmwf.int/tensogram": "file:../typescript",
         "@types/d3-scale-chromatic": "^3.1.0",
         "@types/maplibre-gl": "^1.13.2",
-        "cesium": "^1.140.0",
+        "cesium": "^1.141.0",
         "d3-scale-chromatic": "^3.1.0",
         "deck.gl": "^9.3.0",
         "maplibre-gl": "^5.23.0",
@@ -44,12 +44,12 @@
     },
     "../typescript": {
       "name": "@ecmwf.int/tensogram",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",
         "@vitest/coverage-v8": "^4.1.5",
-        "fast-check": "^3.23.2",
+        "fast-check": "^4.7.0",
         "typescript": "^5.5.0",
         "vitest": "^4.1.5"
       },
@@ -396,9 +396,9 @@
       }
     },
     "node_modules/@cesium/engine": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/@cesium/engine/-/engine-24.0.0.tgz",
-      "integrity": "sha512-zJ2gl0tyw/FFhBtvp6UYw+0JQJb2J9EiTJYvVSndc6+6qPR5GHLFzFjA1msLLxucfcpc7uI9R2pXNEPluheR/g==",
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/@cesium/engine/-/engine-25.0.0.tgz",
+      "integrity": "sha512-vJZfgAAB7WTvUPsI8dFV+wKleweCZgpJj1ckcTIERnC+NWvJ9bjlAx0xPl0We57NoQKcdMDy+6UiFjOvPB/yGg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cesium/wasm-splats": "^0.1.0-alpha.2",
@@ -424,7 +424,7 @@
         "urijs": "^1.19.7"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@cesium/engine/node_modules/earcut": {
@@ -452,16 +452,16 @@
       "license": "Apache-2.0"
     },
     "node_modules/@cesium/widgets": {
-      "version": "14.5.0",
-      "resolved": "https://registry.npmjs.org/@cesium/widgets/-/widgets-14.5.0.tgz",
-      "integrity": "sha512-h/hKVooXyOtUQJUtrfyBFGMIXb+Q3RLwqE6FzXfzyC0JQuuThLXCz8nRzCPbyiRuAR/aAYT/jbbhQrUxfiWqhQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@cesium/widgets/-/widgets-15.0.0.tgz",
+      "integrity": "sha512-a0udi+EKEeCyM4F+pxp9Qx8HXgh2eWVQrksxGO4lSu3f35XWc+eKdYiJBEP2t1d4tjw2MxOsjbVyMj7VQZ4JDw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cesium/engine": "^24.0.0",
+        "@cesium/engine": "^25.0.0",
         "nosleep.js": "^0.12.0"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@deck.gl/aggregation-layers": {
@@ -1858,70 +1858,6 @@
       "integrity": "sha512-4VpAyMHOqydSvPlEyHwXaE+AkIdR03nX+Qhlxsk2D/IW4OVmDZgIsvJB1cDzyEEtcfKcnaEbfXeiPgejBceT6g==",
       "license": "MIT"
     },
-    "node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
-      }
-    },
-    "node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
@@ -2966,9 +2902,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3884,9 +3820,9 @@
       }
     },
     "node_modules/cesium": {
-      "version": "1.140.0",
-      "resolved": "https://registry.npmjs.org/cesium/-/cesium-1.140.0.tgz",
-      "integrity": "sha512-3RvW0rvZWuXiS6regtNE5u9vt0uXohgpsRBIo6Qc922IIIamkitYiEdr4fg+u4qX4EoK9xS3BosCza7iPOExEQ==",
+      "version": "1.141.0",
+      "resolved": "https://registry.npmjs.org/cesium/-/cesium-1.141.0.tgz",
+      "integrity": "sha512-bRwgABDjsXRqNLjeJAxSlCrWCTvAt/yWJD30fY5CbqtoEKR6g/YCOcJW37vk4w/Gq3uMW7sF1uP74ajRrktjEw==",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/engine",
@@ -3894,11 +3830,11 @@
         "packages/sandcastle"
       ],
       "dependencies": {
-        "@cesium/engine": "^24.0.0",
-        "@cesium/widgets": "^14.5.0"
+        "@cesium/engine": "^25.0.0",
+        "@cesium/widgets": "^15.0.0"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/chai": {
@@ -4921,9 +4857,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
+      "integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -5313,9 +5249,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -5324,7 +5260,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -7095,24 +7032,13 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.1.tgz",
-      "integrity": "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.4.0.tgz",
+      "integrity": "sha512-iriNhQ57SYA5Jbdi+41AyPdx6jPPkFO7DODzkOBmqFhgYn/JzX2HxgxYPY18eQAs3CP/AWqtPvkWn8rclRAxdQ==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -8379,6 +8305,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.17"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmldoc": {

--- a/tensoscope/package.json
+++ b/tensoscope/package.json
@@ -18,7 +18,7 @@
     "@ecmwf.int/tensogram": "file:../typescript",
     "@types/d3-scale-chromatic": "^3.1.0",
     "@types/maplibre-gl": "^1.13.2",
-    "cesium": "^1.140.0",
+    "cesium": "^1.141.0",
     "d3-scale-chromatic": "^3.1.0",
     "deck.gl": "^9.3.0",
     "maplibre-gl": "^5.23.0",

--- a/tensoscope/package.json
+++ b/tensoscope/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.20.0",
   "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/tensoscope/src/App.css
+++ b/tensoscope/src/App.css
@@ -703,6 +703,18 @@ h2 {
   background: rgba(17, 19, 24, 0.55);
 }
 
+/* Shown while lazy-loading the Cesium globe module */
+.cesium-loading-fallback {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #1a1a2e;
+  color: #888;
+  font-size: 14px;
+}
+
 .map-loading-spinner {
   width: 40px;
   height: 40px;

--- a/tensoscope/src/components/map/CesiumView.tsx
+++ b/tensoscope/src/components/map/CesiumView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import {
+  Ion,
   Viewer,
   ImageryLayer,
   UrlTemplateImageryProvider,
@@ -19,6 +20,10 @@ import {
   Cartographic,
   SceneTransforms,
 } from 'cesium';
+
+// Suppress the default Cesium Ion token warning -- we use third-party
+// imagery (CARTO basemap tiles) instead of Cesium Ion services.
+Ion.defaultAccessToken = '';
 
 function markerPixelSize(gridSpacing: number | null | undefined): number {
   const s = gridSpacing ?? 2;

--- a/tensoscope/src/components/map/MapView.tsx
+++ b/tensoscope/src/components/map/MapView.tsx
@@ -8,8 +8,7 @@ import { ColorBar } from './ColorBar';
 import { ColorScaleControls } from './ColorScaleControls';
 import { RenderModePicker } from './RenderModePicker';
 import type { FieldOverlayProps, ViewBounds } from './FieldOverlay';
-import { ProjectionPicker, PROJECTION_PRESETS } from './ProjectionPicker';
-import type { ProjectionPreset } from './ProjectionPicker';
+import { ProjectionPicker, PROJECTION_PRESETS, type ProjectionPreset } from './ProjectionPicker';
 import type { CustomStop } from './colormaps';
 
 // Lazy-load CesiumView -- Cesium is ~2.5 MB of JS plus skybox textures,
@@ -142,7 +141,9 @@ export function MapView(props: MapViewProps) {
 
   // Default to flat map -- Cesium (globe) is lazy-loaded and weighs ~2.5 MB.
   // Starting on flat avoids that cost for users who never switch to globe.
-  const [activePreset, setActivePreset] = useState<ProjectionPreset>(PROJECTION_PRESETS[1]);
+  const [activePreset, setActivePreset] = useState<ProjectionPreset>(
+    PROJECTION_PRESETS.find((p) => p.id === 'flat') ?? PROJECTION_PRESETS[0],
+  );
   const [renderMode, setRenderMode] = useState<'heatmap' | 'contours'>('heatmap');
   const [highResEnabled, setHighResEnabled] = usePersistedState('tensoscope.display.highRes', true);
   const [showLabels, setShowLabels] = usePersistedState('tensoscope.display.labels', false);

--- a/tensoscope/src/components/map/MapView.tsx
+++ b/tensoscope/src/components/map/MapView.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useCallback, useRef, useEffect, lazy, Suspense } from 'react';
 import { Map, Source, Layer } from 'react-map-gl/maplibre';
 import type { MapRef, MapLayerMouseEvent } from 'react-map-gl/maplibre';
 import 'maplibre-gl/dist/maplibre-gl.css';
@@ -6,12 +6,18 @@ import type { ClickPoint } from './usePointInspection';
 import { useFieldImage } from './FieldOverlay';
 import { ColorBar } from './ColorBar';
 import { ColorScaleControls } from './ColorScaleControls';
-import { CesiumView } from './CesiumView';
 import { RenderModePicker } from './RenderModePicker';
 import type { FieldOverlayProps, ViewBounds } from './FieldOverlay';
 import { ProjectionPicker, PROJECTION_PRESETS } from './ProjectionPicker';
 import type { ProjectionPreset } from './ProjectionPicker';
 import type { CustomStop } from './colormaps';
+
+// Lazy-load CesiumView -- Cesium is ~2.5 MB of JS plus skybox textures,
+// terrain workers, and other assets.  Deferring the import until the user
+// actually switches to globe mode shaves seconds off the initial load.
+const CesiumView = lazy(() =>
+  import('./CesiumView').then((m) => ({ default: m.CesiumView })),
+);
 
 const BASEMAP_STYLE = 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json';
 
@@ -134,7 +140,9 @@ export function MapView(props: MapViewProps) {
     isLoading,
   } = props;
 
-  const [activePreset, setActivePreset] = useState<ProjectionPreset>(PROJECTION_PRESETS[0]);
+  // Default to flat map -- Cesium (globe) is lazy-loaded and weighs ~2.5 MB.
+  // Starting on flat avoids that cost for users who never switch to globe.
+  const [activePreset, setActivePreset] = useState<ProjectionPreset>(PROJECTION_PRESETS[1]);
   const [renderMode, setRenderMode] = useState<'heatmap' | 'contours'>('heatmap');
   const [highResEnabled, setHighResEnabled] = usePersistedState('tensoscope.display.highRes', true);
   const [showLabels, setShowLabels] = usePersistedState('tensoscope.display.labels', false);
@@ -260,8 +268,20 @@ export function MapView(props: MapViewProps) {
     basemapLineIdsRef.current = lineIds;
     basemapSymbolIdsRef.current = symbolIds;
 
+    // Apply the current toggle state immediately -- the useEffect that
+    // watches [showLabels, showLines, isGlobe] may have already fired
+    // before the map style loaded, so the refs were empty at that point.
+    for (const id of lineIds) {
+      if (!ml.getLayer(id)) continue;
+      ml.setLayoutProperty(id, 'visibility', showLines ? 'visible' : 'none');
+    }
+    for (const id of symbolIds) {
+      if (!ml.getLayer(id)) continue;
+      ml.setLayoutProperty(id, 'visibility', showLabels ? 'visible' : 'none');
+    }
+
     captureViewport();
-  }, [captureViewport]);
+  }, [captureViewport, showLabels, showLines]);
 
   const isGlobe = activePreset.id === 'globe';
 
@@ -405,20 +425,22 @@ export function MapView(props: MapViewProps) {
   return (
     <div style={{ position: 'relative', width: '100%', height: '100%' }}>
       {isGlobe ? (
-        <CesiumView
-          fieldImage={frontGlobeImage}
-          backFieldImage={backGlobeImage}
-          showLabels={showLabels}
-          showLines={showLines}
-          initialCenter={cameraCenter}
-          onUnmount={handleCesiumUnmount}
-          onViewChange={(b, w, h) => { setCesiumBounds(b); setCesiumViewSize({ width: w, height: h }); }}
-          onMapClick={onMapClick}
-          selectedPoint={selectedPoint}
-          selectedPointGridSpacing={selectedPointGridSpacing}
-          onSelectedPointScreen={onSelectedPointScreen}
-          onSelectedPointOutOfView={onSelectedPointOutOfView}
-        />
+        <Suspense fallback={<div className="cesium-loading-fallback">Loading globe...</div>}>
+          <CesiumView
+            fieldImage={frontGlobeImage}
+            backFieldImage={backGlobeImage}
+            showLabels={showLabels}
+            showLines={showLines}
+            initialCenter={cameraCenter}
+            onUnmount={handleCesiumUnmount}
+            onViewChange={(b, w, h) => { setCesiumBounds(b); setCesiumViewSize({ width: w, height: h }); }}
+            onMapClick={onMapClick}
+            selectedPoint={selectedPoint}
+            selectedPointGridSpacing={selectedPointGridSpacing}
+            onSelectedPointScreen={onSelectedPointScreen}
+            onSelectedPointOutOfView={onSelectedPointOutOfView}
+          />
+        </Suspense>
       ) : (
         <Map
           ref={mapRef}

--- a/tensoscope/src/main.tsx
+++ b/tensoscope/src/main.tsx
@@ -1,6 +1,3 @@
-import { Ion } from 'cesium';
-Ion.defaultAccessToken = '';
-
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'

--- a/tensoscope/vite.config.ts
+++ b/tensoscope/vite.config.ts
@@ -4,6 +4,7 @@ import wasm from 'vite-plugin-wasm'
 import cesium from 'vite-plugin-cesium'
 import path from 'path'
 import { readFileSync } from 'fs'
+import { Readable } from 'stream'
 
 const tensogramPkg = path.resolve(
   __dirname, 'node_modules/@ecmwf.int/tensogram/dist/index.js',
@@ -16,7 +17,9 @@ const tgPkg = JSON.parse(readFileSync(
 
 /** Vite plugin: proxy /api/proxy?url=... to bypass CORS for remote .tgm files.
  *  Forwards the request method and Range header so TensogramFile.fromUrl can
- *  use lazy per-message Range requests in dev mode, matching nginx behaviour. */
+ *  use lazy per-message Range requests in dev mode, matching nginx behaviour.
+ *  Streams the upstream response body (instead of buffering it) so large files
+ *  are forwarded incrementally. */
 function corsProxy(): Plugin {
   return {
     name: 'cors-proxy',
@@ -55,16 +58,21 @@ function corsProxy(): Plugin {
             if (val) res.setHeader(key, val);
           }
 
-          if (req.method === 'HEAD') {
+          if (req.method === 'HEAD' || !upstream.body) {
             res.end();
             return;
           }
 
-          const buf = Buffer.from(await upstream.arrayBuffer());
-          res.end(buf);
+          // Stream the response body instead of buffering it in memory.
+          // This lets the client start processing chunks as they arrive,
+          // matching the nginx production proxy's `proxy_buffering off`.
+          const nodeStream = Readable.fromWeb(upstream.body as import('stream/web').ReadableStream);
+          nodeStream.pipe(res);
         } catch (err) {
-          res.statusCode = 502;
-          res.end(`Proxy error: ${err}`);
+          if (!res.headersSent) {
+            res.statusCode = 502;
+            res.end(`Proxy error: ${err}`);
+          }
         }
       });
     },

--- a/tensoscope/vite.config.ts
+++ b/tensoscope/vite.config.ts
@@ -4,7 +4,7 @@ import wasm from 'vite-plugin-wasm'
 import cesium from 'vite-plugin-cesium'
 import path from 'path'
 import { readFileSync } from 'fs'
-import { Readable } from 'stream'
+import { pipeline, Readable } from 'stream'
 
 const tensogramPkg = path.resolve(
   __dirname, 'node_modules/@ecmwf.int/tensogram/dist/index.js',
@@ -67,7 +67,18 @@ function corsProxy(): Plugin {
           // This lets the client start processing chunks as they arrive,
           // matching the nginx production proxy's `proxy_buffering off`.
           const nodeStream = Readable.fromWeb(upstream.body as import('stream/web').ReadableStream);
-          nodeStream.pipe(res);
+
+          // Abort the upstream fetch if the client disconnects early.
+          res.on('close', () => {
+            if (!res.writableFinished) nodeStream.destroy();
+          });
+
+          pipeline(nodeStream, res, (err) => {
+            if (err && !res.headersSent) {
+              res.statusCode = 502;
+              res.end(`Proxy stream error: ${err}`);
+            }
+          });
         } catch (err) {
           if (!res.headersSent) {
             res.statusCode = 502;


### PR DESCRIPTION
## Summary

- **Lazy Cesium loading** — Code-split `CesiumView` behind `React.lazy`/`Suspense` so `cesium.js` (~4 MB) only loads when the user switches to Globe projection. Default projection changed from Globe to Flat to avoid triggering the load on first visit. `Ion.defaultAccessToken` setup moved from `main.tsx` into `CesiumView.tsx` to prevent eagerly importing the cesium module.
- **Label toggle fix** — Basemap labels and boundary lines now correctly reappear after switching between Globe and Flat projections. The fix applies the current `showLabels`/`showLines` visibility state immediately in `handleMapLoad` after populating the layer ID refs.
- **Streaming CORS proxy** — Rewrote the vite dev server CORS proxy to stream response bodies via `Readable.fromWeb().pipe()` instead of buffering the entire response into memory. Matches the production nginx config (`proxy_buffering off`).
- **npm audit** — Bumped `cesium` 1.140.0 → 1.141.0, resolving all audit findings (0 vulnerabilities).

## Verification

- TypeScript compiles cleanly (`tsc -b --noEmit`)
- Production build succeeds; `CesiumView` is code-split into a separate chunk (~5.7 KB)
- Tested in browser: Cesium JS does not load on initial page load; loads correctly on Globe button click
- Labels toggle works correctly across projection switches

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-122
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->