### PR TITLE
Developer & release tooling: full-stack make all, make release-check, and documented workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# Code owners for tensogram.
+#
+# GitHub automatically requests a review from these maintainers on every pull
+# request. Handles are taken from the CONTRIBUTORS file. The full review /
+# approval / merge policy — including the two-approval rule for the elevated
+# paths flagged below — is in AGENTS.md and CONTRIBUTING.md ("Review & merge").
+
+*                               @tlmquintino @sametd @HCookie @tmi
+
+# Elevated review (two approvals): wire format, C ABI / generated header, and
+# security-sensitive code.
+/plans/WIRE_FORMAT.md           @tlmquintino @sametd @HCookie @tmi
+/plans/SECURITY_ANALYSIS.md     @tlmquintino @sametd @HCookie @tmi
+/rust/tensogram/src/wire.rs     @tlmquintino @sametd @HCookie @tmi
+/rust/tensogram/src/framing.rs  @tlmquintino @sametd @HCookie @tmi
+/rust/tensogram-ffi/            @tlmquintino @sametd @HCookie @tmi

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -30,6 +30,20 @@ jobs:
       - name: Build WASM + TypeScript (wasm-pack → typescript/wasm, tsc → dist)
         run: make ts-build
 
+      - name: Verify the wasm blob is in the publishable tarball
+        working-directory: typescript
+        # Regression guard. wasm-pack writes a `.gitignore` ("*") into its
+        # output directory; npm honours that nested ignore file when packing
+        # and silently drops the entire wasm/ directory from the tarball
+        # (this is what shipped broken in @ecmwf.int/tensogram@0.21.0). The
+        # package's `prepack` script removes that file before packing; this
+        # step proves the resulting tarball actually carries the wasm blob,
+        # failing the publish loudly rather than shipping an unusable package.
+        run: |
+          npm pack --dry-run --json > pack.json
+          node -e "const f=require('./pack.json')[0].files.map(x=>x.path); if(!f.includes('wasm/tensogram_wasm_bg.wasm')){console.error('FATAL: wasm blob missing from npm tarball. wasm/ entries present:', f.filter(p=>p.startsWith('wasm'))); process.exit(1);} console.log('ok: wasm blob present in tarball');"
+          rm -f pack.json
+
       - name: Check if version already published
         id: version-check
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 **/build/
 docs/book/
 python/**/dist/
+# Release wheel staging from `make python-dist-extras` / `make release-check`
+/dist/
 python/bindings/Cargo.lock
 rust/tensogram-grib/Cargo.lock
 rust/tensogram-netcdf/Cargo.lock

--- a/.prompts/make-release.md
+++ b/.prompts/make-release.md
@@ -12,107 +12,53 @@ Create a new release of Tensogram.
 Provide the version as argument, e.g. `/make-release 0.14.0`
 If no version given, auto-increment MINOR from the current VERSION file.
 
+> **Canonical procedure:** `docs/src/dev/releasing.md`. This skill automates it;
+> keep the two in sync.
+
 ## Pre-release Checks
 
-Run ALL of the following. If ANY step fails, STOP and prompt the user.
+Run these in order. If ANY step fails, STOP and prompt the user.
 
-### 1. Clean Working Tree
+### 1. Clean working tree
 ```bash
-git status  # must be clean — all changes committed and pushed
-git diff --stat origin/main  # must be empty
+git status                    # must be clean — all changes committed
+git diff --stat origin/main   # must be empty (also pushed)
 ```
 
-### 2. Full Build and Test
+### 2. Full gate
 ```bash
-cargo fmt --check
-cargo clippy --workspace --all-targets --all-features -- -D warnings
-cargo test --workspace
-cargo test -p tensogram --features "remote,async"
-cargo test --manifest-path rust/tensogram-grib/Cargo.toml
-cargo test --manifest-path rust/tensogram-netcdf/Cargo.toml
+make all            # build + test + lint across every language
+make release-check  # version-check, crate packaging + leaf dry-run publish,
+                    # cargo-c header-drift diff, wheels + twine, npm wasm-blob guard
 ```
 
-### 3. Python
-```bash
-source .venv/bin/activate
-uv pip install -e "python/tensogram-xarray/[dask]"
-uv pip install -e python/tensogram-zarr/
-ruff check --config python/bindings/pyproject.toml python/tests/
-python -m pytest python/tests/ -v
-python -m pytest python/tensogram-xarray/tests/ -v
-python -m pytest python/tensogram-zarr/tests/ -v
-```
-
-### 4. Examples Build
-```bash
-cargo build --workspace
-```
-
-### 5. Documentation
-```bash
-which mdbook && mdbook build docs/ || echo "mdbook not installed, skip"
-```
-
-If ANY of the above fails, STOP and report the failure to the user.
+`make all` + `make release-check` are the single source of truth for the local
+release gate — do not re-list the underlying `cargo` / `ruff` / `pytest`
+commands here. The grib/netcdf and macOS matrices and the real dry-run publishes
+run on a clean checkout in the `release-preflight` CI workflow (step 4 below).
 
 ## Release Process
 
-### 1. Version Bump
+### 1. Version bump
 
-Read the current version from `VERSION` file. Bump to the target version.
+`VERSION` is the single source of truth. Bump every manifest with the tooling —
+never hand-edit them:
 
-Update ALL of these locations (they MUST all match):
-- `VERSION` (the source of truth)
-- Root `Cargo.toml` `[workspace.package] version` — since #74 the 9
-  in-workspace member crates (tensogram, tensogram-encodings, tensogram-szip,
-  tensogram-sz3, tensogram-sz3-sys, tensogram-cli, tensogram-ffi, benchmarks,
-  examples/rust) inherit via `version.workspace = true`, so this single edit
-  covers all of them.
-- `Cargo.toml` of each EXCLUDED crate (not workspace members — must be bumped
-  individually): tensogram-python (at `python/bindings/Cargo.toml`),
-  tensogram-grib, tensogram-netcdf, tensogram-wasm.
-- `pyproject.toml` in EVERY Python package: python/bindings, python/tensogram-xarray,
-  python/tensogram-zarr, python/tensogram-anemoi, examples/jupyter
-- `typescript/package.json` AND `examples/typescript/package.json`
-- `CHANGELOG.md` — add new release entry header with today's date
-
-Also bump inter-crate dependency version pins (`version = "=X.Y.Z"` in path
-dependencies). These locations contain exact version pins that must match:
-- Root `Cargo.toml` workspace deps (tensogram-szip, tensogram-sz3, tensogram-sz3-sys)
-- `rust/tensogram-sz3/Cargo.toml` dep on tensogram-sz3-sys
-- `rust/tensogram/Cargo.toml` dep on tensogram-encodings
-- `rust/tensogram-grib/Cargo.toml` deps on tensogram + tensogram-encodings
-- `rust/tensogram-netcdf/Cargo.toml` deps on tensogram + tensogram-encodings
-- `rust/tensogram-cli/Cargo.toml` deps on tensogram + tensogram-grib + tensogram-netcdf
-- `rust/tensogram-ffi/Cargo.toml` deps on tensogram + tensogram-encodings
-- `rust/tensogram-wasm/Cargo.toml` dep on tensogram
-- `python/tensogram-anemoi/pyproject.toml` dependency pin on `tensogram`
-  (uses `>=X.Y.Z,<X.(Y+1)` — bump both bounds, mirrors the jupyter example)
-- `examples/jupyter/pyproject.toml` dependency pins on `tensogram` and
-  `tensogram[xarray]` (uses `>=X.Y.Z,<X.(Y+1).0` — bump both bounds)
-
-Verify no stale version strings remain in first-party files only:
 ```bash
-# Rust
-grep -r 'version = "OLD_VERSION"' --include='Cargo.toml' \
-  VERSION Cargo.toml rust/tensogram-*/Cargo.toml python/bindings/Cargo.toml \
-  rust/benchmarks/Cargo.toml examples/rust/Cargo.toml
-# Python
-grep 'version = "OLD_VERSION"' \
-  python/bindings/pyproject.toml \
-  python/tensogram-xarray/pyproject.toml \
-  python/tensogram-zarr/pyproject.toml \
-  python/tensogram-anemoi/pyproject.toml \
-  examples/jupyter/pyproject.toml
-# TypeScript
-grep '"version": "OLD_VERSION"' \
-  typescript/package.json \
-  examples/typescript/package.json
+make bump-version VERSION=X.Y.Z   # rewrites every manifest, then greps for stragglers
+make version-check                # confirms everything matches VERSION
 ```
 
