### PR TITLE
docs: allow all merge strategies; rebase-default release flow

### DIFF
--- a/.prompts/make-release.md
+++ b/.prompts/make-release.md
@@ -1,5 +1,5 @@
 ---
-description: "Cut a new release — usage: /make-release <X.Y.Z>"
+description: "Cut a new release — usage: /make-release <X.Y.Z> [merge|squash|rebase]"
 agent: build
 ---
 
@@ -9,8 +9,13 @@ Create a new release of Tensogram.
 
 ## Arguments
 
-Provide the version as argument, e.g. `/make-release 0.14.0`
+Provide the version as the first argument, e.g. `/make-release 0.14.0`.
 If no version given, auto-increment MINOR from the current VERSION file.
+
+An optional second argument selects the merge strategy for the release PR —
+one of `merge`, `squash`, or `rebase`. It defaults to **`rebase`**
+(e.g. `/make-release 0.14.0 squash`). Pass it as the `--<strategy>` flag in the
+`gh pr merge` step below.
 
 > **Canonical procedure:** `docs/src/dev/releasing.md`. This skill automates it;
 > keep the two in sync.
@@ -81,11 +86,12 @@ git push -u origin chore/release-X.Y.Z
 gh pr create --base main --title "chore: release X.Y.Z" --body "release X.Y.Z"
 ```
 
-Get it green/reviewed, then **squash-merge** and delete the branch (add
-`--admin` only to bypass a check that is red for known-infra reasons):
+Get it green/reviewed, then merge with the chosen strategy (default
+**rebase**) and delete the branch (add `--admin` only to bypass a check that
+is red for known-infra reasons):
 
 ```bash
-gh pr merge --squash --delete-branch
+gh pr merge --rebase --delete-branch     # or --merge / --squash per the strategy arg
 git checkout main && git pull            # sync before tagging
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,8 +225,10 @@ human-facing version of this list.
 - Run `/copilot-review-loop` to convergence before requesting human review;
   `/address-pr-comments` resolves threads. Pushing new commits dismisses stale
   approvals, so re-request review after addressing feedback.
-- Merge with a **squash merge** (GitHub "Squash and merge"), then delete the
-  branch.
+- Merge with whichever GitHub strategy fits the change — **squash**, **rebase**,
+  or a **merge commit** (all are enabled) — then delete the branch. Release PRs
+  default to **rebase** (`/make-release` takes an optional `merge|squash|rebase`
+  override).
 - Agents NEVER push, merge, or open a PR without explicit user approval.
 
 # Version control

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,8 @@ releases) instead of re-listing raw per-tool commands, removing duplicate
 sources of truth. A new `.github/CODEOWNERS` auto-requests review from the
 maintainers, and a "Review & merge" policy documents PR-only landing on
 `main`, code-owner approvals (two for the wire format / C ABI / security code),
-green CI, and squash merges. Mutation testing stays a deliberate,
+green CI, and a choice of merge strategy (squash, rebase, or merge commit;
+release PRs default to rebase). Mutation testing stays a deliberate,
 human-initiated step and is explicitly excluded from the default gate.
 
 ### Fixed — `resolve_compression` unused-parameter warnings under `--no-default-features`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,7 +184,8 @@ or do it by hand:
   generated header, or security-sensitive code.
 - CI must be green. Run `/copilot-review-loop` to convergence and
   `/address-pr-comments` to resolve threads.
-- Merge with a **squash merge** and delete the branch. (Mutation testing,
+- Merge with whichever strategy fits — squash, rebase, or a merge commit — and
+  delete the branch. (Mutation testing,
   `make mutants-diff`, is heavy and run only by deliberate human choice.)
 
 The full review / approval / merge policy is in [AGENTS.md](AGENTS.md) under

--- a/docs/src/dev/releasing.md
+++ b/docs/src/dev/releasing.md
@@ -118,9 +118,10 @@ clean tagged commit.
 Releases land on `main` through a PR like every other change (see the
 "Review & merge" policy in `AGENTS.md`) — do not push the release commit
 directly. Branch as `chore/release-X.Y.Z`, commit, push, open the PR, get it
-green/reviewed, then **squash-merge** and delete the branch. Sync `main`
-before tagging. **If anything is uncommitted, STOP** — the tag must point at a
-clean tree on `main`.
+green/reviewed, then merge and delete the branch. Releases default to a
+**rebase merge** (`gh pr merge --rebase`); `/make-release` takes an optional
+`merge|squash|rebase` argument to override. Sync `main` before tagging. **If
+anything is uncommitted, STOP** — the tag must point at a clean tree on `main`.
 
 ### 6. (Optional but recommended) Dispatch the CI preflight
 


### PR DESCRIPTION
Per maintainer decision:

- **All three merge strategies are allowed** (squash / rebase / merge commit) — author's choice for general PRs (`allow_merge_commit` re-enabled on the repo).
- The **release flow defaults to a rebase merge**.
- `/make-release` gains an optional `[merge|squash|rebase]` argument (default **rebase**).

Updates `AGENTS.md`, `CONTRIBUTING.md`, `CHANGELOG.md` [0.22.0], `.prompts/make-release.md`, and `docs/src/dev/releasing.md`. Doc-only; merged via `--rebase` (the new default) and `--admin` because the macOS CI runner is down (infra).