### PR TITLE
docs: squash-merge policy and PR-based releases

### DIFF
--- a/.prompts/make-release.md
+++ b/.prompts/make-release.md
@@ -67,23 +67,40 @@ Summarize changes since the last release using `git log <last-tag>..HEAD --oneli
 Organize into Added / Changed / Fixed / Removed sections.
 Include a Stats section with test counts and coverage.
 
-### 3. Commit and Push
+### 3. Commit and open a release PR
+
+Releases land on `main` through a PR like every other change (see AGENTS.md
+"Review & merge") — NEVER push the release commit straight to `main`.
+
 ```bash
-cargo check --workspace  # verify Cargo.lock updates cleanly
-git add -A  # but NOT build artifacts
+cargo check --workspace                 # verify Cargo.lock updates cleanly
+git checkout -b chore/release-X.Y.Z
+git add -A                              # but NOT build artifacts (dist/, build/, target/)
 git commit -m "chore: release X.Y.Z"
-git push
+git push -u origin chore/release-X.Y.Z
+gh pr create --base main --title "chore: release X.Y.Z" --body "release X.Y.Z"
+```
+
+Get it green/reviewed, then **squash-merge** and delete the branch (add
+`--admin` only to bypass a check that is red for known-infra reasons):
+
+```bash
+gh pr merge --squash --delete-branch
+git checkout main && git pull            # sync before tagging
 ```
 
 ### 4. Preflight and Tag
+
+With the release PR squash-merged and `main` checked out:
+
 ```bash
 # Trigger release-preflight.yml workflow (workflow_dispatch, input: version)
 # Wait for it to pass — all green required.
-# release-preflight now also exercises `cargo cbuild -p tensogram-ffi` and
-# the C-API smoke test, so a broken cargo-c metadata or header drift is
-# caught here before tagging.
-git tag X.Y.Z
-git push --tags
+# release-preflight also exercises `cargo cbuild -p tensogram-ffi` and the
+# C-API smoke test, so broken cargo-c metadata or header drift is caught
+# here before tagging.
+git tag X.Y.Z                            # on main, NO 'v' prefix
+git push origin X.Y.Z
 ```
 
 Pushing the tag also triggers `publish-ffi.yml`, which builds the four

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,8 +225,8 @@ human-facing version of this list.
 - Run `/copilot-review-loop` to convergence before requesting human review;
   `/address-pr-comments` resolves threads. Pushing new commits dismisses stale
   approvals, so re-request review after addressing feedback.
-- Merge with a **merge commit** (GitHub "Create a merge commit"), then delete
-  the branch.
+- Merge with a **squash merge** (GitHub "Squash and merge"), then delete the
+  branch.
 - Agents NEVER push, merge, or open a PR without explicit user approval.
 
 # Version control

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ releases) instead of re-listing raw per-tool commands, removing duplicate
 sources of truth. A new `.github/CODEOWNERS` auto-requests review from the
 maintainers, and a "Review & merge" policy documents PR-only landing on
 `main`, code-owner approvals (two for the wire format / C ABI / security code),
-green CI, and merge-commit merges. Mutation testing stays a deliberate,
+green CI, and squash merges. Mutation testing stays a deliberate,
 human-initiated step and is explicitly excluded from the default gate.
 
 ### Fixed — `resolve_compression` unused-parameter warnings under `--no-default-features`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,7 +184,7 @@ or do it by hand:
   generated header, or security-sensitive code.
 - CI must be green. Run `/copilot-review-loop` to convergence and
   `/address-pr-comments` to resolve threads.
-- Merge with a **merge commit** and delete the branch. (Mutation testing,
+- Merge with a **squash merge** and delete the branch. (Mutation testing,
   `make mutants-diff`, is heavy and run only by deliberate human choice.)
 
 The full review / approval / merge policy is in [AGENTS.md](AGENTS.md) under

--- a/docs/src/dev/releasing.md
+++ b/docs/src/dev/releasing.md
@@ -113,10 +113,14 @@ version-bump/changelog edits uncommitted — the packaging checks pass
 `--allow-dirty` for exactly this reason. The *real* publish always runs on the
 clean tagged commit.
 
-### 5. Commit and push
+### 5. Open a release PR and merge it
 
-Commit the version bump and changelog edits and push. **If anything is
-uncommitted, STOP** — a tag must point at a clean tree.
+Releases land on `main` through a PR like every other change (see the
+"Review & merge" policy in `AGENTS.md`) — do not push the release commit
+directly. Branch as `chore/release-X.Y.Z`, commit, push, open the PR, get it
+green/reviewed, then **squash-merge** and delete the branch. Sync `main`
+before tagging. **If anything is uncommitted, STOP** — the tag must point at a
+clean tree on `main`.
 
 ### 6. (Optional but recommended) Dispatch the CI preflight
 


### PR DESCRIPTION
Switches the **Review & merge** policy and the release docs/skill from merge commits to **squash merges**, per maintainer decision:

- `AGENTS.md` / `CONTRIBUTING.md`: "Merge with a squash merge".
- `CHANGELOG.md` [0.22.0]: "squash merges".
- `.prompts/make-release.md` + `docs/src/dev/releasing.md`: replace the direct-`git push` release step with a **release-PR + squash-merge** flow (then tag `main`).

Repo `allow_merge_commit` restored to `false` to match. Doc-only; admin-merged because the macOS CI runner is down (infra).