-**WARNING**: Do NOT grep all `pyproject.toml` files recursively — the vendored
-`rust/tensogram-sz3-sys/SZ3/tools/pysz/pyproject.toml` has `version = "1.0.3"`
-which must NOT be changed.
+`make bump-version` (wrapping `scripts/bump_version.py`) is the authoritative
+list of what carries a version string — including the workspace `version`, the
+excluded-crate Cargo.tomls, the internal `version = "=X.Y.Z"` pins, every Python
+`pyproject.toml`, the `package.json` files, and `fortran/`. It already knows to
+skip the vendored `rust/tensogram-sz3-sys/SZ3/.../pyproject.toml`. The full
+contract is in AGENTS.md "Version control".
+
+It deliberately does NOT touch `CHANGELOG.md` or the Python dependency
+*constraint ranges* (`tensogram>=X.Y.Z,<X.(Y+1)`) — handle those by hand (next
+step).
 
 ### 2. Write CHANGELOG Entry
 

--- a/.prompts/prepare-make-pr.md
+++ b/.prompts/prepare-make-pr.md
@@ -9,36 +9,21 @@ Final preparation check and PR creation workflow.
 
 ## Pre-flight Checks
 
-Run ALL of the following. If ANY step fails, STOP and report the failure.
+Run the full gate. If it fails, STOP and report the failure — do not open the PR.
 
-### 1. Rust
 ```bash
-cargo fmt --check
-cargo clippy --workspace --all-targets --all-features -- -D warnings
-cargo test --workspace
-cargo test -p tensogram --features "remote,async"
+make all          # build + test + lint across Rust, Python, TS, C++, WASM, cargo-c, Fortran
 ```
 
-### 2. Python
-```bash
-source .venv/bin/activate
-ruff check --config python/bindings/pyproject.toml python/tests/
-ruff format --check --config python/bindings/pyproject.toml python/tests/
-python -m pytest python/tests/ -v
-python -m pytest python/tensogram-xarray/tests/ -v
-python -m pytest python/tensogram-zarr/tests/ -v
-```
+`make all` is the single source of truth for the pre-commit gate; it wraps the
+underlying `cargo` / `ruff` / `vitest` / CMake commands (run `make help` for the
+individual targets). Do NOT run a narrower subset in its place.
 
-### 3. Examples
-```bash
-cargo build --workspace  # Rust examples built as part of workspace
-```
+Mutation testing (`make mutants-diff`) is heavy and is a deliberate human
+decision — do not run it as part of opening a PR unless explicitly asked.
 
-### 4. Documentation
-```bash
-# Verify docs build if mdbook is available
-which mdbook && mdbook build docs/ || echo "mdbook not installed, skip"
-```
+(Releases have an extra gate, `make release-check`, and their own skill —
+see `/make-release` and `docs/src/dev/releasing.md`.)
 
 ## PR Creation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,68 @@ cd tensoscope && make build && make run
 ```
 Serves at http://localhost:8000/ (set BASE_PATH env var to deploy under a subpath)
 
+# Development workflow
+
+The lifecycle below maps each phase to the bundled slash-command skills in
+`.prompts/` (opencode resolves them via `.opencode/commands` → `.prompts`) and,
+when your agent harness provides them, to specialised subagents. Humans follow
+the same phases, just without the `/`-commands. CONTRIBUTING.md carries the
+human-facing version of this list.
+
+1. **Onboard** — `/onboard` reads the docs and surveys the code (use a
+   codebase-explorer subagent for the survey).
+2. **Pick work** — take an item from `plans/TODO.md` (the accepted backlog).
+   `plans/IDEAS.md` is speculative and is NOT committed direction.
+3. **Plan** — before writing code, say how you will verify it, plan the TDD
+   tests, take a behaviour-driven approach, ask clarifying questions, and
+   summarise the design + implementation plan (see Guidelines above). Use a
+   planner subagent if you have one; an external-research subagent for
+   unfamiliar formats/libraries.
+4. **Branch** — branch off `main` using the convention in CONTRIBUTING.md
+   ("Branch naming"): `<type>/<kebab-summary>`, where `<type>` matches the
+   commit types (`feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`,
+   `perf`, `build`; plus `security` / `hardening` for audit work).
+5. **Develop** — follow the conventions here and CONTRIBUTING.md's Code Style.
+   Document new features under `docs/` and add a runnable `examples/<lang>/`
+   example for any new public API. Record every user-facing change in
+   `CHANGELOG.md [Unreleased]` as you go — that is the only work-tracking
+   record (no separate status file, no issue ordinals). A domain-specialist
+   subagent fits the implementation; a security-auditor subagent for wire
+   format / FFI / adversarial-sensitive changes.
+6. **Quality passes** — `/make-further-pass` (strictness-graded), plus, as
+   needed, `/improve-code-coverage`, `/improve-edge-cases`,
+   `/improve-error-handling`, and `/doc-fact-check`. A reviewer/auditor subagent
+   fits here. Mutation testing (`make mutants-diff`) is heavy to run locally and
+   is ALWAYS a deliberate human decision — it is NOT part of the default gate.
+7. **Gate** — `make all` must be green (the single pre-commit gate; see
+   Build / lint / test above).
+8. **Open the PR** — `/prepare-make-pr` runs `make all`, then commits on a
+   feature branch with a conventional-commit message, pushes, and opens the PR
+   against `.github/PULL_REQUEST_TEMPLATE.md`. Only commit / push / open a PR
+   when the user has asked you to.
+9. **Review loop** — `/copilot-review-loop` drives the Copilot reviewer to
+   convergence; `/address-pr-comments` resolves human review threads and waits
+   on CI (`gh pr checks --watch`). Review ownership is in `.github/CODEOWNERS`.
+10. **Release** — `/make-release`; full procedure in `docs/src/dev/releasing.md`
+    and "Release process" below.
+
+## Review & merge
+
+- All changes land on `main` through a pull request from a `<type>/…` branch;
+  `main` is protected against direct pushes.
+- `.github/CODEOWNERS` auto-requests review from the maintainers. A PR needs at
+  least one approving review from a code owner — **two** for the wire format
+  (`plans/WIRE_FORMAT.md`, `rust/tensogram/src/wire.rs` / `framing.rs`), the C
+  ABI / generated header (`rust/tensogram-ffi/`), or security-sensitive code.
+- CI (`ci.yml`) must be green before merge; `release-preflight` must be green
+  before any release tag.
+- Run `/copilot-review-loop` to convergence before requesting human review;
+  `/address-pr-comments` resolves threads. Pushing new commits dismisses stale
+  approvals, so re-request review after addressing feedback.
+- Merge with a **merge commit** (GitHub "Create a merge commit"), then delete
+  the branch.
+- Agents NEVER push, merge, or open a PR without explicit user approval.
+
 # Version control
 - Git project in github.com/ecmwf/tensogram
 - IMPORTANT: 
@@ -174,11 +236,27 @@ Serves at http://localhost:8000/ (set BASE_PATH env var to deploy under a subpat
     - NEVER update MAJOR unless users says so. 
     - Increment MINOR for new features. MICRO for bugfixes and documentation updates.
 - NEVER prepend git tag or releases with 'v'
-- REMEBER on releases:
-    - check all is commited and pushed upstream, otherwise STOP and warn user
-    - update the VERSION file
-    - git tag with version
-    - push and create release in github
+- Release process (canonical ordered procedure; full rationale + per-step
+  detail in `docs/src/dev/releasing.md`):
+    1. Ensure `main` is green and every user-facing change is recorded in
+       `CHANGELOG.md` under `[Unreleased]`.
+    2. `make bump-version VERSION=X.Y.Z` — rewrites every manifest from the
+       `VERSION` source of truth (see the list below). By hand, move the
+       `[Unreleased]` CHANGELOG entries under a new `## [X.Y.Z] - DATE` heading.
+    3. `make all` — the full build/test/lint gate (Rust + Python + TS + C++ +
+       WASM + cargo-c + Fortran).
+    4. `make release-check` — the release-only gates `make all` does NOT run
+       (version-check, crate packaging + leaf-crate dry-run publish, the
+       cargo-c header-drift diff, Python wheel + `twine` metadata, npm
+       wasm-blob guard). Requires `cargo-c`, `uv`, and Node on PATH.
+    5. Commit and push everything. STOP and warn the user if anything is
+       uncommitted — a tag must point at a clean tree.
+    6. Optionally dispatch the `release-preflight` GitHub workflow — the
+       authoritative pre-tag gate, which additionally runs the grib/netcdf +
+       macOS matrices and real dry-run publishes on a clean checkout.
+    7. `git tag X.Y.Z` (NO `v` prefix), push the tag, and create the GitHub
+       release. The tag push triggers the `publish-crates` / `publish-pypi` /
+       `publish-npm` / `publish-ffi` workflows.
 
 - NOTE: SINGLE SOURCE OF TRUTH FOR VERSION — The `VERSION` file at the repo root is the
   canonical version for the ENTIRE project. ALL version strings everywhere MUST match it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,87 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed — npm package now ships the WASM blob
+
+The published `@ecmwf.int/tensogram` npm package was missing its entire
+`wasm/` directory — including `tensogram_wasm_bg.wasm` — making the
+package unusable for consumers. `wasm-pack` writes a `.gitignore`
+containing `*` into its output directory, and `npm` honours that nested
+ignore file when building the tarball, silently dropping every file in
+`wasm/` even though `wasm` is listed in the package `files` allowlist.
+A `prepack` script now removes that generated `.gitignore` before the
+tarball is built, so the WASM glue and binary are included. The
+`publish-npm` workflow gained a guard step that fails the publish if the
+`.wasm` blob is absent from the packed tarball, so the regression cannot
+recur silently.
+
+### Added — `tensogram.__version__` in the Python package
+
+The Python `tensogram` module now exposes `__version__` (e.g.
+`"0.21.0"`). It is stamped into the compiled extension from the bindings
+crate's `CARGO_PKG_VERSION`, so it always matches the installed binary
+and tracks the project `VERSION` file through the existing
+`make bump-version` single-source-of-truth tooling.
+
+### Fixed — CONTRIBUTING project-structure tree
+
+The project-structure tree in `CONTRIBUTING.md` was missing several
+directories that have since been added: the `python/tensogram-anemoi`
+and `python/tensogram-earthkit` packages, the top-level `fortran/`,
+`typescript/`, and `tensoscope/` trees, and the `fortran/`, `typescript/`,
+and `jupyter/` example directories. The tree now reflects the current
+layout.
+
+### Changed — `make` build targets and full-stack `make all`
+
+`make all` now compiles **every** language surface before the test and
+lint gates, via a new `build` aggregate: `rust-build`, `python-build`,
+`ts-build`, `cpp-build`, `wasm-build`, `cargo-c-build`, and the Fortran
+binding (linked against a repo-local cargo-c install prefix at
+`build/ffi-prefix`, so there are no writes outside the tree and
+`make clean` removes it). New standalone targets `rust-build`
+(`cargo build --workspace`) and `wasm-build` (`wasm-pack` →
+git-ignored `build/wasm`), plus a `docs` alias for `docs-build`. The
+`cargo-c-smoke` target is renamed `cargo-c-test` and now runs the
+`tensogram-ffi` unit/integration tests in addition to the cargo-c
+install smoke test.
+
+### Added — `make release-check` release-readiness gate
+
+A new `make release-check` runs the release-only gates that `make all`
+does not: `version-check`, the optional-feature test surface
+(`remote` / `remote,async`), crate-tarball packaging plus a leaf-crate
+`cargo publish --dry-run`, the cargo-c header-drift diff, Python wheel +
+`twine` metadata validation, and an npm-tarball wasm-blob guard. Run it
+after a green `make all` when preparing a release; it is the
+locally-runnable subset of the `release-preflight` CI workflow. The full
+release procedure is documented in `docs/src/dev/releasing.md` and
+`AGENTS.md`.
+
+### Added — documented end-to-end development workflow + `CODEOWNERS`
+
+`AGENTS.md` and `CONTRIBUTING.md` now carry a single "Development workflow"
+section that maps each lifecycle phase (onboard → plan → branch → develop →
+PR → review → release) to the bundled `.prompts/` slash-command skills (and,
+where available, specialised subagents), and documents a branch-naming
+convention (`<type>/<kebab-summary>`, matching the commit types). The
+`prepare-make-pr` and `make-release` skills and CONTRIBUTING's gate step now
+defer to `make all` (and `make release-check` / `make bump-version` for
+releases) instead of re-listing raw per-tool commands, removing duplicate
+sources of truth. A new `.github/CODEOWNERS` auto-requests review from the
+maintainers, and a "Review & merge" policy documents PR-only landing on
+`main`, code-owner approvals (two for the wire format / C ABI / security code),
+green CI, and merge-commit merges. Mutation testing stays a deliberate,
+human-initiated step and is explicitly excluded from the default gate.
+
+### Fixed — `resolve_compression` unused-parameter warnings under `--no-default-features`
+
+`resolve_compression`'s `encoding`/`filter` parameters are consumed only
+by the feature-gated `szip`/`blosc2` arms, so a `--no-default-features`
+build (exercised by `make check`) warned they were unused. Scoped an
+`allow(unused_variables)` precisely to that build configuration rather
+than suppressing it globally.
+
 ### Added — version-bump tooling (`make bump-version` / `make version-check`)
 
 A new `scripts/bump_version.py` (zero-dependency, run with plain `python3`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,18 +16,26 @@ Thank you for your interest in contributing. This guide will get you from zero t
 git clone https://github.com/ecmwf/tensogram.git
 cd tensogram
 
-# Build everything
+# Rust-only quick check (needs no optional toolchains)
 cargo build --workspace
-
-# Run the test suite
 cargo test --workspace
-
-# Check formatting and lints
 cargo fmt --check
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 ```
 
-If all of that passes, you're ready to go.
+The **canonical gate** — what CI runs and what you must pass before committing —
+is the top-level Makefile, which covers every language (Rust, Python,
+TypeScript, C++, WASM, cargo-c, Fortran):
+
+```bash
+make all          # build + test + lint, across all languages
+make help         # list every target
+```
+
+`make all` needs the optional toolchains listed under Prerequisites (uv, Node +
+`wasm-pack`, a C/C++ compiler + CMake, gfortran + pkg-config, cargo-c). When
+preparing a release, also run `make release-check` (see
+[docs/src/dev/releasing.md](docs/src/dev/releasing.md)).
 
 ## Project Structure
 
@@ -53,15 +61,23 @@ tensogram/
 │   ├── bindings/               # Python bindings (PyO3, excluded from default build)
 │   ├── tensogram-xarray/       # xarray backend engine
 │   ├── tensogram-zarr/         # Zarr v3 store backend
+│   ├── tensogram-anemoi/       # anemoi-inference output plugin
+│   ├── tensogram-earthkit/     # earthkit-data source + encoder plugin
 │   └── tests/                  # Python test suite
 ├── cpp/
-│   ├── include/                # C++ wrapper header + C header
+│   ├── include/                # C++ wrapper header + C header (incl. async/)
 │   ├── tests/                  # C++ GoogleTest suite
 │   └── CMakeLists.txt          # CMake build system
+├── fortran/                    # Fortran 2008 binding over the C FFI (CMake + fpm)
+├── typescript/                 # TypeScript wrapper over the WASM crate (npm pkg)
+├── tensoscope/                 # Browser-based interactive .tgm viewer (React + WASM)
 ├── examples/
 │   ├── rust/                   # Runnable Rust examples (NN_description.rs)
 │   ├── cpp/                    # C++ examples using the wrapper
-│   └── python/                 # Python examples using the PyO3 bindings
+│   ├── python/                 # Python examples using the PyO3 bindings
+│   ├── fortran/                # Fortran examples using the binding
+│   ├── typescript/             # TypeScript examples using the WASM wrapper
+│   └── jupyter/                # Narrative Jupyter notebook walk-throughs
 ├── docs/                       # mdbook documentation source
 ├── plans/                      # Design docs, implementation status, TODOs
 │   └── ARCHITECTURE.md         # How the crates fit together
@@ -71,9 +87,32 @@ tensogram/
 
 ## Development Workflow
 
+> **Agents:** the full lifecycle (onboard → plan → branch → develop → PR →
+> review → release) and the bundled `/`-skill that drives each phase are
+> documented in [AGENTS.md](AGENTS.md) under "Development workflow". The bundled
+> skills live in `.prompts/` (e.g. `/onboard`, `/prepare-make-pr`,
+> `/make-release`). The steps below are the human-facing version.
+
+### Branch naming
+
+Branch off `main`. Names follow `<type>/<kebab-summary>`, where `<type>` is one
+of the conventional-commit types also used for commit messages:
+
+```
+feat/<summary>      fix/<summary>       docs/<summary>
+chore/<summary>     refactor/<summary>  test/<summary>
+ci/<summary>        perf/<summary>      build/<summary>
+```
+
+Audit / longer-lived work also uses `security/<summary>` and
+`hardening/<summary>`. Examples from history: `feat/fortran-interface`,
+`fix/python-packages-build-system`, `docs/reorganize-documentation`,
+`ci/manylinux-2-28`, `security/hardening-audit`. (`feature/…` appears in older
+history; new branches use the short `feat/` form to match the commit types.)
+
 ### 1. Make your changes
 
-Work on a branch. The codebase follows these conventions:
+Work on a branch (see Branch naming above). The codebase follows these conventions:
 
 - **No panics in library code.** All fallible operations return `Result<T, TensogramError>`.
 - **Immutability by default.** Use `let` unless mutation is required.
@@ -82,18 +121,22 @@ Work on a branch. The codebase follows these conventions:
 
 See the [Code Style](#code-style) section below for the full style guide.
 
-### 2. Run the checks
+### 2. Run the gate
 
-Before submitting, run all four:
+Before submitting, run the full multi-language gate:
 
 ```bash
-cargo build --workspace
-cargo fmt
-cargo clippy --workspace --all-targets --all-features -- -D warnings
-cargo test --workspace
+make all          # = make check test lint, across all languages
 ```
 
-All four must pass with zero warnings. The CI pipeline runs the same commands.
+It must pass with zero warnings — CI runs the same gate. `make all` wraps the
+underlying `cargo` / `ruff` / `vitest` / CMake commands, so there is one source
+of truth (see the Makefile or `make help`). For a fast Rust-only inner loop you
+can still run:
+
+```bash
+cargo fmt && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test --workspace
+```
 
 ### 3. Test optional features
 
@@ -127,6 +170,25 @@ cargo doc --workspace --no-deps
 ### 5. Add examples
 
 If you add a new API surface, add a runnable example in `examples/rust/`. The naming convention is `NN_description.rs` (e.g. `11_new_feature.rs`).
+
+### 6. Open a pull request
+
+Use `/prepare-make-pr` (it runs `make all`, commits, pushes, and opens the PR),
+or do it by hand:
+
+- Branch name follows **Branch naming** above; commits use conventional-commit
+  messages.
+- Fill in the PR template (`.github/PULL_REQUEST_TEMPLATE.md`), including the CLA.
+- `.github/CODEOWNERS` auto-requests review from the maintainers. A PR needs at
+  least one code-owner approval — **two** for the wire format, the C ABI /
+  generated header, or security-sensitive code.
+- CI must be green. Run `/copilot-review-loop` to convergence and
+  `/address-pr-comments` to resolve threads.
+- Merge with a **merge commit** and delete the branch. (Mutation testing,
+  `make mutants-diff`, is heavy and run only by deliberate human choice.)
+
+The full review / approval / merge policy is in [AGENTS.md](AGENTS.md) under
+"Review & merge".
 
 ## Code Style
 

--- a/Makefile
+++ b/Makefile
@@ -9,16 +9,18 @@
 # Top-level Makefile dispatching builds and tests for all languages.
 # Run `make help` to see available targets.
 
-.PHONY: help all check test lint fmt docs clean \
+.PHONY: help all build check test lint fmt docs clean \
         bump-version version-check \
-        rust-check rust-test rust-lint rust-fmt rust-clippy \
+        release-check feature-tests crates-verify cargo-c-header-check \
+        python-release-check npm-pack-check \
+        rust-check rust-build rust-test rust-lint rust-fmt rust-clippy \
         python-build python-dist python-dist-extras python-test python-lint python-fmt \
         earthkit-install earthkit-test earthkit-lint \
         cpp-build cpp-test \
         fortran-build fortran-test fortran-fpm-test fortran-f2008-check \
-        cargo-c-build cargo-c-install cargo-c-smoke \
+        cargo-c-build cargo-c-install cargo-c-test \
         mutants-install mutants mutants-diff mutants-shard \
-        wasm-test docs-build doc-examples \
+        wasm-build wasm-test docs-build doc-examples \
         ts-install ts-build ts-test ts-typecheck \
         remote-parity-rust-build remote-parity-ts-install remote-parity-fixtures \
         remote-parity-build remote-parity remote-parity-clean
@@ -29,13 +31,16 @@ help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
-all: check test lint ## Run all checks, tests, and lints
+all: check build test lint ## Build every language surface, then run all checks, tests, and lints
 
 # ── Rust ──────────────────────────────────────────────────────────────────
 
 rust-check: ## Check Rust workspace compiles
 	cargo check --workspace
 	cargo check -p tensogram --no-default-features
+
+rust-build: ## Build the Rust workspace (debug binaries + libs)
+	cargo build --workspace
 
 rust-test: ## Run all Rust tests
 	cargo test --workspace
@@ -80,7 +85,17 @@ MATURIN_COMPAT_ARG = $(if $(MATURIN_COMPAT),--compatibility $(MATURIN_COMPAT))
 
 python-build: ## Build Python bindings via maturin (dev install into .venv)
 	if [ ! -d .venv ] ; then uv venv ; fi
-	uv pip install maturin
+	# `[patchelf]` ships the patchelf binary maturin uses to set the
+	# shared-library rpath on Linux (matches release-preflight CI; without
+	# it maturin only warns).
+	uv pip install 'maturin[patchelf]'
+	# Force a fresh cdylib link. Across repeated `maturin develop --uv`
+	# runs, cargo/maturin can leave a 0-byte, hardlinked libtensogram.so in
+	# target/ while cargo's fingerprint still reads "fresh", so cargo never
+	# relinks and the next develop aborts with "Object is too small".
+	# Removing the artifacts makes cargo relink a valid, unshared library.
+	rm -f python/bindings/target/release/libtensogram.so python/bindings/target/release/deps/libtensogram*.so
+	rm -rf python/bindings/target/maturin
 	cd python/bindings && $(MATURIN) develop --release --uv
 	uv pip install ./python/tensogram-xarray
 	uv pip install ./python/tensogram-zarr
@@ -177,7 +192,8 @@ cargo-c-build: ## Build the C library + pkg-config + header via cargo-c
 cargo-c-install: ## Install via cargo-c into PREFIX (default $HOME/.local)
 	cargo cinstall --release -p tensogram-ffi --prefix=$(PREFIX) --libdir=lib
 
-cargo-c-smoke: cargo-c-install ## Install + run the C-API smoke test against the install prefix
+cargo-c-test: cargo-c-install ## Run all C-API tests: tensogram-ffi unit/integration tests + cargo-c install smoke test
+	cargo test -p tensogram-ffi --features async-remote
 	bash cpp/tests/test_cargo_c_smoke.sh $(PREFIX)
 
 # ── Mutation testing (cargo-mutants) ──────────────────────────────────────
@@ -269,6 +285,13 @@ mutants-shard: mutants-install ## Run a single mutant shard (SHARD=N/M, e.g. SHA
 
 # ── WASM ──────────────────────────────────────────────────────────────────
 
+# `--out-dir` is resolved relative to the crate directory, so `../../build/wasm`
+# lands at <repo>/build/wasm — git-ignored and removed by `make clean`. This is
+# a standalone "does the wasm crate build" target; the copy the TypeScript
+# wrapper actually consumes is produced by `ts-build` into typescript/wasm.
+wasm-build: ## Build the tensogram-wasm crate to a wasm package (wasm-pack)
+	wasm-pack build rust/tensogram-wasm --release --target web --out-dir ../../build/wasm --out-name tensogram_wasm
+
 wasm-test: ## Run WASM tests
 	wasm-pack test --node rust/tensogram-wasm
 
@@ -287,6 +310,8 @@ ts-typecheck: ts-build ## Strict typecheck source + tests
 	cd typescript && npx tsc --noEmit -p tsconfig.test.json
 
 # ── Docs ──────────────────────────────────────────────────────────────────
+
+docs: docs-build ## Build the documentation site (alias for docs-build)
 
 docs-build: ## Build mdbook documentation
 	mdbook build docs/
@@ -349,9 +374,74 @@ bump-version: ## Bump the project version everywhere: make bump-version VERSION=
 version-check: ## Verify every manifest matches the VERSION file (CI guard)
 	python3 scripts/bump_version.py --check
 
+# ── Release readiness ─────────────────────────────────────────────────────
+#
+# `make release-check` runs the release-only gates that `make all` does NOT,
+# so run it AFTER a green `make all`, before tagging. It mirrors the locally
+# runnable subset of .github/workflows/release-preflight.yml (the authoritative
+# pre-tag CI gate, which additionally runs the grib/netcdf + macOS matrices and
+# the real dry-run publishes on a clean checkout). Full procedure:
+# docs/src/dev/releasing.md.
+
+# Host target triple — cargo-c emits its artefacts under target/<triple>/.
+_HOST_TRIPLE = $(shell rustc -vV | sed -n 's/^host: //p')
+
+feature-tests: ## Test the optional-feature surface that make-all's default-feature run skips
+	cargo test -p tensogram --features remote
+	cargo test -p tensogram --features "remote,async"
+
+crates-verify: ## List every workspace crate tarball + dry-run publish the leaf crates
+	# `--allow-dirty`: release-check is meant to run before the final release
+	# commit (version bump / changelog edits may still be uncommitted). The
+	# real publish runs on the clean tagged commit via publish-crates.yml.
+	for crate in tensogram-szip tensogram-sz3-sys tensogram-sz3 \
+	             tensogram-encodings tensogram tensogram-ffi tensogram-cli; do \
+	  echo "==> cargo package -p $$crate --list"; \
+	  cargo package -p "$$crate" --list --allow-dirty >/dev/null || exit 1; \
+	done
+	# Leaf crates have no path-only deps, so a real dry-run publish compiles
+	# the packaged tarball — catching missing `include` files or bad metadata.
+	# (Crates with sibling path deps cannot be dry-run-published until the deps
+	# are on crates.io; the publish-crates workflow handles their ordering.)
+	cargo publish --dry-run --allow-dirty -p tensogram-szip
+	cargo publish --dry-run --allow-dirty -p tensogram-sz3-sys
+
+cargo-c-header-check: cargo-c-build ## Diff the in-tree FFI header against cargo-c's generated header (drift guard)
+	diff -u rust/tensogram-ffi/tensogram.h \
+	        target/$(_HOST_TRIPLE)/release/include/tensogram/tensogram.h
+
+python-release-check: python-dist python-dist-extras ## Build all wheels + validate their metadata with twine
+	uv pip install twine
+	$(PYTHON) -m twine check python/bindings/dist/*.whl dist/extras/*
+
+npm-pack-check: ts-build ## Verify the published npm tarball would include the wasm blob
+	cd typescript && set -o pipefail && npm pack --dry-run --json 2>/dev/null | \
+	  node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{const f=JSON.parse(d)[0].files.map(x=>x.path); if(!f.includes('wasm/tensogram_wasm_bg.wasm')){console.error('FATAL: wasm blob missing from npm tarball');process.exit(1)} console.log('ok: wasm blob present in npm tarball')})"
+
+release-check: version-check feature-tests crates-verify cargo-c-header-check python-release-check npm-pack-check ## Release-readiness gate — run AFTER `make all`, before tagging
+	@echo ""
+	@echo "release-check: all release gates passed."
+	@echo "Next: see docs/src/dev/releasing.md for the bump / tag / publish steps."
+
 # ── Aggregates ────────────────────────────────────────────────────────────
 
 check: rust-check ## Check all builds
+
+# `build` compiles every language surface in one shot: Rust, Python (maturin),
+# TypeScript (wasm-pack + tsc), C++ (CMake), WASM (wasm-pack), and the cargo-c C
+# library. The Fortran binding links that C ABI via pkg-config, so it is built
+# last against a repo-local install prefix (build/ffi-prefix — no writes outside
+# the tree; `make clean` removes it). The build/fortran CMake dir is wiped first
+# so the configure always re-queries pkg-config against the freshly installed
+# prefix; otherwise a stale cache can pin an absolute include dir from an earlier
+# prefix and fail the generate step. Heavier system prerequisites than the other
+# aggregates: a C/C++ toolchain + CMake, gfortran + pkg-config, wasm-pack,
+# cargo-c, uv, and Node.
+build: rust-build python-build ts-build cpp-build wasm-build cargo-c-build ## Build every language surface (Rust, Python, TS, C++, WASM, cargo-c, Fortran)
+	$(MAKE) cargo-c-install PREFIX=$(CURDIR)/build/ffi-prefix
+	rm -rf $(CURDIR)/build/fortran
+	PKG_CONFIG_PATH="$(CURDIR)/build/ffi-prefix/lib/pkgconfig:$$PKG_CONFIG_PATH" $(MAKE) fortran-build
+
 test: rust-test python-test ts-test ## Run all tests
 lint: rust-lint python-lint python-fmt ts-typecheck ## Run all lints
 fmt: rust-fmt python-fmt ## Check all formatting

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -97,4 +97,5 @@
 - [Error Handling](guide/error-handling.md)
 - [Edge Cases](edge-cases.md)
 - [Mutation Testing](dev/mutation-testing.md)
+- [Releasing](dev/releasing.md)
 - [Internals](internals.md)

--- a/docs/src/dev/releasing.md
+++ b/docs/src/dev/releasing.md
@@ -1,0 +1,155 @@
+# Releasing
+
+This page is the canonical procedure for cutting a Tensogram release. It is
+written for both human maintainers and coding agents. The short version lives
+in `AGENTS.md`; this page adds the per-step detail, the rationale, and the
+prerequisites.
+
+## The gate model
+
+A release passes through three gates, in order:
+
+1. **`make all`** — the everyday build/test/lint gate. Compiles every language
+   surface (Rust, Python, TypeScript, C++, WASM, cargo-c, Fortran) and runs the
+   Rust/Python/TS test suites plus all lints.
+2. **`make release-check`** — the *release-only* gates that `make all` does not
+   run: version consistency, crate packaging, the C header-drift diff, Python
+   wheel metadata, and the npm tarball contents. Run it **after** a green
+   `make all`.
+3. **`release-preflight.yml`** (GitHub Actions, `workflow_dispatch`) — the
+   authoritative pre-tag gate. It runs the same checks on a clean checkout and
+   additionally covers the grib/netcdf and macOS matrices and real dry-run
+   publishes. Local `make release-check` is the fast, locally-runnable subset of
+   this.
+
+`make release-check` is not folded into `make all` because it is slower
+(it builds distributable wheels, dry-run-publishes crates, and builds the
+cargo-c C library) and only relevant when preparing a release.
+
+## Prerequisites
+
+`make release-check` needs more than the core Rust toolchain:
+
+| Tool | Used by | Install |
+| --- | --- | --- |
+| `cargo-c` | `cargo-c-header-check`, the cargo-c leg of `make all` | `cargo install cargo-c --locked` (CI pins `0.10.21 --features vendored-openssl`) |
+| `uv` | Python build/test, wheel build, `twine` | see `astral.sh/uv` |
+| Node ≥ 20 | TypeScript build, `npm-pack-check` | nodejs.org |
+| `wasm-pack` | WASM build | `cargo install wasm-pack` |
+| `gfortran` + `pkg-config` | Fortran leg of `make all` | system package manager |
+
+`maturin` and `patchelf` are installed automatically into `.venv` by the
+Python targets (`maturin[patchelf]`).
+
+## Step-by-step
+
+### 1. Confirm the work is landed and recorded
+
+`main` must be green, and every user-facing change must already be in
+`CHANGELOG.md` under the `[Unreleased]` section. The changelog is the single
+backward-looking record — there is no separate status file.
+
+### 2. Bump the version
+
+```bash
+make bump-version VERSION=X.Y.Z
+```
+
+The `VERSION` file at the repo root is the **single source of truth**. This
+command (wrapping `scripts/bump_version.py`) rewrites every manifest that
+carries a version string and then greps the tree for stragglers. Never
+hand-edit individual manifests.
+
+SemVer rules:
+
+- **MAJOR** — never bump without the user explicitly asking.
+- **MINOR** — new features.
+- **MICRO** — bug fixes and documentation.
+
+Then, **by hand**, move the `[Unreleased]` changelog entries under a new
+`## [X.Y.Z] - YYYY-MM-DD` heading. The bump script deliberately does not touch
+`CHANGELOG.md` or the Python dependency *constraint ranges*
+(`tensogram>=X.Y.Z,<X.Y+1`) — the `<` ceiling is a compatibility policy that is
+surfaced for review rather than rewritten.
+
+Verify everything is consistent at any time with:
+
+```bash
+make version-check
+```
+
+Why it matters: the provenance encoder reads the version via
+`env!("CARGO_PKG_VERSION")`, so a manifest out of sync with `VERSION` stamps the
+wrong provenance into encoded messages.
+
+### 3. Run the full gate
+
+```bash
+make all
+```
+
+This must be green. It is now comprehensive across all languages, so it needs
+the full toolchain (see Prerequisites). It is also idempotent — safe to re-run.
+
+### 4. Run the release-readiness gate
+
+```bash
+make release-check
+```
+
+This runs, in order:
+
+| Sub-target | Checks |
+| --- | --- |
+| `version-check` | Every manifest matches the `VERSION` file. |
+| `feature-tests` | The optional-feature test surface (`remote`, `remote,async`) that `make all`'s default-feature run skips. |
+| `crates-verify` | `cargo package --list` for every workspace crate + a real `cargo publish --dry-run` of the leaf crates (`tensogram-szip`, `tensogram-sz3-sys`), which compiles the packaged tarball and catches missing `include` files or bad metadata. |
+| `cargo-c-header-check` | Diffs the in-tree `rust/tensogram-ffi/tensogram.h` against the header `cargo-c` generates — a drift guard for C/C++ consumers. |
+| `python-release-check` | Builds the binding wheel for every discovered interpreter plus the pure-Python extra packages, then validates their metadata with `twine check`. |
+| `npm-pack-check` | Verifies the published npm tarball would include `wasm/tensogram_wasm_bg.wasm` (wasm-pack writes a `.gitignore` that npm otherwise honours, silently dropping the wasm blob). |
+
+`make release-check` may be run on a working tree that still has the
+version-bump/changelog edits uncommitted — the packaging checks pass
+`--allow-dirty` for exactly this reason. The *real* publish always runs on the
+clean tagged commit.
+
+### 5. Commit and push
+
+Commit the version bump and changelog edits and push. **If anything is
+uncommitted, STOP** — a tag must point at a clean tree.
+
+### 6. (Optional but recommended) Dispatch the CI preflight
+
+Run the `release-preflight` workflow (`workflow_dispatch`, with the expected
+version as input). It re-runs the gates on a clean checkout and adds the
+grib/netcdf and macOS coverage plus real dry-run publishes — things the local
+gate cannot fully cover.
+
+### 7. Tag and publish
+
+```bash
+git tag X.Y.Z          # NO leading 'v'
+git push origin X.Y.Z
+```
+
+Then create the GitHub release. The tag push triggers the publish workflows:
+
+- `publish-crates.yml` — crates.io, in dependency order.
+- `publish-pypi.yml` — the binding wheel + pure-Python packages.
+- `publish-npm.yml` — `@ecmwf.int/tensogram` (with the wasm-blob guard).
+- `publish-ffi.yml` — pre-built C/C++ FFI tarballs attached to the release.
+
+## Troubleshooting
+
+- **`cargo package`/`publish` aborts on "uncommitted changes"** — expected on a
+  dirty tree; `make release-check` already passes `--allow-dirty`. If you call
+  the cargo commands directly, add `--allow-dirty` or commit first.
+- **`maturin failed … Object is too small`** — a stale/zeroed binding cdylib
+  from a previous `maturin develop`. `make python-build` removes the artifact
+  before building to force a clean relink; if you hit it outside make, delete
+  `python/bindings/target/release/libtensogram*.so` and rebuild.
+- **Fortran configure fails with a non-existent include path** — a stale
+  `build/fortran` CMake cache pinned an old prefix. `make build` wipes
+  `build/fortran` first; otherwise `rm -rf build/fortran` and re-run.
+- **`cargo cinstall: no such subcommand`** — `cargo-c` is not installed (see
+  Prerequisites).

--- a/python/bindings/python/tensogram/__init__.py
+++ b/python/bindings/python/tensogram/__init__.py
@@ -12,6 +12,11 @@ from collections import namedtuple
 
 from .tensogram import *  # noqa: F403
 
+# `from .tensogram import *` skips dunder names, so re-export the package
+# version explicitly. It is stamped into the compiled extension from the
+# crate's CARGO_PKG_VERSION, so it always matches the installed binary.
+from .tensogram import __version__ as __version__
+
 Message = namedtuple("Message", ["metadata", "objects"])
 """Decoded message with named fields.
 

--- a/python/bindings/src/lib.rs
+++ b/python/bindings/src/lib.rs
@@ -2995,6 +2995,15 @@ fn tensogram(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // read it without having to decode a message first.
     m.add("WIRE_VERSION", tensogram_lib::WIRE_VERSION)?;
 
+    // Package version (`tensogram.__version__`).  Sourced from the
+    // bindings crate's `CARGO_PKG_VERSION` at compile time, so it always
+    // matches the compiled extension and tracks the project `VERSION`
+    // file via the `make bump-version` single-source-of-truth tooling
+    // (the same env! the provenance encoder reads).  `__init__.py`
+    // re-exports it explicitly because `from .tensogram import *` skips
+    // dunder names.
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+
     // Decode-time integrity exceptions — see `to_py_err` for the
     // hierarchy and `plans/DESIGN.md` §"Integrity Hashing" for
     // the full contract.

--- a/python/tensogram-xarray/tests/test_coverage.py
+++ b/python/tensogram-xarray/tests/test_coverage.py
@@ -27,7 +27,6 @@ import numpy as np
 import pytest
 import tensogram
 import xarray as xr
-
 from tensogram_xarray.array import (
     _is_contiguous_slice,
     _nd_slice_to_flat_ranges,

--- a/python/tensogram-zarr/tests/test_coverage.py
+++ b/python/tensogram-zarr/tests/test_coverage.py
@@ -22,7 +22,6 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 import tensogram
-
 from tensogram_zarr import TensogramStore
 from tensogram_zarr.mapping import (
     build_array_zarr_json,

--- a/rust/tensogram/src/encode.rs
+++ b/rust/tensogram/src/encode.rs
@@ -881,6 +881,16 @@ fn resolve_filter(desc: &DataObjectDescriptor) -> Result<FilterType> {
 /// Resolve the compression type from a descriptor, using the resolved
 /// encoding and filter for any codec that depends on them (szip bits_per_sample,
 /// blosc2 typesize).
+///
+/// `encoding` and `filter` are consumed only by the feature-gated `szip` and
+/// `blosc2` arms below.  With every codec that needs them disabled (e.g. a
+/// `--no-default-features` build) they are genuinely unused, so the `allow`
+/// is scoped precisely to that build configuration rather than applied
+/// unconditionally.
+#[cfg_attr(
+    not(any(feature = "szip", feature = "szip-pure", feature = "blosc2")),
+    allow(unused_variables)
+)]
 fn resolve_compression(
     desc: &DataObjectDescriptor,
     dtype: Dtype,
@@ -1653,7 +1663,7 @@ fn mask_params_cbor(method: &MaskMethod) -> BTreeMap<String, ciborium::Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::decode::{DecodeOptions, decode};
+    use crate::decode::{decode, DecodeOptions};
     use crate::types::{ByteOrder, GlobalMetadata};
     use std::collections::BTreeMap;
 

--- a/rust/tensogram/src/encode.rs
+++ b/rust/tensogram/src/encode.rs
@@ -1663,7 +1663,7 @@ fn mask_params_cbor(method: &MaskMethod) -> BTreeMap<String, ciborium::Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::decode::{decode, DecodeOptions};
+    use crate::decode::{DecodeOptions, decode};
     use crate::types::{ByteOrder, GlobalMetadata};
     use std::collections::BTreeMap;
 

--- a/tensoscope/package-lock.json
+++ b/tensoscope/package-lock.json
@@ -144,13 +144,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -159,9 +159,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -169,21 +169,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -200,14 +200,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -217,14 +217,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -234,9 +234,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -244,29 +244,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -276,9 +276,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -286,9 +286,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -296,9 +296,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -306,27 +306,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -336,33 +336,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -370,14 +370,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -738,9 +738,9 @@
       "link": true
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -749,9 +749,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1785,13 +1785,13 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -1822,9 +1822,9 @@
       "peer": true
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.124.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
-      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -1862,9 +1862,9 @@
       "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -1878,9 +1878,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -1894,9 +1894,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -1910,9 +1910,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -1926,9 +1926,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
-      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -1942,9 +1942,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -1958,9 +1958,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -1974,9 +1974,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -1990,9 +1990,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -2006,9 +2006,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -2022,9 +2022,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -2038,9 +2038,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -2054,27 +2054,27 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
-        "@napi-rs/wasm-runtime": "^1.1.3"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -2088,9 +2088,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -2226,9 +2226,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3622,9 +3622,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
-      "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
+      "version": "2.10.38",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3793,9 +3793,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001788",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
-      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -4860,9 +4860,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
-      "integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -4903,9 +4903,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.340",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
-      "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
+      "version": "1.5.376",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz",
+      "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5961,10 +5961,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6675,9 +6685,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.13",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
+      "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
       "funding": [
         {
           "type": "github",
@@ -6700,11 +6710,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.37",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "version": "2.0.48",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
+      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nosleep.js": {
       "version": "0.12.0",
@@ -6975,9 +6988,9 @@
       "peer": true
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -6994,7 +7007,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7035,10 +7048,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.4.0.tgz",
-      "integrity": "sha512-iriNhQ57SYA5Jbdi+41AyPdx6jPPkFO7DODzkOBmqFhgYn/JzX2HxgxYPY18eQAs3CP/AWqtPvkWn8rclRAxdQ==",
-      "hasInstallScript": true,
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.4.tgz",
+      "integrity": "sha512-/+XMv9JalknuncEJSwsyEVlwcxVLKx2iaoSUXFZA86MJkdqyOdfrlB1sB7S6aKyUk9tl20YY+SgQe5J2sJHTcg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "long": "^5.3.2"
@@ -7214,13 +7226,13 @@
       "peer": true
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
-      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.124.0",
-        "@rolldown/pluginutils": "1.0.0-rc.15"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -7229,27 +7241,27 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "license": "MIT"
     },
     "node_modules/rollup": {
@@ -7775,9 +7787,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -8057,16 +8069,16 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
-      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.15",
-        "tinyglobby": "^0.2.15"
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -8082,7 +8094,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ecmwf.int/tensogram",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ecmwf.int/tensogram",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",
@@ -142,14 +142,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -161,9 +161,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.127.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -171,9 +171,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -188,9 +188,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -205,9 +205,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -222,9 +222,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -239,9 +239,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -256,16 +256,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -276,16 +273,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -296,16 +290,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -316,16 +307,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -336,16 +324,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -356,16 +341,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -376,9 +358,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -393,9 +375,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -412,9 +394,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -429,9 +411,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -446,9 +428,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -460,9 +442,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -987,9 +969,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1011,9 +990,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1035,9 +1011,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1059,9 +1032,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1156,9 +1126,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.13",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
+      "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
       "dev": true,
       "funding": [
         {
@@ -1213,9 +1183,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -1233,7 +1203,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1259,14 +1229,14 @@
       "license": "MIT"
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.127.0",
-        "@rolldown/pluginutils": "1.0.0-rc.17"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -1275,21 +1245,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/semver": {
@@ -1367,9 +1337,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1423,17 +1393,17 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
-        "tinyglobby": "^0.2.16"
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -1449,7 +1419,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -41,6 +41,7 @@
     "build:wasm": "wasm-pack build ../rust/tensogram-wasm --release --target web --out-dir ../../typescript/wasm --out-name tensogram_wasm",
     "build:ts": "tsc",
     "build": "npm run build:wasm && npm run build:ts",
+    "prepack": "node -e \"require('fs').rmSync('wasm/.gitignore', { force: true })\"",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## Description

Hardens the developer & release tooling and documents the end-to-end workflow. The fixes here surfaced while making `make all` build every language and adding a release-readiness gate.

### Fixes
- **npm**: the published `@ecmwf.int/tensogram` tarball was missing the entire `wasm/` dir (wasm-pack writes a `.gitignore` npm honours). A `prepack` removes it; a `publish-npm` guard fails if the blob is absent.
- **encode**: scope the `--no-default-features` unused-param `allow` to that config (no global suppression).

### Features
- **`tensogram.__version__`** in the Python bindings (from `CARGO_PKG_VERSION`).
- **`make all` now builds every language** (Rust + Python + TS + C++ + WASM + cargo-c + Fortran) via a `build` aggregate; new `rust-build`, `wasm-build`, `docs` targets.
- **`make release-check`** — release-only gates: `version-check`, crate packaging + leaf dry-run publish, cargo-c header-drift diff, wheels + `twine`, npm wasm-blob guard.
- **Robust `python-build`** (`maturin[patchelf]` + fresh cdylib relink, fixing intermittent 0-byte `.so`); `cargo-c-smoke` → `cargo-c-test`.

### Docs / process
- New **Development workflow** section (AGENTS.md + CONTRIBUTING.md) mapping each phase to the bundled `.prompts/` skills; documented **branch naming** (`<type>/<kebab-summary>`) and a **Review & merge** policy (PR-only, code-owner approvals — two for wire-format/FFI/security, green CI, **merge commits**).
- New `.github/CODEOWNERS` (maintainers from CONTRIBUTORS).
- `docs/src/dev/releasing.md` release guide; `prepare-make-pr`/`make-release` skills now defer to `make all` / `make release-check` / `make bump-version` (removes duplicate sources of truth).
- Mutation testing (`make mutants-diff`) is documented as a deliberate human step, **not** in the default gate.

## Type of Change
- [x] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Breaking change

## Verification
- `make all` — green end-to-end.
- `make release-check` — green (all six gates).
- 8 focused commits, one concern each.

## Review notes
- Per the new policy this should land as a **merge commit**.
- CODEOWNERS won't auto-request reviewers on *this* PR (it is introduced here); it takes effect once merged to `main`.

## Checklist
- [x] Follows the project's style (`make all` / `make release-check` green)
- [x] Tests pass
- [x] Documentation updated
- [x] Examples updated where applicable (n/a — no new public runtime API)

## Contributor Licence Agreement
By submitting this pull request, I confirm my contribution is made under the Apache License 2.0 and I agree to the ECMWF Contributor Licence Agreement.

<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_BEGIN -->
Docs Preview
https://sites.ecmwf.int/docs/tensogram/pull-requests/PR-136
<!-- PREVIEW-PUBLISH-TENSOGRAM-DOCS_END -->